### PR TITLE
Suppress piecash backup file creation

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -97,7 +97,7 @@ class GnuCashBook:
         for attempt in range(max_retries):
             try:
                 start_time = time.time()
-                book = piecash.open_book(str(self.book_path), readonly=readonly)
+                book = piecash.open_book(str(self.book_path), readonly=readonly, do_backup=False)
                 open_elapsed = (time.time() - start_time) * 1000
                 debug_logger.debug(
                     f"Book opened (readonly={readonly}) in {open_elapsed:.0f}ms"


### PR DESCRIPTION
## Summary
- Add `do_backup=False` to `piecash.open_book()` to prevent automatic backup file creation on every write operation

## Test plan
- [x] All 159 tests pass
- [ ] Manual verification that backup files are no longer created