### PR TITLE
Fix: Use local timezone for audit trail

### DIFF
--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -98,7 +98,9 @@ def setup_logging(
     log_dir = book_path_obj.parent / f"{book_path_obj.name}.mcp"
     _log_dir = log_dir
 
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    now_local = datetime.now().astimezone()
+    today = now_local.strftime("%Y-%m-%d")
+    tz_name = now_local.strftime("%Z") or now_local.strftime("%z")
 
     # Audit log - unless --noaudit
     audit_logger = logging.getLogger(AUDIT_LOGGER_NAME)
@@ -125,7 +127,7 @@ def setup_logging(
 
         # Write text header if needed
         if write_header:
-            header = _format_text_header(today, book_path)
+            header = _format_text_header(today, book_path, tz_name)
             audit_logger.info(header)
             _flush_logger(audit_logger)
     else:
@@ -257,12 +259,13 @@ def _get_split_states_batch(book, split_guids: list[str]) -> dict[str, dict | No
     return results
 
 
-def _format_text_header(date_str: str, book_path: str) -> str:
+def _format_text_header(date_str: str, book_path: str, tz_name: str = "") -> str:
     """Format the header for a text audit log file."""
     line = "═" * 64
+    tz_line = f"\nTimezone: {tz_name}" if tz_name else ""
     return f"""{line}
 GNUCASH MCP AUDIT LOG — {date_str}
-Book: {book_path}
+Book: {book_path}{tz_line}
 {line}"""
 
 
@@ -536,7 +539,7 @@ def audit_log(
         def wrapper(*args, **kwargs) -> str:
             logger = logging.getLogger(AUDIT_LOGGER_NAME)
             debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
-            timestamp = datetime.now(timezone.utc).isoformat()
+            timestamp = datetime.now().astimezone().isoformat()
 
             entry = {
                 "timestamp": timestamp,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -1275,7 +1275,7 @@ def get_audit_log(
         return json.dumps({"error": "Logging not initialized (no book path configured)"})
 
     audit_dir = log_dir / "audit"
-    target_date = log_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    target_date = log_date or datetime.now().astimezone().strftime("%Y-%m-%d")
 
     # Try the configured format first, then fall back to the other
     fmt = get_audit_format()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -90,7 +90,7 @@ class TestAuditLogDecorator:
         result = test_read_tool(account_name="Assets:Checking")
 
         # Read the log file
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         log_file = temp_log_dir / "audit" / f"{today}.jsonl"
         assert log_file.exists()
 
@@ -115,7 +115,7 @@ class TestAuditLogDecorator:
 
         result = test_create_tool(description="Test transaction")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         log_file = temp_log_dir / "audit" / f"{today}.jsonl"
         entries = [json.loads(line) for line in log_file.read_text().strip().split("\n")]
 
@@ -138,7 +138,7 @@ class TestAuditLogDecorator:
         with pytest.raises(ValueError):
             test_failing_tool(name="Nonexistent")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         log_file = temp_log_dir / "audit" / f"{today}.jsonl"
         entries = [json.loads(line) for line in log_file.read_text().strip().split("\n")]
 
@@ -157,7 +157,7 @@ class TestAuditLogDecorator:
 
         result = test_error_response(name="Bad")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         log_file = temp_log_dir / "audit" / f"{today}.jsonl"
         entries = [json.loads(line) for line in log_file.read_text().strip().split("\n")]
 
@@ -196,7 +196,7 @@ class TestDebugLogging:
 
         test_timed_tool()
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         debug_file = temp_log_dir / "debug" / f"{today}.log"
         assert debug_file.exists()
 
@@ -213,7 +213,7 @@ class TestTextFormat:
         """Verify text format creates .txt file, not .jsonl."""
         setup_logging(book_path=str(temp_book_path), debug=False, audit_format="text")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         txt_file = temp_log_dir / "audit" / f"{today}.txt"
         jsonl_file = temp_log_dir / "audit" / f"{today}.jsonl"
 
@@ -224,7 +224,7 @@ class TestTextFormat:
         """Verify text format file has proper header."""
         setup_logging(book_path=str(temp_book_path), debug=False, audit_format="text")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         txt_file = temp_log_dir / "audit" / f"{today}.txt"
         content = txt_file.read_text()
 
@@ -241,7 +241,7 @@ class TestTextFormat:
 
         test_create(description="Test Transaction")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         txt_file = temp_log_dir / "audit" / f"{today}.txt"
         content = txt_file.read_text()
 
@@ -258,7 +258,7 @@ class TestTextFormat:
 
         test_read(name="Test")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         txt_file = temp_log_dir / "audit" / f"{today}.txt"
         content = txt_file.read_text()
 
@@ -291,7 +291,7 @@ class TestAuditLogIntegration:
             ],
         )
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
         log_file = temp_log_dir / "audit" / f"{today}.jsonl"
         entries = [json.loads(line) for line in log_file.read_text().strip().split("\n")]
 


### PR DESCRIPTION
## Summary
- Switch audit log timestamps and file dates from UTC to local timezone so entries land on the correct local date (e.g., a 10 PM PST transaction no longer rolls into tomorrow's log)
- Add timezone name (e.g., PST) to the text format log file header for clarity
- Update test assertions to match local timezone behavior

## Test plan
- [x] Created a test transaction after 4 PM PST, verified it logged to today's (Feb 8) audit file instead of tomorrow's
- [x] Verified the log header displays `Timezone: PST`
- [x] Verified timestamps in log entries reflect local time
- [x] Deleted test transaction to clean up
- [x] All 290 tests pass