### PR TITLE
Add account slot tools for custom metadata

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -3388,3 +3388,112 @@ class GnuCashBook:
                 "title": lot.title,
                 "status": "closed",
             }
+
+    # ============== Account Slot Operations ==============
+
+    def get_account_slots(
+        self, account_name: str, key: str | None = None
+    ) -> dict:
+        """Read all slots (or a specific slot) from an account.
+
+        Args:
+            account_name: Full account path (e.g., "Liabilities:Credit Cards:Capital One").
+            key: Specific slot key to retrieve. If None, return all slots.
+
+        Returns:
+            Dict with account name and slots dict.
+
+        Raises:
+            ValueError: If account not found.
+        """
+        with self.open(readonly=True) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            if key is not None:
+                try:
+                    value = account[key]
+                    slots = {key: str(value.value) if hasattr(value, 'value') else str(value)}
+                except KeyError:
+                    slots = {}
+            else:
+                slots = {}
+                for k, v in account.iteritems():
+                    slots[k] = str(v.value)
+
+            return {
+                "account": account_name,
+                "slots": slots,
+            }
+
+    def set_account_slot(
+        self, account_name: str, key: str, value: str
+    ) -> dict:
+        """Set a single key-value pair on an account.
+
+        Args:
+            account_name: Full account path.
+            key: Slot key (e.g., "apr", "credit_limit").
+            value: Slot value. Stored as string.
+
+        Returns:
+            Dict with account, key, value, and status ("created" or "updated").
+
+        Raises:
+            ValueError: If account not found.
+        """
+        with self.open(readonly=False) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            # Check if key exists to determine created vs updated
+            existing = False
+            try:
+                account[key]
+                existing = True
+            except KeyError:
+                pass
+
+            account[key] = value
+            book.save()
+
+            return {
+                "account": account_name,
+                "key": key,
+                "value": value,
+                "status": "updated" if existing else "created",
+            }
+
+    def delete_account_slot(self, account_name: str, key: str) -> dict:
+        """Remove a slot from an account.
+
+        Args:
+            account_name: Full account path.
+            key: Slot key to remove.
+
+        Returns:
+            Dict with account, key, and status.
+
+        Raises:
+            ValueError: If account not found or key not found.
+        """
+        with self.open(readonly=False) as book:
+            account = self._find_account(book, account_name)
+            if not account:
+                raise ValueError(f"Account not found: {account_name}")
+
+            try:
+                account[key]
+            except KeyError:
+                raise ValueError(f"Slot key not found: {key}")
+
+            del account[key]
+            book.save()
+
+            return {
+                "account": account_name,
+                "key": key,
+                "status": "deleted",
+            }

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -474,6 +474,22 @@ def _format_audit_entry_text(entry: dict) -> str:
             old_state = before.get("reconcile_state", "n") if before else "n"
             lines.append(f"{indent}State: {old_state} → {state}")
 
+    elif entity_type == "account_slot":
+        account = params.get("account", "")
+        key = params.get("key", "")
+
+        if operation == "SET_SLOT":
+            value = params.get("value", "")
+            status = ""
+            if after:
+                status = after.get("status", "")
+            lines.append(f"{time_part}  SET ACCOUNT SLOT  account:{account}")
+            lines.append(f'{indent}key: "{key}"  value: "{value}"  ({status})')
+
+        elif operation == "DELETE_SLOT":
+            lines.append(f"{time_part}  DELETE ACCOUNT SLOT  account:{account}")
+            lines.append(f'{indent}key: "{key}"')
+
     # Handle move_account specially (it's logged as "update" but is conceptually a move)
     if entity_type == "account" and "new_parent" in params:
         # This is actually a MOVE operation

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -1237,6 +1237,71 @@ def close_lot(guid: str) -> str:
     return json.dumps(result, indent=2)
 
 
+# ============== Account Slot Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_account_slots(
+    account: str,
+    key: str | None = None,
+) -> str:
+    """Read slots (custom metadata) from an account.
+
+    Slots are key-value pairs stored on accounts for metadata like APR,
+    credit limit, reward rates, or any custom data.
+
+    Args:
+        account: Full account path (e.g., "Liabilities:Credit Cards:Capital One").
+        key: Specific slot key to retrieve. If omitted, returns all slots.
+    """
+    book = get_book()
+    result = book.get_account_slots(account_name=account, key=key)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="set_slot", entity_type="account_slot")
+def set_account_slot(
+    account: str,
+    key: str,
+    value: str,
+) -> str:
+    """Set a custom metadata slot on an account.
+
+    Stores a key-value pair on the account. Values are stored as strings.
+    Use for APR, credit limits, reward rates, or any per-account metadata.
+
+    Args:
+        account: Full account path (e.g., "Liabilities:Credit Cards:Capital One").
+        key: Slot key (e.g., "apr", "credit_limit").
+        value: Slot value (always stored as string).
+    """
+    book = get_book()
+    result = book.set_account_slot(account_name=account, key=key, value=value)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete_slot", entity_type="account_slot")
+def delete_account_slot(
+    account: str,
+    key: str,
+) -> str:
+    """Remove a custom metadata slot from an account.
+
+    Args:
+        account: Full account path (e.g., "Liabilities:Credit Cards:Capital One").
+        key: Slot key to remove.
+    """
+    book = get_book()
+    result = book.delete_account_slot(account_name=account, key=key)
+    return json.dumps(result, indent=2)
+
+
 # ============== Resources ==============
 
 

--- a/tests/test_account_slots.py
+++ b/tests/test_account_slots.py
@@ -1,0 +1,160 @@
+"""Tests for account slot (KVP metadata) operations."""
+
+from pathlib import Path
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+
+
+class TestGetAccountSlots:
+    """Tests for get_account_slots method."""
+
+    def test_get_all_slots_empty(self, test_book: Path):
+        """Should return empty slots for an account with no custom slots."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_account_slots("Assets:Checking")
+
+        assert result["account"] == "Assets:Checking"
+        assert result["slots"] == {}
+
+    def test_get_all_slots_after_setting(self, test_book: Path):
+        """Should return all slots after setting them."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        gc_book.set_account_slot("Assets:Checking", "credit_limit", "15000")
+
+        result = gc_book.get_account_slots("Assets:Checking")
+        assert result["account"] == "Assets:Checking"
+        assert result["slots"]["apr"] == "24.99"
+        assert result["slots"]["credit_limit"] == "15000"
+
+    def test_get_specific_slot(self, test_book: Path):
+        """Should return only the requested slot when key is specified."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        gc_book.set_account_slot("Assets:Checking", "credit_limit", "15000")
+
+        result = gc_book.get_account_slots("Assets:Checking", key="apr")
+        assert result["slots"] == {"apr": "24.99"}
+
+    def test_get_specific_slot_not_found(self, test_book: Path):
+        """Should return empty slots when requested key doesn't exist."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_account_slots("Assets:Checking", key="nonexistent")
+
+        assert result["account"] == "Assets:Checking"
+        assert result["slots"] == {}
+
+    def test_get_slots_account_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.get_account_slots("Nonexistent:Account")
+
+
+class TestSetAccountSlot:
+    """Tests for set_account_slot method."""
+
+    def test_set_new_slot(self, test_book: Path):
+        """Should create a new slot and return status 'created'."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+
+        assert result["account"] == "Assets:Checking"
+        assert result["key"] == "apr"
+        assert result["value"] == "24.99"
+        assert result["status"] == "created"
+
+    def test_set_existing_slot(self, test_book: Path):
+        """Should update an existing slot and return status 'updated'."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        result = gc_book.set_account_slot("Assets:Checking", "apr", "19.99")
+
+        assert result["status"] == "updated"
+        assert result["value"] == "19.99"
+
+    def test_set_slot_persists(self, test_book: Path):
+        """Should persist the slot value across separate reads."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "reward_rate", "1.5% cash back")
+
+        # Read back in a new session
+        result = gc_book.get_account_slots("Assets:Checking", key="reward_rate")
+        assert result["slots"]["reward_rate"] == "1.5% cash back"
+
+    def test_set_slot_account_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.set_account_slot("Nonexistent:Account", "key", "value")
+
+    def test_set_multiple_slots_different_accounts(self, test_book: Path):
+        """Should handle slots on different accounts independently."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "note", "primary account")
+        gc_book.set_account_slot("Expenses:Groceries", "budget", "500")
+
+        result1 = gc_book.get_account_slots("Assets:Checking")
+        result2 = gc_book.get_account_slots("Expenses:Groceries")
+
+        assert result1["slots"]["note"] == "primary account"
+        assert result2["slots"]["budget"] == "500"
+        assert "budget" not in result1["slots"]
+        assert "note" not in result2["slots"]
+
+
+class TestDeleteAccountSlot:
+    """Tests for delete_account_slot method."""
+
+    def test_delete_existing_slot(self, test_book: Path):
+        """Should delete a slot and return status 'deleted'."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        result = gc_book.delete_account_slot("Assets:Checking", "apr")
+
+        assert result["account"] == "Assets:Checking"
+        assert result["key"] == "apr"
+        assert result["status"] == "deleted"
+
+    def test_delete_slot_is_gone(self, test_book: Path):
+        """Should no longer return the slot after deletion."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        gc_book.delete_account_slot("Assets:Checking", "apr")
+
+        result = gc_book.get_account_slots("Assets:Checking", key="apr")
+        assert result["slots"] == {}
+
+    def test_delete_nonexistent_slot(self, test_book: Path):
+        """Should raise ValueError when key doesn't exist."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Slot key not found"):
+            gc_book.delete_account_slot("Assets:Checking", "nonexistent")
+
+    def test_delete_slot_account_not_found(self, test_book: Path):
+        """Should raise ValueError for non-existent account."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.delete_account_slot("Nonexistent:Account", "key")
+
+    def test_delete_one_slot_leaves_others(self, test_book: Path):
+        """Should only delete the specified slot, leaving others intact."""
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.set_account_slot("Assets:Checking", "apr", "24.99")
+        gc_book.set_account_slot("Assets:Checking", "credit_limit", "15000")
+
+        gc_book.delete_account_slot("Assets:Checking", "apr")
+
+        result = gc_book.get_account_slots("Assets:Checking")
+        assert "apr" not in result["slots"]
+        assert result["slots"]["credit_limit"] == "15000"


### PR DESCRIPTION
## Summary

- Adds `get_account_slots`, `set_account_slot`, and `delete_account_slot` MCP tools for reading/writing KVP metadata on accounts
- Supports use cases like APR tracking, credit limits, reward rates, and arbitrary per-account metadata
- Audit log text formatting for slot set/delete operations
- 15 new tests (305 total)

## Test plan

- [x] All 15 new tests pass (get, set, delete, persistence, error handling)
- [x] Full suite: 305 passed
- [x] Live tested against real GnuCash book