### PR TITLE
Implement GnuCashBook wrapper methods

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -9,6 +9,42 @@ from typing import Generator
 import piecash
 
 
+def _account_to_dict(account: piecash.Account) -> dict:
+    """Convert a piecash Account to a serializable dict."""
+    return {
+        "guid": account.guid,
+        "name": account.name,
+        "fullname": account.fullname,
+        "type": account.type,
+        "commodity": account.commodity.mnemonic if account.commodity else None,
+        "description": account.description or "",
+        "placeholder": account.placeholder,
+    }
+
+
+def _split_to_dict(split: piecash.Split) -> dict:
+    """Convert a piecash Split to a serializable dict."""
+    return {
+        "guid": split.guid,
+        "account": split.account.fullname,
+        "value": str(split.value),
+        "quantity": str(split.quantity),
+        "memo": split.memo or "",
+        "reconcile_state": split.reconcile_state,
+    }
+
+
+def _transaction_to_dict(transaction: piecash.Transaction) -> dict:
+    """Convert a piecash Transaction to a serializable dict."""
+    return {
+        "guid": transaction.guid,
+        "date": transaction.post_date.isoformat(),
+        "description": transaction.description,
+        "currency": transaction.currency.mnemonic,
+        "splits": [_split_to_dict(s) for s in transaction.splits],
+    }
+
+
 class GnuCashBook:
     """Thread-safe wrapper for piecash book operations."""
 
@@ -42,20 +78,77 @@ class GnuCashBook:
         finally:
             book.close()
 
+    def _find_account(self, book: piecash.Book, fullname: str) -> piecash.Account | None:
+        """Find an account by its full name path.
+
+        Args:
+            book: Open piecash book.
+            fullname: Full account path (e.g., 'Assets:Bank:Checking').
+
+        Returns:
+            Account if found, None otherwise.
+        """
+        for account in book.accounts:
+            if account.fullname == fullname:
+                return account
+        return None
+
     def list_accounts(self) -> list[dict]:
-        """List all accounts in the chart of accounts."""
-        # TODO: Implement
-        raise NotImplementedError
+        """List all accounts in the chart of accounts.
+
+        Returns:
+            Flat list of account dicts with full paths.
+        """
+        with self.open(readonly=True) as book:
+            accounts = []
+            for account in book.accounts:
+                # Skip the root template account
+                if account.type == "ROOT":
+                    continue
+                accounts.append(_account_to_dict(account))
+            return sorted(accounts, key=lambda a: a["fullname"])
 
     def get_account(self, name: str) -> dict | None:
-        """Get details for a specific account by full name."""
-        # TODO: Implement
-        raise NotImplementedError
+        """Get details for a specific account by full name.
+
+        Args:
+            name: Full account path (e.g., 'Assets:Bank:Checking').
+
+        Returns:
+            Account dict if found, None otherwise.
+        """
+        with self.open(readonly=True) as book:
+            account = self._find_account(book, name)
+            if account:
+                return _account_to_dict(account)
+            return None
 
     def get_balance(self, account_name: str, as_of_date: date | None = None) -> Decimal:
-        """Get balance for an account, optionally as of a specific date."""
-        # TODO: Implement
-        raise NotImplementedError
+        """Get balance for an account, optionally as of a specific date.
+
+        Returns raw GnuCash balance (accounting sign convention).
+
+        Args:
+            account_name: Full account path.
+            as_of_date: Date to calculate balance as of. Defaults to all time.
+
+        Returns:
+            Account balance as Decimal.
+
+        Raises:
+            ValueError: If account not found.
+        """
+        with self.open(readonly=True) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            balance = Decimal("0")
+            for split in account.splits:
+                if as_of_date is None or split.transaction.post_date <= as_of_date:
+                    balance += split.value
+
+            return balance
 
     def list_transactions(
         self,
@@ -64,14 +157,61 @@ class GnuCashBook:
         end_date: date | None = None,
         limit: int = 50,
     ) -> list[dict]:
-        """List transactions with optional filters."""
-        # TODO: Implement
-        raise NotImplementedError
+        """List transactions with optional filters.
+
+        Args:
+            account: Filter by account full name.
+            start_date: Filter transactions on or after this date.
+            end_date: Filter transactions on or before this date.
+            limit: Maximum number of transactions to return.
+
+        Returns:
+            List of transaction dicts, most recent first.
+
+        Raises:
+            ValueError: If specified account not found.
+        """
+        with self.open(readonly=True) as book:
+            # If filtering by account, get transactions through that account's splits
+            if account:
+                acct = self._find_account(book, account)
+                if not acct:
+                    raise ValueError(f"Account not found: {account}")
+                transactions = {split.transaction for split in acct.splits}
+            else:
+                transactions = set(book.transactions)
+
+            # Apply date filters
+            filtered = []
+            for trans in transactions:
+                if start_date and trans.post_date < start_date:
+                    continue
+                if end_date and trans.post_date > end_date:
+                    continue
+                filtered.append(trans)
+
+            # Sort by date descending
+            filtered.sort(key=lambda t: t.post_date, reverse=True)
+
+            # Apply limit
+            filtered = filtered[:limit]
+
+            return [_transaction_to_dict(t) for t in filtered]
 
     def get_transaction(self, guid: str) -> dict | None:
-        """Get details for a specific transaction by GUID."""
-        # TODO: Implement
-        raise NotImplementedError
+        """Get details for a specific transaction by GUID.
+
+        Args:
+            guid: Transaction GUID (32-character hex string).
+
+        Returns:
+            Transaction dict if found, None otherwise.
+        """
+        with self.open(readonly=True) as book:
+            for transaction in book.transactions:
+                if transaction.guid == guid:
+                    return _transaction_to_dict(transaction)
+            return None
 
     def create_transaction(
         self,
@@ -84,28 +224,134 @@ class GnuCashBook:
 
         Args:
             description: Transaction description.
-            splits: List of splits, each with 'account' and 'amount' keys.
+            splits: List of splits, each with 'account' and 'amount' keys,
+                    and optional 'memo' key.
             trans_date: Transaction date. Defaults to today.
-            memo: Optional memo for the transaction.
+            memo: Optional memo (currently unused, per-split memos preferred).
 
         Returns:
             GUID of the created transaction.
 
         Raises:
-            ValueError: If splits don't balance or accounts don't exist.
+            ValueError: If splits don't balance, fewer than 2 splits,
+                       or accounts don't exist.
         """
-        # TODO: Implement
-        raise NotImplementedError
+        if len(splits) < 2:
+            raise ValueError("Transaction must have at least 2 splits")
+
+        # Validate splits balance to zero
+        total = Decimal("0")
+        for split in splits:
+            total += Decimal(split["amount"])
+        if total != Decimal("0"):
+            raise ValueError(f"Splits do not balance: total is {total}")
+
+        if trans_date is None:
+            trans_date = date.today()
+
+        with self.open(readonly=False) as book:
+            # Validate all accounts exist and build split list
+            piecash_splits = []
+            for split in splits:
+                account = self._find_account(book, split["account"])
+                if not account:
+                    raise ValueError(f"Account not found: {split['account']}")
+
+                piecash_splits.append(
+                    piecash.Split(
+                        account=account,
+                        value=Decimal(split["amount"]),
+                        memo=split.get("memo", ""),
+                    )
+                )
+
+            # Create transaction
+            transaction = piecash.Transaction(
+                currency=book.default_currency,
+                description=description,
+                post_date=trans_date,
+                splits=piecash_splits,
+            )
+
+            book.save()
+            return transaction.guid
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:
         """Search transactions by field.
 
         Args:
-            query: Search string.
+            query: Search string. For 'amount' field, supports:
+                   - Exact: "100.00"
+                   - Greater than: ">100"
+                   - Less than: "<100"
+                   - Range: "100-200"
             field: Field to search: 'description', 'memo', or 'amount'.
 
         Returns:
             List of matching transactions.
+
+        Raises:
+            ValueError: If field is not valid.
         """
-        # TODO: Implement
-        raise NotImplementedError
+        if field not in ("description", "memo", "amount"):
+            raise ValueError(f"Invalid search field: {field}")
+
+        with self.open(readonly=True) as book:
+            results = []
+
+            for transaction in book.transactions:
+                if field == "description":
+                    if query.lower() in transaction.description.lower():
+                        results.append(_transaction_to_dict(transaction))
+
+                elif field == "memo":
+                    # Search across all split memos
+                    for split in transaction.splits:
+                        if split.memo and query.lower() in split.memo.lower():
+                            results.append(_transaction_to_dict(transaction))
+                            break
+
+                elif field == "amount":
+                    # Parse amount query for ranges/comparisons
+                    if self._match_amount(transaction, query):
+                        results.append(_transaction_to_dict(transaction))
+
+            return results
+
+    def _match_amount(self, transaction: piecash.Transaction, query: str) -> bool:
+        """Check if any split amount matches the query.
+
+        Args:
+            transaction: Transaction to check.
+            query: Amount query (exact, >N, <N, or N-M range).
+
+        Returns:
+            True if any split matches.
+        """
+        # Get absolute values of all splits
+        amounts = [abs(split.value) for split in transaction.splits]
+
+        # Parse query
+        query = query.strip()
+
+        # Greater than: >100
+        if query.startswith(">"):
+            threshold = Decimal(query[1:])
+            return any(amt > threshold for amt in amounts)
+
+        # Less than: <100
+        if query.startswith("<"):
+            threshold = Decimal(query[1:])
+            return any(amt < threshold for amt in amounts)
+
+        # Range: 100-200
+        if "-" in query and not query.startswith("-"):
+            parts = query.split("-")
+            if len(parts) == 2:
+                low = Decimal(parts[0])
+                high = Decimal(parts[1])
+                return any(low <= amt <= high for amt in amounts)
+
+        # Exact match
+        target = Decimal(query)
+        return any(amt == target for amt in amounts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 import piecash
 from pathlib import Path
+from datetime import date
+from decimal import Decimal
 
 
 @pytest.fixture
@@ -26,84 +28,95 @@ def test_book(tmp_path: Path) -> Path:
         overwrite=True,
     )
 
-    # Get the root account
+    # Get the root account and currency
     root = book.root_account
+    usd = book.default_currency
 
-    # Create standard account hierarchy
+    # Create standard account hierarchy - must add to session
     assets = piecash.Account(
         name="Assets",
         type="ASSET",
         parent=root,
-        commodity=book.default_currency,
+        commodity=usd,
         placeholder=True,
     )
+    book.session.add(assets)
+
     checking = piecash.Account(
         name="Checking",
         type="BANK",
         parent=assets,
-        commodity=book.default_currency,
+        commodity=usd,
     )
+    book.session.add(checking)
 
     liabilities = piecash.Account(
         name="Liabilities",
         type="LIABILITY",
         parent=root,
-        commodity=book.default_currency,
+        commodity=usd,
         placeholder=True,
     )
+    book.session.add(liabilities)
 
     income = piecash.Account(
         name="Income",
         type="INCOME",
         parent=root,
-        commodity=book.default_currency,
+        commodity=usd,
         placeholder=True,
     )
+    book.session.add(income)
+
     salary = piecash.Account(
         name="Salary",
         type="INCOME",
         parent=income,
-        commodity=book.default_currency,
+        commodity=usd,
     )
+    book.session.add(salary)
 
     expenses = piecash.Account(
         name="Expenses",
         type="EXPENSE",
         parent=root,
-        commodity=book.default_currency,
+        commodity=usd,
         placeholder=True,
     )
+    book.session.add(expenses)
+
     groceries = piecash.Account(
         name="Groceries",
         type="EXPENSE",
         parent=expenses,
-        commodity=book.default_currency,
+        commodity=usd,
     )
+    book.session.add(groceries)
 
     equity = piecash.Account(
         name="Equity",
         type="EQUITY",
         parent=root,
-        commodity=book.default_currency,
+        commodity=usd,
         placeholder=True,
     )
+    book.session.add(equity)
+
     opening_balance = piecash.Account(
         name="Opening Balance",
         type="EQUITY",
         parent=equity,
-        commodity=book.default_currency,
+        commodity=usd,
     )
+    book.session.add(opening_balance)
 
-    # Save accounts
-    book.flush()
+    # Save accounts first
+    book.save()
 
     # Create sample transactions
-    from datetime import date
-    from decimal import Decimal
-
     # Opening balance: $1000 in checking
-    piecash.Transaction(
-        currency=book.default_currency,
+    t1 = piecash.Transaction(
+        currency=usd,
         description="Opening Balance",
         post_date=date(2024, 1, 1),
         splits=[
@@ -111,10 +124,11 @@ def test_book(tmp_path: Path) -> Path:
             piecash.Split(account=opening_balance, value=Decimal("-1000.00")),
         ],
     )
+    book.session.add(t1)
 
     # Salary deposit: $2000
-    piecash.Transaction(
-        currency=book.default_currency,
+    t2 = piecash.Transaction(
+        currency=usd,
         description="Salary Deposit",
         post_date=date(2024, 1, 15),
         splits=[
@@ -122,10 +136,11 @@ def test_book(tmp_path: Path) -> Path:
             piecash.Split(account=salary, value=Decimal("-2000.00")),
         ],
     )
+    book.session.add(t2)
 
     # Grocery expense: $150
-    piecash.Transaction(
-        currency=book.default_currency,
+    t3 = piecash.Transaction(
+        currency=usd,
         description="Weekly Groceries",
         post_date=date(2024, 1, 20),
         splits=[
@@ -133,8 +148,9 @@ def test_book(tmp_path: Path) -> Path:
             piecash.Split(account=checking, value=Decimal("-150.00")),
         ],
     )
+    book.session.add(t3)
 
-    book.flush()
+    book.save()
     book.close()
 
     return book_path

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1,5 +1,7 @@
 """Tests for GnuCashBook wrapper."""
 
+from datetime import date
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -29,7 +31,6 @@ class TestGnuCashBookOpen:
         gc_book = GnuCashBook(str(test_book))
         with gc_book.open(readonly=True) as book:
             assert book is not None
-            # Verify we can read accounts
             assert book.root_account is not None
 
     def test_open_readwrite(self, test_book: Path):
@@ -39,11 +40,315 @@ class TestGnuCashBookOpen:
             assert book is not None
 
 
-# TODO: Add tests for each book method as they are implemented
-# class TestListAccounts:
-# class TestGetAccount:
-# class TestGetBalance:
-# class TestListTransactions:
-# class TestGetTransaction:
-# class TestCreateTransaction:
-# class TestSearchTransactions:
+class TestListAccounts:
+    """Tests for list_accounts method."""
+
+    def test_list_accounts_returns_all(self, test_book: Path):
+        """Should return all non-root accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        accounts = gc_book.list_accounts()
+
+        # Should have our test accounts
+        fullnames = {a["fullname"] for a in accounts}
+        assert "Assets" in fullnames
+        assert "Assets:Checking" in fullnames
+        assert "Expenses:Groceries" in fullnames
+        assert "Income:Salary" in fullnames
+
+    def test_list_accounts_sorted(self, test_book: Path):
+        """Should return accounts sorted by fullname."""
+        gc_book = GnuCashBook(str(test_book))
+        accounts = gc_book.list_accounts()
+
+        fullnames = [a["fullname"] for a in accounts]
+        assert fullnames == sorted(fullnames)
+
+    def test_list_accounts_structure(self, test_book: Path):
+        """Should return proper account dict structure."""
+        gc_book = GnuCashBook(str(test_book))
+        accounts = gc_book.list_accounts()
+
+        account = accounts[0]
+        assert "guid" in account
+        assert "name" in account
+        assert "fullname" in account
+        assert "type" in account
+        assert "commodity" in account
+        assert "description" in account
+        assert "placeholder" in account
+
+
+class TestGetAccount:
+    """Tests for get_account method."""
+
+    def test_get_existing_account(self, test_book: Path):
+        """Should return account details for existing account."""
+        gc_book = GnuCashBook(str(test_book))
+        account = gc_book.get_account("Assets:Checking")
+
+        assert account is not None
+        assert account["name"] == "Checking"
+        assert account["fullname"] == "Assets:Checking"
+        assert account["type"] == "BANK"
+
+    def test_get_nonexistent_account(self, test_book: Path):
+        """Should return None for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+        account = gc_book.get_account("Nonexistent:Account")
+
+        assert account is None
+
+
+class TestGetBalance:
+    """Tests for get_balance method."""
+
+    def test_get_balance_all_time(self, test_book: Path):
+        """Should return correct balance for all time."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Checking: +1000 (opening) +2000 (salary) -150 (groceries) = 2850
+        balance = gc_book.get_balance("Assets:Checking")
+        assert balance == Decimal("2850")
+
+    def test_get_balance_as_of_date(self, test_book: Path):
+        """Should return correct balance as of specific date."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # As of Jan 10, only opening balance: 1000
+        balance = gc_book.get_balance("Assets:Checking", as_of_date=date(2024, 1, 10))
+        assert balance == Decimal("1000")
+
+        # As of Jan 15, opening + salary: 3000
+        balance = gc_book.get_balance("Assets:Checking", as_of_date=date(2024, 1, 15))
+        assert balance == Decimal("3000")
+
+    def test_get_balance_nonexistent_account(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.get_balance("Nonexistent:Account")
+
+
+class TestListTransactions:
+    """Tests for list_transactions method."""
+
+    def test_list_all_transactions(self, test_book: Path):
+        """Should return all transactions."""
+        gc_book = GnuCashBook(str(test_book))
+        transactions = gc_book.list_transactions()
+
+        assert len(transactions) == 3
+        descriptions = {t["description"] for t in transactions}
+        assert "Opening Balance" in descriptions
+        assert "Salary Deposit" in descriptions
+        assert "Weekly Groceries" in descriptions
+
+    def test_list_transactions_by_account(self, test_book: Path):
+        """Should filter transactions by account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Groceries account only has one transaction
+        transactions = gc_book.list_transactions(account="Expenses:Groceries")
+        assert len(transactions) == 1
+        assert transactions[0]["description"] == "Weekly Groceries"
+
+    def test_list_transactions_date_range(self, test_book: Path):
+        """Should filter transactions by date range."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Only Jan 10-18 should get salary deposit
+        transactions = gc_book.list_transactions(
+            start_date=date(2024, 1, 10),
+            end_date=date(2024, 1, 18),
+        )
+        assert len(transactions) == 1
+        assert transactions[0]["description"] == "Salary Deposit"
+
+    def test_list_transactions_limit(self, test_book: Path):
+        """Should respect limit parameter."""
+        gc_book = GnuCashBook(str(test_book))
+        transactions = gc_book.list_transactions(limit=2)
+
+        assert len(transactions) == 2
+
+    def test_list_transactions_sorted_descending(self, test_book: Path):
+        """Should return transactions sorted by date descending."""
+        gc_book = GnuCashBook(str(test_book))
+        transactions = gc_book.list_transactions()
+
+        dates = [t["date"] for t in transactions]
+        assert dates == sorted(dates, reverse=True)
+
+    def test_list_transactions_nonexistent_account(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.list_transactions(account="Nonexistent:Account")
+
+
+class TestGetTransaction:
+    """Tests for get_transaction method."""
+
+    def test_get_existing_transaction(self, test_book: Path):
+        """Should return transaction details for existing GUID."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # First get a valid GUID
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        # Then fetch by GUID
+        transaction = gc_book.get_transaction(guid)
+        assert transaction is not None
+        assert transaction["guid"] == guid
+        assert "date" in transaction
+        assert "description" in transaction
+        assert "splits" in transaction
+
+    def test_get_nonexistent_transaction(self, test_book: Path):
+        """Should return None for non-existent GUID."""
+        gc_book = GnuCashBook(str(test_book))
+        transaction = gc_book.get_transaction("nonexistent_guid_12345")
+
+        assert transaction is None
+
+
+class TestCreateTransaction:
+    """Tests for create_transaction method."""
+
+    def test_create_simple_transaction(self, test_book: Path):
+        """Should create a simple two-split transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        guid = gc_book.create_transaction(
+            description="Test Transaction",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=date(2024, 2, 1),
+        )
+
+        assert guid is not None
+        assert len(guid) == 32  # GnuCash GUID format
+
+        # Verify transaction was created
+        transaction = gc_book.get_transaction(guid)
+        assert transaction["description"] == "Test Transaction"
+        assert transaction["date"] == "2024-02-01"
+        assert len(transaction["splits"]) == 2
+
+    def test_create_transaction_with_memo(self, test_book: Path):
+        """Should create transaction with split memos."""
+        gc_book = GnuCashBook(str(test_book))
+
+        guid = gc_book.create_transaction(
+            description="Transaction with Memo",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "25.00", "memo": "Weekly shop"},
+                {"account": "Assets:Checking", "amount": "-25.00", "memo": "Debit"},
+            ],
+        )
+
+        transaction = gc_book.get_transaction(guid)
+        memos = {s["memo"] for s in transaction["splits"]}
+        assert "Weekly shop" in memos
+        assert "Debit" in memos
+
+    def test_create_transaction_unbalanced(self, test_book: Path):
+        """Should raise ValueError for unbalanced splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="do not balance"):
+            gc_book.create_transaction(
+                description="Unbalanced",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-40.00"},
+                ],
+            )
+
+    def test_create_transaction_single_split(self, test_book: Path):
+        """Should raise ValueError for single split."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="at least 2 splits"):
+            gc_book.create_transaction(
+                description="Single Split",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "50.00"},
+                ],
+            )
+
+    def test_create_transaction_invalid_account(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.create_transaction(
+                description="Invalid Account",
+                splits=[
+                    {"account": "Nonexistent:Account", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-50.00"},
+                ],
+            )
+
+
+class TestSearchTransactions:
+    """Tests for search_transactions method."""
+
+    def test_search_by_description(self, test_book: Path):
+        """Should find transactions by description."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("Salary", field="description")
+        assert len(results) == 1
+        assert results[0]["description"] == "Salary Deposit"
+
+    def test_search_by_description_case_insensitive(self, test_book: Path):
+        """Should search case-insensitively."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("salary", field="description")
+        assert len(results) == 1
+
+    def test_search_by_amount_exact(self, test_book: Path):
+        """Should find transactions by exact amount."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("150", field="amount")
+        assert len(results) == 1
+        assert results[0]["description"] == "Weekly Groceries"
+
+    def test_search_by_amount_greater_than(self, test_book: Path):
+        """Should find transactions with amount greater than threshold."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions(">500", field="amount")
+        # Opening (1000) and Salary (2000) transactions
+        assert len(results) == 2
+
+    def test_search_by_amount_less_than(self, test_book: Path):
+        """Should find transactions with amount less than threshold."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("<200", field="amount")
+        assert len(results) == 1
+        assert results[0]["description"] == "Weekly Groceries"
+
+    def test_search_by_amount_range(self, test_book: Path):
+        """Should find transactions with amount in range."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("100-500", field="amount")
+        assert len(results) == 1
+        assert results[0]["description"] == "Weekly Groceries"
+
+    def test_search_invalid_field(self, test_book: Path):
+        """Should raise ValueError for invalid field."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Invalid search field"):
+            gc_book.search_transactions("test", field="invalid")


### PR DESCRIPTION
## Summary

- Implement all 7 GnuCashBook methods for reading/writing GnuCash data
- Add comprehensive test suite (32 tests for book.py)
- Fix piecash persistence (use `book.save()` not `book.flush()`)

### Methods implemented:
- `list_accounts` - Flat list sorted by fullname
- `get_account` - Lookup by full path
- `get_balance` - Raw balance with optional as_of_date
- `list_transactions` - Filter by account, date range, limit
- `get_transaction` - Lookup by GUID
- `create_transaction` - With split validation
- `search_transactions` - Substring match + amount ranges

## Test plan

- [x] All 35 tests pass (`uv run pytest`)
- [x] Test fixture creates valid GnuCash book with sample data
- [x] Transaction creation properly persists to database