### PR TITLE
Add scheduled transaction support

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -372,6 +372,147 @@ class GnuCashBook:
             result.add(child)
             self._collect_descendants(child, result)
 
+    # ============== Scheduled Transaction Helpers ==============
+
+    VALID_FREQUENCIES = {
+        "weekly", "biweekly", "monthly", "quarterly", "yearly",
+    }
+
+    FREQUENCY_TO_RECURRENCE = {
+        "weekly": ("week", 1),
+        "biweekly": ("week", 2),
+        "monthly": ("month", 1),
+        "quarterly": ("month", 3),
+        "yearly": ("year", 1),
+    }
+
+    RECURRENCE_TO_FREQUENCY = {
+        ("week", 1): "weekly",
+        ("week", 2): "biweekly",
+        ("month", 1): "monthly",
+        ("month", 3): "quarterly",
+        ("year", 1): "yearly",
+    }
+
+    def _next_occurrence(
+        self,
+        start_date: date,
+        frequency: str,
+        after: date | None = None,
+        end_date: date | None = None,
+    ) -> date | None:
+        """Calculate the next occurrence of a scheduled transaction.
+
+        Args:
+            start_date: First occurrence date.
+            frequency: One of VALID_FREQUENCIES.
+            after: Find next occurrence after this date.
+                   Defaults to today.
+            end_date: If set, return None if next occurrence
+                      would be past this date.
+
+        Returns:
+            Next occurrence date, or None if past end_date.
+        """
+        from dateutil.relativedelta import relativedelta
+
+        if after is None:
+            after = date.today()
+
+        delta_map = {
+            "weekly": relativedelta(weeks=1),
+            "biweekly": relativedelta(weeks=2),
+            "monthly": relativedelta(months=1),
+            "quarterly": relativedelta(months=3),
+            "yearly": relativedelta(years=1),
+        }
+        delta = delta_map[frequency]
+
+        occurrence = start_date
+        while occurrence <= after:
+            occurrence += delta
+
+        if end_date and occurrence > end_date:
+            return None
+        return occurrence
+
+    def _sx_to_dict(self, sx, frequency: str | None = None) -> dict:
+        """Serialize a ScheduledTransaction to a dict.
+
+        Args:
+            sx: piecash ScheduledTransaction object.
+            frequency: Pre-computed frequency string. If None, derived
+                       from recurrence.
+
+        Returns:
+            Dict with scheduled transaction details.
+        """
+        if frequency is None:
+            rec = sx.recurrence
+            key = (rec.recurrence_period_type, rec.recurrence_mult)
+            frequency = self.RECURRENCE_TO_FREQUENCY.get(key, "unknown")
+
+        start = sx.start_date
+        if isinstance(start, datetime):
+            start = start.date()
+
+        end = sx.end_date
+        if isinstance(end, datetime):
+            end = end.date()
+
+        last = sx.last_occur
+        if isinstance(last, datetime):
+            last = last.date()
+
+        next_occ = self._next_occurrence(
+            start, frequency, after=date.today() - timedelta(days=1),
+            end_date=end,
+        ) if frequency != "unknown" else None
+
+        return {
+            "guid": sx.guid,
+            "name": sx.name,
+            "enabled": bool(sx.enabled),
+            "frequency": frequency,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat() if end else None,
+            "last_occurrence": last.isoformat() if last else None,
+            "next_occurrence": (
+                next_occ.isoformat() if next_occ else None
+            ),
+            "instance_count": sx.instance_count,
+            "auto_create": bool(sx.auto_create),
+        }
+
+    def _get_sx_splits(self, book, sx) -> list[dict]:
+        """Read split templates from the scheduled transaction's slot.
+
+        The split templates are stored as JSON in a slot named
+        'splits-json' on the ScheduledTransaction.
+
+        Args:
+            book: Open piecash book.
+            sx: ScheduledTransaction object.
+
+        Returns:
+            List of split dicts with 'account', 'amount', and
+            optional 'memo'.
+        """
+        import json
+
+        from sqlalchemy import text
+
+        row = book.session.execute(
+            text(
+                "SELECT string_val FROM slots "
+                "WHERE obj_guid = :guid AND name = :name"
+            ),
+            {"guid": sx.guid, "name": "splits-json"},
+        ).first()
+        if row:
+            return json.loads(row[0])
+        return []
+
     def list_commodities(self) -> dict:
         """List all commodities in the book with latest prices.
 
@@ -2432,6 +2573,466 @@ class GnuCashBook:
             }
 
             book.session.delete(budget)
+            book.save()
+
+            return result
+
+    # ============== Scheduled Transaction Methods ==============
+
+    def create_scheduled_transaction(
+        self,
+        name: str,
+        description: str,
+        splits: list[dict],
+        start_date: str,
+        frequency: str,
+        end_date: str | None = None,
+        enabled: bool = True,
+    ) -> dict:
+        """Create a recurring transaction template.
+
+        Args:
+            name: Name for the scheduled transaction.
+            description: Transaction description when created.
+            splits: List of splits, same format as create_transaction:
+                [{"account": "Expenses:Rent", "amount": "1850.00"}, ...]
+            start_date: First occurrence date (YYYY-MM-DD).
+            frequency: How often: "weekly", "biweekly", "monthly",
+                      "quarterly", "yearly".
+            end_date: Optional last occurrence date (YYYY-MM-DD).
+            enabled: Whether active. Default True.
+
+        Returns:
+            Dict with guid, name, next_occurrence, and status.
+
+        Raises:
+            ValueError: If invalid frequency, accounts not found,
+                       or splits don't balance.
+        """
+        import json
+        import uuid
+
+        from piecash._common import Recurrence
+        from piecash.core.transaction import ScheduledTransaction
+        from piecash.kvp import KVP_Type, Slot
+
+        if frequency not in self.VALID_FREQUENCIES:
+            raise ValueError(
+                f"Invalid frequency: {frequency}. "
+                f"Valid: {', '.join(sorted(self.VALID_FREQUENCIES))}"
+            )
+
+        parsed_start = date.fromisoformat(start_date)
+        parsed_end = (
+            date.fromisoformat(end_date) if end_date else None
+        )
+
+        # Validate splits balance to zero
+        total = Decimal("0")
+        for s in splits:
+            total += Decimal(s["amount"])
+        if total != 0:
+            raise ValueError(
+                f"Splits must balance to zero (total: {total})"
+            )
+
+        rec_period_type, rec_mult = self.FREQUENCY_TO_RECURRENCE[
+            frequency
+        ]
+
+        with self.open(readonly=False) as book:
+            # Validate all account names exist
+            for s in splits:
+                acct = self._find_account(book, s["account"])
+                if not acct:
+                    raise ValueError(
+                        f"Account not found: {s['account']}"
+                    )
+
+            # Check duplicate name
+            for sx in book.session.query(
+                ScheduledTransaction
+            ).all():
+                if sx.name == name:
+                    raise ValueError(
+                        f"Scheduled transaction already exists: "
+                        f"{name}"
+                    )
+
+            sx_guid = uuid.uuid4().hex
+
+            # Create template account under root_template
+            template_acct = piecash.Account(
+                name=name,
+                type="BANK",
+                parent=book.root_template,
+                commodity=book.default_currency,
+            )
+            book.session.add(template_acct)
+            book.session.flush()
+
+            # Insert ScheduledTransaction (blocked constructor)
+            book.session.execute(
+                ScheduledTransaction.__table__.insert().values(
+                    guid=sx_guid,
+                    name=name,
+                    enabled=1 if enabled else 0,
+                    start_date=parsed_start,
+                    end_date=parsed_end,
+                    last_occur=None,
+                    num_occur=0,
+                    rem_occur=0,
+                    auto_create=0,
+                    auto_notify=0,
+                    adv_creation=0,
+                    adv_notify=0,
+                    instance_count=0,
+                    template_act_guid=template_acct.guid,
+                )
+            )
+
+            # Insert Recurrence
+            book.session.execute(
+                Recurrence.__table__.insert().values(
+                    obj_guid=sx_guid,
+                    recurrence_mult=rec_mult,
+                    recurrence_period_type=rec_period_type,
+                    recurrence_period_start=parsed_start,
+                    recurrence_weekend_adjust="none",
+                )
+            )
+
+            # Store split templates as JSON in a slot
+            splits_json = json.dumps([
+                {
+                    "account": s["account"],
+                    "amount": s["amount"],
+                    "memo": s.get("memo", ""),
+                }
+                for s in splits
+            ])
+            book.session.execute(
+                Slot.__table__.insert().values(
+                    obj_guid=sx_guid,
+                    name="splits-json",
+                    slot_type=KVP_Type.KVP_TYPE_STRING,
+                    string_val=splits_json,
+                )
+            )
+
+            book.save()
+
+            next_occ = self._next_occurrence(
+                parsed_start, frequency,
+                after=date.today() - timedelta(days=1),
+                end_date=parsed_end,
+            )
+
+            return {
+                "guid": sx_guid,
+                "name": name,
+                "frequency": frequency,
+                "next_occurrence": (
+                    next_occ.isoformat() if next_occ else None
+                ),
+                "status": "created",
+            }
+
+    def list_scheduled_transactions(
+        self,
+        enabled_only: bool = True,
+    ) -> list[dict]:
+        """List all scheduled transactions.
+
+        Args:
+            enabled_only: If True, only show enabled schedules.
+                         Default True.
+
+        Returns:
+            List of scheduled transaction dicts.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        with self.open(readonly=True) as book:
+            all_sx = book.session.query(
+                ScheduledTransaction
+            ).all()
+
+            results = []
+            for sx in all_sx:
+                if enabled_only and not sx.enabled:
+                    continue
+                d = self._sx_to_dict(sx)
+                d["splits"] = self._get_sx_splits(book, sx)
+                results.append(d)
+
+            return results
+
+    def get_upcoming_transactions(
+        self,
+        days: int = 14,
+    ) -> list[dict]:
+        """Get scheduled transactions due within a time window.
+
+        Args:
+            days: Look ahead window in days. Default 14.
+
+        Returns:
+            List of upcoming occurrences sorted by date.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        today = date.today()
+        window_end = today + timedelta(days=days)
+
+        with self.open(readonly=True) as book:
+            all_sx = book.session.query(
+                ScheduledTransaction
+            ).all()
+
+            upcoming = []
+            for sx in all_sx:
+                if not sx.enabled:
+                    continue
+
+                rec = sx.recurrence
+                key = (
+                    rec.recurrence_period_type,
+                    rec.recurrence_mult,
+                )
+                frequency = self.RECURRENCE_TO_FREQUENCY.get(
+                    key, None
+                )
+                if not frequency:
+                    continue
+
+                start = sx.start_date
+                if isinstance(start, datetime):
+                    start = start.date()
+
+                end = sx.end_date
+                if isinstance(end, datetime):
+                    end = end.date()
+
+                next_occ = self._next_occurrence(
+                    start, frequency,
+                    after=today - timedelta(days=1),
+                    end_date=end,
+                )
+
+                if next_occ and next_occ <= window_end:
+                    splits = self._get_sx_splits(book, sx)
+
+                    # Calculate total amount (sum of positive splits)
+                    total = Decimal("0")
+                    for s in splits:
+                        amt = Decimal(s["amount"])
+                        if amt > 0:
+                            total += amt
+
+                    upcoming.append({
+                        "guid": sx.guid,
+                        "name": sx.name,
+                        "occurrence_date": next_occ.isoformat(),
+                        "days_until": (next_occ - today).days,
+                        "amount": str(total),
+                        "splits": splits,
+                    })
+
+            # Sort by occurrence date
+            upcoming.sort(key=lambda x: x["occurrence_date"])
+            return upcoming
+
+    def create_transaction_from_scheduled(
+        self,
+        guid: str,
+        transaction_date: str | None = None,
+    ) -> dict:
+        """Create an actual transaction from a scheduled template.
+
+        Args:
+            guid: Scheduled transaction GUID.
+            transaction_date: Date for the transaction (YYYY-MM-DD).
+                            Defaults to next occurrence date.
+
+        Returns:
+            Dict with created transaction guid and updated schedule.
+
+        Raises:
+            ValueError: If scheduled transaction not found or disabled.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        with self.open(readonly=False) as book:
+            sx = book.session.query(
+                ScheduledTransaction
+            ).filter_by(guid=guid).first()
+            if not sx:
+                raise ValueError(
+                    f"Scheduled transaction not found: {guid}"
+                )
+            if not sx.enabled:
+                raise ValueError(
+                    "Scheduled transaction is disabled"
+                )
+
+            rec = sx.recurrence
+            key = (
+                rec.recurrence_period_type,
+                rec.recurrence_mult,
+            )
+            frequency = self.RECURRENCE_TO_FREQUENCY.get(key)
+            if not frequency:
+                raise ValueError("Unknown recurrence frequency")
+
+            start = sx.start_date
+            if isinstance(start, datetime):
+                start = start.date()
+
+            end = sx.end_date
+            if isinstance(end, datetime):
+                end = end.date()
+
+            # Determine transaction date
+            if transaction_date:
+                txn_date = date.fromisoformat(transaction_date)
+            else:
+                txn_date = self._next_occurrence(
+                    start, frequency,
+                    after=date.today() - timedelta(days=1),
+                    end_date=end,
+                )
+                if not txn_date:
+                    raise ValueError(
+                        "No upcoming occurrence (past end date)"
+                    )
+
+            # Get split templates
+            splits = self._get_sx_splits(book, sx)
+            if not splits:
+                raise ValueError(
+                    "No split templates found for scheduled "
+                    "transaction"
+                )
+
+            # Update schedule tracking
+            sx.last_occur = txn_date
+            sx.instance_count += 1
+
+            # Capture values before session closes
+            sx_name = sx.name
+            instance_count = sx.instance_count
+
+            book.save()
+
+        # Create the actual transaction (separate session)
+        txn_guid = self.create_transaction(
+            description=sx_name,
+            splits=splits,
+            trans_date=txn_date,
+        )
+
+        return {
+            "transaction_guid": txn_guid,
+            "scheduled_transaction": sx_name,
+            "transaction_date": txn_date.isoformat(),
+            "instance_count": instance_count,
+            "status": "created",
+        }
+
+    def update_scheduled_transaction(
+        self,
+        guid: str,
+        enabled: bool | None = None,
+        end_date: str | None = None,
+    ) -> dict:
+        """Update a scheduled transaction.
+
+        Args:
+            guid: Scheduled transaction GUID.
+            enabled: Enable or disable.
+            end_date: Set end date (YYYY-MM-DD), or empty string
+                     to clear.
+
+        Returns:
+            Dict with updated scheduled transaction details.
+
+        Raises:
+            ValueError: If not found.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        with self.open(readonly=False) as book:
+            sx = book.session.query(
+                ScheduledTransaction
+            ).filter_by(guid=guid).first()
+            if not sx:
+                raise ValueError(
+                    f"Scheduled transaction not found: {guid}"
+                )
+
+            if enabled is not None:
+                sx.enabled = 1 if enabled else 0
+
+            if end_date is not None:
+                if end_date == "":
+                    sx.end_date = None
+                else:
+                    sx.end_date = date.fromisoformat(end_date)
+
+            book.save()
+
+            return self._sx_to_dict(sx)
+
+    def delete_scheduled_transaction(self, guid: str) -> dict:
+        """Delete a scheduled transaction.
+
+        Does not affect transactions already created from this
+        schedule.
+
+        Args:
+            guid: Scheduled transaction GUID.
+
+        Returns:
+            Dict with name, guid, and status.
+
+        Raises:
+            ValueError: If not found.
+        """
+        from sqlalchemy import text
+
+        from piecash.core.transaction import ScheduledTransaction
+
+        with self.open(readonly=False) as book:
+            sx = book.session.query(
+                ScheduledTransaction
+            ).filter_by(guid=guid).first()
+            if not sx:
+                raise ValueError(
+                    f"Scheduled transaction not found: {guid}"
+                )
+
+            result = {
+                "name": sx.name,
+                "guid": sx.guid,
+                "status": "deleted",
+            }
+
+            # Delete the splits-json slot via raw SQL
+            book.session.execute(
+                text(
+                    "DELETE FROM slots "
+                    "WHERE obj_guid = :guid AND name = :name"
+                ),
+                {"guid": sx.guid, "name": "splits-json"},
+            )
+
+            # Delete the template account
+            template_acct = sx.template_account
+            book.session.delete(sx)
+            if template_acct:
+                book.session.delete(template_acct)
+
             book.save()
 
             return result

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -943,6 +943,155 @@ def delete_budget(name: str) -> str:
     return json.dumps(result, indent=2)
 
 
+# ============== Scheduled Transaction Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="scheduled_transaction")
+def create_scheduled_transaction(
+    name: str,
+    description: str,
+    splits: list[dict],
+    start_date: str,
+    frequency: str,
+    end_date: str | None = None,
+    enabled: bool = True,
+) -> str:
+    """Create a recurring transaction template.
+
+    Args:
+        name: Name for the scheduled transaction (e.g., "Monthly Rent").
+        description: Transaction description when created.
+        splits: List of splits, same format as create_transaction:
+            [{"account": "Expenses:Rent", "amount": "1850.00"}, ...]
+        start_date: First occurrence date (YYYY-MM-DD).
+        frequency: How often it recurs:
+            - "weekly"
+            - "biweekly" (every 2 weeks)
+            - "monthly"
+            - "quarterly" (every 3 months)
+            - "yearly"
+        end_date: Optional last occurrence date (YYYY-MM-DD).
+        enabled: Whether the schedule is active. Default True.
+    """
+    book = get_book()
+    result = book.create_scheduled_transaction(
+        name=name,
+        description=description,
+        splits=splits,
+        start_date=start_date,
+        frequency=frequency,
+        end_date=end_date,
+        enabled=enabled,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_scheduled_transactions(
+    enabled_only: bool = True,
+) -> str:
+    """List all scheduled transactions.
+
+    Args:
+        enabled_only: If True, only show enabled schedules. Default True.
+
+    Returns:
+        JSON list with guid, name, frequency, next_occurrence, enabled.
+    """
+    book = get_book()
+    result = book.list_scheduled_transactions(
+        enabled_only=enabled_only,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_upcoming_transactions(
+    days: int = 14,
+) -> str:
+    """Get scheduled transactions due within a time window.
+
+    This is the "what bills are coming up?" query.
+
+    Args:
+        days: Look ahead window in days. Default 14.
+
+    Returns:
+        JSON list of upcoming occurrences:
+        [{"name": "...", "occurrence_date": "...", "amount": "...", "days_until": N}]
+    """
+    book = get_book()
+    result = book.get_upcoming_transactions(days=days)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="transaction")
+def create_transaction_from_scheduled(
+    guid: str,
+    transaction_date: str | None = None,
+) -> str:
+    """Create an actual transaction from a scheduled template.
+
+    Args:
+        guid: Scheduled transaction GUID.
+        transaction_date: Date for the transaction. Defaults to next occurrence.
+    """
+    book = get_book()
+    result = book.create_transaction_from_scheduled(
+        guid=guid,
+        transaction_date=transaction_date,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="update", entity_type="scheduled_transaction")
+def update_scheduled_transaction(
+    guid: str,
+    enabled: bool | None = None,
+    end_date: str | None = None,
+) -> str:
+    """Update a scheduled transaction.
+
+    Args:
+        guid: Scheduled transaction GUID.
+        enabled: Enable or disable.
+        end_date: Set end date (empty string to clear).
+    """
+    book = get_book()
+    result = book.update_scheduled_transaction(
+        guid=guid,
+        enabled=enabled,
+        end_date=end_date,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete", entity_type="scheduled_transaction")
+def delete_scheduled_transaction(guid: str) -> str:
+    """Delete a scheduled transaction.
+
+    Does not affect transactions already created from this schedule.
+
+    Args:
+        guid: Scheduled transaction GUID.
+    """
+    book = get_book()
+    result = book.delete_scheduled_transaction(guid=guid)
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,3 +514,98 @@ def budget_book(tmp_path: Path) -> Path:
     book.close()
 
     return book_path
+
+
+@pytest.fixture
+def scheduled_book(tmp_path: Path) -> Path:
+    """Create a GnuCash book for scheduled transaction testing.
+
+    Creates a USD-default book with:
+    - Accounts: Assets:Checking, Expenses:Rent, Expenses:Utilities,
+      Income:Salary, Equity:Opening Balance
+    - Opening balance: $10000 in checking
+
+    No pre-existing scheduled transactions — tests create their own.
+
+    Returns:
+        Path to the temporary GnuCash SQLite file.
+    """
+    book_path = tmp_path / "scheduled_test.gnucash"
+
+    book = piecash.create_book(
+        str(book_path),
+        currency="USD",
+        overwrite=True,
+    )
+
+    root = book.root_account
+    usd = book.default_currency
+
+    # Accounts
+    assets = piecash.Account(
+        name="Assets", type="ASSET", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(assets)
+
+    checking = piecash.Account(
+        name="Checking", type="BANK", parent=assets, commodity=usd,
+    )
+    book.session.add(checking)
+
+    income = piecash.Account(
+        name="Income", type="INCOME", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(income)
+
+    salary = piecash.Account(
+        name="Salary", type="INCOME", parent=income, commodity=usd,
+    )
+    book.session.add(salary)
+
+    expenses = piecash.Account(
+        name="Expenses", type="EXPENSE", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(expenses)
+
+    rent = piecash.Account(
+        name="Rent", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(rent)
+
+    utilities = piecash.Account(
+        name="Utilities", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(utilities)
+
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(equity)
+
+    opening = piecash.Account(
+        name="Opening Balance", type="EQUITY", parent=equity, commodity=usd,
+    )
+    book.session.add(opening)
+
+    book.save()
+
+    # Opening balance: $10000 in checking
+    t0 = piecash.Transaction(
+        currency=usd,
+        description="Opening Balance",
+        post_date=date(2025, 12, 31),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("10000")),
+            piecash.Split(account=opening, value=Decimal("-10000")),
+        ],
+    )
+    book.session.add(t0)
+
+    book.save()
+    book.close()
+
+    return book_path

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -1,0 +1,557 @@
+"""Tests for scheduled transaction tools."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+
+
+# ── Create ──────────────────────────────────────────────────
+
+
+class TestCreateScheduled:
+    """Tests for create_scheduled_transaction."""
+
+    def test_monthly_rent(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent payment",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        assert result["status"] == "created"
+        assert result["name"] == "Monthly Rent"
+        assert result["frequency"] == "monthly"
+        assert result["guid"]
+
+    def test_biweekly_paycheck(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb.create_scheduled_transaction(
+            name="Paycheck",
+            description="Bi-weekly salary",
+            splits=[
+                {"account": "Assets:Checking", "amount": "2500.00"},
+                {"account": "Income:Salary", "amount": "-2500.00"},
+            ],
+            start_date="2026-01-09",
+            frequency="biweekly",
+        )
+        assert result["status"] == "created"
+        assert result["frequency"] == "biweekly"
+
+    def test_with_end_date(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb.create_scheduled_transaction(
+            name="Lease Payment",
+            description="Office lease",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "500.00"},
+                {"account": "Assets:Checking", "amount": "-500.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+            end_date="2026-12-31",
+        )
+        assert result["status"] == "created"
+
+    def test_duplicate_name_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        with pytest.raises(ValueError, match="already exists"):
+            gb.create_scheduled_transaction(
+                name="Monthly Rent",
+                description="Rent again",
+                splits=[
+                    {"account": "Expenses:Rent", "amount": "1850.00"},
+                    {"account": "Assets:Checking", "amount": "-1850.00"},
+                ],
+                start_date="2026-02-01",
+                frequency="monthly",
+            )
+
+    def test_invalid_frequency_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="Invalid frequency"):
+            gb.create_scheduled_transaction(
+                name="Bad Schedule",
+                description="Nope",
+                splits=[
+                    {"account": "Expenses:Rent", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-100.00"},
+                ],
+                start_date="2026-01-01",
+                frequency="daily",
+            )
+
+    def test_unbalanced_splits_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="balance to zero"):
+            gb.create_scheduled_transaction(
+                name="Unbalanced",
+                description="Nope",
+                splits=[
+                    {"account": "Expenses:Rent", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-50.00"},
+                ],
+                start_date="2026-01-01",
+                frequency="monthly",
+            )
+
+    def test_invalid_account_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="Account not found"):
+            gb.create_scheduled_transaction(
+                name="Bad Account",
+                description="Nope",
+                splits=[
+                    {"account": "Expenses:Nonexistent", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-100.00"},
+                ],
+                start_date="2026-01-01",
+                frequency="monthly",
+            )
+
+
+# ── List ────────────────────────────────────────────────────
+
+
+class TestListScheduled:
+    """Tests for list_scheduled_transactions."""
+
+    def test_empty_list(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb.list_scheduled_transactions()
+        assert result == []
+
+    def test_lists_created(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.list_scheduled_transactions()
+        assert len(result) == 1
+        assert result[0]["name"] == "Rent"
+        assert result[0]["frequency"] == "monthly"
+        assert result[0]["splits"] == [
+            {"account": "Expenses:Rent", "amount": "1850.00", "memo": ""},
+            {"account": "Assets:Checking", "amount": "-1850.00", "memo": ""},
+        ]
+
+    def test_enabled_only_filter(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        r1 = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb.create_scheduled_transaction(
+            name="Utils",
+            description="Utils",
+            splits=[
+                {"account": "Expenses:Utilities", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        # Disable one
+        gb.update_scheduled_transaction(r1["guid"], enabled=False)
+
+        # Default: enabled_only=True
+        enabled = gb.list_scheduled_transactions(enabled_only=True)
+        assert len(enabled) == 1
+        assert enabled[0]["name"] == "Utils"
+
+        # All
+        all_sx = gb.list_scheduled_transactions(enabled_only=False)
+        assert len(all_sx) == 2
+
+
+# ── Get Upcoming ────────────────────────────────────────────
+
+
+class TestGetUpcoming:
+    """Tests for get_upcoming_transactions."""
+
+    def test_within_window(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        # Start date = tomorrow, so next occurrence is tomorrow
+        tomorrow = date.today() + timedelta(days=1)
+        gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date=tomorrow.isoformat(),
+            frequency="monthly",
+        )
+        result = gb.get_upcoming_transactions(days=14)
+        assert len(result) == 1
+        assert result[0]["name"] == "Rent"
+        assert result[0]["amount"] == "1850.00"
+        assert result[0]["days_until"] >= 0
+
+    def test_outside_window(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        # Start date far in the future
+        future = date.today() + timedelta(days=60)
+        gb.create_scheduled_transaction(
+            name="Future Rent",
+            description="Far out",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date=future.isoformat(),
+            frequency="monthly",
+        )
+        result = gb.get_upcoming_transactions(days=14)
+        assert len(result) == 0
+
+    def test_disabled_excluded(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        tomorrow = date.today() + timedelta(days=1)
+        r = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date=tomorrow.isoformat(),
+            frequency="monthly",
+        )
+        gb.update_scheduled_transaction(r["guid"], enabled=False)
+        result = gb.get_upcoming_transactions(days=14)
+        assert len(result) == 0
+
+
+# ── Create From Scheduled ──────────────────────────────────
+
+
+class TestCreateFromScheduled:
+    """Tests for create_transaction_from_scheduled."""
+
+    def test_creates_real_transaction(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"],
+            transaction_date="2026-02-01",
+        )
+        assert result["status"] == "created"
+        assert result["transaction_guid"]
+        assert result["transaction_date"] == "2026-02-01"
+        assert result["instance_count"] == 1
+
+        # Verify the transaction actually exists
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert txn is not None
+        assert txn["description"] == "Monthly Rent"
+
+    def test_updates_tracking(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        # Create twice
+        gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-01-01",
+        )
+        r2 = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        assert r2["instance_count"] == 2
+
+    def test_disabled_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb.update_scheduled_transaction(sx["guid"], enabled=False)
+        with pytest.raises(ValueError, match="disabled"):
+            gb.create_transaction_from_scheduled(
+                guid=sx["guid"],
+                transaction_date="2026-02-01",
+            )
+
+    def test_not_found_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.create_transaction_from_scheduled(
+                guid="a" * 32,
+                transaction_date="2026-02-01",
+            )
+
+
+# ── Update ──────────────────────────────────────────────────
+
+
+class TestUpdateScheduled:
+    """Tests for update_scheduled_transaction."""
+
+    def test_disable(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.update_scheduled_transaction(
+            sx["guid"], enabled=False,
+        )
+        assert result["enabled"] is False
+
+    def test_set_end_date(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.update_scheduled_transaction(
+            sx["guid"], end_date="2026-12-31",
+        )
+        assert result["end_date"] == "2026-12-31"
+
+    def test_not_found_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.update_scheduled_transaction(
+                "b" * 32, enabled=False,
+            )
+
+
+# ── Delete ──────────────────────────────────────────────────
+
+
+class TestDeleteScheduled:
+    """Tests for delete_scheduled_transaction."""
+
+    def test_delete_existing(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.delete_scheduled_transaction(sx["guid"])
+        assert result["status"] == "deleted"
+        assert result["name"] == "Rent"
+
+        # Verify gone
+        listed = gb.list_scheduled_transactions(enabled_only=False)
+        assert len(listed) == 0
+
+    def test_delete_nonexistent_error(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.delete_scheduled_transaction("c" * 32)
+
+
+# ── Next Occurrence Helper ──────────────────────────────────
+
+
+class TestNextOccurrence:
+    """Tests for _next_occurrence helper."""
+
+    def test_monthly_from_past(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 1),
+            frequency="monthly",
+            after=date(2026, 3, 15),
+        )
+        assert result == date(2026, 4, 1)
+
+    def test_weekly(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 5),  # Monday
+            frequency="weekly",
+            after=date(2026, 1, 5),  # same day
+        )
+        assert result == date(2026, 1, 12)
+
+    def test_respects_end_date(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 1),
+            frequency="monthly",
+            after=date(2026, 11, 15),
+            end_date=date(2026, 12, 1),
+        )
+        assert result == date(2026, 12, 1)
+
+    def test_past_end_date_returns_none(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 1),
+            frequency="monthly",
+            after=date(2026, 12, 15),
+            end_date=date(2026, 12, 31),
+        )
+        assert result is None
+
+    def test_biweekly(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 9),
+            frequency="biweekly",
+            after=date(2026, 1, 9),
+        )
+        assert result == date(2026, 1, 23)
+
+    def test_yearly(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2025, 1, 1),
+            frequency="yearly",
+            after=date(2026, 6, 1),
+        )
+        assert result == date(2027, 1, 1)
+
+
+# ── Integration ─────────────────────────────────────────────
+
+
+class TestScheduledIntegration:
+    """Full workflow tests."""
+
+    def test_full_lifecycle(self, scheduled_book):
+        """Create → list → create_from → verify → delete."""
+        gb = GnuCashBook(str(scheduled_book))
+
+        # Create
+        sx = gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent payment",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+
+        # List
+        listed = gb.list_scheduled_transactions()
+        assert len(listed) == 1
+        assert listed[0]["name"] == "Monthly Rent"
+        assert listed[0]["enabled"] is True
+
+        # Create real transaction
+        txn = gb.create_transaction_from_scheduled(
+            guid=sx["guid"],
+            transaction_date="2026-01-01",
+        )
+        assert txn["status"] == "created"
+
+        # Verify transaction exists with correct details
+        real_txn = gb.get_transaction(txn["transaction_guid"])
+        assert real_txn["description"] == "Monthly Rent"
+        assert len(real_txn["splits"]) == 2
+
+        # Check amounts in splits
+        amounts = {s["account"]: s["value"] for s in real_txn["splits"]}
+        assert Decimal(amounts["Expenses:Rent"]) == Decimal("1850")
+        assert Decimal(amounts["Assets:Checking"]) == Decimal("-1850")
+
+        # Verify balance changed
+        balance = gb.get_balance("Assets:Checking")
+        assert balance == Decimal("8150")  # 10000 - 1850
+
+        # Delete
+        gb.delete_scheduled_transaction(sx["guid"])
+        listed = gb.list_scheduled_transactions(enabled_only=False)
+        assert len(listed) == 0
+
+    def test_multiple_frequencies(self, scheduled_book):
+        """Create scheduled transactions with different frequencies."""
+        gb = GnuCashBook(str(scheduled_book))
+
+        for freq in ["weekly", "biweekly", "monthly", "quarterly", "yearly"]:
+            gb.create_scheduled_transaction(
+                name=f"Test {freq}",
+                description=f"Test {freq}",
+                splits=[
+                    {"account": "Expenses:Utilities", "amount": "100.00"},
+                    {"account": "Assets:Checking", "amount": "-100.00"},
+                ],
+                start_date="2026-01-01",
+                frequency=freq,
+            )
+
+        listed = gb.list_scheduled_transactions()
+        assert len(listed) == 5
+        freqs = {sx["frequency"] for sx in listed}
+        assert freqs == {"weekly", "biweekly", "monthly", "quarterly", "yearly"}


### PR DESCRIPTION
## Summary

- 6 new tools for managing recurring transaction templates: create, list, get upcoming, instantiate from template, update, and delete
- Simplified model stores split templates as JSON in the slots table rather than full GnuCash template account hierarchy
- Uses direct table inserts for ScheduledTransaction, Recurrence, and Slot (all have blocked ORM constructors)
- Uses raw SQL for slot reads/deletes to avoid piecash ORM polymorphic relationship issues
- Supports weekly, biweekly, monthly, quarterly, and yearly frequencies
- 30 new tests (267 total), all passing; live-tested 6/6 with Junior

## Test plan

- [x] 30 automated tests covering all 6 tools, validation errors, and integration workflows
- [x] Full suite regression (267 tests pass)
- [x] Live test with Junior: create monthly rent, list, get upcoming, instantiate real transaction, update, delete