### PR TITLE
Add transaction notes support

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -49,13 +49,16 @@ def _split_to_dict(split: piecash.Split) -> dict:
 
 def _transaction_to_dict(transaction: piecash.Transaction) -> dict:
     """Convert a piecash Transaction to a serializable dict."""
-    return {
+    result = {
         "guid": transaction.guid,
         "date": transaction.post_date.isoformat(),
         "description": transaction.description,
         "currency": transaction.currency.mnemonic,
         "splits": [_split_to_dict(s) for s in transaction.splits],
     }
+    if transaction.notes:
+        result["notes"] = transaction.notes
+    return result
 
 
 class GnuCashBook:
@@ -355,6 +358,7 @@ class GnuCashBook:
         splits: list[dict],
         trans_date: date | None = None,
         currency: str | None = None,
+        notes: str | None = None,
     ) -> str:
         """Create a new transaction with splits.
 
@@ -369,6 +373,8 @@ class GnuCashBook:
             trans_date: Transaction date. Defaults to today.
             currency: ISO currency code for the transaction (e.g., "USD", "EUR").
                       Defaults to book's default currency.
+            notes: Transaction notes (optional). Free-text annotation
+                   stored separately from the description.
 
         Returns:
             GUID of the created transaction.
@@ -443,6 +449,7 @@ class GnuCashBook:
             transaction = piecash.Transaction(
                 currency=trans_currency,
                 description=description,
+                notes=notes,
                 post_date=trans_date,
                 splits=piecash_splits,
             )
@@ -459,7 +466,8 @@ class GnuCashBook:
                    - Greater than: ">100"
                    - Less than: "<100"
                    - Range: "100-200"
-            field: Field to search: 'description', 'memo', or 'amount'.
+            field: Field to search: 'description', 'memo', 'notes',
+                   or 'amount'.
 
         Returns:
             List of matching transactions.
@@ -467,7 +475,7 @@ class GnuCashBook:
         Raises:
             ValueError: If field is not valid.
         """
-        if field not in ("description", "memo", "amount"):
+        if field not in ("description", "memo", "notes", "amount"):
             raise ValueError(f"Invalid search field: {field}")
 
         with self.open(readonly=True) as book:
@@ -476,6 +484,10 @@ class GnuCashBook:
             for transaction in book.transactions:
                 if field == "description":
                     if query.lower() in transaction.description.lower():
+                        results.append(_transaction_to_dict(transaction))
+
+                elif field == "notes":
+                    if transaction.notes and query.lower() in transaction.notes.lower():
                         results.append(_transaction_to_dict(transaction))
 
                 elif field == "memo":
@@ -803,6 +815,7 @@ class GnuCashBook:
         description: str | None = None,
         trans_date: date | None = None,
         splits: list[dict] | None = None,
+        notes: str | None = None,
     ) -> dict:
         """Update an existing transaction.
 
@@ -815,6 +828,8 @@ class GnuCashBook:
                     splits by account name. For cross-currency splits,
                     'quantity' is required when the account commodity differs
                     from the transaction currency.
+            notes: New transaction notes (optional). Pass empty string
+                   to clear existing notes.
 
         Returns:
             Dict with updated transaction details.
@@ -832,6 +847,10 @@ class GnuCashBook:
             # Update description if provided
             if description is not None:
                 transaction.description = description
+
+            # Update notes if provided
+            if notes is not None:
+                transaction.notes = notes if notes else None
 
             # Update date if provided
             if trans_date is not None:

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -215,6 +215,7 @@ def create_transaction(
     splits: list[dict],
     transaction_date: str | None = None,
     currency: str | None = None,
+    notes: str | None = None,
 ) -> str:
     """Create a new transaction with splits. Splits must balance to zero.
 
@@ -229,6 +230,8 @@ def create_transaction(
         transaction_date: Transaction date in ISO format (YYYY-MM-DD). Defaults to today.
         currency: ISO currency code for transaction (e.g., "USD", "EUR").
                   Defaults to book's default currency.
+        notes: Transaction notes (optional). Free-text annotation stored
+               separately from description.
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
@@ -237,6 +240,7 @@ def create_transaction(
         splits=splits,
         trans_date=trans_date,
         currency=currency,
+        notes=notes,
     )
     return json.dumps({"guid": guid, "status": "created"}, indent=2)
 
@@ -245,11 +249,11 @@ def create_transaction(
 @safe_tool
 @audit_log(classification="read")
 def search_transactions(query: str, field: str = "description") -> str:
-    """Search transactions by description, memo, or amount.
+    """Search transactions by description, memo, notes, or amount.
 
     Args:
         query: Search query string. For amount, supports: exact ("100"), greater (">100"), less ("<100"), range ("100-200")
-        field: Field to search: 'description', 'memo', or 'amount'
+        field: Field to search: 'description', 'memo', 'notes', or 'amount'
     """
     book = get_book()
     result = book.search_transactions(query, field)
@@ -369,6 +373,7 @@ def update_transaction(
     description: str | None = None,
     transaction_date: str | None = None,
     splits: list[dict] | None = None,
+    notes: str | None = None,
 ) -> str:
     """Update an existing transaction.
 
@@ -379,6 +384,7 @@ def update_transaction(
         splits: List of split updates with 'account' and 'amount' (optional).
                 Must match existing splits by account name and balance to zero.
                 For cross-currency splits, include 'quantity' (amount in account's commodity).
+        notes: New transaction notes (optional). Pass empty string to clear.
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
@@ -387,6 +393,7 @@ def update_transaction(
         description=description,
         trans_date=trans_date,
         splits=splits,
+        notes=notes,
     )
     return json.dumps(result, indent=2)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -295,6 +295,41 @@ class TestCreateTransaction:
                 ],
             )
 
+    def test_create_transaction_with_notes(self, test_book: Path):
+        """Should create transaction with notes field."""
+        gc_book = GnuCashBook(str(test_book))
+
+        guid = gc_book.create_transaction(
+            description="Safeway",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "75.00", "memo": "Meats"},
+                {"account": "Assets:Checking", "amount": "-75.00"},
+            ],
+            notes="P2W1 groceries",
+        )
+
+        transaction = gc_book.get_transaction(guid)
+        assert transaction["description"] == "Safeway"
+        assert transaction["notes"] == "P2W1 groceries"
+        # Verify memo is separate from notes
+        memos = {s["memo"] for s in transaction["splits"]}
+        assert "Meats" in memos
+
+    def test_create_transaction_without_notes(self, test_book: Path):
+        """Transaction without notes should not include notes key."""
+        gc_book = GnuCashBook(str(test_book))
+
+        guid = gc_book.create_transaction(
+            description="No Notes",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+                {"account": "Assets:Checking", "amount": "-10.00"},
+            ],
+        )
+
+        transaction = gc_book.get_transaction(guid)
+        assert "notes" not in transaction
+
 
 class TestSearchTransactions:
     """Tests for search_transactions method."""
@@ -345,6 +380,32 @@ class TestSearchTransactions:
         results = gc_book.search_transactions("100-500", field="amount")
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
+
+    def test_search_by_notes(self, test_book: Path):
+        """Should find transactions by notes field."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Create a transaction with notes
+        gc_book.create_transaction(
+            description="Safeway",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "30.00"},
+                {"account": "Assets:Checking", "amount": "-30.00"},
+            ],
+            notes="P2W1 groceries",
+        )
+
+        results = gc_book.search_transactions("P2W1", field="notes")
+        assert len(results) == 1
+        assert results[0]["description"] == "Safeway"
+        assert results[0]["notes"] == "P2W1 groceries"
+
+    def test_search_by_notes_no_match(self, test_book: Path):
+        """Should return empty list when no notes match."""
+        gc_book = GnuCashBook(str(test_book))
+
+        results = gc_book.search_transactions("nonexistent", field="notes")
+        assert len(results) == 0
 
     def test_search_invalid_field(self, test_book: Path):
         """Should raise ValueError for invalid field."""
@@ -811,6 +872,47 @@ class TestUpdateTransaction:
                     {"account": "Assets:Checking", "amount": "-100.00"},
                 ],
             )
+
+    def test_update_notes(self, test_book: Path):
+        """Should add notes to an existing transaction."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            notes="P2W1 groceries",
+        )
+
+        assert result["status"] == "updated"
+        assert result["notes"] == "P2W1 groceries"
+
+        # Verify persistence
+        updated = gc_book.get_transaction(guid)
+        assert updated["notes"] == "P2W1 groceries"
+
+    def test_clear_notes(self, test_book: Path):
+        """Should clear notes when empty string is passed."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Create transaction with notes
+        guid = gc_book.create_transaction(
+            description="With Notes",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "20.00"},
+                {"account": "Assets:Checking", "amount": "-20.00"},
+            ],
+            notes="Some notes",
+        )
+
+        # Clear notes
+        result = gc_book.update_transaction(guid=guid, notes="")
+        assert "notes" not in result
+
+        # Verify persistence
+        updated = gc_book.get_transaction(guid)
+        assert "notes" not in updated
 
 
 class TestSetReconcileState:


### PR DESCRIPTION
## Summary

- Wire piecash's `notes` field (slot-backed, stored as `name="notes"` in the slots table) through `create_transaction` and `update_transaction`
- Include `notes` in `_transaction_to_dict` output — omitted when empty to avoid noise on the majority of transactions
- Add `notes` as a searchable field in `search_transactions` (alongside `description`, `memo`, `amount`)
- Passing empty string to `update_transaction(notes="")` clears existing notes

This gives transactions three distinct text fields: `description` (payee), `notes` (free-text annotation), and per-split `memo` (line-item detail).

## Test plan

- [x] All 193 tests pass (187 existing + 6 new)
- [x] Create transaction with notes — notes round-trips through get_transaction
- [x] Create transaction without notes — notes key omitted from output
- [x] Search by notes field — finds matching transactions
- [x] Search by notes with no matches — returns empty list
- [x] Update transaction to add notes — persists correctly
- [x] Update transaction to clear notes — empty string removes notes