### PR TITLE
Add lot support for cost basis tracking

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -55,6 +55,7 @@ def _split_to_dict(split: piecash.Split) -> dict:
         "memo": split.memo or "",
         "reconcile_state": split.reconcile_state,
         "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date else None,
+        "lot_guid": split.lot.guid if split.lot else None,
     }
 
 
@@ -3036,3 +3037,350 @@ class GnuCashBook:
             book.save()
 
             return result
+
+    # ── Lot (Cost Basis Tracking) Methods ─────────────────────────
+
+    def _find_lot(self, book: piecash.Book, guid: str):
+        """Find a lot by GUID.
+
+        Args:
+            book: Open piecash book.
+            guid: Lot GUID.
+
+        Returns:
+            Lot if found, None otherwise.
+        """
+        from piecash.core.transaction import Lot
+
+        return book.session.query(Lot).filter_by(guid=guid).first()
+
+    def _lot_summary(self, lot) -> dict:
+        """Compute current state of a lot from its splits.
+
+        Returns:
+            Dict with quantity, cost_basis, cost_per_share as strings.
+        """
+        purchase_quantity = Decimal(0)
+        purchase_value = Decimal(0)
+        sale_quantity = Decimal(0)
+
+        for split in lot.splits:
+            if split.quantity > 0:
+                purchase_quantity += Decimal(str(split.quantity))
+                purchase_value += Decimal(str(split.value))
+            else:
+                sale_quantity += abs(Decimal(str(split.quantity)))
+
+        remaining = purchase_quantity - sale_quantity
+
+        if purchase_quantity > 0:
+            cost_per_share = purchase_value / purchase_quantity
+            remaining_cost_basis = cost_per_share * remaining
+        else:
+            cost_per_share = Decimal(0)
+            remaining_cost_basis = Decimal(0)
+
+        return {
+            "quantity": str(remaining),
+            "cost_basis": str(remaining_cost_basis),
+            "cost_per_share": str(cost_per_share),
+            "is_closed": bool(lot.is_closed),
+        }
+
+    def create_lot(
+        self,
+        account: str,
+        title: str,
+        notes: str = "",
+    ) -> dict:
+        """Create a new lot for cost basis tracking.
+
+        Lots group investment purchases for tracking cost basis and
+        calculating capital gains when selling.
+
+        Args:
+            account: Full path of investment account (e.g., "Assets:Investments:VTSAX").
+            title: Lot identifier (e.g., "VTSAX 2026-01-15 purchase").
+            notes: Optional notes.
+
+        Returns:
+            Dict with guid, title, account, and status.
+
+        Raises:
+            ValueError: If account not found.
+        """
+        from piecash.core.transaction import Lot
+
+        with self.open(readonly=False) as book:
+            acct = self._find_account(book, account)
+            if not acct:
+                raise ValueError(f"Account not found: {account}")
+
+            lot = Lot(
+                title=title,
+                account=acct,
+                notes=notes,
+                is_closed=0,
+            )
+            book.session.add(lot)
+            book.save()
+
+            return {
+                "guid": lot.guid,
+                "title": title,
+                "account": account,
+                "notes": notes,
+                "status": "created",
+            }
+
+    def list_lots(
+        self,
+        account: str,
+        include_closed: bool = False,
+    ) -> list[dict]:
+        """List all lots for an investment account.
+
+        Args:
+            account: Full path of investment account.
+            include_closed: If True, include fully-sold lots. Default False.
+
+        Returns:
+            List of lot dicts with guid, title, notes, is_closed,
+            quantity, cost_basis, cost_per_share.
+
+        Raises:
+            ValueError: If account not found.
+        """
+        with self.open(readonly=True) as book:
+            acct = self._find_account(book, account)
+            if not acct:
+                raise ValueError(f"Account not found: {account}")
+
+            results = []
+            for lot in acct.lots:
+                if not include_closed and lot.is_closed:
+                    continue
+                summary = self._lot_summary(lot)
+                results.append({
+                    "guid": lot.guid,
+                    "title": lot.title,
+                    "notes": lot.notes or "",
+                    **summary,
+                })
+
+            return results
+
+    def get_lot(self, guid: str) -> dict:
+        """Get detailed information about a lot.
+
+        Args:
+            guid: Lot GUID.
+
+        Returns:
+            Dict with lot details including all splits and summary.
+
+        Raises:
+            ValueError: If lot not found.
+        """
+        with self.open(readonly=True) as book:
+            lot = self._find_lot(book, guid)
+            if not lot:
+                raise ValueError(f"Lot not found: {guid}")
+
+            splits = []
+            for split in lot.splits:
+                splits.append({
+                    "guid": split.guid,
+                    "date": split.transaction.post_date.isoformat(),
+                    "description": split.transaction.description,
+                    "quantity": str(split.quantity),
+                    "value": str(split.value),
+                })
+
+            summary = self._lot_summary(lot)
+
+            return {
+                "guid": lot.guid,
+                "title": lot.title,
+                "account": lot.account.fullname,
+                "notes": lot.notes or "",
+                "is_closed": bool(lot.is_closed),
+                "splits": splits,
+                "summary": summary,
+            }
+
+    def assign_split_to_lot(
+        self,
+        split_guid: str,
+        lot_guid: str,
+    ) -> dict:
+        """Assign a transaction split to a lot.
+
+        Use after creating a buy/sell transaction to link the investment
+        account split to its lot for cost basis tracking.
+
+        Args:
+            split_guid: GUID of the split (from transaction's investment account).
+            lot_guid: GUID of the lot.
+
+        Returns:
+            Dict with status and updated lot summary.
+
+        Raises:
+            ValueError: If split or lot not found, split is in wrong account,
+                       split already assigned to a lot, or lot is closed.
+        """
+        with self.open(readonly=False) as book:
+            split = self._find_split(book, split_guid)
+            if not split:
+                raise ValueError(f"Split not found: {split_guid}")
+
+            lot = self._find_lot(book, lot_guid)
+            if not lot:
+                raise ValueError(f"Lot not found: {lot_guid}")
+
+            if lot.is_closed:
+                raise ValueError("Cannot assign split to a closed lot")
+
+            if split.account != lot.account:
+                raise ValueError(
+                    f"Split account ({split.account.fullname}) does not match "
+                    f"lot account ({lot.account.fullname})"
+                )
+
+            if split.lot is not None:
+                raise ValueError(
+                    f"Split is already assigned to lot: {split.lot.guid}"
+                )
+
+            split.lot = lot
+            book.save()
+
+            summary = self._lot_summary(lot)
+
+            # Auto-close if quantity reaches zero
+            if Decimal(summary["quantity"]) == 0 and len(lot.splits) > 0:
+                lot.is_closed = 1
+                book.save()
+                summary["is_closed"] = True
+
+            return {
+                "status": "assigned",
+                "split_guid": split_guid,
+                "lot_guid": lot_guid,
+                **summary,
+            }
+
+    def calculate_lot_gain(
+        self,
+        lot_guid: str,
+        shares: str | None = None,
+        sale_price: str | None = None,
+    ) -> dict:
+        """Calculate potential or actual capital gain for a lot.
+
+        If shares and sale_price provided, calculates hypothetical gain.
+        Otherwise uses lot's current state and latest price.
+
+        Args:
+            lot_guid: Lot GUID.
+            shares: Optional number of shares to calculate for.
+                    Defaults to all remaining shares.
+            sale_price: Optional sale price per share.
+                        Defaults to latest price for the commodity.
+
+        Returns:
+            Dict with shares, cost_basis, sale_proceeds, capital_gain, gain_percent.
+
+        Raises:
+            ValueError: If lot not found, no shares remaining, or no price available.
+        """
+        with self.open(readonly=True) as book:
+            lot = self._find_lot(book, lot_guid)
+            if not lot:
+                raise ValueError(f"Lot not found: {lot_guid}")
+
+            summary = self._lot_summary(lot)
+            remaining = Decimal(summary["quantity"])
+
+            if remaining <= 0:
+                raise ValueError("Lot has no remaining shares")
+
+            # Determine shares to sell
+            if shares is not None:
+                shares_to_sell = Decimal(shares)
+                if shares_to_sell > remaining:
+                    raise ValueError(
+                        f"Cannot sell {shares_to_sell}; lot has {remaining} shares"
+                    )
+            else:
+                shares_to_sell = remaining
+
+            # Determine sale price
+            if sale_price is not None:
+                price = Decimal(sale_price)
+            else:
+                # Look up latest price for the commodity (inline, since
+                # we're already inside an open session)
+                commodity = lot.account.commodity
+                latest_price = None
+                latest_date = None
+                for p in book.prices:
+                    if p.commodity != commodity:
+                        continue
+                    p_date = _to_date(p.date)
+                    if latest_date is None or p_date > latest_date:
+                        latest_date = p_date
+                        latest_price = p
+                if latest_price is None:
+                    raise ValueError(
+                        f"No price found for {commodity.mnemonic}. "
+                        "Provide sale_price explicitly."
+                    )
+                price = Decimal(str(latest_price.value))
+
+            cost_per_share = Decimal(summary["cost_per_share"])
+            cost_basis = cost_per_share * shares_to_sell
+            proceeds = price * shares_to_sell
+            gain = proceeds - cost_basis
+            gain_pct = (gain / cost_basis * 100) if cost_basis else Decimal(0)
+
+            return {
+                "shares": str(shares_to_sell),
+                "cost_basis": str(cost_basis),
+                "sale_proceeds": str(proceeds),
+                "capital_gain": str(gain),
+                "gain_percent": str(gain_pct),
+            }
+
+    def close_lot(self, guid: str) -> dict:
+        """Mark a lot as closed.
+
+        Use when a lot is fully sold but wasn't automatically marked closed,
+        or to manually close a lot with zero shares.
+
+        Args:
+            guid: Lot GUID.
+
+        Returns:
+            Dict with status.
+
+        Raises:
+            ValueError: If lot not found or already closed.
+        """
+        with self.open(readonly=False) as book:
+            lot = self._find_lot(book, guid)
+            if not lot:
+                raise ValueError(f"Lot not found: {guid}")
+
+            if lot.is_closed:
+                raise ValueError("Lot is already closed")
+
+            lot.is_closed = 1
+            book.save()
+
+            return {
+                "guid": guid,
+                "title": lot.title,
+                "status": "closed",
+            }

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -1092,6 +1092,151 @@ def delete_scheduled_transaction(guid: str) -> str:
     return json.dumps(result, indent=2)
 
 
+# ============== Lot (Cost Basis) Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="lot")
+def create_lot(
+    account: str,
+    title: str,
+    notes: str = "",
+) -> str:
+    """Create a new lot for cost basis tracking.
+
+    Lots group investment purchases for tracking cost basis and
+    calculating capital gains when selling.
+
+    Args:
+        account: Full path of investment account (e.g., "Assets:Investments:VTSAX").
+        title: Lot identifier (e.g., "VTSAX 2026-01-15 purchase").
+        notes: Optional notes.
+    """
+    book = get_book()
+    result = book.create_lot(account=account, title=title, notes=notes)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_lots(
+    account: str,
+    include_closed: bool = False,
+) -> str:
+    """List all lots for an investment account.
+
+    Args:
+        account: Full path of investment account.
+        include_closed: If True, include fully-sold lots. Default False.
+
+    Returns:
+        JSON list of lots with:
+        - guid, title, notes, is_closed
+        - quantity (shares remaining)
+        - cost_basis (original cost of remaining shares)
+        - cost_per_share
+    """
+    book = get_book()
+    result = book.list_lots(account=account, include_closed=include_closed)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_lot(guid: str) -> str:
+    """Get detailed information about a lot.
+
+    Args:
+        guid: Lot GUID.
+
+    Returns:
+        JSON with lot details including all splits:
+        - title, notes, is_closed
+        - splits: list of all splits with date, quantity, value
+        - summary: total quantity, cost basis, cost per share
+    """
+    book = get_book()
+    result = book.get_lot(guid=guid)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="update", entity_type="lot")
+def assign_split_to_lot(
+    split_guid: str,
+    lot_guid: str,
+) -> str:
+    """Assign a transaction split to a lot.
+
+    Use after creating a buy/sell transaction to link the investment
+    account split to its lot for cost basis tracking.
+
+    Args:
+        split_guid: GUID of the split (from transaction's investment account).
+        lot_guid: GUID of the lot.
+
+    Workflow:
+        1. create_lot("Assets:VTSAX", "VTSAX Jan 2026")
+        2. create_transaction(...buy 10 shares...)
+        3. assign_split_to_lot(investment_split_guid, lot_guid)
+    """
+    book = get_book()
+    result = book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot_guid)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def calculate_lot_gain(
+    lot_guid: str,
+    shares: str | None = None,
+    sale_price: str | None = None,
+) -> str:
+    """Calculate potential or actual capital gain for a lot.
+
+    If shares and sale_price provided, calculates hypothetical gain.
+    Otherwise uses lot's current state and latest price.
+
+    Args:
+        lot_guid: Lot GUID.
+        shares: Optional number of shares to calculate for.
+                Defaults to all remaining shares.
+        sale_price: Optional sale price per share.
+                    Defaults to latest price for the commodity.
+    """
+    book = get_book()
+    result = book.calculate_lot_gain(
+        lot_guid=lot_guid, shares=shares, sale_price=sale_price,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="update", entity_type="lot")
+def close_lot(guid: str) -> str:
+    """Mark a lot as closed.
+
+    Use when a lot is fully sold but wasn't automatically marked closed,
+    or to manually close a lot with zero shares.
+
+    Args:
+        guid: Lot GUID.
+
+    Note:
+        Lots are automatically marked closed when their quantity reaches zero
+        through assigned splits. This tool is for manual cleanup.
+    """
+    book = get_book()
+    result = book.close_lot(guid=guid)
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,3 +609,121 @@ def scheduled_book(tmp_path: Path) -> Path:
     book.close()
 
     return book_path
+
+
+@pytest.fixture
+def investment_book(tmp_path: Path) -> Path:
+    """Create a GnuCash book with investment accounts for lot testing.
+
+    Creates a USD-default book with:
+    - Assets:Checking (BANK, USD)
+    - Assets:Investments (ASSET, USD, placeholder)
+    - Assets:Investments:VTSAX (MUTUAL, commodity=VTSAX)
+    - Income:Capital Gains (INCOME, USD)
+    - Equity:Opening Balance (EQUITY, USD)
+    - VTSAX commodity (FUND namespace, fraction=10000)
+    - VTSAX price: $125.00 on 2026-01-15
+    - Opening balance: $10000 in checking
+
+    No pre-existing lots or investment transactions.
+
+    Returns:
+        Path to the temporary GnuCash SQLite file.
+    """
+    book_path = tmp_path / "investment_test.gnucash"
+
+    book = piecash.create_book(
+        str(book_path),
+        currency="USD",
+        overwrite=True,
+    )
+
+    root = book.root_account
+    usd = book.default_currency
+
+    # Create VTSAX commodity
+    vtsax = piecash.Commodity(
+        namespace="FUND",
+        mnemonic="VTSAX",
+        fullname="Vanguard Total Stock Market",
+        fraction=10000,
+    )
+    book.session.add(vtsax)
+
+    # Accounts
+    assets = piecash.Account(
+        name="Assets", type="ASSET", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(assets)
+
+    checking = piecash.Account(
+        name="Checking", type="BANK", parent=assets, commodity=usd,
+    )
+    book.session.add(checking)
+
+    investments = piecash.Account(
+        name="Investments", type="ASSET", parent=assets,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(investments)
+
+    vtsax_acct = piecash.Account(
+        name="VTSAX", type="MUTUAL", parent=investments,
+        commodity=vtsax,
+    )
+    book.session.add(vtsax_acct)
+
+    income = piecash.Account(
+        name="Income", type="INCOME", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(income)
+
+    cap_gains = piecash.Account(
+        name="Capital Gains", type="INCOME", parent=income,
+        commodity=usd,
+    )
+    book.session.add(cap_gains)
+
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(equity)
+
+    opening = piecash.Account(
+        name="Opening Balance", type="EQUITY", parent=equity,
+        commodity=usd,
+    )
+    book.session.add(opening)
+
+    book.save()
+
+    # Record VTSAX price
+    p = piecash.Price(
+        commodity=vtsax,
+        currency=usd,
+        date=date(2026, 1, 15),
+        value=Decimal("125"),
+        type="nav",
+        source="user:price",
+    )
+    book.session.add(p)
+
+    # Opening balance: $10000 in checking
+    t0 = piecash.Transaction(
+        currency=usd,
+        description="Opening Balance",
+        post_date=date(2025, 12, 31),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("10000")),
+            piecash.Split(account=opening, value=Decimal("-10000")),
+        ],
+    )
+    book.session.add(t0)
+
+    book.save()
+    book.close()
+
+    return book_path

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -1,0 +1,382 @@
+"""Tests for lot (cost basis tracking) functionality."""
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _buy_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date) -> str:
+    """Create a buy transaction and return the VTSAX split GUID.
+
+    Accounting: cash decreases (checking -total), investment increases (VTSAX +total in USD, +shares in quantity).
+    """
+    total = price * shares
+    guid = book.create_transaction(
+        description=f"Buy {shares} VTSAX @ {price}",
+        splits=[
+            {"account": "Assets:Investments:VTSAX", "amount": str(total), "quantity": str(shares)},
+            {"account": "Assets:Checking", "amount": str(-total)},
+        ],
+        trans_date=txn_date,
+    )
+    txn = book.get_transaction(guid)
+    for s in txn["splits"]:
+        if s["account"] == "Assets:Investments:VTSAX":
+            return s["guid"]
+    raise RuntimeError("VTSAX split not found")
+
+
+def _sell_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date) -> str:
+    """Create a sell transaction and return the VTSAX split GUID.
+
+    Accounting: cash increases (checking +proceeds), investment decreases (VTSAX -proceeds in USD, -shares in quantity).
+    """
+    proceeds = price * shares
+    guid = book.create_transaction(
+        description=f"Sell {shares} VTSAX @ {price}",
+        splits=[
+            {"account": "Assets:Investments:VTSAX", "amount": str(-proceeds), "quantity": str(-shares)},
+            {"account": "Assets:Checking", "amount": str(proceeds)},
+        ],
+        trans_date=txn_date,
+    )
+    txn = book.get_transaction(guid)
+    for s in txn["splits"]:
+        if s["account"] == "Assets:Investments:VTSAX":
+            return s["guid"]
+    raise RuntimeError("VTSAX split not found")
+
+
+# ── TestCreateLot ────────────────────────────────────────────
+
+
+class TestCreateLot:
+    def test_create_lot_success(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        result = book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="VTSAX 2026-01-15",
+        )
+        assert result["status"] == "created"
+        assert result["title"] == "VTSAX 2026-01-15"
+        assert result["account"] == "Assets:Investments:VTSAX"
+        assert len(result["guid"]) == 32
+
+    def test_create_lot_with_notes(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        result = book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="VTSAX Feb purchase",
+            notes="Bought at $125/share",
+        )
+        assert result["notes"] == "Bought at $125/share"
+
+    def test_create_lot_account_not_found(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        with pytest.raises(ValueError, match="Account not found"):
+            book.create_lot(account="Assets:Nope", title="Bad lot")
+
+
+# ── TestListLots ─────────────────────────────────────────────
+
+
+class TestListLots:
+    def test_list_lots_empty(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        result = book.list_lots(account="Assets:Investments:VTSAX")
+        assert result == []
+
+    def test_list_lots_with_lots(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        book.create_lot(account="Assets:Investments:VTSAX", title="Lot A")
+        book.create_lot(account="Assets:Investments:VTSAX", title="Lot B")
+        result = book.list_lots(account="Assets:Investments:VTSAX")
+        assert len(result) == 2
+        titles = {r["title"] for r in result}
+        assert titles == {"Lot A", "Lot B"}
+
+    def test_list_lots_exclude_closed(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot_a = book.create_lot(account="Assets:Investments:VTSAX", title="Open Lot")
+        lot_b = book.create_lot(account="Assets:Investments:VTSAX", title="Closed Lot")
+        book.close_lot(guid=lot_b["guid"])
+
+        # Default: exclude closed
+        result = book.list_lots(account="Assets:Investments:VTSAX")
+        assert len(result) == 1
+        assert result[0]["title"] == "Open Lot"
+
+        # Include closed
+        result = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True)
+        assert len(result) == 2
+
+
+# ── TestGetLot ───────────────────────────────────────────────
+
+
+class TestGetLot:
+    def test_get_lot_not_found(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        with pytest.raises(ValueError, match="Lot not found"):
+            book.get_lot(guid="00000000000000000000000000000000")
+
+    def test_get_lot_empty(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Empty Lot")
+        result = book.get_lot(guid=lot["guid"])
+        assert result["title"] == "Empty Lot"
+        assert result["splits"] == []
+        assert result["summary"]["quantity"] == "0"
+        assert result["summary"]["cost_basis"] == "0"
+
+    def test_get_lot_with_splits(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Test Lot")
+        split_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+
+        result = book.get_lot(guid=lot["guid"])
+        assert len(result["splits"]) == 1
+        assert Decimal(result["summary"]["quantity"]) == Decimal("10")
+        assert Decimal(result["summary"]["cost_basis"]) == Decimal("1250")
+        assert Decimal(result["summary"]["cost_per_share"]) == Decimal("125")
+
+
+# ── TestAssignSplitToLot ─────────────────────────────────────
+
+
+class TestAssignSplitToLot:
+    def test_assign_purchase_split(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Buy Lot")
+        split_guid = _buy_shares(book, 8, Decimal("125"), date(2026, 1, 15))
+
+        result = book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+        assert result["status"] == "assigned"
+        assert Decimal(result["quantity"]) == Decimal("8")
+        assert Decimal(result["cost_basis"]) == Decimal("1000")
+
+    def test_assign_sale_split(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Sell Lot")
+
+        # Buy 10 shares
+        buy_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=buy_guid, lot_guid=lot["guid"])
+
+        # Sell 3 shares
+        sell_guid = _sell_shares(book, 3, Decimal("130"), date(2026, 2, 1))
+        result = book.assign_split_to_lot(split_guid=sell_guid, lot_guid=lot["guid"])
+
+        assert result["status"] == "assigned"
+        assert Decimal(result["quantity"]) == Decimal("7")
+
+    def test_assign_split_not_found(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Test")
+        with pytest.raises(ValueError, match="Split not found"):
+            book.assign_split_to_lot(
+                split_guid="00000000000000000000000000000000",
+                lot_guid=lot["guid"],
+            )
+
+    def test_assign_lot_not_found(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        split_guid = _buy_shares(book, 5, Decimal("125"), date(2026, 1, 15))
+        with pytest.raises(ValueError, match="Lot not found"):
+            book.assign_split_to_lot(
+                split_guid=split_guid,
+                lot_guid="00000000000000000000000000000000",
+            )
+
+    def test_assign_wrong_account(self, investment_book: Path):
+        """Split from checking account can't be assigned to VTSAX lot."""
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Test")
+
+        # Get the checking split from a buy transaction
+        txn_guid = book.create_transaction(
+            description="Buy VTSAX",
+            splits=[
+                {"account": "Assets:Investments:VTSAX", "amount": "1250", "quantity": "10"},
+                {"account": "Assets:Checking", "amount": "-1250"},
+            ],
+            trans_date=date(2026, 1, 15),
+        )
+        txn = book.get_transaction(txn_guid)
+        checking_split_guid = None
+        for s in txn["splits"]:
+            if s["account"] == "Assets:Checking":
+                checking_split_guid = s["guid"]
+                break
+
+        with pytest.raises(ValueError, match="does not match"):
+            book.assign_split_to_lot(
+                split_guid=checking_split_guid,
+                lot_guid=lot["guid"],
+            )
+
+
+# ── TestCalculateLotGain ─────────────────────────────────────
+
+
+class TestCalculateLotGain:
+    def test_gain_with_explicit_price(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Gain Test")
+        split_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+
+        result = book.calculate_lot_gain(lot_guid=lot["guid"], sale_price="130")
+        assert Decimal(result["shares"]) == Decimal("10")
+        assert Decimal(result["cost_basis"]) == Decimal("1250")
+        assert Decimal(result["sale_proceeds"]) == Decimal("1300")
+        assert Decimal(result["capital_gain"]) == Decimal("50")
+
+    def test_gain_with_latest_price(self, investment_book: Path):
+        """Uses the $125 price from fixture when no explicit price given."""
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Price Test")
+        split_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+
+        result = book.calculate_lot_gain(lot_guid=lot["guid"])
+        # Price is $125, cost is $125 → zero gain
+        assert Decimal(result["capital_gain"]) == Decimal("0")
+        assert Decimal(result["sale_proceeds"]) == Decimal("1250")
+
+    def test_gain_partial_sale(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Partial")
+        split_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+
+        result = book.calculate_lot_gain(
+            lot_guid=lot["guid"], shares="4", sale_price="130",
+        )
+        assert Decimal(result["shares"]) == Decimal("4")
+        assert Decimal(result["cost_basis"]) == Decimal("500")
+        assert Decimal(result["sale_proceeds"]) == Decimal("520")
+        assert Decimal(result["capital_gain"]) == Decimal("20")
+
+    def test_gain_no_remaining_shares(self, investment_book: Path):
+        """Empty lot raises error."""
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Empty")
+        with pytest.raises(ValueError, match="no remaining shares"):
+            book.calculate_lot_gain(lot_guid=lot["guid"], sale_price="130")
+
+
+# ── TestCloseLot ─────────────────────────────────────────────
+
+
+class TestCloseLot:
+    def test_close_lot_success(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="To Close")
+        result = book.close_lot(guid=lot["guid"])
+        assert result["status"] == "closed"
+
+    def test_close_lot_already_closed(self, investment_book: Path):
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="Already")
+        book.close_lot(guid=lot["guid"])
+        with pytest.raises(ValueError, match="already closed"):
+            book.close_lot(guid=lot["guid"])
+
+
+# ── TestFullLotWorkflow ──────────────────────────────────────
+
+
+class TestFullLotWorkflow:
+    def test_buy_assign_sell_autoclose(self, investment_book: Path):
+        """Full lifecycle: buy → assign → sell → assign → auto-close."""
+        book = GnuCashBook(str(investment_book))
+
+        # Create lot
+        lot = book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="VTSAX 2026-01-15",
+            notes="Full lifecycle test",
+        )
+
+        # Buy 10 shares at $125
+        buy_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        result = book.assign_split_to_lot(split_guid=buy_guid, lot_guid=lot["guid"])
+        assert Decimal(result["quantity"]) == Decimal("10")
+        assert Decimal(result["cost_basis"]) == Decimal("1250")
+        assert result["is_closed"] is False
+
+        # Check gain at $130
+        gain = book.calculate_lot_gain(lot_guid=lot["guid"], sale_price="130")
+        assert Decimal(gain["capital_gain"]) == Decimal("50")
+
+        # Sell all 10 shares at $130
+        sell_guid = _sell_shares(book, 10, Decimal("130"), date(2026, 2, 1))
+        result = book.assign_split_to_lot(split_guid=sell_guid, lot_guid=lot["guid"])
+        assert Decimal(result["quantity"]) == Decimal("0")
+        assert result["is_closed"] is True
+
+        # Verify lot shows as closed in get_lot
+        lot_detail = book.get_lot(guid=lot["guid"])
+        assert lot_detail["is_closed"] is True
+        assert len(lot_detail["splits"]) == 2
+
+        # Verify excluded from default list
+        lots = book.list_lots(account="Assets:Investments:VTSAX")
+        assert len(lots) == 0
+
+        # Verify included when include_closed=True
+        lots = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True)
+        assert len(lots) == 1
+        assert lots[0]["is_closed"] is True
+
+
+class TestSplitToDictLotGuid:
+    """Verify that _split_to_dict includes lot_guid."""
+
+    def test_split_has_lot_guid_none(self, investment_book: Path):
+        """Splits without lots should have lot_guid=None."""
+        book = GnuCashBook(str(investment_book))
+        txn_guid = book.create_transaction(
+            description="No lot test",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-100"},
+                {"account": "Assets:Investments:VTSAX", "amount": "100", "quantity": "0.8000"},
+            ],
+            trans_date=date(2026, 1, 20),
+        )
+        txn = book.get_transaction(txn_guid)
+        for s in txn["splits"]:
+            assert "lot_guid" in s
+            assert s["lot_guid"] is None
+
+    def test_split_has_lot_guid_assigned(self, investment_book: Path):
+        """Splits assigned to lots should show the lot GUID."""
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(account="Assets:Investments:VTSAX", title="GUID test")
+        split_guid = _buy_shares(book, 5, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot["guid"])
+
+        # Re-read the transaction to check _split_to_dict output
+        txn_guid = None
+        # Get the transaction that contains this split
+        lot_detail = book.get_lot(guid=lot["guid"])
+        txn_date = lot_detail["splits"][0]["date"]
+        txn_desc = lot_detail["splits"][0]["description"]
+
+        # Search for the transaction
+        txns = book.search_transactions(query=txn_desc, field="description")
+        assert len(txns) > 0
+        txn = book.get_transaction(txns[0]["guid"])
+
+        for s in txn["splits"]:
+            if s["account"] == "Assets:Investments:VTSAX":
+                assert s["lot_guid"] == lot["guid"]


### PR DESCRIPTION
## Summary

- Add 6 lot tools: `create_lot`, `list_lots`, `get_lot`, `assign_split_to_lot`, `calculate_lot_gain`, `close_lot`
- Lots group investment splits for cost basis tracking and capital gain/loss calculation
- Auto-close lots when remaining share quantity reaches zero
- Add `lot_guid` field to split output for cross-referencing
- 23 new tests covering full lot lifecycle plus `investment_book` fixture

## Test plan

- [x] 290 automated tests pass (267 existing + 23 new)
- [x] Live test 12/12 passed: create, list, buy, assign, get, gain calc, partial sell, full sell, auto-close