### PR TITLE
Update uv.lock for version 0.9.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "gnucash-mcp"
-version = "0.1.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Sync uv.lock with the 0.9.0 version already in pyproject.toml

## Test plan
- [x] Lockfile only changes version string from 0.1.0 to 0.9.0