### PR TITLE
Add delete and update transaction tools

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -430,3 +430,111 @@ class GnuCashBook:
                 "fullname": new_account.fullname,
                 "status": "created",
             }
+
+    def delete_transaction(self, guid: str) -> dict:
+        """Delete a transaction by GUID.
+
+        Args:
+            guid: Transaction GUID (32-character hex string).
+
+        Returns:
+            Dict with guid, description, and status.
+
+        Raises:
+            ValueError: If transaction not found.
+        """
+        with self.open(readonly=False) as book:
+            # Find the transaction
+            transaction = None
+            for t in book.transactions:
+                if t.guid == guid:
+                    transaction = t
+                    break
+
+            if not transaction:
+                raise ValueError(f"Transaction not found: {guid}")
+
+            # Capture info before deletion
+            result = {
+                "guid": guid,
+                "description": transaction.description,
+                "status": "deleted",
+            }
+
+            # Delete the transaction
+            book.session.delete(transaction)
+            book.save()
+
+            return result
+
+    def update_transaction(
+        self,
+        guid: str,
+        description: str | None = None,
+        trans_date: date | None = None,
+        splits: list[dict] | None = None,
+    ) -> dict:
+        """Update an existing transaction.
+
+        Args:
+            guid: Transaction GUID to update.
+            description: New description (optional).
+            trans_date: New transaction date (optional).
+            splits: List of split updates with 'account' and 'amount' (optional).
+                    Must match existing splits by account name.
+
+        Returns:
+            Dict with updated transaction details.
+
+        Raises:
+            ValueError: If transaction not found, splits don't balance,
+                       or account not found in splits.
+        """
+        with self.open(readonly=False) as book:
+            # Find the transaction
+            transaction = None
+            for t in book.transactions:
+                if t.guid == guid:
+                    transaction = t
+                    break
+
+            if not transaction:
+                raise ValueError(f"Transaction not found: {guid}")
+
+            # Update description if provided
+            if description is not None:
+                transaction.description = description
+
+            # Update date if provided
+            if trans_date is not None:
+                transaction.post_date = trans_date
+
+            # Update splits if provided
+            if splits is not None:
+                # Validate splits balance to zero
+                total = Decimal("0")
+                for split in splits:
+                    total += Decimal(split["amount"])
+                if total != Decimal("0"):
+                    raise ValueError(f"Splits do not balance: total is {total}")
+
+                # Build a map of account -> new amount
+                split_updates = {s["account"]: Decimal(s["amount"]) for s in splits}
+
+                # Update existing splits
+                for split in transaction.splits:
+                    account_name = split.account.fullname
+                    if account_name in split_updates:
+                        new_value = split_updates[account_name]
+                        split.value = new_value
+                        split.quantity = new_value
+                        del split_updates[account_name]
+
+                # Check if all provided accounts were found
+                if split_updates:
+                    missing = list(split_updates.keys())[0]
+                    raise ValueError(f"Account not found in transaction: {missing}")
+
+            book.save()
+
+            return _transaction_to_dict(transaction) | {"status": "updated"}

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -185,6 +185,51 @@ def create_account(
         return json.dumps({"error": str(e)})
 
 
+@mcp.tool()
+def delete_transaction(guid: str) -> str:
+    """Delete a transaction by GUID.
+
+    Args:
+        guid: Transaction GUID (32-character hex string)
+    """
+    book = get_book()
+    try:
+        result = book.delete_transaction(guid)
+        return json.dumps(result, indent=2)
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+def update_transaction(
+    guid: str,
+    description: str | None = None,
+    transaction_date: str | None = None,
+    splits: list[dict] | None = None,
+) -> str:
+    """Update an existing transaction.
+
+    Args:
+        guid: Transaction GUID to update
+        description: New transaction description (optional)
+        transaction_date: New date in ISO format YYYY-MM-DD (optional)
+        splits: List of split updates with 'account' and 'amount' (optional).
+                Must match existing splits by account name and balance to zero.
+    """
+    book = get_book()
+    try:
+        trans_date = date.fromisoformat(transaction_date) if transaction_date else None
+        result = book.update_transaction(
+            guid=guid,
+            description=description,
+            trans_date=trans_date,
+            splits=splits,
+        )
+        return json.dumps(result, indent=2)
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+
+
 # ============== Resources ==============
 
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -458,3 +458,152 @@ class TestCreateAccount:
         )
 
         assert result["status"] == "created"
+
+
+class TestDeleteTransaction:
+    """Tests for delete_transaction method."""
+
+    def test_delete_transaction_success(self, test_book: Path):
+        """Should delete an existing transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a transaction to delete
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+        description = transactions[0]["description"]
+
+        result = gc_book.delete_transaction(guid)
+
+        assert result["status"] == "deleted"
+        assert result["guid"] == guid
+        assert result["description"] == description
+
+        # Verify transaction is gone
+        assert gc_book.get_transaction(guid) is None
+
+    def test_delete_transaction_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Transaction not found"):
+            gc_book.delete_transaction("nonexistent_guid_12345")
+
+
+class TestUpdateTransaction:
+    """Tests for update_transaction method."""
+
+    def test_update_description_only(self, test_book: Path):
+        """Should update only the description."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            description="Updated Description",
+        )
+
+        assert result["status"] == "updated"
+        assert result["description"] == "Updated Description"
+
+    def test_update_date_only(self, test_book: Path):
+        """Should update only the date."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            trans_date=date(2024, 6, 15),
+        )
+
+        assert result["status"] == "updated"
+        assert result["date"] == "2024-06-15"
+
+    def test_update_splits(self, test_book: Path):
+        """Should update split amounts."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get the groceries transaction (150.00)
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "175.00"},
+                {"account": "Assets:Checking", "amount": "-175.00"},
+            ],
+        )
+
+        assert result["status"] == "updated"
+        # Verify new amounts
+        updated = gc_book.get_transaction(guid)
+        for split in updated["splits"]:
+            if split["account"] == "Expenses:Groceries":
+                assert split["value"] == "175"
+
+    def test_update_everything(self, test_book: Path):
+        """Should update description, date, and splits together."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            description="Safeway Groceries",
+            trans_date=date(2024, 1, 21),
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "160.00"},
+                {"account": "Assets:Checking", "amount": "-160.00"},
+            ],
+        )
+
+        assert result["status"] == "updated"
+        assert result["description"] == "Safeway Groceries"
+        assert result["date"] == "2024-01-21"
+
+    def test_update_transaction_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Transaction not found"):
+            gc_book.update_transaction(
+                guid="nonexistent_guid",
+                description="Test",
+            )
+
+    def test_update_splits_unbalanced(self, test_book: Path):
+        """Should raise ValueError for unbalanced splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="do not balance"):
+            gc_book.update_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-90.00"},
+                ],
+            )
+
+    def test_update_splits_account_not_found(self, test_book: Path):
+        """Should raise ValueError if split account not in transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="Account not found in transaction"):
+            gc_book.update_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Nonexistent", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-100.00"},
+                ],
+            )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -198,6 +198,114 @@ class TestCreateAccountTool:
         assert "not found" in data["error"].lower()
 
 
+class TestDeleteTransactionTool:
+    """Tests for delete_transaction tool."""
+
+    def test_delete_transaction(self, setup_book_env):
+        """Should delete a transaction and return result."""
+        # First get a transaction to delete
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.delete_transaction(guid)
+
+        data = json.loads(result)
+        assert data["status"] == "deleted"
+        assert data["guid"] == guid
+
+        # Verify it's gone
+        get_result = server_module.get_transaction(guid)
+        assert "error" in json.loads(get_result)
+
+    def test_delete_nonexistent_transaction(self, setup_book_env):
+        """Should return error for missing transaction."""
+        result = server_module.delete_transaction("nonexistent_guid_12345")
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "not found" in data["error"].lower()
+
+
+class TestUpdateTransactionTool:
+    """Tests for update_transaction tool."""
+
+    def test_update_description(self, setup_book_env):
+        """Should update transaction description."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.update_transaction(
+            guid=guid,
+            description="Updated Description",
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "updated"
+        assert data["description"] == "Updated Description"
+
+    def test_update_date(self, setup_book_env):
+        """Should update transaction date."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.update_transaction(
+            guid=guid,
+            transaction_date="2024-06-15",
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "updated"
+        assert data["date"] == "2024-06-15"
+
+    def test_update_splits(self, setup_book_env):
+        """Should update transaction split amounts."""
+        # Find the groceries transaction which has known accounts
+        transactions = json.loads(server_module.list_transactions())
+        groceries_trans = next(
+            t for t in transactions if t["description"] == "Weekly Groceries"
+        )
+        guid = groceries_trans["guid"]
+
+        result = server_module.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-200.00"},
+                {"account": "Expenses:Groceries", "amount": "200.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "updated"
+
+    def test_update_nonexistent_transaction(self, setup_book_env):
+        """Should return error for missing transaction."""
+        result = server_module.update_transaction(
+            guid="nonexistent_guid_12345",
+            description="New Description",
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "not found" in data["error"].lower()
+
+    def test_update_unbalanced_splits(self, setup_book_env):
+        """Should return error for unbalanced splits."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-100.00"},
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "balance" in data["error"].lower()
+
+
 class TestResources:
     """Tests for MCP resources."""
 


### PR DESCRIPTION
## Summary
- Add `delete_transaction` tool to remove transactions by GUID
- Add `update_transaction` tool to modify existing transactions (description, date, splits)
- Both operations include input validation and proper error handling

## Test plan
- [x] Unit tests for `GnuCashBook.delete_transaction()` method
- [x] Unit tests for `GnuCashBook.update_transaction()` method
- [x] Integration tests for MCP server tool wrappers
- [x] All 71 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)