### PR TITLE
Fix: Apply memo updates in update_transaction

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -1469,6 +1469,10 @@ class GnuCashBook:
                                 f"transaction currency ({trans_currency.mnemonic})"
                             )
 
+                        # Update memo if provided
+                        if "memo" in update:
+                            split.memo = update["memo"]
+
                         del split_updates[account_name]
 
                 # Check if all provided accounts were found


### PR DESCRIPTION
## Summary
- Fix split memo field being silently ignored when passed in `update_transaction` split updates

## Test plan
- [x] Verified the memo field is now applied during split updates