### PR TITLE
Add budget support

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -4,7 +4,7 @@ import logging
 import sqlite3
 import time
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Generator
@@ -213,6 +213,164 @@ class GnuCashBook:
             return book.currencies(mnemonic=mnemonic)
         except (KeyError, ValueError) as e:
             raise ValueError(f"Invalid currency code '{mnemonic}': {e}") from e
+
+    def _find_budget(self, book: piecash.Book, name: str):
+        """Find a budget by name.
+
+        Args:
+            book: Open piecash book.
+            name: Budget name.
+
+        Returns:
+            Budget if found, None otherwise.
+        """
+        from piecash.budget import Budget
+
+        for budget in book.session.query(Budget).all():
+            if budget.name == name:
+                return budget
+        return None
+
+    def _budget_to_dict(self, budget) -> dict:
+        """Convert a piecash Budget to a serializable dict."""
+        rec = budget.recurrence
+
+        # Reverse-map recurrence to period_type string
+        period_type = "monthly"
+        if rec.recurrence_period_type == "month" and rec.recurrence_mult == 3:
+            period_type = "quarterly"
+        elif rec.recurrence_period_type == "week":
+            period_type = "weekly"
+
+        start = rec.recurrence_period_start
+        if isinstance(start, datetime):
+            start = start.date()
+
+        return {
+            "guid": budget.guid,
+            "name": budget.name,
+            "description": budget.description or "",
+            "num_periods": budget.num_periods,
+            "period_type": period_type,
+            "start_date": start.isoformat(),
+        }
+
+    def _period_to_date_range(
+        self, budget, period_num: int
+    ) -> tuple[date, date]:
+        """Convert a budget period number to a date range.
+
+        Args:
+            budget: piecash Budget object.
+            period_num: Zero-indexed period number.
+
+        Returns:
+            Tuple of (period_start, period_end) as dates.
+
+        Raises:
+            ValueError: If period_num is out of range.
+        """
+        from dateutil.relativedelta import relativedelta
+
+        if period_num < 0 or period_num >= budget.num_periods:
+            raise ValueError(
+                f"Period {period_num} out of range "
+                f"(0-{budget.num_periods - 1})"
+            )
+
+        rec = budget.recurrence
+        anchor = rec.recurrence_period_start
+        if isinstance(anchor, datetime):
+            anchor = anchor.date()
+
+        period_type = rec.recurrence_period_type
+        mult = rec.recurrence_mult
+
+        if period_type == "month":
+            delta = relativedelta(months=mult)
+        elif period_type == "week":
+            delta = relativedelta(weeks=mult)
+        else:
+            raise ValueError(f"Unsupported period type: {period_type}")
+
+        start = anchor + delta * period_num
+        end = anchor + delta * (period_num + 1) - timedelta(days=1)
+
+        return start, end
+
+    def _current_period(self, budget) -> int | None:
+        """Get the current period number based on today's date.
+
+        Args:
+            budget: piecash Budget object.
+
+        Returns:
+            Period number (0-indexed), or None if today is outside budget range.
+        """
+        today = date.today()
+        for p in range(budget.num_periods):
+            start, end = self._period_to_date_range(budget, p)
+            if start <= today <= end:
+                return p
+        return None
+
+    def _resolve_periods(
+        self, budget, period: int | str | None
+    ) -> list[int]:
+        """Resolve a period specifier to a list of period numbers.
+
+        Args:
+            budget: piecash Budget object.
+            period: None/"all" for all, int for specific, "q1"-"q4" for quarter.
+
+        Returns:
+            List of period numbers.
+
+        Raises:
+            ValueError: If period is invalid or out of range.
+        """
+        num = budget.num_periods
+
+        if period is None or period == "all":
+            return list(range(num))
+
+        if isinstance(period, int):
+            if period < 0 or period >= num:
+                raise ValueError(
+                    f"Period {period} out of range (0-{num - 1})"
+                )
+            return [period]
+
+        if isinstance(period, str):
+            quarter_map = {
+                "q1": (0, 3),
+                "q2": (3, 6),
+                "q3": (6, 9),
+                "q4": (9, 12),
+            }
+            period_lower = period.lower()
+            if period_lower in quarter_map:
+                start, end = quarter_map[period_lower]
+                result = [p for p in range(start, end) if p < num]
+                if not result:
+                    raise ValueError(
+                        f"Quarter {period} has no periods in this budget "
+                        f"(budget has {num} periods)"
+                    )
+                return result
+
+        raise ValueError(
+            f"Invalid period: {period}. "
+            f"Use None, 'all', an integer, or 'q1'-'q4'."
+        )
+
+    def _collect_descendants(
+        self, account, result: set
+    ) -> None:
+        """Recursively collect all descendant accounts."""
+        for child in account.children:
+            result.add(child)
+            self._collect_descendants(child, result)
 
     def list_commodities(self) -> dict:
         """List all commodities in the book with latest prices.
@@ -1863,3 +2021,417 @@ class GnuCashBook:
                 "outflows": str(outflows),
                 "net": str(inflows - outflows),
             }
+
+    # ============== Budget Methods ==============
+
+    VALID_BUDGET_PERIOD_TYPES = {"monthly", "quarterly", "weekly"}
+
+    def list_budgets(self) -> list[dict]:
+        """List all budgets in the book.
+
+        Returns:
+            List of budget dicts with guid, name, description,
+            num_periods, period_type, and start_date.
+        """
+        from piecash.budget import Budget
+
+        with self.open(readonly=True) as book:
+            budgets = book.session.query(Budget).all()
+            return [self._budget_to_dict(b) for b in budgets]
+
+    def get_budget(self, name: str) -> dict | None:
+        """Get full details of a budget including all budget amounts.
+
+        Args:
+            name: Budget name.
+
+        Returns:
+            Dict with budget info and all account/period amounts,
+            or None if not found.
+        """
+        with self.open(readonly=True) as book:
+            budget = self._find_budget(book, name)
+            if not budget:
+                return None
+
+            result = self._budget_to_dict(budget)
+
+            # Group amounts by account
+            accounts: dict[str, dict[int, str]] = {}
+            for ba in budget.amounts:
+                acct_name = ba.account.fullname
+                if acct_name not in accounts:
+                    accounts[acct_name] = {}
+                accounts[acct_name][ba.period_num] = str(ba.amount)
+
+            result["accounts"] = [
+                {
+                    "account": acct_name,
+                    "periods": periods,
+                }
+                for acct_name, periods in sorted(accounts.items())
+            ]
+
+            return result
+
+    def create_budget(
+        self,
+        name: str,
+        year: int | None = None,
+        num_periods: int = 12,
+        period_type: str = "monthly",
+        description: str = "",
+    ) -> dict:
+        """Create a new budget.
+
+        Args:
+            name: Budget name (e.g., "2026 Budget").
+            year: Budget year. Defaults to current year.
+            num_periods: Number of periods. Default 12.
+            period_type: "monthly" (default), "quarterly", or "weekly".
+            description: Optional description.
+
+        Returns:
+            Dict with guid, name, and status.
+
+        Raises:
+            ValueError: If budget with same name already exists,
+                       invalid period_type, or invalid num_periods.
+        """
+        import uuid
+
+        from piecash._common import Recurrence
+        from piecash.budget import Budget
+
+        if period_type not in self.VALID_BUDGET_PERIOD_TYPES:
+            raise ValueError(
+                f"Invalid period_type: {period_type}. "
+                f"Valid types: {', '.join(sorted(self.VALID_BUDGET_PERIOD_TYPES))}"
+            )
+        if num_periods < 1:
+            raise ValueError("num_periods must be at least 1")
+
+        if year is None:
+            year = date.today().year
+
+        recurrence_map = {
+            "monthly": ("month", 1),
+            "quarterly": ("month", 3),
+            "weekly": ("week", 1),
+        }
+        rec_period_type, rec_mult = recurrence_map[period_type]
+
+        with self.open(readonly=False) as book:
+            existing = self._find_budget(book, name)
+            if existing:
+                raise ValueError(f"Budget already exists: {name}")
+
+            budget_guid = uuid.uuid4().hex
+
+            # Use direct table inserts — piecash blocks Budget
+            # and Recurrence constructors (read-only ORM objects)
+            book.session.execute(
+                Budget.__table__.insert().values(
+                    guid=budget_guid,
+                    name=name,
+                    description=description,
+                    num_periods=num_periods,
+                )
+            )
+
+            book.session.execute(
+                Recurrence.__table__.insert().values(
+                    obj_guid=budget_guid,
+                    recurrence_mult=rec_mult,
+                    recurrence_period_type=rec_period_type,
+                    recurrence_period_start=date(year, 1, 1),
+                    recurrence_weekend_adjust="none",
+                )
+            )
+
+            book.save()
+
+            return {
+                "guid": budget_guid,
+                "name": name,
+                "status": "created",
+            }
+
+    def set_budget_amount(
+        self,
+        budget_name: str,
+        account: str,
+        amount: str,
+        period: int | str | None = None,
+    ) -> dict:
+        """Set a budget target for an account.
+
+        Args:
+            budget_name: Name of the budget.
+            account: Full account path (e.g., "Expenses:Groceries").
+            amount: Budget amount as string (e.g., "500.00").
+            period: Which period(s) to set:
+                - None or "all": All periods (default)
+                - Integer 0..N-1: Specific period
+                - "q1", "q2", "q3", "q4": All periods in quarter
+
+        Returns:
+            Dict with budget, account, amount, periods set, and status.
+
+        Raises:
+            ValueError: If budget not found, account not found,
+                       or invalid period.
+        """
+        from piecash.budget import BudgetAmount
+
+        amount_decimal = Decimal(amount)
+
+        with self.open(readonly=False) as book:
+            budget = self._find_budget(book, budget_name)
+            if not budget:
+                raise ValueError(f"Budget not found: {budget_name}")
+
+            acct = self._find_account(book, account)
+            if not acct:
+                raise ValueError(f"Account not found: {account}")
+
+            periods = self._resolve_periods(budget, period)
+
+            # Convert Decimal to num/denom for direct inserts
+            # Multiply by 100 for 2 decimal places
+            amount_denom = 100
+            amount_num = int(amount_decimal * amount_denom)
+
+            for p in periods:
+                try:
+                    existing = budget.amounts(
+                        account=acct, period_num=p
+                    )
+                    # Update existing amount
+                    existing.amount = amount_decimal
+                except KeyError:
+                    # No existing amount — insert via table
+                    # (BudgetAmount constructor is blocked by piecash)
+                    book.session.execute(
+                        BudgetAmount.__table__.insert().values(
+                            budget_guid=budget.guid,
+                            account_guid=acct.guid,
+                            period_num=p,
+                            amount_num=amount_num,
+                            amount_denom=amount_denom,
+                        )
+                    )
+
+            book.save()
+
+            return {
+                "budget": budget_name,
+                "account": account,
+                "amount": amount,
+                "periods_set": periods,
+                "status": "updated",
+            }
+
+    def get_budget_report(
+        self,
+        budget_name: str,
+        period: int | str | None = None,
+        account: str | None = None,
+        include_children: bool = True,
+    ) -> dict:
+        """Compare actual spending against budget.
+
+        Args:
+            budget_name: Name of the budget.
+            period: Which period to report:
+                - None: Current period based on today's date (default)
+                - Integer 0-N: Specific period
+                - "ytd": Year to date (all periods up to current)
+                - "all": All periods
+            account: Optional filter to specific account or parent.
+            include_children: If True and account specified, include
+                            child accounts. Default True.
+
+        Returns:
+            Dict with budget name, period info, account breakdown
+            (budgeted, actual, remaining, percent_used), and totals.
+
+        Raises:
+            ValueError: If budget not found, invalid period, or
+                       account not found.
+        """
+        with self.open(readonly=True) as book:
+            budget = self._find_budget(book, budget_name)
+            if not budget:
+                raise ValueError(f"Budget not found: {budget_name}")
+
+            # Resolve which periods to report on
+            if period is None:
+                current = self._current_period(budget)
+                if current is None:
+                    raise ValueError(
+                        "Today's date is outside the budget period range"
+                    )
+                report_periods = [current]
+            elif period == "ytd":
+                current = self._current_period(budget)
+                if current is None:
+                    raise ValueError(
+                        "Today's date is outside the budget period range"
+                    )
+                report_periods = list(range(current + 1))
+            elif period == "all":
+                report_periods = list(range(budget.num_periods))
+            elif isinstance(period, int):
+                if period < 0 or period >= budget.num_periods:
+                    raise ValueError(
+                        f"Period {period} out of range "
+                        f"(0-{budget.num_periods - 1})"
+                    )
+                report_periods = [period]
+            else:
+                raise ValueError(f"Invalid period: {period}")
+
+            # Calculate date range
+            first_start, _ = self._period_to_date_range(
+                budget, report_periods[0]
+            )
+            _, last_end = self._period_to_date_range(
+                budget, report_periods[-1]
+            )
+
+            # Determine target accounts
+            if account:
+                filter_acct = self._find_account(book, account)
+                if not filter_acct:
+                    raise ValueError(f"Account not found: {account}")
+
+                if include_children:
+                    target_accounts = set()
+                    self._collect_descendants(filter_acct, target_accounts)
+                    target_accounts.add(filter_acct)
+                else:
+                    target_accounts = {filter_acct}
+            else:
+                target_accounts = None
+
+            # Gather budgeted amounts
+            budgeted: dict[str, Decimal] = {}
+            for ba in budget.amounts:
+                if ba.period_num not in report_periods:
+                    continue
+                acct_name = ba.account.fullname
+                if target_accounts is not None and ba.account not in target_accounts:
+                    continue
+                budgeted[acct_name] = budgeted.get(
+                    acct_name, Decimal("0")
+                ) + ba.amount
+
+            # Calculate actuals from transactions
+            actuals: dict[str, Decimal] = {}
+            for transaction in book.transactions:
+                if not (first_start <= transaction.post_date <= last_end):
+                    continue
+                for split in transaction.splits:
+                    acct_name = split.account.fullname
+                    if acct_name not in budgeted:
+                        continue
+                    amount = split.quantity
+                    if split.account.type == "EXPENSE" and amount > 0:
+                        actuals[acct_name] = actuals.get(
+                            acct_name, Decimal("0")
+                        ) + amount
+                    elif split.account.type == "INCOME" and amount < 0:
+                        actuals[acct_name] = actuals.get(
+                            acct_name, Decimal("0")
+                        ) + (-amount)
+
+            # Build results
+            accounts_result = []
+            total_budgeted = Decimal("0")
+            total_actual = Decimal("0")
+
+            for acct_name in sorted(budgeted.keys()):
+                b = budgeted[acct_name]
+                a = actuals.get(acct_name, Decimal("0"))
+                remaining = b - a
+                pct = (
+                    (a / b * 100).quantize(Decimal("0.1"))
+                    if b > 0
+                    else Decimal("0")
+                )
+
+                accounts_result.append({
+                    "account": acct_name,
+                    "budgeted": str(b),
+                    "actual": str(a),
+                    "remaining": str(remaining),
+                    "percent_used": str(pct),
+                })
+
+                total_budgeted += b
+                total_actual += a
+
+            total_remaining = total_budgeted - total_actual
+            total_pct = (
+                (total_actual / total_budgeted * 100).quantize(
+                    Decimal("0.1")
+                )
+                if total_budgeted > 0
+                else Decimal("0")
+            )
+
+            # Period info string
+            if len(report_periods) == 1:
+                p_start, p_end = self._period_to_date_range(
+                    budget, report_periods[0]
+                )
+                period_info = (
+                    f"Period {report_periods[0]} "
+                    f"({p_start.isoformat()} to {p_end.isoformat()})"
+                )
+            else:
+                period_info = (
+                    f"Periods {report_periods[0]}-{report_periods[-1]} "
+                    f"({first_start.isoformat()} to {last_end.isoformat()})"
+                )
+
+            return {
+                "budget": budget_name,
+                "period": period_info,
+                "accounts": accounts_result,
+                "totals": {
+                    "budgeted": str(total_budgeted),
+                    "actual": str(total_actual),
+                    "remaining": str(total_remaining),
+                    "percent_used": str(total_pct),
+                },
+            }
+
+    def delete_budget(self, name: str) -> dict:
+        """Delete a budget.
+
+        Args:
+            name: Budget name.
+
+        Returns:
+            Dict with name, guid, and status.
+
+        Raises:
+            ValueError: If budget not found.
+        """
+        with self.open(readonly=False) as book:
+            budget = self._find_budget(book, name)
+            if not budget:
+                raise ValueError(f"Budget not found: {name}")
+
+            result = {
+                "name": name,
+                "guid": budget.guid,
+                "status": "deleted",
+            }
+
+            book.session.delete(budget)
+            book.save()
+
+            return result

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -798,6 +798,151 @@ def cash_flow(
     return json.dumps(result, indent=2)
 
 
+# ============== Budget Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_budgets() -> str:
+    """List all budgets in the book.
+
+    Returns:
+        JSON list of budgets with guid, name, description,
+        num_periods, and period_type.
+    """
+    book = get_book()
+    result = book.list_budgets()
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_budget(name: str) -> str:
+    """Get full details of a budget including all budget amounts.
+
+    Args:
+        name: Budget name.
+
+    Returns:
+        JSON with budget info and all account/period amounts.
+    """
+    book = get_book()
+    result = book.get_budget(name)
+    if result is None:
+        return json.dumps({"error": f"Budget not found: {name}"})
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="budget")
+def create_budget(
+    name: str,
+    year: int | None = None,
+    num_periods: int = 12,
+    period_type: str = "monthly",
+    description: str = "",
+) -> str:
+    """Create a new budget.
+
+    Args:
+        name: Budget name (e.g., "2026 Budget").
+        year: Budget year. Defaults to current year. Used to set start date.
+        num_periods: Number of periods. Default 12 (monthly for a year).
+        period_type: Period length:
+            - "monthly" (default)
+            - "quarterly"
+            - "weekly"
+        description: Optional description.
+    """
+    book = get_book()
+    result = book.create_budget(
+        name=name,
+        year=year,
+        num_periods=num_periods,
+        period_type=period_type,
+        description=description,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="update", entity_type="budget")
+def set_budget_amount(
+    budget_name: str,
+    account: str,
+    amount: str,
+    period: int | str | None = None,
+) -> str:
+    """Set a budget target for an account.
+
+    Args:
+        budget_name: Name of the budget.
+        account: Full account path (e.g., "Expenses:Groceries").
+        amount: Monthly budget amount as string (e.g., "500.00").
+        period: Which period(s) to set:
+            - None or "all": Set same amount for all periods (default)
+            - Integer 0-11: Set specific period (0 = January for yearly budget)
+            - "q1", "q2", "q3", "q4": Set all periods in quarter
+    """
+    book = get_book()
+    result = book.set_budget_amount(
+        budget_name=budget_name,
+        account=account,
+        amount=amount,
+        period=period,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_budget_report(
+    budget_name: str,
+    period: int | str | None = None,
+    account: str | None = None,
+    include_children: bool = True,
+) -> str:
+    """Compare actual spending against budget.
+
+    Args:
+        budget_name: Name of the budget.
+        period: Which period to report:
+            - None: Current period based on today's date (default)
+            - Integer 0-11: Specific period
+            - "ytd": Year to date (all periods up to current)
+            - "all": All periods
+        account: Optional filter to specific account or parent account.
+        include_children: If True and account specified, include child accounts.
+    """
+    book = get_book()
+    result = book.get_budget_report(
+        budget_name=budget_name,
+        period=period,
+        account=account,
+        include_children=include_children,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete", entity_type="budget")
+def delete_budget(name: str) -> str:
+    """Delete a budget.
+
+    Args:
+        name: Budget name.
+    """
+    book = get_book()
+    result = book.delete_budget(name=name)
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,3 +302,215 @@ def multi_currency_book(tmp_path: Path) -> Path:
     book.close()
 
     return book_path
+
+
+@pytest.fixture
+def budget_book(tmp_path: Path) -> Path:
+    """Create a GnuCash book with data suitable for budget testing.
+
+    Creates a USD-default book with:
+    - Accounts: Assets:Checking, Income:Salary, Expenses:Groceries,
+      Expenses:Dining, Expenses:Entertainment, Equity:Opening Balance
+    - Jan 2026: Salary $5000, Groceries $120+$180+$200=$500,
+      Dining $85+$65=$150
+    - Feb 2026: Salary $5000, Groceries $150, Dining $95
+
+    Returns:
+        Path to the temporary GnuCash SQLite file.
+    """
+    book_path = tmp_path / "budget_test.gnucash"
+
+    book = piecash.create_book(
+        str(book_path),
+        currency="USD",
+        overwrite=True,
+    )
+
+    root = book.root_account
+    usd = book.default_currency
+
+    # Accounts
+    assets = piecash.Account(
+        name="Assets", type="ASSET", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(assets)
+
+    checking = piecash.Account(
+        name="Checking", type="BANK", parent=assets, commodity=usd,
+    )
+    book.session.add(checking)
+
+    income = piecash.Account(
+        name="Income", type="INCOME", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(income)
+
+    salary = piecash.Account(
+        name="Salary", type="INCOME", parent=income, commodity=usd,
+    )
+    book.session.add(salary)
+
+    expenses = piecash.Account(
+        name="Expenses", type="EXPENSE", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(expenses)
+
+    groceries = piecash.Account(
+        name="Groceries", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(groceries)
+
+    dining = piecash.Account(
+        name="Dining", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(dining)
+
+    entertainment = piecash.Account(
+        name="Entertainment", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(entertainment)
+
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(equity)
+
+    opening = piecash.Account(
+        name="Opening Balance", type="EQUITY", parent=equity, commodity=usd,
+    )
+    book.session.add(opening)
+
+    book.save()
+
+    # Opening balance: $20000 in checking
+    t0 = piecash.Transaction(
+        currency=usd,
+        description="Opening Balance",
+        post_date=date(2025, 12, 31),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("20000")),
+            piecash.Split(account=opening, value=Decimal("-20000")),
+        ],
+    )
+    book.session.add(t0)
+
+    # === January 2026 ===
+
+    # Salary $5000
+    t1 = piecash.Transaction(
+        currency=usd,
+        description="January Salary",
+        post_date=date(2026, 1, 15),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("5000")),
+            piecash.Split(account=salary, value=Decimal("-5000")),
+        ],
+    )
+    book.session.add(t1)
+
+    # Groceries: $120
+    t2 = piecash.Transaction(
+        currency=usd,
+        description="Grocery Store A",
+        post_date=date(2026, 1, 5),
+        splits=[
+            piecash.Split(account=groceries, value=Decimal("120")),
+            piecash.Split(account=checking, value=Decimal("-120")),
+        ],
+    )
+    book.session.add(t2)
+
+    # Groceries: $180
+    t3 = piecash.Transaction(
+        currency=usd,
+        description="Grocery Store B",
+        post_date=date(2026, 1, 12),
+        splits=[
+            piecash.Split(account=groceries, value=Decimal("180")),
+            piecash.Split(account=checking, value=Decimal("-180")),
+        ],
+    )
+    book.session.add(t3)
+
+    # Groceries: $200
+    t4b = piecash.Transaction(
+        currency=usd,
+        description="Grocery Store C",
+        post_date=date(2026, 1, 20),
+        splits=[
+            piecash.Split(account=groceries, value=Decimal("200")),
+            piecash.Split(account=checking, value=Decimal("-200")),
+        ],
+    )
+    book.session.add(t4b)
+
+    # Dining: $85
+    t5 = piecash.Transaction(
+        currency=usd,
+        description="Restaurant A",
+        post_date=date(2026, 1, 8),
+        splits=[
+            piecash.Split(account=dining, value=Decimal("85")),
+            piecash.Split(account=checking, value=Decimal("-85")),
+        ],
+    )
+    book.session.add(t5)
+
+    # Dining: $65
+    t6 = piecash.Transaction(
+        currency=usd,
+        description="Restaurant B",
+        post_date=date(2026, 1, 22),
+        splits=[
+            piecash.Split(account=dining, value=Decimal("65")),
+            piecash.Split(account=checking, value=Decimal("-65")),
+        ],
+    )
+    book.session.add(t6)
+
+    # === February 2026 ===
+
+    # Salary $5000
+    t7 = piecash.Transaction(
+        currency=usd,
+        description="February Salary",
+        post_date=date(2026, 2, 15),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("5000")),
+            piecash.Split(account=salary, value=Decimal("-5000")),
+        ],
+    )
+    book.session.add(t7)
+
+    # Groceries: $150
+    t8 = piecash.Transaction(
+        currency=usd,
+        description="Grocery Store D",
+        post_date=date(2026, 2, 10),
+        splits=[
+            piecash.Split(account=groceries, value=Decimal("150")),
+            piecash.Split(account=checking, value=Decimal("-150")),
+        ],
+    )
+    book.session.add(t8)
+
+    # Dining: $95
+    t9 = piecash.Transaction(
+        currency=usd,
+        description="Restaurant C",
+        post_date=date(2026, 2, 18),
+        splits=[
+            piecash.Split(account=dining, value=Decimal("95")),
+            piecash.Split(account=checking, value=Decimal("-95")),
+        ],
+    )
+    book.session.add(t9)
+
+    book.save()
+    book.close()
+
+    return book_path

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,594 @@
+"""Tests for budget tools."""
+
+import pytest
+from decimal import Decimal
+from pathlib import Path
+
+from gnucash_mcp.book import GnuCashBook
+
+
+# ============== TestCreateBudget ==============
+
+
+class TestCreateBudget:
+    """Tests for create_budget."""
+
+    def test_create_monthly_budget(self, budget_book: Path):
+        """Create a standard 12-period monthly budget."""
+        book = GnuCashBook(str(budget_book))
+        result = book.create_budget(
+            name="2026 Budget",
+            year=2026,
+            num_periods=12,
+            period_type="monthly",
+            description="Annual household budget",
+        )
+
+        assert result["name"] == "2026 Budget"
+        assert result["status"] == "created"
+        assert result["guid"]  # non-empty GUID
+
+        # Verify via get_budget
+        budget = book.get_budget("2026 Budget")
+        assert budget is not None
+        assert budget["num_periods"] == 12
+        assert budget["period_type"] == "monthly"
+        assert budget["start_date"] == "2026-01-01"
+        assert budget["description"] == "Annual household budget"
+
+    def test_create_quarterly_budget(self, budget_book: Path):
+        """Create a 4-period quarterly budget."""
+        book = GnuCashBook(str(budget_book))
+        result = book.create_budget(
+            name="Q Budget",
+            year=2026,
+            num_periods=4,
+            period_type="quarterly",
+        )
+
+        assert result["status"] == "created"
+
+        budget = book.get_budget("Q Budget")
+        assert budget["num_periods"] == 4
+        assert budget["period_type"] == "quarterly"
+
+    def test_create_weekly_budget(self, budget_book: Path):
+        """Create a weekly budget."""
+        book = GnuCashBook(str(budget_book))
+        result = book.create_budget(
+            name="Weekly Budget",
+            year=2026,
+            num_periods=52,
+            period_type="weekly",
+        )
+
+        assert result["status"] == "created"
+
+        budget = book.get_budget("Weekly Budget")
+        assert budget["num_periods"] == 52
+        assert budget["period_type"] == "weekly"
+
+    def test_create_duplicate_name_raises(self, budget_book: Path):
+        """Duplicate budget name raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026)
+
+        with pytest.raises(ValueError, match="Budget already exists"):
+            book.create_budget(name="2026 Budget", year=2026)
+
+    def test_create_invalid_period_type_raises(self, budget_book: Path):
+        """Invalid period_type raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+
+        with pytest.raises(ValueError, match="Invalid period_type"):
+            book.create_budget(
+                name="Bad Budget",
+                year=2026,
+                period_type="biweekly",
+            )
+
+    def test_create_invalid_num_periods_raises(self, budget_book: Path):
+        """num_periods < 1 raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+
+        with pytest.raises(ValueError, match="num_periods must be at least 1"):
+            book.create_budget(
+                name="Bad Budget",
+                year=2026,
+                num_periods=0,
+            )
+
+
+# ============== TestSetBudgetAmount ==============
+
+
+class TestSetBudgetAmount:
+    """Tests for set_budget_amount."""
+
+    def test_set_all_periods(self, budget_book: Path):
+        """Set budget amount for all periods."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        result = book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="500.00",
+        )
+
+        assert result["status"] == "updated"
+        assert result["account"] == "Expenses:Groceries"
+        assert result["amount"] == "500.00"
+        assert len(result["periods_set"]) == 12
+
+        # Verify via get_budget
+        budget = book.get_budget("2026 Budget")
+        grocery_amounts = None
+        for acct in budget["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                grocery_amounts = acct["periods"]
+                break
+        assert grocery_amounts is not None
+        assert len(grocery_amounts) == 12
+        for p in range(12):
+            assert Decimal(grocery_amounts[p]) == Decimal("500.00")
+
+    def test_set_single_period(self, budget_book: Path):
+        """Set budget amount for a single period."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        result = book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="600.00",
+            period=0,
+        )
+
+        assert result["periods_set"] == [0]
+
+        budget = book.get_budget("2026 Budget")
+        grocery_amounts = None
+        for acct in budget["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                grocery_amounts = acct["periods"]
+                break
+        assert grocery_amounts is not None
+        assert len(grocery_amounts) == 1
+        assert Decimal(grocery_amounts[0]) == Decimal("600.00")
+
+    def test_set_quarter_periods(self, budget_book: Path):
+        """Set budget amount for a quarter (q1 = periods 0,1,2)."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        result = book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Dining",
+            amount="200.00",
+            period="q1",
+        )
+
+        assert result["periods_set"] == [0, 1, 2]
+
+    def test_overwrite_existing_amount(self, budget_book: Path):
+        """Overwriting an existing budget amount works."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        # Set initial amount
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="500.00",
+            period=0,
+        )
+
+        # Overwrite
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="700.00",
+            period=0,
+        )
+
+        budget = book.get_budget("2026 Budget")
+        for acct in budget["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                assert Decimal(acct["periods"][0]) == Decimal("700.00")
+                break
+
+    def test_set_nonexistent_budget_raises(self, budget_book: Path):
+        """Setting amount on nonexistent budget raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+
+        with pytest.raises(ValueError, match="Budget not found"):
+            book.set_budget_amount(
+                budget_name="Nonexistent",
+                account="Expenses:Groceries",
+                amount="500.00",
+            )
+
+    def test_set_nonexistent_account_raises(self, budget_book: Path):
+        """Setting amount for nonexistent account raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        with pytest.raises(ValueError, match="Account not found"):
+            book.set_budget_amount(
+                budget_name="2026 Budget",
+                account="Expenses:NonExistent",
+                amount="500.00",
+            )
+
+
+# ============== TestGetBudgetReport ==============
+
+
+class TestGetBudgetReport:
+    """Tests for get_budget_report."""
+
+    def _create_budget_with_amounts(self, book: GnuCashBook):
+        """Helper: create a 2026 monthly budget with amounts set."""
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="600.00",
+        )
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Dining",
+            amount="200.00",
+        )
+
+    def test_report_specific_period_january(self, budget_book: Path):
+        """Report for period 0 (January) with known actuals."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=0,  # January 2026
+        )
+
+        assert report["budget"] == "2026 Budget"
+        assert "Period 0" in report["period"]
+        assert "2026-01-01" in report["period"]
+
+        # Find groceries — Jan actual should be $500
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                assert Decimal(acct["budgeted"]) == Decimal("600")
+                assert Decimal(acct["actual"]) == Decimal("500")
+                assert Decimal(acct["remaining"]) == Decimal("100")
+                break
+        else:
+            pytest.fail("Expenses:Groceries not found in report")
+
+        # Find dining — Jan actual should be $150
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Dining":
+                assert Decimal(acct["budgeted"]) == Decimal("200")
+                assert Decimal(acct["actual"]) == Decimal("150")
+                assert Decimal(acct["remaining"]) == Decimal("50")
+                break
+        else:
+            pytest.fail("Expenses:Dining not found in report")
+
+    def test_report_over_budget(self, budget_book: Path):
+        """Report shows negative remaining when over budget."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        # Set groceries budget to $300 — actual is $500 in January
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="300.00",
+        )
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=0,
+        )
+
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                assert Decimal(acct["budgeted"]) == Decimal("300")
+                assert Decimal(acct["actual"]) == Decimal("500")
+                assert Decimal(acct["remaining"]) == Decimal("-200")
+                # percent_used should be > 100
+                assert Decimal(acct["percent_used"]) > Decimal("100")
+                break
+
+    def test_report_no_transactions_period(self, budget_book: Path):
+        """Report for period with no transactions shows actual=0."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        # Period 2 = March 2026, no transactions exist
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=2,
+        )
+
+        for acct in report["accounts"]:
+            assert Decimal(acct["actual"]) == Decimal("0")
+            assert acct["remaining"] == acct["budgeted"]
+
+    def test_report_february(self, budget_book: Path):
+        """Report for period 1 (February) with known actuals."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=1,  # February 2026
+        )
+
+        # Feb groceries: $150
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                assert Decimal(acct["actual"]) == Decimal("150")
+                break
+
+        # Feb dining: $95
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Dining":
+                assert Decimal(acct["actual"]) == Decimal("95")
+                break
+
+    def test_report_all_periods(self, budget_book: Path):
+        """Report for all periods aggregates correctly."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period="all",
+        )
+
+        assert "Periods 0-11" in report["period"]
+
+        # Groceries: total budgeted = 600*12 = 7200, actual = 500 + 150 = 650
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                assert Decimal(acct["budgeted"]) == Decimal("7200")
+                assert Decimal(acct["actual"]) == Decimal("650")
+                break
+
+        # Dining: total budgeted = 200*12 = 2400, actual = 150 + 95 = 245
+        for acct in report["accounts"]:
+            if acct["account"] == "Expenses:Dining":
+                assert Decimal(acct["budgeted"]) == Decimal("2400")
+                assert Decimal(acct["actual"]) == Decimal("245")
+                break
+
+    def test_report_account_filter(self, budget_book: Path):
+        """Report filtered to a specific account only shows that account."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=0,
+            account="Expenses:Groceries",
+        )
+
+        assert len(report["accounts"]) == 1
+        assert report["accounts"][0]["account"] == "Expenses:Groceries"
+
+    def test_report_totals(self, budget_book: Path):
+        """Report totals aggregate across accounts."""
+        book = GnuCashBook(str(budget_book))
+        self._create_budget_with_amounts(book)
+
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=0,
+        )
+
+        # Jan totals: budgeted 600+200=800, actual 500+150=650
+        assert Decimal(report["totals"]["budgeted"]) == Decimal("800")
+        assert Decimal(report["totals"]["actual"]) == Decimal("650")
+        assert Decimal(report["totals"]["remaining"]) == Decimal("150")
+
+    def test_report_nonexistent_budget_raises(self, budget_book: Path):
+        """Reporting on nonexistent budget raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+
+        with pytest.raises(ValueError, match="Budget not found"):
+            book.get_budget_report(budget_name="Nonexistent", period=0)
+
+
+# ============== TestListAndGetBudget ==============
+
+
+class TestListAndGetBudget:
+    """Tests for list_budgets and get_budget."""
+
+    def test_list_empty(self, budget_book: Path):
+        """Listing budgets on a book with no budgets returns empty list."""
+        book = GnuCashBook(str(budget_book))
+        result = book.list_budgets()
+        assert result == []
+
+    def test_list_single_budget(self, budget_book: Path):
+        """Listing budgets returns created budgets."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        result = book.list_budgets()
+        assert len(result) == 1
+        assert result[0]["name"] == "2026 Budget"
+        assert result[0]["num_periods"] == 12
+        assert result[0]["period_type"] == "monthly"
+
+    def test_get_budget_with_amounts(self, budget_book: Path):
+        """get_budget returns amounts grouped by account and period."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="500.00",
+            period=0,
+        )
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="550.00",
+            period=1,
+        )
+
+        budget = book.get_budget("2026 Budget")
+        assert budget is not None
+        assert len(budget["accounts"]) == 1
+        assert budget["accounts"][0]["account"] == "Expenses:Groceries"
+        assert Decimal(budget["accounts"][0]["periods"][0]) == Decimal("500.00")
+        assert Decimal(budget["accounts"][0]["periods"][1]) == Decimal("550.00")
+
+    def test_get_nonexistent_returns_none(self, budget_book: Path):
+        """get_budget returns None for nonexistent budget."""
+        book = GnuCashBook(str(budget_book))
+        assert book.get_budget("Nonexistent") is None
+
+
+# ============== TestDeleteBudget ==============
+
+
+class TestDeleteBudget:
+    """Tests for delete_budget."""
+
+    def test_delete_existing(self, budget_book: Path):
+        """Delete an existing budget."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026)
+
+        result = book.delete_budget("2026 Budget")
+        assert result["status"] == "deleted"
+        assert result["name"] == "2026 Budget"
+
+        # Verify it's gone
+        assert book.get_budget("2026 Budget") is None
+        assert book.list_budgets() == []
+
+    def test_delete_with_amounts(self, budget_book: Path):
+        """Delete a budget with amounts (cascade delete)."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="500.00",
+        )
+
+        result = book.delete_budget("2026 Budget")
+        assert result["status"] == "deleted"
+        assert book.list_budgets() == []
+
+    def test_delete_nonexistent_raises(self, budget_book: Path):
+        """Deleting a nonexistent budget raises ValueError."""
+        book = GnuCashBook(str(budget_book))
+
+        with pytest.raises(ValueError, match="Budget not found"):
+            book.delete_budget("Nonexistent")
+
+
+# ============== TestBudgetIntegration ==============
+
+
+class TestBudgetIntegration:
+    """Integration tests for the full budget workflow."""
+
+    def test_full_workflow(self, budget_book: Path):
+        """Full workflow: create → set amounts → verify report."""
+        book = GnuCashBook(str(budget_book))
+
+        # Create budget
+        result = book.create_budget(
+            name="2026 Budget",
+            year=2026,
+            num_periods=12,
+            period_type="monthly",
+        )
+        assert result["status"] == "created"
+
+        # Set budget amounts for multiple accounts
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="600.00",
+        )
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Dining",
+            amount="200.00",
+        )
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Entertainment",
+            amount="100.00",
+        )
+
+        # Verify listing
+        budgets = book.list_budgets()
+        assert len(budgets) == 1
+        assert budgets[0]["name"] == "2026 Budget"
+
+        # Get full budget details
+        budget = book.get_budget("2026 Budget")
+        assert len(budget["accounts"]) == 3
+
+        # Get January report
+        report = book.get_budget_report(
+            budget_name="2026 Budget",
+            period=0,
+        )
+
+        # Verify: Groceries budgeted=600, actual=500 (under budget)
+        # Dining budgeted=200, actual=150 (under budget)
+        # Entertainment budgeted=100, actual=0 (no transactions)
+        accounts_by_name = {a["account"]: a for a in report["accounts"]}
+
+        assert Decimal(accounts_by_name["Expenses:Groceries"]["actual"]) == Decimal("500")
+        assert Decimal(accounts_by_name["Expenses:Dining"]["actual"]) == Decimal("150")
+        assert Decimal(accounts_by_name["Expenses:Entertainment"]["actual"]) == Decimal("0")
+
+        # Totals: budgeted=900, actual=650
+        assert Decimal(report["totals"]["budgeted"]) == Decimal("900")
+        assert Decimal(report["totals"]["actual"]) == Decimal("650")
+
+    def test_quarter_override(self, budget_book: Path):
+        """Set all periods then override a quarter with different amount."""
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        # Set $500 for all periods
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="500.00",
+        )
+
+        # Override Q4 with $700
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="700.00",
+            period="q4",
+        )
+
+        budget = book.get_budget("2026 Budget")
+        for acct in budget["accounts"]:
+            if acct["account"] == "Expenses:Groceries":
+                # Q1-Q3 (periods 0-8) should be $500
+                for p in range(9):
+                    assert Decimal(acct["periods"][p]) == Decimal("500.00")
+                # Q4 (periods 9-11) should be $700
+                for p in range(9, 12):
+                    assert Decimal(acct["periods"][p]) == Decimal("700.00")
+                break
+        else:
+            pytest.fail("Expenses:Groceries not found in budget")


### PR DESCRIPTION
## Summary

- 6 new tools: `list_budgets`, `get_budget`, `create_budget`, `set_budget_amount`, `get_budget_report`, `delete_budget`
- Budget vs actual comparison with period-level granularity (monthly, quarterly, weekly)
- Period selectors: specific period (int), quarter shorthand (`q1`-`q4`), `all`, `ytd`
- Uses direct SQLAlchemy table inserts to bypass piecash's blocked `Budget`/`BudgetAmount`/`Recurrence` constructors
- Handles `KeyError` from piecash `CallableList` lookups (not `None` as docs imply)
- 29 new tests (237 total), `budget_book` fixture with Jan/Feb 2026 transaction data

## Test plan

- [x] 29 unit tests covering create, set amounts, report, list/get, delete, and integration workflows
- [x] 237 total tests pass (no regressions)
- [x] Live tested with Junior — 6/6 budget tools confirmed working