### PR TITLE
Add reconciliation and void transaction tools

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -39,6 +39,7 @@ def _split_to_dict(split: piecash.Split) -> dict:
         "quantity": str(split.quantity),
         "memo": split.memo or "",
         "reconcile_state": split.reconcile_state,
+        "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date else None,
     }
 
 
@@ -581,3 +582,345 @@ class GnuCashBook:
             book.save()
 
             return _transaction_to_dict(transaction) | {"status": "updated"}
+
+    def _find_split(self, book: piecash.Book, guid: str) -> piecash.Split | None:
+        """Find a split by GUID.
+
+        Args:
+            book: Open piecash book.
+            guid: Split GUID.
+
+        Returns:
+            Split if found, None otherwise.
+        """
+        for transaction in book.transactions:
+            for split in transaction.splits:
+                if split.guid == guid:
+                    return split
+        return None
+
+    # Valid reconcile states
+    VALID_RECONCILE_STATES = {"n", "c", "y"}  # new, cleared, reconciled
+
+    def set_reconcile_state(
+        self,
+        split_guid: str,
+        state: str,
+        reconcile_date: date | None = None,
+    ) -> dict:
+        """Set the reconciliation state for a split.
+
+        Args:
+            split_guid: GUID of the split to update.
+            state: New reconcile state ('n'=new, 'c'=cleared, 'y'=reconciled).
+            reconcile_date: Date of reconciliation. Required if state is 'y',
+                           defaults to today if not provided.
+
+        Returns:
+            Dict with split details and status.
+
+        Raises:
+            ValueError: If split not found or invalid state.
+        """
+        state = state.lower()
+        if state not in self.VALID_RECONCILE_STATES:
+            raise ValueError(
+                f"Invalid reconcile state: {state}. "
+                f"Valid states: 'n' (new), 'c' (cleared), 'y' (reconciled)"
+            )
+
+        with self.open(readonly=False) as book:
+            split = self._find_split(book, split_guid)
+            if not split:
+                raise ValueError(f"Split not found: {split_guid}")
+
+            # Set the reconcile state
+            split.reconcile_state = state
+
+            # Handle reconcile date
+            if state == "y":
+                from datetime import datetime
+                if reconcile_date:
+                    split.reconcile_date = datetime.combine(
+                        reconcile_date, datetime.min.time()
+                    )
+                else:
+                    split.reconcile_date = datetime.now()
+            elif state == "n":
+                # Clear the reconcile date when unmarking
+                split.reconcile_date = None
+
+            book.save()
+
+            return {
+                "split_guid": split_guid,
+                "account": split.account.fullname,
+                "value": str(split.value),
+                "reconcile_state": state,
+                "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date else None,
+                "status": "updated",
+            }
+
+    def get_unreconciled_splits(
+        self,
+        account_name: str,
+        as_of_date: date | None = None,
+    ) -> dict:
+        """Get all unreconciled splits for an account.
+
+        Args:
+            account_name: Full account path.
+            as_of_date: Only include splits on or before this date.
+
+        Returns:
+            Dict with account info, splits list, and running totals.
+
+        Raises:
+            ValueError: If account not found.
+        """
+        with self.open(readonly=True) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            unreconciled = []
+            cleared_total = Decimal("0")
+            uncleared_total = Decimal("0")
+
+            # Get splits sorted by date
+            splits = sorted(
+                account.splits,
+                key=lambda s: (s.transaction.post_date, s.transaction.enter_date)
+            )
+
+            for split in splits:
+                # Apply date filter
+                if as_of_date and split.transaction.post_date > as_of_date:
+                    continue
+
+                # Only include non-reconciled splits (n or c, not y)
+                if split.reconcile_state != "y":
+                    split_dict = {
+                        "guid": split.guid,
+                        "date": split.transaction.post_date.isoformat(),
+                        "description": split.transaction.description,
+                        "value": str(split.value),
+                        "reconcile_state": split.reconcile_state,
+                        "memo": split.memo or "",
+                    }
+                    unreconciled.append(split_dict)
+
+                    if split.reconcile_state == "c":
+                        cleared_total += split.value
+                    else:
+                        uncleared_total += split.value
+
+            return {
+                "account": account_name,
+                "as_of_date": as_of_date.isoformat() if as_of_date else None,
+                "splits": unreconciled,
+                "cleared_total": str(cleared_total),
+                "uncleared_total": str(uncleared_total),
+                "count": len(unreconciled),
+            }
+
+    def reconcile_account(
+        self,
+        account_name: str,
+        statement_date: date,
+        statement_balance: str,
+        split_guids: list[str],
+    ) -> dict:
+        """Reconcile multiple splits against a statement balance.
+
+        Args:
+            account_name: Full account path.
+            statement_date: Statement ending date.
+            statement_balance: Expected balance from statement (as string).
+            split_guids: List of split GUIDs to mark as reconciled.
+
+        Returns:
+            Dict with reconciliation results.
+
+        Raises:
+            ValueError: If account not found, split not found, or balance mismatch.
+        """
+        expected_balance = Decimal(statement_balance)
+
+        with self.open(readonly=False) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            from datetime import datetime
+
+            # Calculate current reconciled balance
+            reconciled_balance = Decimal("0")
+            for split in account.splits:
+                if split.reconcile_state == "y":
+                    reconciled_balance += split.value
+
+            # Find and validate all splits to reconcile
+            splits_to_reconcile = []
+            reconciling_total = Decimal("0")
+
+            for guid in split_guids:
+                split = self._find_split(book, guid)
+                if not split:
+                    raise ValueError(f"Split not found: {guid}")
+                if split.account.fullname != account_name:
+                    raise ValueError(
+                        f"Split {guid} belongs to account '{split.account.fullname}', "
+                        f"not '{account_name}'"
+                    )
+                if split.reconcile_state == "y":
+                    raise ValueError(f"Split {guid} is already reconciled")
+
+                splits_to_reconcile.append(split)
+                reconciling_total += split.value
+
+            # Check if balance will match
+            new_balance = reconciled_balance + reconciling_total
+            if new_balance != expected_balance:
+                raise ValueError(
+                    f"Balance mismatch: reconciled balance would be {new_balance}, "
+                    f"but statement balance is {expected_balance}. "
+                    f"Difference: {expected_balance - new_balance}"
+                )
+
+            # Perform reconciliation
+            reconcile_datetime = datetime.combine(statement_date, datetime.min.time())
+            for split in splits_to_reconcile:
+                split.reconcile_state = "y"
+                split.reconcile_date = reconcile_datetime
+
+            book.save()
+
+            return {
+                "account": account_name,
+                "statement_date": statement_date.isoformat(),
+                "statement_balance": statement_balance,
+                "splits_reconciled": len(splits_to_reconcile),
+                "new_reconciled_balance": str(new_balance),
+                "status": "reconciled",
+            }
+
+    def void_transaction(self, guid: str, reason: str) -> dict:
+        """Void a transaction (proper accounting void, not delete).
+
+        Voiding preserves the transaction for audit purposes but zeroes out
+        all split values. Original values are stored in slots for potential
+        unvoiding.
+
+        Args:
+            guid: Transaction GUID to void.
+            reason: Reason for voiding (required for audit trail).
+
+        Returns:
+            Dict with transaction details and status.
+
+        Raises:
+            ValueError: If transaction not found or already voided.
+        """
+        if not reason or not reason.strip():
+            raise ValueError("Void reason is required")
+
+        with self.open(readonly=False) as book:
+            # Find the transaction
+            transaction = None
+            for t in book.transactions:
+                if t.guid == guid:
+                    transaction = t
+                    break
+
+            if not transaction:
+                raise ValueError(f"Transaction not found: {guid}")
+
+            # Check if already voided (any split has 'v' state)
+            if any(s.reconcile_state == "v" for s in transaction.splits):
+                raise ValueError(f"Transaction {guid} is already voided")
+
+            from datetime import datetime
+
+            # Store void metadata in transaction slots
+            # GnuCash uses these slot keys for void info
+            transaction["void-reason"] = reason
+            transaction["void-time"] = datetime.now().isoformat()
+
+            # Store original values and zero out each split
+            for split in transaction.splits:
+                # Store original values in slots
+                split["void-former-value"] = str(split.value)
+                split["void-former-quantity"] = str(split.quantity)
+
+                # Zero out the split
+                split.value = Decimal("0")
+                split.quantity = Decimal("0")
+
+                # Set reconcile state to voided
+                split.reconcile_state = "v"
+
+            book.save()
+
+            return {
+                "guid": guid,
+                "description": transaction.description,
+                "void_reason": reason,
+                "status": "voided",
+            }
+
+    def unvoid_transaction(self, guid: str) -> dict:
+        """Restore a voided transaction.
+
+        Restores original split values from stored slots and removes void markers.
+
+        Args:
+            guid: Transaction GUID to unvoid.
+
+        Returns:
+            Dict with transaction details and status.
+
+        Raises:
+            ValueError: If transaction not found or not voided.
+        """
+        with self.open(readonly=False) as book:
+            # Find the transaction
+            transaction = None
+            for t in book.transactions:
+                if t.guid == guid:
+                    transaction = t
+                    break
+
+            if not transaction:
+                raise ValueError(f"Transaction not found: {guid}")
+
+            # Check if actually voided
+            if not any(s.reconcile_state == "v" for s in transaction.splits):
+                raise ValueError(f"Transaction {guid} is not voided")
+
+            # Restore each split
+            for split in transaction.splits:
+                # Restore original values from slots
+                former_value = split.get("void-former-value")
+                former_quantity = split.get("void-former-quantity")
+
+                if former_value is not None:
+                    split.value = Decimal(former_value)
+                    del split["void-former-value"]
+
+                if former_quantity is not None:
+                    split.quantity = Decimal(former_quantity)
+                    del split["void-former-quantity"]
+
+                # Reset reconcile state to new
+                split.reconcile_state = "n"
+
+            # Remove void metadata from transaction
+            if "void-reason" in transaction:
+                del transaction["void-reason"]
+            if "void-time" in transaction:
+                del transaction["void-time"]
+
+            book.save()
+
+            return _transaction_to_dict(transaction) | {"status": "unvoided"}

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -273,6 +273,121 @@ def update_transaction(
     return json.dumps(result, indent=2)
 
 
+# ============== Reconciliation Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+def set_reconcile_state(
+    split_guid: str,
+    state: str,
+    reconcile_date: str | None = None,
+) -> str:
+    """Set the reconciliation state for a split.
+
+    Args:
+        split_guid: GUID of the split to update
+        state: New reconcile state: 'n' (new), 'c' (cleared), 'y' (reconciled)
+        reconcile_date: Date in ISO format (YYYY-MM-DD). Required for 'y', defaults to today.
+    """
+    book = get_book()
+    rec_date = date.fromisoformat(reconcile_date) if reconcile_date else None
+    result = book.set_reconcile_state(
+        split_guid=split_guid,
+        state=state,
+        reconcile_date=rec_date,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def get_unreconciled_splits(
+    account: str,
+    as_of_date: str | None = None,
+) -> str:
+    """Get all unreconciled splits for an account.
+
+    Args:
+        account: Full account name (e.g., 'Assets:Bank:Checking')
+        as_of_date: Only include splits on or before this date (YYYY-MM-DD)
+    """
+    book = get_book()
+    date_obj = date.fromisoformat(as_of_date) if as_of_date else None
+    result = book.get_unreconciled_splits(
+        account_name=account,
+        as_of_date=date_obj,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def reconcile_account(
+    account: str,
+    statement_date: str,
+    statement_balance: str,
+    split_guids: list[str],
+) -> str:
+    """Reconcile multiple splits against a statement balance.
+
+    Marks all specified splits as reconciled if the resulting balance matches
+    the statement balance. This is an atomic operation - either all splits are
+    reconciled or none are.
+
+    Args:
+        account: Full account name (e.g., 'Assets:Bank:Checking')
+        statement_date: Statement ending date (YYYY-MM-DD)
+        statement_balance: Expected balance from statement (as string, e.g., '1234.56')
+        split_guids: List of split GUIDs to mark as reconciled
+    """
+    book = get_book()
+    stmt_date = date.fromisoformat(statement_date)
+    result = book.reconcile_account(
+        account_name=account,
+        statement_date=stmt_date,
+        statement_balance=statement_balance,
+        split_guids=split_guids,
+    )
+    return json.dumps(result, indent=2)
+
+
+# ============== Void Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+def void_transaction(guid: str, reason: str) -> str:
+    """Void a transaction (proper accounting void, not delete).
+
+    Voiding preserves the transaction for audit purposes but zeroes out
+    all split values. Use this instead of delete when you need to maintain
+    an audit trail.
+
+    Args:
+        guid: Transaction GUID to void
+        reason: Reason for voiding (required for audit trail)
+    """
+    book = get_book()
+    result = book.void_transaction(guid=guid, reason=reason)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def unvoid_transaction(guid: str) -> str:
+    """Restore a voided transaction.
+
+    Restores original split values and removes void markers.
+
+    Args:
+        guid: Transaction GUID to unvoid
+    """
+    book = get_book()
+    result = book.unvoid_transaction(guid=guid)
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -614,3 +614,268 @@ class TestUpdateTransaction:
                     {"account": "Assets:Checking", "amount": "-100.00"},
                 ],
             )
+
+
+class TestSetReconcileState:
+    """Tests for set_reconcile_state method."""
+
+    def test_set_reconcile_cleared(self, test_book: Path):
+        """Should set split to cleared state."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a split guid
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        result = gc_book.set_reconcile_state(split_guid, "c")
+
+        assert result["status"] == "updated"
+        assert result["reconcile_state"] == "c"
+
+    def test_set_reconcile_reconciled(self, test_book: Path):
+        """Should set split to reconciled state with date."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        result = gc_book.set_reconcile_state(
+            split_guid, "y", reconcile_date=date(2024, 1, 31)
+        )
+
+        assert result["status"] == "updated"
+        assert result["reconcile_state"] == "y"
+        assert result["reconcile_date"] is not None
+
+    def test_set_reconcile_new(self, test_book: Path):
+        """Should reset split to new state."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        # First set to cleared
+        gc_book.set_reconcile_state(split_guid, "c")
+
+        # Then reset to new
+        result = gc_book.set_reconcile_state(split_guid, "n")
+
+        assert result["reconcile_state"] == "n"
+        assert result["reconcile_date"] is None
+
+    def test_set_reconcile_invalid_state(self, test_book: Path):
+        """Should raise ValueError for invalid state."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        with pytest.raises(ValueError, match="Invalid reconcile state"):
+            gc_book.set_reconcile_state(split_guid, "x")
+
+    def test_set_reconcile_split_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent split."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Split not found"):
+            gc_book.set_reconcile_state("nonexistent_guid", "c")
+
+
+class TestGetUnreconciledSplits:
+    """Tests for get_unreconciled_splits method."""
+
+    def test_get_unreconciled_splits(self, test_book: Path):
+        """Should return unreconciled splits for account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.get_unreconciled_splits("Assets:Checking")
+
+        assert "splits" in result
+        assert "cleared_total" in result
+        assert "uncleared_total" in result
+        assert result["account"] == "Assets:Checking"
+        # All splits should be unreconciled initially
+        assert result["count"] > 0
+
+    def test_get_unreconciled_splits_with_date(self, test_book: Path):
+        """Should filter splits by date."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get splits before a specific date
+        result = gc_book.get_unreconciled_splits(
+            "Assets:Checking", as_of_date=date(2024, 1, 10)
+        )
+
+        # All returned splits should be on or before the date
+        for split in result["splits"]:
+            assert split["date"] <= "2024-01-10"
+
+    def test_get_unreconciled_splits_account_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.get_unreconciled_splits("Nonexistent:Account")
+
+
+class TestReconcileAccount:
+    """Tests for reconcile_account method."""
+
+    def test_reconcile_account_success(self, test_book: Path):
+        """Should reconcile splits when balance matches."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get unreconciled splits
+        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking")
+
+        # Calculate what the balance should be
+        total = Decimal("0")
+        guids = []
+        for split in unreconciled["splits"]:
+            total += Decimal(split["value"])
+            guids.append(split["guid"])
+
+        # Reconcile all splits
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(total),
+            split_guids=guids,
+        )
+
+        assert result["status"] == "reconciled"
+        assert result["splits_reconciled"] == len(guids)
+
+    def test_reconcile_account_balance_mismatch(self, test_book: Path):
+        """Should raise ValueError when balance doesn't match."""
+        gc_book = GnuCashBook(str(test_book))
+
+        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking")
+        guids = [s["guid"] for s in unreconciled["splits"]]
+
+        with pytest.raises(ValueError, match="Balance mismatch"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 31),
+                statement_balance="9999999.99",  # Wrong balance
+                split_guids=guids,
+            )
+
+    def test_reconcile_account_split_wrong_account(self, test_book: Path):
+        """Should raise ValueError if split belongs to different account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a split from a different account
+        transactions = gc_book.list_transactions()
+        expense_split = None
+        for split in transactions[0]["splits"]:
+            if "Expenses" in split["account"]:
+                expense_split = split["guid"]
+                break
+
+        if expense_split:
+            with pytest.raises(ValueError, match="belongs to account"):
+                gc_book.reconcile_account(
+                    account_name="Assets:Checking",
+                    statement_date=date(2024, 1, 31),
+                    statement_balance="0",
+                    split_guids=[expense_split],
+                )
+
+
+class TestVoidTransaction:
+    """Tests for void_transaction method."""
+
+    def test_void_transaction_success(self, test_book: Path):
+        """Should void a transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a transaction to void
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        result = gc_book.void_transaction(guid, reason="Entered in error")
+
+        assert result["status"] == "voided"
+        assert result["void_reason"] == "Entered in error"
+
+        # Verify the transaction is voided (splits have 0 value and 'v' state)
+        voided = gc_book.get_transaction(guid)
+        for split in voided["splits"]:
+            assert split["value"] == "0"
+            assert split["reconcile_state"] == "v"
+
+    def test_void_transaction_no_reason(self, test_book: Path):
+        """Should raise ValueError if no reason provided."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="reason is required"):
+            gc_book.void_transaction(guid, reason="")
+
+    def test_void_transaction_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Transaction not found"):
+            gc_book.void_transaction("nonexistent_guid", reason="Test")
+
+    def test_void_transaction_already_voided(self, test_book: Path):
+        """Should raise ValueError if already voided."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        # Void once
+        gc_book.void_transaction(guid, reason="First void")
+
+        # Try to void again
+        with pytest.raises(ValueError, match="already voided"):
+            gc_book.void_transaction(guid, reason="Second void")
+
+
+class TestUnvoidTransaction:
+    """Tests for unvoid_transaction method."""
+
+    def test_unvoid_transaction_success(self, test_book: Path):
+        """Should restore a voided transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get original transaction values
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+        original = gc_book.get_transaction(guid)
+        original_values = {s["account"]: s["value"] for s in original["splits"]}
+
+        # Void it
+        gc_book.void_transaction(guid, reason="Test void")
+
+        # Unvoid it
+        result = gc_book.unvoid_transaction(guid)
+
+        assert result["status"] == "unvoided"
+
+        # Verify values are restored
+        for split in result["splits"]:
+            assert split["value"] == original_values[split["account"]]
+            assert split["reconcile_state"] == "n"
+
+    def test_unvoid_transaction_not_voided(self, test_book: Path):
+        """Should raise ValueError if transaction is not voided."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="not voided"):
+            gc_book.unvoid_transaction(guid)
+
+    def test_unvoid_transaction_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Transaction not found"):
+            gc_book.unvoid_transaction("nonexistent_guid")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -307,6 +307,153 @@ class TestUpdateTransactionTool:
         assert "balance" in data["error"].lower()
 
 
+class TestSetReconcileStateTool:
+    """Tests for set_reconcile_state tool."""
+
+    def test_set_reconcile_state(self, setup_book_env):
+        """Should set reconcile state on a split."""
+        transactions = json.loads(server_module.list_transactions())
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        result = server_module.set_reconcile_state(split_guid, "c")
+
+        data = json.loads(result)
+        assert data["status"] == "updated"
+        assert data["reconcile_state"] == "c"
+
+    def test_set_reconcile_state_invalid(self, setup_book_env):
+        """Should return error for invalid state."""
+        transactions = json.loads(server_module.list_transactions())
+        split_guid = transactions[0]["splits"][0]["guid"]
+
+        result = server_module.set_reconcile_state(split_guid, "x")
+
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestGetUnreconciledSplitsTool:
+    """Tests for get_unreconciled_splits tool."""
+
+    def test_get_unreconciled_splits(self, setup_book_env):
+        """Should return unreconciled splits for account."""
+        result = server_module.get_unreconciled_splits("Assets:Checking")
+
+        data = json.loads(result)
+        assert "splits" in data
+        assert data["account"] == "Assets:Checking"
+        assert data["count"] > 0
+
+    def test_get_unreconciled_splits_not_found(self, setup_book_env):
+        """Should return error for non-existent account."""
+        result = server_module.get_unreconciled_splits("Nonexistent:Account")
+
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestReconcileAccountTool:
+    """Tests for reconcile_account tool."""
+
+    def test_reconcile_account(self, setup_book_env):
+        """Should reconcile account when balance matches."""
+        from decimal import Decimal
+
+        # Get unreconciled splits
+        unreconciled = json.loads(
+            server_module.get_unreconciled_splits("Assets:Checking")
+        )
+
+        # Calculate expected balance
+        total = Decimal("0")
+        guids = []
+        for split in unreconciled["splits"]:
+            total += Decimal(split["value"])
+            guids.append(split["guid"])
+
+        result = server_module.reconcile_account(
+            account="Assets:Checking",
+            statement_date="2024-01-31",
+            statement_balance=str(total),
+            split_guids=guids,
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "reconciled"
+
+    def test_reconcile_account_balance_mismatch(self, setup_book_env):
+        """Should return error when balance doesn't match."""
+        unreconciled = json.loads(
+            server_module.get_unreconciled_splits("Assets:Checking")
+        )
+        guids = [s["guid"] for s in unreconciled["splits"]]
+
+        result = server_module.reconcile_account(
+            account="Assets:Checking",
+            statement_date="2024-01-31",
+            statement_balance="9999999.99",
+            split_guids=guids,
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "mismatch" in data["error"].lower()
+
+
+class TestVoidTransactionTool:
+    """Tests for void_transaction tool."""
+
+    def test_void_transaction(self, setup_book_env):
+        """Should void a transaction."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.void_transaction(guid, "Test void reason")
+
+        data = json.loads(result)
+        assert data["status"] == "voided"
+        assert data["void_reason"] == "Test void reason"
+
+    def test_void_transaction_no_reason(self, setup_book_env):
+        """Should return error if no reason provided."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.void_transaction(guid, "")
+
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestUnvoidTransactionTool:
+    """Tests for unvoid_transaction tool."""
+
+    def test_unvoid_transaction(self, setup_book_env):
+        """Should restore a voided transaction."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        # Void first
+        server_module.void_transaction(guid, "Test void")
+
+        # Then unvoid
+        result = server_module.unvoid_transaction(guid)
+
+        data = json.loads(result)
+        assert data["status"] == "unvoided"
+
+    def test_unvoid_not_voided(self, setup_book_env):
+        """Should return error if transaction not voided."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.unvoid_transaction(guid)
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "not voided" in data["error"].lower()
+
+
 class TestResources:
     """Tests for MCP resources."""
 


### PR DESCRIPTION
## Summary

- Add reconciliation tools for bank statement workflows
- Add void/unvoid transaction tools for proper accounting (not delete)

### New Tools

**Reconciliation:**
- `set_reconcile_state` - Set split to new/cleared/reconciled
- `get_unreconciled_splits` - List unreconciled splits with running totals
- `reconcile_account` - Batch reconcile with statement balance validation

**Void:**
- `void_transaction` - Void with reason, preserves audit trail
- `unvoid_transaction` - Restore from stored original values

## Test plan

- [x] 28 new unit/integration tests (all passing)
- [x] Live tested against real GnuCash book
- [x] Verified changes visible in GnuCash UI