### PR TITLE
Add create_account tool for creating new accounts

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -18,7 +18,7 @@ def _account_to_dict(account: piecash.Account) -> dict:
         "type": account.type,
         "commodity": account.commodity.mnemonic if account.commodity else None,
         "description": account.description or "",
-        "placeholder": account.placeholder,
+        "placeholder": bool(account.placeholder),
     }
 
 
@@ -355,3 +355,78 @@ class GnuCashBook:
         # Exact match
         target = Decimal(query)
         return any(amt == target for amt in amounts)
+
+    # Valid GnuCash account types
+    VALID_ACCOUNT_TYPES = {
+        "ASSET",
+        "BANK",
+        "CASH",
+        "CREDIT",
+        "EQUITY",
+        "EXPENSE",
+        "INCOME",
+        "LIABILITY",
+        "MUTUAL",
+        "STOCK",
+    }
+
+    def create_account(
+        self,
+        name: str,
+        account_type: str,
+        parent: str,
+        description: str = "",
+        placeholder: bool = False,
+    ) -> dict:
+        """Create a new account in the chart of accounts.
+
+        Args:
+            name: Account name (e.g., "AI Subscriptions").
+            account_type: GnuCash account type (ASSET, EXPENSE, etc.).
+            parent: Full path of parent account (e.g., "Expenses:Online Services").
+            description: Optional description.
+            placeholder: If True, account is container-only. Default False.
+
+        Returns:
+            Dict with guid, fullname, and status.
+
+        Raises:
+            ValueError: If parent not found, invalid type, or duplicate name.
+        """
+        # Validate account type
+        if account_type.upper() not in self.VALID_ACCOUNT_TYPES:
+            raise ValueError(
+                f"Invalid account type: {account_type}. "
+                f"Valid types: {', '.join(sorted(self.VALID_ACCOUNT_TYPES))}"
+            )
+
+        with self.open(readonly=False) as book:
+            # Find parent account
+            parent_account = self._find_account(book, parent)
+            if not parent_account:
+                raise ValueError(f"Parent account not found: {parent}")
+
+            # Check for duplicate - same name under same parent
+            for child in parent_account.children:
+                if child.name == name:
+                    raise ValueError(
+                        f"Account '{name}' already exists under '{parent}'"
+                    )
+
+            # Create the account
+            new_account = piecash.Account(
+                name=name,
+                type=account_type.upper(),
+                parent=parent_account,
+                commodity=book.default_currency,
+                description=description,
+                placeholder=placeholder,
+            )
+
+            book.save()
+
+            return {
+                "guid": new_account.guid,
+                "fullname": new_account.fullname,
+                "status": "created",
+            }

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -154,6 +154,37 @@ def search_transactions(query: str, field: str = "description") -> str:
         return json.dumps({"error": str(e)})
 
 
+@mcp.tool()
+def create_account(
+    name: str,
+    account_type: str,
+    parent: str,
+    description: str = "",
+    placeholder: bool = False,
+) -> str:
+    """Create a new account in the chart of accounts.
+
+    Args:
+        name: Account name (e.g., "AI Subscriptions")
+        account_type: GnuCash account type (ASSET, BANK, CASH, CREDIT, EQUITY, EXPENSE, INCOME, LIABILITY, MUTUAL, STOCK)
+        parent: Full path of parent account (e.g., "Expenses:Online Services")
+        description: Optional description
+        placeholder: If true, account is container-only. Default: false
+    """
+    book = get_book()
+    try:
+        result = book.create_account(
+            name=name,
+            account_type=account_type,
+            parent=parent,
+            description=description,
+            placeholder=placeholder,
+        )
+        return json.dumps(result, indent=2)
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+
+
 # ============== Resources ==============
 
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -352,3 +352,109 @@ class TestSearchTransactions:
 
         with pytest.raises(ValueError, match="Invalid search field"):
             gc_book.search_transactions("test", field="invalid")
+
+
+class TestCreateAccount:
+    """Tests for create_account method."""
+
+    def test_create_account_success(self, test_book: Path):
+        """Should create a new account under existing parent."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.create_account(
+            name="Test Category",
+            account_type="EXPENSE",
+            parent="Expenses",
+            description="A test expense category",
+        )
+
+        assert result["status"] == "created"
+        assert result["fullname"] == "Expenses:Test Category"
+        assert len(result["guid"]) == 32
+
+        # Verify account exists
+        account = gc_book.get_account("Expenses:Test Category")
+        assert account is not None
+        assert account["description"] == "A test expense category"
+
+    def test_create_account_nested(self, test_book: Path):
+        """Should create account under nested parent."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # First create a parent
+        gc_book.create_account(
+            name="Online Services",
+            account_type="EXPENSE",
+            parent="Expenses",
+            placeholder=True,
+        )
+
+        # Then create child
+        result = gc_book.create_account(
+            name="AI Subscriptions",
+            account_type="EXPENSE",
+            parent="Expenses:Online Services",
+            description="Claude, ChatGPT, etc.",
+        )
+
+        assert result["fullname"] == "Expenses:Online Services:AI Subscriptions"
+
+    def test_create_account_placeholder(self, test_book: Path):
+        """Should create placeholder account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.create_account(
+            name="Placeholder Category",
+            account_type="EXPENSE",
+            parent="Expenses",
+            placeholder=True,
+        )
+
+        account = gc_book.get_account("Expenses:Placeholder Category")
+        assert account["placeholder"] is True
+
+    def test_create_account_parent_not_found(self, test_book: Path):
+        """Should raise ValueError if parent doesn't exist."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Parent account not found"):
+            gc_book.create_account(
+                name="Test",
+                account_type="EXPENSE",
+                parent="Nonexistent:Parent",
+            )
+
+    def test_create_account_duplicate(self, test_book: Path):
+        """Should raise ValueError if account with same name exists under parent."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Groceries already exists under Expenses
+        with pytest.raises(ValueError, match="already exists"):
+            gc_book.create_account(
+                name="Groceries",
+                account_type="EXPENSE",
+                parent="Expenses",
+            )
+
+    def test_create_account_invalid_type(self, test_book: Path):
+        """Should raise ValueError for invalid account type."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Invalid account type"):
+            gc_book.create_account(
+                name="Test",
+                account_type="INVALID",
+                parent="Expenses",
+            )
+
+    def test_create_account_type_case_insensitive(self, test_book: Path):
+        """Should accept lowercase account types."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.create_account(
+            name="Lowercase Type Test",
+            account_type="expense",
+            parent="Expenses",
+        )
+
+        assert result["status"] == "created"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -169,6 +169,35 @@ class TestSearchTransactionsTool:
         assert len(data) == 2  # Opening Balance (1000) and Salary (2000)
 
 
+class TestCreateAccountTool:
+    """Tests for create_account tool."""
+
+    def test_create_account(self, setup_book_env):
+        """Should create account and return result."""
+        result = server_module.create_account(
+            name="Test Category",
+            account_type="EXPENSE",
+            parent="Expenses",
+            description="A test category",
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "created"
+        assert data["fullname"] == "Expenses:Test Category"
+
+    def test_create_account_invalid_parent(self, setup_book_env):
+        """Should return error for invalid parent."""
+        result = server_module.create_account(
+            name="Test",
+            account_type="EXPENSE",
+            parent="Nonexistent:Parent",
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "not found" in data["error"].lower()
+
+
 class TestResources:
     """Tests for MCP resources."""
 


### PR DESCRIPTION
## Summary

Implements the `create_account` tool per CREATE_ACCOUNT_SPEC.md, allowing creation of new accounts in the GnuCash chart of accounts without leaving Claude.

### Features:
- Create accounts under any existing parent
- Supports all GnuCash account types (ASSET, BANK, EXPENSE, etc.)
- Optional description and placeholder flag
- Validation: parent must exist, no duplicates, valid types

### Example usage:
```
create_account(
    name="AI Subscriptions",
    account_type="EXPENSE",
    parent="Expenses:Online Services",
    description="Claude, ChatGPT, etc."
)
```

## Test plan

- [x] All 55 tests pass
- [x] 9 new tests for create_account (success, nested, placeholder, errors)