### PR TITLE
Add investment support

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -15,6 +15,17 @@ import piecash
 debug_logger = logging.getLogger("gnucash_mcp.debug")
 
 
+def _to_date(dt: date | datetime) -> date:
+    """Convert a datetime or date to a date object.
+
+    piecash may return either datetime or date for price dates depending
+    on how the price was created. This normalizes to date.
+    """
+    if isinstance(dt, datetime):
+        return dt.date()
+    return dt
+
+
 class GnuCashLockError(Exception):
     """Raised when the GnuCash book is locked by another process."""
 
@@ -204,24 +215,45 @@ class GnuCashBook:
             raise ValueError(f"Invalid currency code '{mnemonic}': {e}") from e
 
     def list_commodities(self) -> dict:
-        """List all commodities in the book.
+        """List all commodities in the book with latest prices.
 
         Returns:
             Dict with commodities grouped by namespace, plus the default currency.
+            Non-currency commodities include their latest price when available.
         """
         with self.open(readonly=True) as book:
             by_namespace: dict[str, list[dict]] = {}
+
+            # Build a map of latest prices by commodity
+            latest_prices: dict[str, tuple] = {}  # commodity_key -> (date, price)
+            for p in book.prices:
+                key = f"{p.commodity.namespace}:{p.commodity.mnemonic}"
+                p_date = _to_date(p.date)
+                if key not in latest_prices or p_date > latest_prices[key][0]:
+                    latest_prices[key] = (p_date, p)
 
             for commodity in book.commodities:
                 ns = commodity.namespace
                 if ns not in by_namespace:
                     by_namespace[ns] = []
 
-                by_namespace[ns].append({
+                entry: dict = {
                     "mnemonic": commodity.mnemonic,
                     "fullname": commodity.fullname,
                     "fraction": commodity.fraction,
-                })
+                }
+
+                # Add latest price for non-currency commodities
+                key = f"{ns}:{commodity.mnemonic}"
+                if key in latest_prices:
+                    _, price = latest_prices[key]
+                    entry["latest_price"] = {
+                        "value": str(price.value),
+                        "currency": price.currency.mnemonic,
+                        "date": _to_date(price.date).isoformat(),
+                    }
+
+                by_namespace[ns].append(entry)
 
             # Sort each namespace's commodities
             for ns in by_namespace:
@@ -230,6 +262,245 @@ class GnuCashBook:
             return {
                 "default_currency": book.default_currency.mnemonic,
                 "commodities": by_namespace,
+            }
+
+    def create_commodity(
+        self,
+        mnemonic: str,
+        fullname: str,
+        namespace: str = "FUND",
+        fraction: int = 10000,
+        cusip: str | None = None,
+    ) -> dict:
+        """Create a new commodity (stock, mutual fund, etc.) in the book.
+
+        Args:
+            mnemonic: Symbol (e.g., "VTSAX", "AAPL"). Must be unique within namespace.
+            fullname: Full name (e.g., "Vanguard Total Stock Market Index Fund").
+            namespace: Grouping category. Common values: "FUND", "NASDAQ",
+                       "NYSE", "AMEX", or any custom string. Default "FUND".
+            fraction: Smallest fractional unit. Use 10000 for 4 decimal places
+                      (standard for shares), 100 for 2, 1000000 for 6 (crypto).
+                      Default 10000.
+            cusip: Optional CUSIP/ISIN identifier for the security.
+
+        Returns:
+            Dict with mnemonic, namespace, fullname, fraction, and status.
+
+        Raises:
+            ValueError: If commodity already exists in that namespace.
+        """
+        with self.open(readonly=False) as book:
+            # Check for duplicate
+            existing = self._find_commodity(book, mnemonic, namespace)
+            if existing:
+                raise ValueError(
+                    f"Commodity {namespace}:{mnemonic} already exists"
+                )
+
+            commodity = piecash.Commodity(
+                namespace=namespace,
+                mnemonic=mnemonic,
+                fullname=fullname,
+                fraction=fraction,
+                cusip=cusip or "",
+                book=book,
+            )
+
+            book.save()
+
+            return {
+                "mnemonic": commodity.mnemonic,
+                "namespace": commodity.namespace,
+                "fullname": commodity.fullname,
+                "fraction": commodity.fraction,
+                "status": "created",
+            }
+
+    def create_price(
+        self,
+        commodity: str,
+        namespace: str,
+        value: str,
+        currency: str = "USD",
+        price_date: date | None = None,
+        price_type: str = "nav",
+        source: str = "user:price",
+    ) -> dict:
+        """Record a price for a commodity (stock price, NAV, exchange rate).
+
+        Args:
+            commodity: Symbol of the commodity (e.g., "VTSAX", "AAPL").
+            namespace: Namespace of the commodity (e.g., "FUND", "NASDAQ").
+            value: Price per unit as decimal string (e.g., "250.45").
+            currency: Currency the price is denominated in. Default "USD".
+            price_date: Price date. Defaults to today.
+            price_type: Type of price: "nav", "last", "bid", "ask", "unknown".
+                        Default "nav".
+            source: Source identifier. Default "user:price".
+
+        Returns:
+            Dict with commodity, date, value, type, and status.
+
+        Raises:
+            ValueError: If commodity not found or invalid currency.
+        """
+        if price_date is None:
+            price_date = date.today()
+
+        with self.open(readonly=False) as book:
+            # Find the commodity
+            comm = self._find_commodity(book, commodity, namespace)
+            if not comm:
+                raise ValueError(
+                    f"Commodity not found: {namespace}:{commodity}"
+                )
+
+            # Find the currency
+            curr = self._get_or_create_currency(book, currency)
+
+            # Check for existing price (same commodity/currency/date/source)
+            existing = None
+            for p in book.prices:
+                if (
+                    p.commodity == comm
+                    and p.currency == curr
+                    and _to_date(p.date) == price_date
+                    and p.source == source
+                ):
+                    existing = p
+                    break
+
+            if existing:
+                # Update existing price
+                existing.value = Decimal(value)
+                existing.type = price_type
+            else:
+                # Create new price
+                # piecash expects datetime.date, not datetime.datetime
+                piecash.Price(
+                    commodity=comm,
+                    currency=curr,
+                    date=price_date,
+                    value=Decimal(value),
+                    type=price_type,
+                    source=source,
+                )
+
+            book.save()
+
+            return {
+                "commodity": commodity,
+                "namespace": namespace,
+                "currency": currency,
+                "date": price_date.isoformat(),
+                "value": value,
+                "type": price_type,
+                "status": "updated" if existing else "created",
+            }
+
+    def get_prices(
+        self,
+        commodity: str,
+        namespace: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        currency: str | None = None,
+    ) -> list[dict]:
+        """Get price history for a commodity.
+
+        Args:
+            commodity: Symbol of the commodity (e.g., "VTSAX").
+            namespace: Namespace of the commodity (e.g., "FUND").
+            start_date: Optional start date filter.
+            end_date: Optional end date filter.
+            currency: Optional currency filter (e.g., "USD").
+
+        Returns:
+            List of price dicts sorted by date descending (most recent first).
+
+        Raises:
+            ValueError: If commodity not found.
+        """
+        with self.open(readonly=True) as book:
+            comm = self._find_commodity(book, commodity, namespace)
+            if not comm:
+                raise ValueError(
+                    f"Commodity not found: {namespace}:{commodity}"
+                )
+
+            prices = []
+            for p in book.prices:
+                if p.commodity != comm:
+                    continue
+                if currency and p.currency.mnemonic != currency:
+                    continue
+                p_date = _to_date(p.date)
+                if start_date and p_date < start_date:
+                    continue
+                if end_date and p_date > end_date:
+                    continue
+
+                prices.append({
+                    "date": p_date.isoformat(),
+                    "value": str(p.value),
+                    "currency": p.currency.mnemonic,
+                    "type": p.type,
+                    "source": p.source,
+                })
+
+            # Sort by date descending
+            prices.sort(key=lambda x: x["date"], reverse=True)
+
+            return prices
+
+    def get_latest_price(
+        self,
+        commodity: str,
+        namespace: str,
+        currency: str = "USD",
+    ) -> dict | None:
+        """Get the most recent price for a commodity.
+
+        Args:
+            commodity: Symbol of the commodity (e.g., "VTSAX").
+            namespace: Namespace of the commodity (e.g., "FUND").
+            currency: Currency for the price. Default "USD".
+
+        Returns:
+            Price dict with date, value, type, and source, or None if no price exists.
+
+        Raises:
+            ValueError: If commodity not found.
+        """
+        with self.open(readonly=True) as book:
+            comm = self._find_commodity(book, commodity, namespace)
+            if not comm:
+                raise ValueError(
+                    f"Commodity not found: {namespace}:{commodity}"
+                )
+
+            latest = None
+            latest_date = None
+            for p in book.prices:
+                if p.commodity != comm:
+                    continue
+                if p.currency.mnemonic != currency:
+                    continue
+                p_date = _to_date(p.date)
+                if latest_date is None or p_date > latest_date:
+                    latest_date = p_date
+                    latest = p
+
+            if latest is None:
+                return None
+
+            return {
+                "date": latest_date.isoformat(),
+                "value": str(latest.value),
+                "currency": latest.currency.mnemonic,
+                "type": latest.type,
+                "source": latest.source,
             }
 
     def list_accounts(self) -> list[dict]:

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -132,6 +132,159 @@ def list_commodities() -> str:
 
 @mcp.tool()
 @safe_tool
+@audit_log(classification="write", operation="create", entity_type="commodity")
+def create_commodity(
+    mnemonic: str,
+    fullname: str,
+    namespace: str = "FUND",
+    fraction: int = 10000,
+    cusip: str | None = None,
+) -> str:
+    """Create a new commodity (stock, mutual fund, etc.) in the book.
+
+    Args:
+        mnemonic: Symbol (e.g., "VTSAX", "AAPL"). Must be unique within namespace.
+        fullname: Full name (e.g., "Vanguard Total Stock Market Index Fund").
+        namespace: Grouping category. Common values:
+            - "FUND" for mutual funds (default)
+            - "NASDAQ", "NYSE", "AMEX" for stocks
+            - Any custom string for other assets
+        fraction: Smallest fractional unit. Use:
+            - 1 for whole units only
+            - 100 for 2 decimal places
+            - 10000 for 4 decimal places (default, standard for shares)
+            - 1000000 for 6 decimal places (crypto)
+        cusip: Optional CUSIP/ISIN identifier for the security.
+    """
+    book = get_book()
+    result = book.create_commodity(
+        mnemonic=mnemonic,
+        fullname=fullname,
+        namespace=namespace,
+        fraction=fraction,
+        cusip=cusip,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="price")
+def create_price(
+    commodity: str,
+    namespace: str,
+    value: str,
+    currency: str = "USD",
+    date: str | None = None,
+    price_type: str = "nav",
+    source: str = "user:price",
+) -> str:
+    """Record a price for a commodity (stock price, NAV, exchange rate).
+
+    Args:
+        commodity: Symbol of the commodity (e.g., "VTSAX", "AAPL").
+        namespace: Namespace of the commodity (e.g., "FUND", "NASDAQ").
+        value: Price per unit as decimal string (e.g., "250.45").
+        currency: Currency the price is denominated in. Default "USD".
+        date: Price date in ISO format (YYYY-MM-DD). Defaults to today.
+        price_type: Type of price:
+            - "nav" for mutual fund net asset value (default)
+            - "last" for last trade price
+            - "bid" / "ask" for bid/ask prices
+            - "unknown" for unspecified
+        source: Source identifier. Default "user:price".
+
+    Note:
+        If a price already exists for the same commodity/currency/date/source,
+        it will be updated rather than creating a duplicate.
+    """
+    book = get_book()
+    price_date = None
+    if date:
+        from datetime import date as date_type
+
+        price_date = date_type.fromisoformat(date)
+
+    result = book.create_price(
+        commodity=commodity,
+        namespace=namespace,
+        value=value,
+        currency=currency,
+        price_date=price_date,
+        price_type=price_type,
+        source=source,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_prices(
+    commodity: str,
+    namespace: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    currency: str | None = None,
+) -> str:
+    """Get price history for a commodity.
+
+    Args:
+        commodity: Symbol of the commodity (e.g., "VTSAX").
+        namespace: Namespace of the commodity (e.g., "FUND").
+        start_date: Optional start date filter (YYYY-MM-DD).
+        end_date: Optional end date filter (YYYY-MM-DD).
+        currency: Optional currency filter (e.g., "USD").
+
+    Returns:
+        JSON with list of prices sorted by date descending (most recent first).
+    """
+    book = get_book()
+    from datetime import date as date_type
+
+    start = date_type.fromisoformat(start_date) if start_date else None
+    end = date_type.fromisoformat(end_date) if end_date else None
+
+    result = book.get_prices(
+        commodity=commodity,
+        namespace=namespace,
+        start_date=start,
+        end_date=end,
+        currency=currency,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_latest_price(
+    commodity: str,
+    namespace: str,
+    currency: str = "USD",
+) -> str:
+    """Get the most recent price for a commodity.
+
+    Args:
+        commodity: Symbol of the commodity (e.g., "VTSAX").
+        namespace: Namespace of the commodity (e.g., "FUND").
+        currency: Currency for the price. Default "USD".
+
+    Returns:
+        JSON with date, value, type, and source of most recent price.
+        Returns null if no price exists.
+    """
+    book = get_book()
+    result = book.get_latest_price(
+        commodity=commodity,
+        namespace=namespace,
+        currency=currency,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
 @audit_log(classification="read")
 def get_account(name: str) -> str:
     """Get details for a specific account by name.
@@ -270,6 +423,7 @@ def create_account(
     description: str = "",
     placeholder: bool = False,
     commodity: str | None = None,
+    commodity_namespace: str = "CURRENCY",
 ) -> str:
     """Create a new account in the chart of accounts.
 
@@ -279,7 +433,15 @@ def create_account(
         parent: Full path of parent account (e.g., "Expenses:Online Services")
         description: Optional description
         placeholder: If true, account is container-only. Default: false
-        commodity: ISO currency code (e.g., "USD", "EUR"). Defaults to book's default currency.
+        commodity: Symbol for the account's commodity:
+            - For currencies: ISO code (e.g., "USD", "EUR")
+            - For investments: Fund/stock symbol (e.g., "VTSAX", "AAPL")
+            Defaults to book's default currency.
+        commodity_namespace: Namespace of the commodity:
+            - "CURRENCY" (default) for currencies
+            - "FUND" for mutual funds
+            - "NASDAQ", "NYSE", etc. for stocks
+            Required when commodity is not a currency.
     """
     book = get_book()
     result = book.create_account(
@@ -289,6 +451,7 @@ def create_account(
         description=description,
         placeholder=placeholder,
         commodity=commodity,
+        commodity_namespace=commodity_namespace,
     )
     return json.dumps(result, indent=2)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1647,3 +1647,489 @@ class TestMultiCurrencyBalances:
         assert result["total"] == "3000"
         assert len(result["sources"]) == 1
         assert result["sources"][0]["account"] == "Income:Salary"
+
+
+class TestCreateCommodity:
+    """Tests for create_commodity method."""
+
+    def test_create_commodity(self, test_book: Path):
+        """Should create a new commodity and return it in list_commodities."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result = gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market Index Fund Admiral",
+            namespace="FUND",
+            fraction=10000,
+            cusip="922908728",
+        )
+
+        assert result["status"] == "created"
+        assert result["mnemonic"] == "VTSAX"
+        assert result["namespace"] == "FUND"
+        assert result["fullname"] == "Vanguard Total Stock Market Index Fund Admiral"
+        assert result["fraction"] == 10000
+
+        # Verify it appears in list_commodities
+        commodities = gc_book.list_commodities()
+        assert "FUND" in commodities["commodities"]
+        mnemonics = [c["mnemonic"] for c in commodities["commodities"]["FUND"]]
+        assert "VTSAX" in mnemonics
+
+    def test_create_commodity_duplicate(self, test_book: Path):
+        """Should raise ValueError when commodity already exists in namespace."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        with pytest.raises(ValueError, match="already exists"):
+            gc_book.create_commodity(
+                mnemonic="VTSAX",
+                fullname="Duplicate",
+                namespace="FUND",
+            )
+
+    def test_create_commodity_different_namespace(self, test_book: Path):
+        """Should allow same mnemonic in different namespaces."""
+        gc_book = GnuCashBook(str(test_book))
+
+        result1 = gc_book.create_commodity(
+            mnemonic="TEST",
+            fullname="Test Fund",
+            namespace="FUND",
+        )
+        result2 = gc_book.create_commodity(
+            mnemonic="TEST",
+            fullname="Test Stock",
+            namespace="NASDAQ",
+        )
+
+        assert result1["status"] == "created"
+        assert result2["status"] == "created"
+
+        commodities = gc_book.list_commodities()
+        assert "FUND" in commodities["commodities"]
+        assert "NASDAQ" in commodities["commodities"]
+
+
+class TestCreateAccountWithCommodity:
+    """Tests for create_account with non-currency commodities."""
+
+    def test_create_account_with_fund_commodity(self, test_book: Path):
+        """Should create MUTUAL account with FUND commodity."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # First create the commodity
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        # Create a parent for investments
+        gc_book.create_account(
+            name="Investments",
+            account_type="ASSET",
+            parent="Assets",
+            placeholder=True,
+        )
+
+        # Create the fund account
+        result = gc_book.create_account(
+            name="VTSAX",
+            account_type="MUTUAL",
+            parent="Assets:Investments",
+            commodity="VTSAX",
+            commodity_namespace="FUND",
+        )
+
+        assert result["status"] == "created"
+        assert result["fullname"] == "Assets:Investments:VTSAX"
+
+        # Verify the account commodity
+        account = gc_book.get_account("Assets:Investments:VTSAX")
+        assert account is not None
+        assert account["commodity"] == "VTSAX"
+
+    def test_create_account_missing_commodity(self, test_book: Path):
+        """Should raise ValueError when commodity doesn't exist."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Commodity not found"):
+            gc_book.create_account(
+                name="Missing Fund",
+                account_type="MUTUAL",
+                parent="Assets",
+                commodity="NONEXISTENT",
+                commodity_namespace="FUND",
+            )
+
+
+class TestPrices:
+    """Tests for price management methods."""
+
+    def test_create_price(self, test_book: Path):
+        """Should record a price and retrieve it."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        result = gc_book.create_price(
+            commodity="VTSAX",
+            namespace="FUND",
+            value="127.50",
+            currency="USD",
+            price_date=date(2026, 2, 7),
+            price_type="nav",
+        )
+
+        assert result["status"] == "created"
+        assert result["value"] == "127.50"
+        assert result["date"] == "2026-02-07"
+
+        # Verify via get_prices
+        prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        assert len(prices) == 1
+        assert Decimal(prices[0]["value"]) == Decimal("127.50")
+        assert prices[0]["type"] == "nav"
+
+    def test_create_price_update(self, test_book: Path):
+        """Should update existing price with same date/source."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        # Create initial price
+        gc_book.create_price(
+            commodity="VTSAX",
+            namespace="FUND",
+            value="127.50",
+            price_date=date(2026, 2, 7),
+        )
+
+        # Update with new value (same date and source)
+        result = gc_book.create_price(
+            commodity="VTSAX",
+            namespace="FUND",
+            value="128.75",
+            price_date=date(2026, 2, 7),
+        )
+
+        assert result["status"] == "updated"
+        assert result["value"] == "128.75"
+
+        # Should still be only 1 price, not 2
+        prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        assert len(prices) == 1
+        assert prices[0]["value"] == "128.75"
+
+    def test_get_prices_filtered(self, test_book: Path):
+        """Should filter prices by date range."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        # Create prices on multiple dates
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="125.00", price_date=date(2026, 2, 1),
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="126.50", price_date=date(2026, 2, 5),
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="128.75", price_date=date(2026, 2, 10),
+        )
+
+        # Filter to middle date
+        prices = gc_book.get_prices(
+            commodity="VTSAX",
+            namespace="FUND",
+            start_date=date(2026, 2, 3),
+            end_date=date(2026, 2, 8),
+        )
+        assert len(prices) == 1
+        assert Decimal(prices[0]["value"]) == Decimal("126.50")
+
+        # All prices, should be descending
+        all_prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        assert len(all_prices) == 3
+        assert all_prices[0]["date"] == "2026-02-10"  # Most recent first
+        assert all_prices[2]["date"] == "2026-02-01"  # Oldest last
+
+    def test_get_latest_price(self, test_book: Path):
+        """Should return the most recent price."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="125.00", price_date=date(2026, 2, 1),
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="128.75", price_date=date(2026, 2, 10),
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="126.50", price_date=date(2026, 2, 5),
+        )
+
+        result = gc_book.get_latest_price(
+            commodity="VTSAX", namespace="FUND", currency="USD",
+        )
+        assert result is not None
+        assert result["value"] == "128.75"
+        assert result["date"] == "2026-02-10"
+
+    def test_get_latest_price_no_prices(self, test_book: Path):
+        """Should return None when no prices exist."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        result = gc_book.get_latest_price(
+            commodity="VTSAX", namespace="FUND", currency="USD",
+        )
+        assert result is None
+
+    def test_create_price_commodity_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent commodity."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Commodity not found"):
+            gc_book.create_price(
+                commodity="NONEXISTENT",
+                namespace="FUND",
+                value="100.00",
+            )
+
+
+class TestInvestmentWorkflow:
+    """Integration tests for the full investment workflow."""
+
+    def test_full_investment_workflow(self, test_book: Path):
+        """Full workflow: create fund, account, price, buy shares, check balance."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # 1. Create commodity
+        gc_book.create_commodity(
+            mnemonic="VTSAX",
+            fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+            fraction=10000,
+        )
+
+        # 2. Create account hierarchy
+        gc_book.create_account(
+            name="Investments",
+            account_type="ASSET",
+            parent="Assets",
+            placeholder=True,
+        )
+        gc_book.create_account(
+            name="401k",
+            account_type="ASSET",
+            parent="Assets:Investments",
+            placeholder=True,
+        )
+        gc_book.create_account(
+            name="VTSAX",
+            account_type="MUTUAL",
+            parent="Assets:Investments:401k",
+            commodity="VTSAX",
+            commodity_namespace="FUND",
+        )
+
+        # 3. Record price
+        gc_book.create_price(
+            commodity="VTSAX",
+            namespace="FUND",
+            value="127.50",
+            price_date=date(2026, 2, 7),
+        )
+
+        # 4. Buy shares: $500 at $127.50/share = 3.9216 shares
+        guid = gc_book.create_transaction(
+            description="VTSAX purchase",
+            splits=[
+                {
+                    "account": "Assets:Investments:401k:VTSAX",
+                    "amount": "500.00",
+                    "quantity": "3.9216",
+                },
+                {
+                    "account": "Assets:Checking",
+                    "amount": "-500.00",
+                },
+            ],
+            trans_date=date(2026, 2, 7),
+            currency="USD",
+        )
+        assert guid is not None
+
+        # 5. Check balance — should show share count
+        balance = gc_book.get_balance("Assets:Investments:401k:VTSAX")
+        assert balance == Decimal("3.9216")
+
+        # 6. Get latest price
+        price = gc_book.get_latest_price(
+            commodity="VTSAX", namespace="FUND", currency="USD",
+        )
+        assert Decimal(price["value"]) == Decimal("127.50")
+
+    def test_sell_shares(self, test_book: Path):
+        """Should handle selling shares (negative quantity)."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Setup: create fund, account, buy shares
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+        gc_book.create_account(
+            name="Investments", account_type="ASSET",
+            parent="Assets", placeholder=True,
+        )
+        gc_book.create_account(
+            name="VTSAX", account_type="MUTUAL",
+            parent="Assets:Investments",
+            commodity="VTSAX", commodity_namespace="FUND",
+        )
+
+        # Buy 10 shares at $100
+        gc_book.create_transaction(
+            description="Buy VTSAX",
+            splits=[
+                {"account": "Assets:Investments:VTSAX", "amount": "1000.00", "quantity": "10"},
+                {"account": "Assets:Checking", "amount": "-1000.00"},
+            ],
+            trans_date=date(2026, 1, 15),
+            currency="USD",
+        )
+
+        # Sell 3 shares at $110
+        gc_book.create_transaction(
+            description="Sell VTSAX",
+            splits=[
+                {"account": "Assets:Investments:VTSAX", "amount": "-330.00", "quantity": "-3"},
+                {"account": "Assets:Checking", "amount": "330.00"},
+            ],
+            trans_date=date(2026, 2, 7),
+            currency="USD",
+        )
+
+        # Balance should be 7 shares
+        balance = gc_book.get_balance("Assets:Investments:VTSAX")
+        assert balance == Decimal("7")
+
+    def test_multiple_funds(self, test_book: Path):
+        """Should handle multiple funds in same account hierarchy."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Create two funds
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+        gc_book.create_commodity(
+            mnemonic="VTIAX", fullname="Vanguard Total International",
+            namespace="FUND",
+        )
+
+        # Create accounts
+        gc_book.create_account(
+            name="Investments", account_type="ASSET",
+            parent="Assets", placeholder=True,
+        )
+        gc_book.create_account(
+            name="VTSAX", account_type="MUTUAL",
+            parent="Assets:Investments",
+            commodity="VTSAX", commodity_namespace="FUND",
+        )
+        gc_book.create_account(
+            name="VTIAX", account_type="MUTUAL",
+            parent="Assets:Investments",
+            commodity="VTIAX", commodity_namespace="FUND",
+        )
+
+        # Buy both
+        gc_book.create_transaction(
+            description="Buy VTSAX",
+            splits=[
+                {"account": "Assets:Investments:VTSAX", "amount": "500.00", "quantity": "4"},
+                {"account": "Assets:Checking", "amount": "-500.00"},
+            ],
+            trans_date=date(2026, 2, 7),
+            currency="USD",
+        )
+        gc_book.create_transaction(
+            description="Buy VTIAX",
+            splits=[
+                {"account": "Assets:Investments:VTIAX", "amount": "300.00", "quantity": "10"},
+                {"account": "Assets:Checking", "amount": "-300.00"},
+            ],
+            trans_date=date(2026, 2, 7),
+            currency="USD",
+        )
+
+        # Check balances
+        vtsax_bal = gc_book.get_balance("Assets:Investments:VTSAX")
+        vtiax_bal = gc_book.get_balance("Assets:Investments:VTIAX")
+        assert vtsax_bal == Decimal("4")
+        assert vtiax_bal == Decimal("10")
+
+    def test_list_commodities_with_prices(self, test_book: Path):
+        """Enhanced list_commodities should show latest prices."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Vanguard Total Stock Market",
+            namespace="FUND",
+        )
+
+        # Add prices
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="125.00", price_date=date(2026, 2, 1),
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND",
+            value="128.75", price_date=date(2026, 2, 7),
+        )
+
+        commodities = gc_book.list_commodities()
+        fund_entries = commodities["commodities"]["FUND"]
+        vtsax = next(c for c in fund_entries if c["mnemonic"] == "VTSAX")
+
+        assert "latest_price" in vtsax
+        assert vtsax["latest_price"]["value"] == "128.75"
+        assert vtsax["latest_price"]["date"] == "2026-02-07"
+        assert vtsax["latest_price"]["currency"] == "USD"


### PR DESCRIPTION
## Summary

- Add 4 new tools: `create_commodity`, `create_price`, `get_prices`, `get_latest_price`
- Expose `commodity_namespace` parameter on `create_account` for fund/stock accounts
- Enhance `list_commodities` to include latest price info per commodity
- Add `_to_date` helper for piecash date type normalization (returns date vs datetime inconsistently)
- 15 new tests across 4 test classes (208 total)

## Test plan

- [x] 208 unit tests pass (`uv run pytest`)
- [x] Live tested 7/7 with Junior in Claude Desktop:
  - [x] Create VTSAX commodity
  - [x] Create MUTUAL account with FUND commodity
  - [x] Record NAV price
  - [x] Buy shares (create_transaction with quantity)
  - [x] Check balance shows share count
  - [x] Update existing price (same date/source)
  - [x] List commodities shows latest price