### PR TITLE
Add reporting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Model Context Protocol (MCP) server for GnuCash, enabling AI assistants to rea
 | Account Management | ✅ Complete |
 | Reconciliation | ✅ Complete |
 | Void/Unvoid | ✅ Complete |
-| Reporting | 🔲 Backlog |
+| Reporting | ✅ Complete |
 | Import/Export | 🔲 Backlog |
 
 ## Overview
@@ -47,6 +47,13 @@ This MCP server provides tools for interacting with GnuCash books stored in SQLi
 - `set_reconcile_state` - Set split state (new/cleared/reconciled)
 - `get_unreconciled_splits` - List unreconciled splits for an account
 - `reconcile_account` - Batch reconcile with statement balance validation
+
+**Reporting:**
+- `spending_by_category` - Expense breakdown by category for a period
+- `income_by_source` - Income breakdown by source for a period
+- `balance_sheet` - Assets, liabilities, equity at a point in time
+- `net_worth` - Calculate net worth (point-in-time or time series)
+- `cash_flow` - Inflows and outflows for a period
 
 ### Resources
 
@@ -138,18 +145,12 @@ gnucash-mcp/
 - [x] Reconciliation tools (set state, get unreconciled, batch reconcile)
 - [x] Void/unvoid transactions
 - [x] Account management (update, move, delete with safeguards)
+- [x] Reporting (spending, income, balance sheet, net worth, cash flow)
 
 ### 🔲 Backlog
 
 **Transaction Operations:**
 - [ ] Duplicate transaction
-
-**Reporting:**
-- [ ] Spending by category
-- [ ] Income by source
-- [ ] Balance sheet
-- [ ] Net worth over time
-- [ ] Cash flow report
 
 **Import/Export:**
 - [ ] Export transactions to CSV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 dependencies = [
     "mcp[cli]>=1.0.0",
     "piecash>=1.2.0",
+    "python-dateutil>=2.8.0",
 ]
 
 [project.scripts]

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -1058,3 +1058,362 @@ class GnuCashBook:
             book.save()
 
             return _transaction_to_dict(transaction) | {"status": "unvoided"}
+
+    # ============== Reporting Methods ==============
+
+    def _get_account_depth(self, account: piecash.Account) -> int:
+        """Get the depth of an account in the hierarchy (root = 0)."""
+        depth = 0
+        current = account
+        while current.parent and current.parent.type != "ROOT":
+            depth += 1
+            current = current.parent
+        return depth
+
+    def _get_account_at_depth(
+        self, account: piecash.Account, target_depth: int
+    ) -> piecash.Account:
+        """Get the ancestor of an account at a specific depth."""
+        # First get to root and build path
+        path = [account]
+        current = account
+        while current.parent and current.parent.type != "ROOT":
+            current = current.parent
+            path.append(current)
+        path.reverse()  # Now path[0] is top-level, path[-1] is the account
+
+        # Return account at target depth (0-indexed from top)
+        if target_depth >= len(path):
+            return account
+        return path[target_depth]
+
+    def spending_by_category(
+        self,
+        start_date: date,
+        end_date: date,
+        depth: int = 1,
+    ) -> dict:
+        """Get spending breakdown by expense category.
+
+        Args:
+            start_date: Start of period (inclusive).
+            end_date: End of period (inclusive).
+            depth: Hierarchy depth for grouping (1 = top-level, 2 = subcategories).
+
+        Returns:
+            Dict with period, total, and category breakdown.
+        """
+        with self.open(readonly=True) as book:
+            totals: dict[str, Decimal] = {}
+
+            for transaction in book.transactions:
+                if not (start_date <= transaction.post_date <= end_date):
+                    continue
+
+                for split in transaction.splits:
+                    if split.account.type != "EXPENSE":
+                        continue
+
+                    # Get the account at the requested depth
+                    group_account = self._get_account_at_depth(
+                        split.account, depth - 1
+                    )
+                    account_name = group_account.fullname
+
+                    # Expense splits are positive when money is spent
+                    amount = split.value
+                    if amount > 0:
+                        totals[account_name] = totals.get(
+                            account_name, Decimal("0")
+                        ) + amount
+
+            # Calculate total and percentages
+            total = sum(totals.values())
+            categories = []
+            for account_name, amount in sorted(
+                totals.items(), key=lambda x: x[1], reverse=True
+            ):
+                percent = (
+                    (amount / total * 100) if total > 0 else Decimal("0")
+                )
+                categories.append({
+                    "account": account_name,
+                    "amount": str(amount),
+                    "percent": str(percent.quantize(Decimal("0.1"))),
+                })
+
+            return {
+                "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
+                "total": str(total),
+                "categories": categories,
+            }
+
+    def income_by_source(
+        self,
+        start_date: date,
+        end_date: date,
+        depth: int = 1,
+    ) -> dict:
+        """Get income breakdown by source.
+
+        Args:
+            start_date: Start of period (inclusive).
+            end_date: End of period (inclusive).
+            depth: Hierarchy depth for grouping (1 = top-level, 2 = subcategories).
+
+        Returns:
+            Dict with period, total, and source breakdown.
+        """
+        with self.open(readonly=True) as book:
+            totals: dict[str, Decimal] = {}
+
+            for transaction in book.transactions:
+                if not (start_date <= transaction.post_date <= end_date):
+                    continue
+
+                for split in transaction.splits:
+                    if split.account.type != "INCOME":
+                        continue
+
+                    # Get the account at the requested depth
+                    group_account = self._get_account_at_depth(
+                        split.account, depth - 1
+                    )
+                    account_name = group_account.fullname
+
+                    # Income splits are negative (money coming in)
+                    amount = -split.value
+                    if amount > 0:
+                        totals[account_name] = totals.get(
+                            account_name, Decimal("0")
+                        ) + amount
+
+            # Calculate total and percentages
+            total = sum(totals.values())
+            sources = []
+            for account_name, amount in sorted(
+                totals.items(), key=lambda x: x[1], reverse=True
+            ):
+                percent = (
+                    (amount / total * 100) if total > 0 else Decimal("0")
+                )
+                sources.append({
+                    "account": account_name,
+                    "amount": str(amount),
+                    "percent": str(percent.quantize(Decimal("0.1"))),
+                })
+
+            return {
+                "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
+                "total": str(total),
+                "sources": sources,
+            }
+
+    def balance_sheet(self, as_of_date: date) -> dict:
+        """Generate a balance sheet as of a specific date.
+
+        Args:
+            as_of_date: Date to calculate balances as of.
+
+        Returns:
+            Dict with assets, liabilities, equity sections and totals.
+        """
+        with self.open(readonly=True) as book:
+            assets: dict[str, Decimal] = {}
+            liabilities: dict[str, Decimal] = {}
+            equity: dict[str, Decimal] = {}
+
+            asset_types = {"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"}
+            liability_types = {"LIABILITY", "CREDIT"}
+            equity_types = {"EQUITY"}
+
+            for account in book.accounts:
+                if account.type == "ROOT":
+                    continue
+
+                # Calculate balance as of date
+                balance = Decimal("0")
+                for split in account.splits:
+                    if split.transaction.post_date <= as_of_date:
+                        balance += split.value
+
+                # Skip zero balances
+                if balance == 0:
+                    continue
+
+                if account.type in asset_types:
+                    assets[account.fullname] = balance
+                elif account.type in liability_types:
+                    # Liabilities are stored as negative, show as positive
+                    liabilities[account.fullname] = -balance
+                elif account.type in equity_types:
+                    equity[account.fullname] = -balance
+
+            # Also include net income (Income - Expenses) in equity
+            net_income = Decimal("0")
+            for account in book.accounts:
+                if account.type in ("INCOME", "EXPENSE"):
+                    for split in account.splits:
+                        if split.transaction.post_date <= as_of_date:
+                            net_income -= split.value  # Income negative, expense positive
+
+            assets_total = sum(assets.values())
+            liabilities_total = sum(liabilities.values())
+            equity_total = sum(equity.values()) + net_income
+
+            def format_accounts(accounts_dict: dict[str, Decimal]) -> list[dict]:
+                return [
+                    {"account": name, "balance": str(bal)}
+                    for name, bal in sorted(accounts_dict.items())
+                ]
+
+            return {
+                "as_of_date": as_of_date.isoformat(),
+                "assets": {
+                    "total": str(assets_total),
+                    "accounts": format_accounts(assets),
+                },
+                "liabilities": {
+                    "total": str(liabilities_total),
+                    "accounts": format_accounts(liabilities),
+                },
+                "equity": {
+                    "total": str(equity_total),
+                    "accounts": format_accounts(equity) + (
+                        [{"account": "Retained Earnings", "balance": str(net_income)}]
+                        if net_income != 0 else []
+                    ),
+                },
+                "balanced": assets_total == liabilities_total + equity_total,
+            }
+
+    def net_worth(
+        self,
+        end_date: date,
+        start_date: date | None = None,
+        interval: str | None = None,
+    ) -> dict:
+        """Calculate net worth (assets minus liabilities).
+
+        Args:
+            end_date: Calculate net worth as of this date.
+            start_date: If provided with interval, calculate series over time.
+            interval: 'month', 'quarter', or 'year' for time series.
+
+        Returns:
+            Dict with net worth value or time series.
+        """
+        from dateutil.relativedelta import relativedelta
+
+        def calc_net_worth_at(book: piecash.Book, at_date: date) -> Decimal:
+            """Calculate net worth at a specific date."""
+            asset_types = {"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"}
+            liability_types = {"LIABILITY", "CREDIT"}
+
+            total = Decimal("0")
+            for account in book.accounts:
+                if account.type in asset_types:
+                    for split in account.splits:
+                        if split.transaction.post_date <= at_date:
+                            total += split.value
+                elif account.type in liability_types:
+                    for split in account.splits:
+                        if split.transaction.post_date <= at_date:
+                            total += split.value  # Already negative
+
+            return total
+
+        with self.open(readonly=True) as book:
+            # Point-in-time calculation
+            if not start_date or not interval:
+                nw = calc_net_worth_at(book, end_date)
+                return {
+                    "as_of_date": end_date.isoformat(),
+                    "net_worth": str(nw),
+                }
+
+            # Time series calculation
+            if interval not in ("month", "quarter", "year"):
+                raise ValueError(f"Invalid interval: {interval}. Use 'month', 'quarter', or 'year'")
+
+            delta = {
+                "month": relativedelta(months=1),
+                "quarter": relativedelta(months=3),
+                "year": relativedelta(years=1),
+            }[interval]
+
+            series = []
+            current = start_date
+            while current <= end_date:
+                nw = calc_net_worth_at(book, current)
+                series.append({
+                    "date": current.isoformat(),
+                    "net_worth": str(nw),
+                })
+                current += delta
+
+            # Always include end_date if not already included
+            if series and series[-1]["date"] != end_date.isoformat():
+                nw = calc_net_worth_at(book, end_date)
+                series.append({
+                    "date": end_date.isoformat(),
+                    "net_worth": str(nw),
+                })
+
+            return {
+                "start_date": start_date.isoformat(),
+                "end_date": end_date.isoformat(),
+                "interval": interval,
+                "series": series,
+            }
+
+    def cash_flow(
+        self,
+        start_date: date,
+        end_date: date,
+        account: str | None = None,
+    ) -> dict:
+        """Calculate cash flow (inflows and outflows) for a period.
+
+        Args:
+            start_date: Start of period (inclusive).
+            end_date: End of period (inclusive).
+            account: Optional account to filter (e.g., specific bank account).
+
+        Returns:
+            Dict with inflows, outflows, and net cash flow.
+        """
+        with self.open(readonly=True) as book:
+            # If account specified, only look at that account
+            if account:
+                target_account = self._find_account(book, account)
+                if not target_account:
+                    raise ValueError(f"Account not found: {account}")
+                accounts_to_check = [target_account]
+            else:
+                # Default to cash/bank accounts
+                cash_types = {"BANK", "CASH"}
+                accounts_to_check = [
+                    a for a in book.accounts if a.type in cash_types
+                ]
+
+            inflows = Decimal("0")
+            outflows = Decimal("0")
+
+            for acc in accounts_to_check:
+                for split in acc.splits:
+                    if not (start_date <= split.transaction.post_date <= end_date):
+                        continue
+
+                    if split.value > 0:
+                        inflows += split.value
+                    else:
+                        outflows += -split.value
+
+            return {
+                "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
+                "account": account if account else "All cash/bank accounts",
+                "inflows": str(inflows),
+                "outflows": str(outflows),
+                "net": str(inflows - outflows),
+            }

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -443,6 +443,118 @@ def unvoid_transaction(guid: str) -> str:
     return json.dumps(result, indent=2)
 
 
+# ============== Reporting Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+def spending_by_category(
+    start_date: str,
+    end_date: str,
+    depth: int = 1,
+) -> str:
+    """Get spending breakdown by expense category for a period.
+
+    Args:
+        start_date: Start of period (YYYY-MM-DD)
+        end_date: End of period (YYYY-MM-DD)
+        depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
+    """
+    book = get_book()
+    result = book.spending_by_category(
+        start_date=date.fromisoformat(start_date),
+        end_date=date.fromisoformat(end_date),
+        depth=depth,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def income_by_source(
+    start_date: str,
+    end_date: str,
+    depth: int = 1,
+) -> str:
+    """Get income breakdown by source for a period.
+
+    Args:
+        start_date: Start of period (YYYY-MM-DD)
+        end_date: End of period (YYYY-MM-DD)
+        depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
+    """
+    book = get_book()
+    result = book.income_by_source(
+        start_date=date.fromisoformat(start_date),
+        end_date=date.fromisoformat(end_date),
+        depth=depth,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def balance_sheet(as_of_date: str) -> str:
+    """Generate a balance sheet as of a specific date.
+
+    Shows assets, liabilities, and equity with account breakdowns.
+
+    Args:
+        as_of_date: Date to calculate balances as of (YYYY-MM-DD)
+    """
+    book = get_book()
+    result = book.balance_sheet(as_of_date=date.fromisoformat(as_of_date))
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def net_worth(
+    end_date: str,
+    start_date: str | None = None,
+    interval: str | None = None,
+) -> str:
+    """Calculate net worth (assets minus liabilities).
+
+    Can calculate a single point-in-time value or a time series.
+
+    Args:
+        end_date: Calculate net worth as of this date (YYYY-MM-DD)
+        start_date: Optional start date for time series (YYYY-MM-DD)
+        interval: Optional interval for time series: 'month', 'quarter', or 'year'
+    """
+    book = get_book()
+    result = book.net_worth(
+        end_date=date.fromisoformat(end_date),
+        start_date=date.fromisoformat(start_date) if start_date else None,
+        interval=interval,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+def cash_flow(
+    start_date: str,
+    end_date: str,
+    account: str | None = None,
+) -> str:
+    """Calculate cash flow (inflows and outflows) for a period.
+
+    Args:
+        start_date: Start of period (YYYY-MM-DD)
+        end_date: End of period (YYYY-MM-DD)
+        account: Optional specific account to analyze (defaults to all cash/bank accounts)
+    """
+    book = get_book()
+    result = book.cash_flow(
+        start_date=date.fromisoformat(start_date),
+        end_date=date.fromisoformat(end_date),
+        account=account,
+    )
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1076,3 +1076,148 @@ class TestUnvoidTransaction:
 
         with pytest.raises(ValueError, match="Transaction not found"):
             gc_book.unvoid_transaction("nonexistent_guid")
+
+
+class TestSpendingByCategory:
+    """Tests for spending_by_category method."""
+
+    def test_spending_by_category(self, test_book: Path):
+        """Should return spending breakdown."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.spending_by_category(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+
+        assert "period" in result
+        assert "total" in result
+        assert "categories" in result
+        assert Decimal(result["total"]) > 0
+
+    def test_spending_by_category_empty_period(self, test_book: Path):
+        """Should return zero for period with no transactions."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.spending_by_category(
+            start_date=date(2020, 1, 1),
+            end_date=date(2020, 1, 31),
+        )
+
+        assert result["total"] == "0"
+        assert result["categories"] == []
+
+
+class TestIncomeBySource:
+    """Tests for income_by_source method."""
+
+    def test_income_by_source(self, test_book: Path):
+        """Should return income breakdown."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.income_by_source(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+
+        assert "period" in result
+        assert "total" in result
+        assert "sources" in result
+        assert Decimal(result["total"]) > 0
+
+
+class TestBalanceSheet:
+    """Tests for balance_sheet method."""
+
+    def test_balance_sheet(self, test_book: Path):
+        """Should return balance sheet with assets, liabilities, equity."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+
+        assert "as_of_date" in result
+        assert "assets" in result
+        assert "liabilities" in result
+        assert "equity" in result
+        assert "total" in result["assets"]
+        assert "accounts" in result["assets"]
+
+
+class TestNetWorth:
+    """Tests for net_worth method."""
+
+    def test_net_worth_point_in_time(self, test_book: Path):
+        """Should calculate net worth at a point in time."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.net_worth(end_date=date(2024, 12, 31))
+
+        assert "as_of_date" in result
+        assert "net_worth" in result
+
+    def test_net_worth_time_series(self, test_book: Path):
+        """Should calculate net worth time series."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.net_worth(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            interval="month",
+        )
+
+        assert "series" in result
+        assert len(result["series"]) > 0
+        assert "date" in result["series"][0]
+        assert "net_worth" in result["series"][0]
+
+    def test_net_worth_invalid_interval(self, test_book: Path):
+        """Should raise ValueError for invalid interval."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Invalid interval"):
+            gc_book.net_worth(
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 12, 31),
+                interval="invalid",
+            )
+
+
+class TestCashFlow:
+    """Tests for cash_flow method."""
+
+    def test_cash_flow(self, test_book: Path):
+        """Should calculate cash flow."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.cash_flow(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+
+        assert "period" in result
+        assert "inflows" in result
+        assert "outflows" in result
+        assert "net" in result
+
+    def test_cash_flow_specific_account(self, test_book: Path):
+        """Should calculate cash flow for specific account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.cash_flow(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            account="Assets:Checking",
+        )
+
+        assert result["account"] == "Assets:Checking"
+
+    def test_cash_flow_invalid_account(self, test_book: Path):
+        """Should raise ValueError for invalid account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.cash_flow(
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 12, 31),
+                account="Nonexistent:Account",
+            )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -628,3 +628,84 @@ class TestErrorHandling:
         assert "error" in data
         assert data["error_type"] == "unexpected_error"
         assert "RuntimeError" in data["error"]
+
+
+class TestSpendingByCategoryTool:
+    """Tests for spending_by_category tool."""
+
+    def test_spending_by_category(self, setup_book_env):
+        """Should return spending breakdown."""
+        result = server_module.spending_by_category(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        data = json.loads(result)
+        assert "total" in data
+        assert "categories" in data
+
+
+class TestIncomeBySourcTool:
+    """Tests for income_by_source tool."""
+
+    def test_income_by_source(self, setup_book_env):
+        """Should return income breakdown."""
+        result = server_module.income_by_source(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        data = json.loads(result)
+        assert "total" in data
+        assert "sources" in data
+
+
+class TestBalanceSheetTool:
+    """Tests for balance_sheet tool."""
+
+    def test_balance_sheet(self, setup_book_env):
+        """Should return balance sheet."""
+        result = server_module.balance_sheet(as_of_date="2024-12-31")
+
+        data = json.loads(result)
+        assert "assets" in data
+        assert "liabilities" in data
+        assert "equity" in data
+
+
+class TestNetWorthTool:
+    """Tests for net_worth tool."""
+
+    def test_net_worth_point_in_time(self, setup_book_env):
+        """Should calculate net worth at a point in time."""
+        result = server_module.net_worth(end_date="2024-12-31")
+
+        data = json.loads(result)
+        assert "net_worth" in data
+
+    def test_net_worth_time_series(self, setup_book_env):
+        """Should calculate net worth time series."""
+        result = server_module.net_worth(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            interval="month",
+        )
+
+        data = json.loads(result)
+        assert "series" in data
+
+
+class TestCashFlowTool:
+    """Tests for cash_flow tool."""
+
+    def test_cash_flow(self, setup_book_env):
+        """Should calculate cash flow."""
+        result = server_module.cash_flow(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        data = json.loads(result)
+        assert "inflows" in data
+        assert "outflows" in data
+        assert "net" in data

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,7 @@ source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "piecash" },
+    { name = "python-dateutil" },
 ]
 
 [package.optional-dependencies]
@@ -248,6 +249,7 @@ requires-dist = [
     { name = "piecash", specifier = ">=1.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "python-dateutil", specifier = ">=2.8.0" },
 ]
 provides-extras = ["dev"]
 
@@ -691,6 +693,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -895,6 +909,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `spending_by_category` - Expense breakdown with configurable hierarchy depth
- `income_by_source` - Income breakdown with configurable hierarchy depth
- `balance_sheet` - Assets, liabilities, equity at a point in time
- `net_worth` - Point-in-time or time series (month/quarter/year intervals)
- `cash_flow` - Inflows and outflows for a period

Adds python-dateutil dependency for time series intervals.

## Test plan

- [x] 16 new unit/integration tests (all passing)
- [x] Live tested against real GnuCash book
- [x] Verified report output matches expected values