### PR TITLE
Transaction creation pipeline with validation, auto-fill, and warnings

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -930,7 +930,7 @@ class GnuCashBook:
         trans_date: date | None = None,
         currency: str | None = None,
         notes: str | None = None,
-    ) -> str:
+    ) -> dict:
         """Create a new transaction with splits.
 
         Args:
@@ -948,7 +948,7 @@ class GnuCashBook:
                    stored separately from the description.
 
         Returns:
-            GUID of the created transaction.
+            Dict with 'guid' and 'status' keys.
 
         Raises:
             ValueError: If splits don't balance, fewer than 2 splits,
@@ -1026,7 +1026,7 @@ class GnuCashBook:
             )
 
             book.save()
-            return transaction.guid
+            return {"guid": transaction.guid, "status": "created"}
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:
         """Search transactions by field.
@@ -2965,14 +2965,14 @@ class GnuCashBook:
             book.save()
 
         # Create the actual transaction (separate session)
-        txn_guid = self.create_transaction(
+        txn_result = self.create_transaction(
             description=sx_name,
             splits=splits,
             trans_date=txn_date,
         )
 
         return {
-            "transaction_guid": txn_guid,
+            "transaction_guid": txn_result["guid"],
             "scheduled_transaction": sx_name,
             "transaction_date": txn_date.isoformat(),
             "instance_count": instance_count,

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -923,6 +923,71 @@ class GnuCashBook:
                 return _transaction_to_dict(transaction)
             return None
 
+    _FUNDING_ACCOUNT_TYPES = {
+        "BANK", "CASH", "ASSET", "CREDIT", "LIABILITY", "EQUITY",
+    }
+
+    @staticmethod
+    def _extract_account_pattern(accounts) -> frozenset[str]:
+        """Extract categorization (non-funding) account names.
+
+        Filters out funding account types (BANK, CASH, ASSET, CREDIT,
+        LIABILITY, EQUITY) to isolate expense/income categorization.
+        Falls back to all accounts if filtering leaves nothing
+        (e.g., bank-to-bank transfers).
+
+        Args:
+            accounts: Iterable of piecash Account objects.
+
+        Returns:
+            frozenset of account fullnames representing the pattern.
+        """
+        all_names = frozenset(a.fullname for a in accounts)
+        categorization = frozenset(
+            a.fullname for a in accounts
+            if a.type not in GnuCashBook._FUNDING_ACCOUNT_TYPES
+        )
+        return categorization if categorization else all_names
+
+    def _find_recent_description_matches(
+        self,
+        book,
+        description: str,
+        limit: int = 5,
+        days: int = 90,
+    ) -> list:
+        """Find recent transactions with matching descriptions.
+
+        Uses bidirectional case-insensitive substring matching
+        (same logic as _auto_fill_splits and _find_duplicates).
+
+        Args:
+            book: Open piecash book (readonly).
+            description: Description to match.
+            limit: Maximum matches to return.
+            days: How far back to search.
+
+        Returns:
+            List of piecash Transaction objects, most recent first.
+        """
+        desc_lower = description.lower()
+        cutoff = date.today() - timedelta(days=days)
+        matches = []
+
+        sorted_txns = sorted(
+            book.transactions, key=lambda t: t.post_date, reverse=True
+        )
+        for txn in sorted_txns:
+            if txn.post_date < cutoff:
+                break
+            txn_desc_lower = txn.description.lower()
+            if desc_lower in txn_desc_lower or txn_desc_lower in desc_lower:
+                matches.append(txn)
+                if len(matches) >= limit:
+                    break
+
+        return matches
+
     @staticmethod
     def _generate_warnings(
         trans_date: date,
@@ -1027,6 +1092,108 @@ class GnuCashBook:
                     return filled_splits, source_info
 
         return None
+
+    def _check_split_consistency(
+        self,
+        description: str,
+        splits: list[dict],
+        resolved_accounts: list,
+        days: int = 30,
+    ) -> list[dict]:
+        """Check if proposed splits' account pattern matches recent history.
+
+        Compares categorization accounts in the proposed transaction
+        against recent transactions with the same description. Warns
+        if the account pattern differs.
+
+        Args:
+            description: Transaction description.
+            splits: Proposed split dicts with 'account' keys.
+            resolved_accounts: Resolved piecash Account objects,
+                same order as splits.
+            days: How far back to search for comparison.
+
+        Returns:
+            List of warning dicts (possibly empty).
+        """
+        proposed_pattern = self._extract_account_pattern(resolved_accounts)
+
+        with self.open(readonly=True) as book:
+            matches = self._find_recent_description_matches(
+                book, description, limit=5, days=days
+            )
+
+            if not matches:
+                return []
+
+            # Capture data inside session to avoid DetachedInstanceError
+            recent_accounts = [s.account for s in matches[0].splits]
+            recent_pattern = self._extract_account_pattern(recent_accounts)
+            recent_desc = matches[0].description
+
+        if proposed_pattern == recent_pattern:
+            return []
+
+        return [{
+            "type": "split_consistency",
+            "message": (
+                f"Recent '{recent_desc}' transactions used "
+                f"{', '.join(sorted(recent_pattern))}, but this transaction "
+                f"uses {', '.join(sorted(proposed_pattern))}."
+            ),
+        }]
+
+    def _check_auto_fill_stability(
+        self,
+        description: str,
+        limit: int = 5,
+        days: int = 90,
+    ) -> list[dict]:
+        """Check if recent matching transactions have consistent patterns.
+
+        Examines recent transactions with the same description and warns
+        if they use different categorization account patterns — meaning
+        auto-fill is drawing from an inconsistent history.
+
+        Args:
+            description: Transaction description to match.
+            limit: Number of recent matches to examine.
+            days: How far back to search.
+
+        Returns:
+            List of warning dicts (possibly empty).
+        """
+        with self.open(readonly=True) as book:
+            matches = self._find_recent_description_matches(
+                book, description, limit=limit, days=days
+            )
+
+            if len(matches) < 2:
+                return []
+
+            # Capture all data inside session to avoid DetachedInstanceError
+            patterns = []
+            for txn in matches:
+                accounts = [s.account for s in txn.splits]
+                patterns.append(self._extract_account_pattern(accounts))
+
+            most_recent_date = matches[0].post_date.isoformat()
+
+        first_pattern = patterns[0]
+        if all(p == first_pattern for p in patterns):
+            return []
+
+        different_count = sum(1 for p in patterns[1:] if p != first_pattern)
+
+        return [{
+            "type": "auto_fill_unstable",
+            "message": (
+                f"Recent '{description}' transactions use different account "
+                f"patterns. Auto-filled from most recent ({most_recent_date}), "
+                f"but {different_count} of {len(matches)} recent matches used "
+                f"different categorization."
+            ),
+        }]
 
     def _find_duplicates(
         self,
@@ -1163,6 +1330,11 @@ class GnuCashBook:
                 )
             splits, auto_filled_from = auto_result
 
+        # Stage 0b: Auto-fill stability check
+        auto_fill_warnings = []
+        if auto_filled_from:
+            auto_fill_warnings = self._check_auto_fill_stability(description)
+
         if len(splits) < 2:
             raise ValueError("Transaction must have at least 2 splits")
 
@@ -1194,7 +1366,7 @@ class GnuCashBook:
         if dry_run:
             return self._dry_run_transaction(
                 description, splits, trans_date, currency, notes,
-                duplicates, auto_filled_from,
+                duplicates, auto_filled_from, auto_fill_warnings,
             )
 
         # Stage 4: Write
@@ -1273,6 +1445,31 @@ class GnuCashBook:
             warnings = self._generate_warnings(
                 trans_date, splits, resolved_accounts
             )
+
+            # Split consistency check (uses already-open book)
+            proposed_pattern = self._extract_account_pattern(
+                resolved_accounts
+            )
+            recent = self._find_recent_description_matches(
+                book, description, limit=5, days=30
+            )
+            # Exclude the transaction we just created
+            recent = [t for t in recent if t.guid != transaction.guid]
+            if recent:
+                recent_accts = [s.account for s in recent[0].splits]
+                recent_pattern = self._extract_account_pattern(recent_accts)
+                if proposed_pattern != recent_pattern:
+                    warnings.append({
+                        "type": "split_consistency",
+                        "message": (
+                            f"Recent '{recent[0].description}' transactions "
+                            f"used {', '.join(sorted(recent_pattern))}, but "
+                            f"this transaction uses "
+                            f"{', '.join(sorted(proposed_pattern))}."
+                        ),
+                    })
+
+            warnings.extend(auto_fill_warnings)
             if warnings:
                 result["warnings"] = warnings
             if duplicates:
@@ -1290,6 +1487,7 @@ class GnuCashBook:
         notes: str | None,
         duplicates: list[dict],
         auto_filled_from: dict | None = None,
+        auto_fill_warnings: list[dict] | None = None,
     ) -> dict:
         """Validate a proposed transaction without writing.
 
@@ -1354,6 +1552,30 @@ class GnuCashBook:
             warnings = self._generate_warnings(
                 trans_date, splits, resolved_accounts
             )
+
+            # Split consistency check (uses already-open book)
+            proposed_pattern = self._extract_account_pattern(
+                resolved_accounts
+            )
+            recent = self._find_recent_description_matches(
+                book, description, limit=5, days=30
+            )
+            if recent:
+                recent_accts = [s.account for s in recent[0].splits]
+                recent_pattern = self._extract_account_pattern(recent_accts)
+                if proposed_pattern != recent_pattern:
+                    warnings.append({
+                        "type": "split_consistency",
+                        "message": (
+                            f"Recent '{recent[0].description}' transactions "
+                            f"used {', '.join(sorted(recent_pattern))}, but "
+                            f"this transaction uses "
+                            f"{', '.join(sorted(proposed_pattern))}."
+                        ),
+                    })
+
+            if auto_fill_warnings:
+                warnings.extend(auto_fill_warnings)
 
         result = {
             "dry_run": True,

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -979,6 +979,55 @@ class GnuCashBook:
 
         return warnings
 
+    def _auto_fill_splits(
+        self, description: str
+    ) -> tuple[list[dict], dict] | None:
+        """Find the most recent matching transaction and extract its splits.
+
+        Uses bidirectional case-insensitive substring matching on
+        description (same logic as _find_duplicates).
+
+        Args:
+            description: Transaction description to match against.
+
+        Returns:
+            Tuple of (splits_list, source_info) if match found, None otherwise.
+            splits_list is in create_transaction input format.
+            source_info has guid, description, and date of the source.
+        """
+        desc_lower = description.lower()
+
+        with self.open(readonly=True) as book:
+            # Sort by date descending to find most recent match
+            sorted_txns = sorted(
+                book.transactions, key=lambda t: t.post_date, reverse=True
+            )
+
+            for txn in sorted_txns:
+                txn_desc_lower = txn.description.lower()
+                if desc_lower in txn_desc_lower or txn_desc_lower in desc_lower:
+                    # Extract splits into input format
+                    filled_splits = []
+                    for s in txn.splits:
+                        split_dict = {
+                            "account": s.account.fullname,
+                            "amount": str(s.value),
+                        }
+                        if s.quantity != s.value:
+                            split_dict["quantity"] = str(s.quantity)
+                        if s.memo:
+                            split_dict["memo"] = s.memo
+                        filled_splits.append(split_dict)
+
+                    source_info = {
+                        "guid": txn.guid,
+                        "description": txn.description,
+                        "date": txn.post_date.isoformat(),
+                    }
+                    return filled_splits, source_info
+
+        return None
+
     def _find_duplicates(
         self,
         description: str,
@@ -1062,7 +1111,7 @@ class GnuCashBook:
     def create_transaction(
         self,
         description: str,
-        splits: list[dict],
+        splits: list[dict] | None = None,
         trans_date: date | None = None,
         currency: str | None = None,
         notes: str | None = None,
@@ -1080,6 +1129,8 @@ class GnuCashBook:
                 - 'quantity' (optional): Amount in account's commodity.
                   Required if account commodity differs from transaction currency.
                 - 'memo' (optional): Split memo.
+                If omitted or empty, auto-fills from the most recent
+                transaction with a matching description.
             trans_date: Transaction date. Defaults to today.
             currency: ISO currency code for the transaction (e.g., "USD", "EUR").
                       Defaults to book's default currency.
@@ -1090,16 +1141,28 @@ class GnuCashBook:
             dry_run: Validate and return proposal without writing.
 
         Returns:
-            Dict with 'guid' and 'status' keys. May include 'warnings'
-            and 'duplicates'. If a HIGH duplicate is found and force_create
-            is False, returns 'status': 'rejected' instead. In dry_run
-            mode, returns 'dry_run': True with proposed transaction.
+            Dict with 'guid' and 'status' keys. May include 'warnings',
+            'duplicates', and 'auto_filled_from'. If a HIGH duplicate is
+            found and force_create is False, returns 'status': 'rejected'
+            instead. In dry_run mode, returns 'dry_run': True with
+            proposed transaction.
 
         Raises:
             ValueError: If splits don't balance, fewer than 2 splits,
-                       accounts don't exist, or cross-currency splits
-                       are missing quantity.
+                       accounts don't exist, cross-currency splits
+                       missing quantity, or no match found for auto-fill.
         """
+        # Stage 0: Auto-fill splits from previous matching transaction
+        auto_filled_from = None
+        if not splits:
+            auto_result = self._auto_fill_splits(description)
+            if auto_result is None:
+                raise ValueError(
+                    "No matching transaction found for auto-fill. "
+                    "Provide explicit splits."
+                )
+            splits, auto_filled_from = auto_result
+
         if len(splits) < 2:
             raise ValueError("Transaction must have at least 2 splits")
 
@@ -1131,7 +1194,7 @@ class GnuCashBook:
         if dry_run:
             return self._dry_run_transaction(
                 description, splits, trans_date, currency, notes,
-                duplicates,
+                duplicates, auto_filled_from,
             )
 
         # Stage 4: Write
@@ -1214,6 +1277,8 @@ class GnuCashBook:
                 result["warnings"] = warnings
             if duplicates:
                 result["duplicates"] = duplicates
+            if auto_filled_from:
+                result["auto_filled_from"] = auto_filled_from
             return result
 
     def _dry_run_transaction(
@@ -1224,6 +1289,7 @@ class GnuCashBook:
         currency: str | None,
         notes: str | None,
         duplicates: list[dict],
+        auto_filled_from: dict | None = None,
     ) -> dict:
         """Validate a proposed transaction without writing.
 
@@ -1302,6 +1368,8 @@ class GnuCashBook:
         }
         if notes:
             result["proposed_transaction"]["notes"] = notes
+        if auto_filled_from:
+            result["auto_filled_from"] = auto_filled_from
         return result
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -1350,22 +1350,35 @@ class GnuCashBook:
 
             return result
 
-    def delete_transaction(self, guid: str) -> dict:
+    def delete_transaction(self, guid: str, force: bool = False) -> dict:
         """Delete a transaction by GUID.
 
         Args:
             guid: Transaction GUID (32-character hex string).
+            force: If True, allow deleting transactions with reconciled splits.
 
         Returns:
             Dict with guid, description, and status.
 
         Raises:
-            ValueError: If transaction not found.
+            ValueError: If transaction not found, or has reconciled splits
+                       and force is False.
         """
         with self.open(readonly=False) as book:
             transaction = self._find_transaction(book, guid)
             if not transaction:
                 raise ValueError(f"Transaction not found: {guid}")
+
+            # Check for reconciled splits
+            reconciled = [
+                s for s in transaction.splits if s.reconcile_state == "y"
+            ]
+            if reconciled and not force:
+                acct_names = ", ".join(s.account.fullname for s in reconciled)
+                raise ValueError(
+                    f"Transaction has reconciled splits in: {acct_names}. "
+                    f"Deleting will break reconciliation. Use force=true to override."
+                )
 
             # Capture info before deletion
             result = {
@@ -1373,6 +1386,8 @@ class GnuCashBook:
                 "description": transaction.description,
                 "status": "deleted",
             }
+            if reconciled:
+                result["reconciled_splits_affected"] = len(reconciled)
 
             # Delete the transaction
             book.session.delete(transaction)
@@ -1387,6 +1402,7 @@ class GnuCashBook:
         trans_date: date | None = None,
         splits: list[dict] | None = None,
         notes: str | None = None,
+        force: bool = False,
     ) -> dict:
         """Update an existing transaction.
 
@@ -1401,19 +1417,37 @@ class GnuCashBook:
                     from the transaction currency.
             notes: New transaction notes (optional). Pass empty string
                    to clear existing notes.
+            force: If True, allow modifying transactions with reconciled
+                   splits. Only checked when splits are being updated.
 
         Returns:
             Dict with updated transaction details.
 
         Raises:
             ValueError: If transaction not found, splits don't balance,
-                       account not found in splits, or cross-currency split
-                       missing quantity.
+                       account not found in splits, cross-currency split
+                       missing quantity, or has reconciled splits and
+                       force is False.
         """
         with self.open(readonly=False) as book:
             transaction = self._find_transaction(book, guid)
             if not transaction:
                 raise ValueError(f"Transaction not found: {guid}")
+
+            # Check for reconciled splits when modifying splits
+            if splits is not None:
+                reconciled = [
+                    s for s in transaction.splits if s.reconcile_state == "y"
+                ]
+                if reconciled and not force:
+                    acct_names = ", ".join(
+                        s.account.fullname for s in reconciled
+                    )
+                    raise ValueError(
+                        f"Transaction has reconciled splits in: {acct_names}. "
+                        f"Modifying will break reconciliation. "
+                        f"Use force=true to override."
+                    )
 
             # Update description if provided
             if description is not None:

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -923,6 +923,62 @@ class GnuCashBook:
                 return _transaction_to_dict(transaction)
             return None
 
+    @staticmethod
+    def _generate_warnings(
+        trans_date: date,
+        splits: list[dict],
+        accounts: list,
+    ) -> list[dict]:
+        """Generate warnings for unusual but valid transaction attributes.
+
+        Args:
+            trans_date: Transaction date.
+            splits: Original split dicts with 'amount' keys.
+            accounts: Resolved piecash account objects, same order as splits.
+
+        Returns:
+            List of warning dicts with 'type' and 'message' keys.
+        """
+        warnings = []
+        today = date.today()
+
+        if trans_date > today:
+            warnings.append({
+                "type": "future_date",
+                "message": f"Transaction date {trans_date.isoformat()} is in the future",
+            })
+
+        days_old = (today - trans_date).days
+        if days_old > 365:
+            warnings.append({
+                "type": "old_date",
+                "message": (
+                    f"Transaction date {trans_date.isoformat()} "
+                    f"is {days_old} days in the past"
+                ),
+            })
+
+        for split_data, account in zip(splits, accounts):
+            amount = Decimal(split_data["amount"])
+            if account.type == "EXPENSE" and amount < 0:
+                warnings.append({
+                    "type": "negative_expense",
+                    "message": (
+                        f"Negative amount ({amount}) to expense account "
+                        f"'{account.fullname}'"
+                    ),
+                })
+            elif account.type == "INCOME" and amount > 0:
+                warnings.append({
+                    "type": "positive_income",
+                    "message": (
+                        f"Positive amount ({amount}) to income account "
+                        f"'{account.fullname}'"
+                    ),
+                })
+
+        return warnings
+
     def create_transaction(
         self,
         description: str,
@@ -977,6 +1033,7 @@ class GnuCashBook:
 
             # Validate all accounts exist and build split list
             piecash_splits = []
+            resolved_accounts = []
             for split in splits:
                 account = self._find_account(book, split["account"])
                 if not account:
@@ -992,6 +1049,7 @@ class GnuCashBook:
                         f"Use one of: {children_hint}"
                     )
 
+                resolved_accounts.append(account)
                 value = Decimal(split["amount"])
 
                 # Determine quantity
@@ -1036,7 +1094,14 @@ class GnuCashBook:
             )
 
             book.save()
-            return {"guid": transaction.guid, "status": "created"}
+
+            result = {"guid": transaction.guid, "status": "created"}
+            warnings = self._generate_warnings(
+                trans_date, splits, resolved_accounts
+            )
+            if warnings:
+                result["warnings"] = warnings
+            return result
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:
         """Search transactions by field.

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -1068,6 +1068,7 @@ class GnuCashBook:
         notes: str | None = None,
         check_duplicates: bool = True,
         force_create: bool = False,
+        dry_run: bool = False,
     ) -> dict:
         """Create a new transaction with splits.
 
@@ -1086,11 +1087,13 @@ class GnuCashBook:
                    stored separately from the description.
             check_duplicates: Run duplicate detection. Default True.
             force_create: Create even if HIGH confidence duplicates found.
+            dry_run: Validate and return proposal without writing.
 
         Returns:
             Dict with 'guid' and 'status' keys. May include 'warnings'
             and 'duplicates'. If a HIGH duplicate is found and force_create
-            is False, returns 'status': 'rejected' instead.
+            is False, returns 'status': 'rejected' instead. In dry_run
+            mode, returns 'dry_run': True with proposed transaction.
 
         Raises:
             ValueError: If splits don't balance, fewer than 2 splits,
@@ -1117,13 +1120,21 @@ class GnuCashBook:
                 description, splits, trans_date
             )
             has_high = any(d["confidence"] == "HIGH" for d in duplicates)
-            if has_high and not force_create:
+            if has_high and not force_create and not dry_run:
                 return {
                     "status": "rejected",
                     "reason": "duplicate_detected",
                     "duplicates": duplicates,
                 }
 
+        # Stage 3: Dry run — validate readonly, return proposal
+        if dry_run:
+            return self._dry_run_transaction(
+                description, splits, trans_date, currency, notes,
+                duplicates,
+            )
+
+        # Stage 4: Write
         with self.open(readonly=False) as book:
             # Determine transaction currency
             if currency is None:
@@ -1204,6 +1215,94 @@ class GnuCashBook:
             if duplicates:
                 result["duplicates"] = duplicates
             return result
+
+    def _dry_run_transaction(
+        self,
+        description: str,
+        splits: list[dict],
+        trans_date: date,
+        currency: str | None,
+        notes: str | None,
+        duplicates: list[dict],
+    ) -> dict:
+        """Validate a proposed transaction without writing.
+
+        Opens the book readonly to validate accounts, placeholders,
+        and cross-currency requirements.
+
+        Returns:
+            Dict with dry_run=True, proposed_transaction, warnings,
+            and duplicates.
+        """
+        with self.open(readonly=True) as book:
+            # Determine transaction currency (readonly — no creation)
+            if currency is None:
+                trans_currency = book.default_currency
+                currency_mnemonic = trans_currency.mnemonic
+            else:
+                trans_currency = self._find_commodity(book, currency)
+                if not trans_currency:
+                    raise ValueError(
+                        f"Currency '{currency}' not found in book. "
+                        f"Dry run cannot create new currencies."
+                    )
+                currency_mnemonic = trans_currency.mnemonic
+
+            # Validate all accounts
+            resolved_accounts = []
+            for split in splits:
+                account = self._find_account(book, split["account"])
+                if not account:
+                    raise ValueError(f"Account not found: {split['account']}")
+
+                if account.placeholder:
+                    children_hint = ", ".join(
+                        c.fullname for c in account.children
+                    )
+                    raise ValueError(
+                        f"Account '{account.fullname}' is a placeholder and "
+                        f"cannot receive transactions. "
+                        f"Use one of: {children_hint}"
+                    )
+
+                resolved_accounts.append(account)
+
+                # Cross-currency validation
+                if account.commodity != trans_currency:
+                    if "quantity" not in split:
+                        raise ValueError(
+                            f"Split for '{split['account']}' requires "
+                            f"'quantity' because account commodity "
+                            f"({account.commodity.mnemonic}) differs from "
+                            f"transaction currency ({currency_mnemonic})"
+                        )
+                    value = Decimal(split["amount"])
+                    quantity = Decimal(split["quantity"])
+                    if quantity * value < 0:
+                        raise ValueError(
+                            f"Split for '{split['account']}': quantity and "
+                            f"value must have same sign "
+                            f"(got value={value}, quantity={quantity})"
+                        )
+
+            warnings = self._generate_warnings(
+                trans_date, splits, resolved_accounts
+            )
+
+        result = {
+            "dry_run": True,
+            "proposed_transaction": {
+                "description": description,
+                "date": trans_date.isoformat(),
+                "currency": currency_mnemonic,
+                "splits": splits,
+            },
+            "warnings": warnings,
+            "duplicates": duplicates,
+        }
+        if notes:
+            result["proposed_transaction"]["notes"] = notes
+        return result
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:
         """Search transactions by field.

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -979,6 +979,86 @@ class GnuCashBook:
 
         return warnings
 
+    def _find_duplicates(
+        self,
+        description: str,
+        splits: list[dict],
+        trans_date: date,
+        window_days: int = 30,
+    ) -> list[dict]:
+        """Find potential duplicate transactions.
+
+        Uses three signals: description match (case-insensitive substring),
+        amount match (any split ±$1.00), and date match (±2 days).
+
+        Args:
+            description: Proposed transaction description.
+            splits: Proposed split dicts with 'amount' keys.
+            trans_date: Proposed transaction date.
+            window_days: Days before/after trans_date to search.
+
+        Returns:
+            List of duplicate candidates sorted by confidence (HIGH first).
+        """
+        proposed_amounts = [abs(Decimal(s["amount"])) for s in splits]
+        date_start = trans_date - timedelta(days=window_days)
+        date_end = trans_date + timedelta(days=window_days)
+        desc_lower = description.lower()
+
+        candidates = []
+
+        with self.open(readonly=True) as book:
+            for txn in book.transactions:
+                if txn.post_date < date_start or txn.post_date > date_end:
+                    continue
+
+                # Signal 1: Description match (substring both directions)
+                txn_desc_lower = txn.description.lower()
+                desc_match = (
+                    desc_lower in txn_desc_lower
+                    or txn_desc_lower in desc_lower
+                )
+
+                # Signal 2: Amount match (any split ±$1.00)
+                amount_match = False
+                txn_amounts = [abs(s.value) for s in txn.splits]
+                for proposed_amt in proposed_amounts:
+                    for txn_amt in txn_amounts:
+                        if abs(proposed_amt - txn_amt) <= Decimal("1.00"):
+                            amount_match = True
+                            break
+                    if amount_match:
+                        break
+
+                # Signal 3: Date match (±2 days)
+                date_match = abs((txn.post_date - trans_date).days) <= 2
+
+                signals = sum([desc_match, amount_match, date_match])
+                if signals == 0:
+                    continue
+
+                if signals == 3:
+                    confidence = "HIGH"
+                elif signals == 2:
+                    confidence = "MEDIUM"
+                else:
+                    confidence = "LOW"
+
+                candidates.append({
+                    "confidence": confidence,
+                    "existing_transaction": _transaction_to_dict(txn),
+                    "match_signals": {
+                        "description": desc_match,
+                        "amount": amount_match,
+                        "date": date_match,
+                    },
+                })
+
+        # Sort: HIGH first, then MEDIUM, then LOW
+        order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+        candidates.sort(key=lambda c: order[c["confidence"]])
+        return candidates
+
     def create_transaction(
         self,
         description: str,
@@ -986,6 +1066,8 @@ class GnuCashBook:
         trans_date: date | None = None,
         currency: str | None = None,
         notes: str | None = None,
+        check_duplicates: bool = True,
+        force_create: bool = False,
     ) -> dict:
         """Create a new transaction with splits.
 
@@ -1002,9 +1084,13 @@ class GnuCashBook:
                       Defaults to book's default currency.
             notes: Transaction notes (optional). Free-text annotation
                    stored separately from the description.
+            check_duplicates: Run duplicate detection. Default True.
+            force_create: Create even if HIGH confidence duplicates found.
 
         Returns:
-            Dict with 'guid' and 'status' keys.
+            Dict with 'guid' and 'status' keys. May include 'warnings'
+            and 'duplicates'. If a HIGH duplicate is found and force_create
+            is False, returns 'status': 'rejected' instead.
 
         Raises:
             ValueError: If splits don't balance, fewer than 2 splits,
@@ -1023,6 +1109,20 @@ class GnuCashBook:
 
         if trans_date is None:
             trans_date = date.today()
+
+        # Stage 2: Duplicate check (readonly scan)
+        duplicates = []
+        if check_duplicates:
+            duplicates = self._find_duplicates(
+                description, splits, trans_date
+            )
+            has_high = any(d["confidence"] == "HIGH" for d in duplicates)
+            if has_high and not force_create:
+                return {
+                    "status": "rejected",
+                    "reason": "duplicate_detected",
+                    "duplicates": duplicates,
+                }
 
         with self.open(readonly=False) as book:
             # Determine transaction currency
@@ -1101,6 +1201,8 @@ class GnuCashBook:
             )
             if warnings:
                 result["warnings"] = warnings
+            if duplicates:
+                result["duplicates"] = duplicates
             return result
 
     def search_transactions(self, query: str, field: str = "description") -> list[dict]:

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -982,6 +982,16 @@ class GnuCashBook:
                 if not account:
                     raise ValueError(f"Account not found: {split['account']}")
 
+                if account.placeholder:
+                    children_hint = ", ".join(
+                        c.fullname for c in account.children
+                    )
+                    raise ValueError(
+                        f"Account '{account.fullname}' is a placeholder and "
+                        f"cannot receive transactions. "
+                        f"Use one of: {children_hint}"
+                    )
+
                 value = Decimal(split["amount"])
 
                 # Determine quantity

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -369,6 +369,8 @@ def create_transaction(
     transaction_date: str | None = None,
     currency: str | None = None,
     notes: str | None = None,
+    check_duplicates: bool = True,
+    force_create: bool = False,
 ) -> str:
     """Create a new transaction with splits. Splits must balance to zero.
 
@@ -385,6 +387,8 @@ def create_transaction(
                   Defaults to book's default currency.
         notes: Transaction notes (optional). Free-text annotation stored
                separately from description.
+        check_duplicates: Run duplicate detection against existing transactions.
+        force_create: Create even if HIGH confidence duplicates are found.
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
@@ -394,6 +398,8 @@ def create_transaction(
         trans_date=trans_date,
         currency=currency,
         notes=notes,
+        check_duplicates=check_duplicates,
+        force_create=force_create,
     )
     return json.dumps(result, indent=2)
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -365,7 +365,7 @@ def get_transaction(guid: str) -> str:
 @audit_log(classification="write", operation="create", entity_type="transaction")
 def create_transaction(
     description: str,
-    splits: list[dict],
+    splits: list[dict] | None = None,
     transaction_date: str | None = None,
     currency: str | None = None,
     notes: str | None = None,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -388,14 +388,14 @@ def create_transaction(
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
-    guid = book.create_transaction(
+    result = book.create_transaction(
         description=description,
         splits=splits,
         trans_date=trans_date,
         currency=currency,
         notes=notes,
     )
-    return json.dumps({"guid": guid, "status": "created"}, indent=2)
+    return json.dumps(result, indent=2)
 
 
 @mcp.tool()

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -517,14 +517,18 @@ def delete_account(name: str) -> str:
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="delete", entity_type="transaction")
-def delete_transaction(guid: str) -> str:
+def delete_transaction(guid: str, force: bool = False) -> str:
     """Delete a transaction by GUID.
+
+    Safeguards prevent deletion if the transaction has reconciled splits.
+    Use force=true to override.
 
     Args:
         guid: Transaction GUID (32-character hex string)
+        force: Allow deleting transactions with reconciled splits
     """
     book = get_book()
-    result = book.delete_transaction(guid)
+    result = book.delete_transaction(guid, force=force)
     return json.dumps(result, indent=2)
 
 
@@ -537,6 +541,7 @@ def update_transaction(
     transaction_date: str | None = None,
     splits: list[dict] | None = None,
     notes: str | None = None,
+    force: bool = False,
 ) -> str:
     """Update an existing transaction.
 
@@ -548,6 +553,7 @@ def update_transaction(
                 Must match existing splits by account name and balance to zero.
                 For cross-currency splits, include 'quantity' (amount in account's commodity).
         notes: New transaction notes (optional). Pass empty string to clear.
+        force: Allow modifying transactions with reconciled splits
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
@@ -557,6 +563,7 @@ def update_transaction(
         trans_date=trans_date,
         splits=splits,
         notes=notes,
+        force=force,
     )
     return json.dumps(result, indent=2)
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -371,6 +371,7 @@ def create_transaction(
     notes: str | None = None,
     check_duplicates: bool = True,
     force_create: bool = False,
+    dry_run: bool = False,
 ) -> str:
     """Create a new transaction with splits. Splits must balance to zero.
 
@@ -389,6 +390,7 @@ def create_transaction(
                separately from description.
         check_duplicates: Run duplicate detection against existing transactions.
         force_create: Create even if HIGH confidence duplicates are found.
+        dry_run: Run validation and dupe check, return proposal without writing.
     """
     book = get_book()
     trans_date = date.fromisoformat(transaction_date) if transaction_date else None
@@ -400,6 +402,7 @@ def create_transaction(
         notes=notes,
         check_duplicates=check_duplicates,
         force_create=force_create,
+        dry_run=dry_run,
     )
     return json.dumps(result, indent=2)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -753,6 +753,33 @@ class TestDeleteTransaction:
         with pytest.raises(ValueError, match="Transaction not found"):
             gc_book.delete_transaction("nonexistent_guid_12345")
 
+    def test_delete_reconciled_transaction_rejected(self, test_book: Path):
+        """Should reject deletion of transaction with reconciled splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        guid = transactions[0]["guid"]
+        with pytest.raises(ValueError, match="reconciled splits"):
+            gc_book.delete_transaction(guid)
+
+    def test_delete_reconciled_transaction_force(self, test_book: Path):
+        """Should allow deletion with force=True despite reconciled splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions()
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        guid = transactions[0]["guid"]
+        result = gc_book.delete_transaction(guid, force=True)
+
+        assert result["status"] == "deleted"
+        assert result["reconciled_splits_affected"] == 1
+        assert gc_book.get_transaction(guid) is None
+
 
 class TestUpdateTransaction:
     """Tests for update_transaction method."""
@@ -913,6 +940,60 @@ class TestUpdateTransaction:
         # Verify persistence
         updated = gc_book.get_transaction(guid)
         assert "notes" not in updated
+
+    def test_update_reconciled_splits_rejected(self, test_book: Path):
+        """Should reject split updates on transactions with reconciled splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get the groceries transaction and reconcile a split
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        with pytest.raises(ValueError, match="reconciled splits"):
+            gc_book.update_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "175.00"},
+                    {"account": "Assets:Checking", "amount": "-175.00"},
+                ],
+            )
+
+    def test_update_reconciled_splits_force(self, test_book: Path):
+        """Should allow split updates with force=True despite reconciled splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "175.00"},
+                {"account": "Assets:Checking", "amount": "-175.00"},
+            ],
+            force=True,
+        )
+        assert result["status"] == "updated"
+
+    def test_update_description_on_reconciled_ok(self, test_book: Path):
+        """Should allow description/date/notes changes without force on reconciled."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        # Description change should work without force
+        result = gc_book.update_transaction(
+            guid=guid, description="Updated Groceries"
+        )
+        assert result["status"] == "updated"
+        assert result["description"] == "Updated Groceries"
 
 
 class TestSetReconcileState:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1,6 +1,6 @@
 """Tests for GnuCashBook wrapper."""
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 
@@ -358,6 +358,99 @@ class TestCreateTransaction:
 
         transaction = gc_book.get_transaction(result["guid"])
         assert "notes" not in transaction
+
+
+class TestCreateTransactionWarnings:
+    """Tests for transaction creation warnings."""
+
+    def test_future_date_warning(self, test_book: Path):
+        """Should warn about future-dated transactions but still create them."""
+        gc_book = GnuCashBook(str(test_book))
+        future = date.today() + timedelta(days=30)
+        result = gc_book.create_transaction(
+            description="Future Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=future,
+        )
+        assert result["status"] == "created"
+        assert any(w["type"] == "future_date" for w in result["warnings"])
+
+    def test_old_date_warning(self, test_book: Path):
+        """Should warn about dates more than 365 days in the past."""
+        gc_book = GnuCashBook(str(test_book))
+        old = date.today() - timedelta(days=400)
+        result = gc_book.create_transaction(
+            description="Old Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=old,
+        )
+        assert result["status"] == "created"
+        assert any(w["type"] == "old_date" for w in result["warnings"])
+
+    def test_normal_date_no_warning(self, test_book: Path):
+        """Should not warn about normal dates."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Normal Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=date.today(),
+        )
+        assert result["status"] == "created"
+        assert "warnings" not in result
+
+    def test_negative_expense_warning(self, test_book: Path):
+        """Should warn about negative amounts to expense accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Expense Reversal",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "-25.00"},
+                {"account": "Assets:Checking", "amount": "25.00"},
+            ],
+        )
+        assert result["status"] == "created"
+        assert any(w["type"] == "negative_expense" for w in result["warnings"])
+
+    def test_positive_income_warning(self, test_book: Path):
+        """Should warn about positive amounts to income accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Income Reversal",
+            splits=[
+                {"account": "Income:Salary", "amount": "100.00"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+        )
+        assert result["status"] == "created"
+        assert any(w["type"] == "positive_income" for w in result["warnings"])
+
+    def test_warnings_dont_block_creation(self, test_book: Path):
+        """Warnings should not prevent transaction creation."""
+        gc_book = GnuCashBook(str(test_book))
+        future = date.today() + timedelta(days=30)
+        result = gc_book.create_transaction(
+            description="Warned but Created",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "-10.00"},
+                {"account": "Assets:Checking", "amount": "10.00"},
+            ],
+            trans_date=future,
+        )
+        assert result["status"] == "created"
+        assert result["guid"]
+        # Should have both future_date and negative_expense warnings
+        warning_types = {w["type"] for w in result["warnings"]}
+        assert "future_date" in warning_types
+        assert "negative_expense" in warning_types
 
 
 class TestSearchTransactions:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -296,6 +296,34 @@ class TestCreateTransaction:
                 ],
             )
 
+    def test_create_transaction_placeholder_rejected(self, test_book: Path):
+        """Should reject transaction targeting a placeholder account."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="placeholder") as exc_info:
+            gc_book.create_transaction(
+                description="Bad Transaction",
+                splits=[
+                    {"account": "Expenses", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-50.00"},
+                ],
+            )
+        # Error should suggest child accounts
+        assert "Expenses:Groceries" in str(exc_info.value)
+
+    def test_create_transaction_placeholder_suggests_children(self, test_book: Path):
+        """Error message should list the placeholder's child accounts."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Use one of:"):
+            gc_book.create_transaction(
+                description="Bad Transaction",
+                splits=[
+                    {"account": "Assets", "amount": "-50.00"},
+                    {"account": "Expenses:Groceries", "amount": "50.00"},
+                ],
+            )
+
     def test_create_transaction_with_notes(self, test_book: Path):
         """Should create transaction with notes field."""
         gc_book = GnuCashBook(str(test_book))

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -810,6 +810,343 @@ class TestAutoFillTransaction:
                 assert s["value"] == "200"
 
 
+class TestSplitConsistency:
+    """Tests for split consistency warnings."""
+
+    def _create_dining_account(self, gc_book):
+        """Helper to add Expenses:Dining account."""
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+    def _seed_groceries(self, gc_book, count=2):
+        """Create recent grocery transactions for consistency baseline."""
+        today = date.today()
+        for i in range(count):
+            gc_book.create_transaction(
+                description="Weekly Groceries",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+                trans_date=today - timedelta(days=7 * (i + 1)),
+                check_duplicates=False,
+            )
+
+    def test_no_history(self, test_book: Path):
+        """First transaction with a new description produces no warning."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        result = gc_book.create_transaction(
+            description="Brand New Vendor XYZ",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "25.00"},
+                {"account": "Assets:Checking", "amount": "-25.00"},
+            ],
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        assert len(consistency) == 0
+
+    def test_matching_pattern(self, test_book: Path):
+        """Same expense account as recent history produces no warning."""
+        gc_book = GnuCashBook(str(test_book))
+        self._seed_groceries(gc_book)
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "175.00"},
+                {"account": "Assets:Checking", "amount": "-175.00"},
+            ],
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        assert len(consistency) == 0
+
+    def test_different_pattern(self, test_book: Path):
+        """Different expense account triggers split_consistency warning."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        self._seed_groceries(gc_book)
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        assert len(consistency) == 1
+        assert "Expenses:Groceries" in consistency[0]["message"]
+        assert "Expenses:Dining" in consistency[0]["message"]
+
+    def test_ignores_funding_account(self, test_book: Path):
+        """Changing funding account (Checking→Credit Card) with same
+        expense should NOT trigger warning."""
+        gc_book = GnuCashBook(str(test_book))
+        self._seed_groceries(gc_book)
+        # Add a credit card account
+        gc_book.create_account(
+            name="Credit Card",
+            account_type="CREDIT",
+            parent="Liabilities",
+        )
+        # Pay groceries from credit card instead of checking
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Liabilities:Credit Card", "amount": "-150.00"},
+            ],
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        assert len(consistency) == 0
+
+    def test_transfer_pattern(self, test_book: Path):
+        """Bank-to-bank transfer detects changed target account."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Savings",
+            account_type="BANK",
+            parent="Assets",
+        )
+        gc_book.create_account(
+            name="Emergency Fund",
+            account_type="BANK",
+            parent="Assets",
+        )
+        today = date.today()
+        # Seed: transfer Checking → Savings
+        gc_book.create_transaction(
+            description="Monthly Transfer",
+            splits=[
+                {"account": "Assets:Savings", "amount": "500.00"},
+                {"account": "Assets:Checking", "amount": "-500.00"},
+            ],
+            trans_date=today - timedelta(days=7),
+            check_duplicates=False,
+        )
+        # New: transfer Checking → Emergency Fund (different target)
+        result = gc_book.create_transaction(
+            description="Monthly Transfer",
+            splits=[
+                {"account": "Assets:Emergency Fund", "amount": "500.00"},
+                {"account": "Assets:Checking", "amount": "-500.00"},
+            ],
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        # Transfer between funding accounts → fallback uses all accounts
+        assert len(consistency) == 1
+
+    def test_with_dry_run(self, test_book: Path):
+        """Split consistency warning appears in dry-run result."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        self._seed_groceries(gc_book)
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            dry_run=True,
+            check_duplicates=False,
+        )
+        assert result["dry_run"] is True
+        consistency = [
+            w for w in result["warnings"]
+            if w["type"] == "split_consistency"
+        ]
+        assert len(consistency) == 1
+        assert "Expenses:Groceries" in consistency[0]["message"]
+
+
+class TestAutoFillStability:
+    """Tests for auto-fill stability warnings."""
+
+    def _seed_consistent(self, gc_book, count=3):
+        """Create consistent grocery transactions."""
+        today = date.today()
+        for i in range(count):
+            gc_book.create_transaction(
+                description="Weekly Groceries",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+                trans_date=today - timedelta(days=7 * (i + 1)),
+                check_duplicates=False,
+            )
+
+    def _create_dining_account(self, gc_book):
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+    def test_stable_pattern(self, test_book: Path):
+        """All recent matches consistent, no warning."""
+        gc_book = GnuCashBook(str(test_book))
+        self._seed_consistent(gc_book)
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        assert "auto_filled_from" in result
+        warnings = result.get("warnings", [])
+        stability = [w for w in warnings if w["type"] == "auto_fill_unstable"]
+        assert len(stability) == 0
+
+    def test_unstable_pattern(self, test_book: Path):
+        """Recent matches differ, auto_fill_unstable warning fires."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        today = date.today()
+        # Older: groceries account
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=14),
+            check_duplicates=False,
+        )
+        # More recent: dining account (different pattern)
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=7),
+            check_duplicates=False,
+        )
+        # Auto-fill should trigger instability warning
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        assert "auto_filled_from" in result
+        warnings = result.get("warnings", [])
+        stability = [w for w in warnings if w["type"] == "auto_fill_unstable"]
+        assert len(stability) == 1
+        assert "different account patterns" in stability[0]["message"]
+
+    def test_single_match(self, test_book: Path):
+        """Only one prior transaction, no instability warning."""
+        gc_book = GnuCashBook(str(test_book))
+        today = date.today()
+        gc_book.create_transaction(
+            description="One-Time Vendor",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=today - timedelta(days=7),
+            check_duplicates=False,
+        )
+        result = gc_book.create_transaction(
+            description="One-Time Vendor",
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        warnings = result.get("warnings", [])
+        stability = [w for w in warnings if w["type"] == "auto_fill_unstable"]
+        assert len(stability) == 0
+
+    def test_stability_with_dry_run(self, test_book: Path):
+        """Instability warning appears in dry-run result."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        today = date.today()
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=14),
+            check_duplicates=False,
+        )
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=7),
+            check_duplicates=False,
+        )
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            dry_run=True,
+            check_duplicates=False,
+        )
+        assert result["dry_run"] is True
+        stability = [
+            w for w in result["warnings"]
+            if w["type"] == "auto_fill_unstable"
+        ]
+        assert len(stability) == 1
+
+    def test_unstable_no_consistency_conflict(self, test_book: Path):
+        """Stability warning fires but NOT consistency warning when
+        proposed splits match most recent transaction."""
+        gc_book = GnuCashBook(str(test_book))
+        self._create_dining_account(gc_book)
+        today = date.today()
+        # Older: groceries
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=14),
+            check_duplicates=False,
+        )
+        # More recent: dining
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=today - timedelta(days=7),
+            check_duplicates=False,
+        )
+        # Auto-fill grabs most recent (dining) — matches recent so no
+        # consistency warning, but stability warning should fire
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            check_duplicates=False,
+        )
+        warnings = result.get("warnings", [])
+        stability = [w for w in warnings if w["type"] == "auto_fill_unstable"]
+        consistency = [w for w in warnings if w["type"] == "split_consistency"]
+        assert len(stability) == 1
+        assert len(consistency) == 0
+
+
 class TestSearchTransactions:
     """Tests for search_transactions method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -453,6 +453,156 @@ class TestCreateTransactionWarnings:
         assert "negative_expense" in warning_types
 
 
+class TestDuplicateDetection:
+    """Tests for duplicate transaction detection."""
+
+    def test_high_duplicate_rejected(self, test_book: Path):
+        """Should reject when all 3 signals match (description, amount, date)."""
+        gc_book = GnuCashBook(str(test_book))
+        # Existing: "Weekly Groceries", $150, 2024-01-20
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "rejected"
+        assert result["reason"] == "duplicate_detected"
+        assert len(result["duplicates"]) > 0
+        assert result["duplicates"][0]["confidence"] == "HIGH"
+
+    def test_high_duplicate_force_create(self, test_book: Path):
+        """Should create when force_create overrides HIGH duplicate."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+            force_create=True,
+        )
+        assert result["status"] == "created"
+        assert "guid" in result
+        assert len(result["duplicates"]) > 0
+
+    def test_medium_duplicate_allowed(self, test_book: Path):
+        """Should allow creation with MEDIUM confidence (2/3 signals)."""
+        gc_book = GnuCashBook(str(test_book))
+        # Same description and date, different amount
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "200.00"},
+                {"account": "Assets:Checking", "amount": "-200.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "created"
+        assert any(
+            d["confidence"] == "MEDIUM" for d in result.get("duplicates", [])
+        )
+
+    def test_low_duplicate_included(self, test_book: Path):
+        """LOW confidence duplicates should be included for reference."""
+        gc_book = GnuCashBook(str(test_book))
+        # Only amount matches (~$150), different description, different date
+        result = gc_book.create_transaction(
+            description="Totally Different Store",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.50"},
+                {"account": "Assets:Checking", "amount": "-150.50"},
+            ],
+            trans_date=date(2024, 1, 25),
+        )
+        assert result["status"] == "created"
+        # Should have LOW confidence match (amount only)
+        if result.get("duplicates"):
+            assert any(
+                d["confidence"] == "LOW" for d in result["duplicates"]
+            )
+
+    def test_check_duplicates_false_skips(self, test_book: Path):
+        """Should skip duplicate check entirely when check_duplicates=False."""
+        gc_book = GnuCashBook(str(test_book))
+        # Exact duplicate but check disabled
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        assert "duplicates" not in result
+
+    def test_substring_description_match(self, test_book: Path):
+        """Substring matching should work in both directions."""
+        gc_book = GnuCashBook(str(test_book))
+        # "Groceries" is substring of "Weekly Groceries"
+        result = gc_book.create_transaction(
+            description="Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "rejected"
+        high = [d for d in result["duplicates"] if d["confidence"] == "HIGH"]
+        assert len(high) > 0
+        assert high[0]["match_signals"]["description"] is True
+
+    def test_amount_tolerance(self, test_book: Path):
+        """Amount match should use ±$1.00 tolerance."""
+        gc_book = GnuCashBook(str(test_book))
+        # $150.99 is within $1.00 of $150.00
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.99"},
+                {"account": "Assets:Checking", "amount": "-150.99"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "rejected"
+        assert result["duplicates"][0]["match_signals"]["amount"] is True
+
+    def test_date_window(self, test_book: Path):
+        """Date match should use ±2 day window."""
+        gc_book = GnuCashBook(str(test_book))
+        # 2 days after existing (2024-01-20), should still match
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 22),
+        )
+        assert result["status"] == "rejected"
+        assert result["duplicates"][0]["match_signals"]["date"] is True
+
+    def test_no_duplicates_distant_date(self, test_book: Path):
+        """Should find no duplicates when date is far from existing."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2025, 6, 15),
+        )
+        assert result["status"] == "created"
+        assert "duplicates" not in result
+
+
 class TestSearchTransactions:
     """Tests for search_transactions method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -222,7 +222,7 @@ class TestCreateTransaction:
         """Should create a simple two-split transaction."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Test Transaction",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "50.00"},
@@ -231,7 +231,8 @@ class TestCreateTransaction:
             trans_date=date(2024, 2, 1),
         )
 
-        assert guid is not None
+        assert result["status"] == "created"
+        guid = result["guid"]
         assert len(guid) == 32  # GnuCash GUID format
 
         # Verify transaction was created
@@ -244,7 +245,7 @@ class TestCreateTransaction:
         """Should create transaction with split memos."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Transaction with Memo",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "25.00", "memo": "Weekly shop"},
@@ -252,7 +253,7 @@ class TestCreateTransaction:
             ],
         )
 
-        transaction = gc_book.get_transaction(guid)
+        transaction = gc_book.get_transaction(result["guid"])
         memos = {s["memo"] for s in transaction["splits"]}
         assert "Weekly shop" in memos
         assert "Debit" in memos
@@ -299,7 +300,7 @@ class TestCreateTransaction:
         """Should create transaction with notes field."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Safeway",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "75.00", "memo": "Meats"},
@@ -308,7 +309,7 @@ class TestCreateTransaction:
             notes="P2W1 groceries",
         )
 
-        transaction = gc_book.get_transaction(guid)
+        transaction = gc_book.get_transaction(result["guid"])
         assert transaction["description"] == "Safeway"
         assert transaction["notes"] == "P2W1 groceries"
         # Verify memo is separate from notes
@@ -319,7 +320,7 @@ class TestCreateTransaction:
         """Transaction without notes should not include notes key."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="No Notes",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "10.00"},
@@ -327,7 +328,7 @@ class TestCreateTransaction:
             ],
         )
 
-        transaction = gc_book.get_transaction(guid)
+        transaction = gc_book.get_transaction(result["guid"])
         assert "notes" not in transaction
 
 
@@ -924,7 +925,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Create transaction with notes
-        guid = gc_book.create_transaction(
+        create_result = gc_book.create_transaction(
             description="With Notes",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "20.00"},
@@ -932,6 +933,7 @@ class TestUpdateTransaction:
             ],
             notes="Some notes",
         )
+        guid = create_result["guid"]
 
         # Clear notes
         result = gc_book.update_transaction(guid=guid, notes="")
@@ -1512,7 +1514,7 @@ class TestCreateTransactionMultiCurrency:
         """Should create transaction with specified currency."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Explicit USD Transaction",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "50.00"},
@@ -1522,7 +1524,7 @@ class TestCreateTransactionMultiCurrency:
             currency="USD",
         )
 
-        assert guid is not None
+        guid = result["guid"]
         transaction = gc_book.get_transaction(guid)
         assert transaction["currency"] == "USD"
 
@@ -1530,7 +1532,7 @@ class TestCreateTransactionMultiCurrency:
         """Should use default currency when none specified."""
         gc_book = GnuCashBook(str(test_book))
 
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Default Currency Transaction",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "30.00"},
@@ -1538,7 +1540,7 @@ class TestCreateTransactionMultiCurrency:
             ],
         )
 
-        transaction = gc_book.get_transaction(guid)
+        transaction = gc_book.get_transaction(result["guid"])
         assert transaction["currency"] == "USD"
 
     def test_create_cross_currency_transaction(self, test_book: Path):
@@ -1554,7 +1556,7 @@ class TestCreateTransactionMultiCurrency:
         )
 
         # Create a cross-currency transaction: USD transaction with EUR split
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Dinner in Paris",
             currency="USD",
             splits=[
@@ -1568,7 +1570,7 @@ class TestCreateTransactionMultiCurrency:
             trans_date=date(2024, 3, 1),
         )
 
-        assert guid is not None
+        guid = result["guid"]
         transaction = gc_book.get_transaction(guid)
         assert transaction["currency"] == "USD"
 
@@ -1631,7 +1633,7 @@ class TestCreateTransactionMultiCurrency:
         gc_book = GnuCashBook(str(test_book))
 
         # No currency, no quantity - original API
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="Backward Compatible",
             splits=[
                 {"account": "Expenses:Groceries", "amount": "85.00"},
@@ -1639,7 +1641,7 @@ class TestCreateTransactionMultiCurrency:
             ],
         )
 
-        assert guid is not None
+        guid = result["guid"]
         transaction = gc_book.get_transaction(guid)
         assert transaction["description"] == "Backward Compatible"
 
@@ -2058,7 +2060,7 @@ class TestInvestmentWorkflow:
         )
 
         # 4. Buy shares: $500 at $127.50/share = 3.9216 shares
-        guid = gc_book.create_transaction(
+        result = gc_book.create_transaction(
             description="VTSAX purchase",
             splits=[
                 {
@@ -2074,7 +2076,7 @@ class TestInvestmentWorkflow:
             trans_date=date(2026, 2, 7),
             currency="USD",
         )
-        assert guid is not None
+        assert result["status"] == "created"
 
         # 5. Check balance — should show share count
         balance = gc_book.get_balance("Assets:Investments:401k:VTSAX")

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -603,6 +603,114 @@ class TestDuplicateDetection:
         assert "duplicates" not in result
 
 
+class TestDryRun:
+    """Tests for dry run mode on create_transaction."""
+
+    def test_dry_run_returns_proposal(self, test_book: Path):
+        """Should return proposed transaction without writing."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Dry Run Test",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=date(2024, 3, 1),
+            dry_run=True,
+        )
+        assert result["dry_run"] is True
+        assert result["proposed_transaction"]["description"] == "Dry Run Test"
+        assert result["proposed_transaction"]["date"] == "2024-03-01"
+        assert result["proposed_transaction"]["currency"] == "USD"
+        assert len(result["proposed_transaction"]["splits"]) == 2
+
+    def test_dry_run_no_write(self, test_book: Path):
+        """Dry run should not create a transaction in the book."""
+        gc_book = GnuCashBook(str(test_book))
+        before = gc_book.list_transactions()
+        gc_book.create_transaction(
+            description="Ghost Transaction",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "99.99"},
+                {"account": "Assets:Checking", "amount": "-99.99"},
+            ],
+            dry_run=True,
+        )
+        after = gc_book.list_transactions()
+        assert len(after) == len(before)
+
+    def test_dry_run_includes_warnings(self, test_book: Path):
+        """Dry run should include warnings."""
+        gc_book = GnuCashBook(str(test_book))
+        future = date.today() + timedelta(days=30)
+        result = gc_book.create_transaction(
+            description="Future Dry Run",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=future,
+            dry_run=True,
+        )
+        assert result["dry_run"] is True
+        assert any(w["type"] == "future_date" for w in result["warnings"])
+
+    def test_dry_run_includes_duplicates(self, test_book: Path):
+        """Dry run should include duplicate candidates."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+            dry_run=True,
+        )
+        assert result["dry_run"] is True
+        assert len(result["duplicates"]) > 0
+
+    def test_dry_run_validation_errors_raised(self, test_book: Path):
+        """Dry run should still raise validation errors."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="do not balance"):
+            gc_book.create_transaction(
+                description="Unbalanced Dry Run",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-40.00"},
+                ],
+                dry_run=True,
+            )
+
+    def test_dry_run_placeholder_rejected(self, test_book: Path):
+        """Dry run should reject placeholder accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="placeholder"):
+            gc_book.create_transaction(
+                description="Placeholder Dry Run",
+                splits=[
+                    {"account": "Expenses", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-50.00"},
+                ],
+                dry_run=True,
+            )
+
+    def test_dry_run_unknown_currency(self, test_book: Path):
+        """Dry run should raise error for unknown currency."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="not found"):
+            gc_book.create_transaction(
+                description="Bad Currency Dry Run",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "50.00"},
+                    {"account": "Assets:Checking", "amount": "-50.00"},
+                ],
+                currency="XYZ",
+                dry_run=True,
+            )
+
+
 class TestSearchTransactions:
     """Tests for search_transactions method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -711,6 +711,105 @@ class TestDryRun:
             )
 
 
+class TestAutoFillTransaction:
+    """Tests for auto-fill splits from previous transactions."""
+
+    def test_auto_fill_from_description(self, test_book: Path):
+        """Should auto-fill splits from most recent matching transaction."""
+        gc_book = GnuCashBook(str(test_book))
+        # "Weekly Groceries" exists in fixture: $150 groceries / -$150 checking
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            trans_date=date(2024, 3, 1),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        # Verify the transaction was created with auto-filled splits
+        txn = gc_book.get_transaction(result["guid"])
+        accounts = {s["account"] for s in txn["splits"]}
+        assert "Expenses:Groceries" in accounts
+        assert "Assets:Checking" in accounts
+
+    def test_auto_fill_result_includes_source(self, test_book: Path):
+        """Should include auto_filled_from with source transaction info."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            trans_date=date(2024, 3, 1),
+            check_duplicates=False,
+        )
+        assert "auto_filled_from" in result
+        assert result["auto_filled_from"]["description"] == "Weekly Groceries"
+        assert "guid" in result["auto_filled_from"]
+        assert "date" in result["auto_filled_from"]
+
+    def test_auto_fill_no_match(self, test_book: Path):
+        """Should raise ValueError when no matching transaction found."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="No matching transaction found"):
+            gc_book.create_transaction(
+                description="Never Seen Before XYZ123",
+            )
+
+    def test_auto_fill_with_dry_run(self, test_book: Path):
+        """Should auto-fill and return proposal in dry run mode."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            dry_run=True,
+            check_duplicates=False,
+        )
+        assert result["dry_run"] is True
+        assert "auto_filled_from" in result
+        # Proposed splits should come from the auto-fill
+        proposed_splits = result["proposed_transaction"]["splits"]
+        accounts = {s["account"] for s in proposed_splits}
+        assert "Expenses:Groceries" in accounts
+
+    def test_auto_fill_preserves_memo(self, test_book: Path):
+        """Auto-fill should preserve memo from source transaction."""
+        gc_book = GnuCashBook(str(test_book))
+        # First create a transaction with a memo
+        gc_book.create_transaction(
+            description="Coffee Shop",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "5.00", "memo": "Latte"},
+                {"account": "Assets:Checking", "amount": "-5.00"},
+            ],
+            trans_date=date(2024, 2, 1),
+            check_duplicates=False,
+        )
+        # Auto-fill from it
+        result = gc_book.create_transaction(
+            description="Coffee Shop",
+            trans_date=date(2024, 3, 1),
+            check_duplicates=False,
+        )
+        txn = gc_book.get_transaction(result["guid"])
+        memos = {s["memo"] for s in txn["splits"]}
+        assert "Latte" in memos
+
+    def test_explicit_splits_no_auto_fill(self, test_book: Path):
+        """Providing explicit splits should bypass auto-fill."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "200.00"},
+                {"account": "Assets:Checking", "amount": "-200.00"},
+            ],
+            trans_date=date(2024, 3, 1),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        assert "auto_filled_from" not in result
+        # Verify the explicit amount was used, not auto-filled
+        txn = gc_book.get_transaction(result["guid"])
+        for s in txn["splits"]:
+            if s["account"] == "Expenses:Groceries":
+                assert s["value"] == "200"
+
+
 class TestSearchTransactions:
     """Tests for search_transactions method."""
 

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -18,7 +18,7 @@ def _buy_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date) 
     Accounting: cash decreases (checking -total), investment increases (VTSAX +total in USD, +shares in quantity).
     """
     total = price * shares
-    guid = book.create_transaction(
+    result = book.create_transaction(
         description=f"Buy {shares} VTSAX @ {price}",
         splits=[
             {"account": "Assets:Investments:VTSAX", "amount": str(total), "quantity": str(shares)},
@@ -26,7 +26,7 @@ def _buy_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date) 
         ],
         trans_date=txn_date,
     )
-    txn = book.get_transaction(guid)
+    txn = book.get_transaction(result["guid"])
     for s in txn["splits"]:
         if s["account"] == "Assets:Investments:VTSAX":
             return s["guid"]
@@ -39,7 +39,7 @@ def _sell_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date)
     Accounting: cash increases (checking +proceeds), investment decreases (VTSAX -proceeds in USD, -shares in quantity).
     """
     proceeds = price * shares
-    guid = book.create_transaction(
+    result = book.create_transaction(
         description=f"Sell {shares} VTSAX @ {price}",
         splits=[
             {"account": "Assets:Investments:VTSAX", "amount": str(-proceeds), "quantity": str(-shares)},
@@ -47,7 +47,7 @@ def _sell_shares(book: GnuCashBook, shares: int, price: Decimal, txn_date: date)
         ],
         trans_date=txn_date,
     )
-    txn = book.get_transaction(guid)
+    txn = book.get_transaction(result["guid"])
     for s in txn["splits"]:
         if s["account"] == "Assets:Investments:VTSAX":
             return s["guid"]
@@ -202,7 +202,7 @@ class TestAssignSplitToLot:
         lot = book.create_lot(account="Assets:Investments:VTSAX", title="Test")
 
         # Get the checking split from a buy transaction
-        txn_guid = book.create_transaction(
+        txn_result = book.create_transaction(
             description="Buy VTSAX",
             splits=[
                 {"account": "Assets:Investments:VTSAX", "amount": "1250", "quantity": "10"},
@@ -210,7 +210,7 @@ class TestAssignSplitToLot:
             ],
             trans_date=date(2026, 1, 15),
         )
-        txn = book.get_transaction(txn_guid)
+        txn = book.get_transaction(txn_result["guid"])
         checking_split_guid = None
         for s in txn["splits"]:
             if s["account"] == "Assets:Checking":
@@ -345,7 +345,7 @@ class TestSplitToDictLotGuid:
     def test_split_has_lot_guid_none(self, investment_book: Path):
         """Splits without lots should have lot_guid=None."""
         book = GnuCashBook(str(investment_book))
-        txn_guid = book.create_transaction(
+        txn_result = book.create_transaction(
             description="No lot test",
             splits=[
                 {"account": "Assets:Checking", "amount": "-100"},
@@ -353,7 +353,7 @@ class TestSplitToDictLotGuid:
             ],
             trans_date=date(2026, 1, 20),
         )
-        txn = book.get_transaction(txn_guid)
+        txn = book.get_transaction(txn_result["guid"])
         for s in txn["splits"]:
             assert "lot_guid" in s
             assert s["lot_guid"] is None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -164,6 +164,37 @@ class TestCreateTransactionTool:
         assert "error" in data
         assert "placeholder" in data["error"].lower()
 
+    def test_create_transaction_duplicate_rejected(self, setup_book_env):
+        """Should reject HIGH confidence duplicates via server layer."""
+        result = server_module.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            transaction_date="2024-01-20",
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "rejected"
+        assert data["reason"] == "duplicate_detected"
+
+    def test_create_transaction_duplicate_force(self, setup_book_env):
+        """Should create with force_create despite HIGH duplicate."""
+        result = server_module.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            transaction_date="2024-01-20",
+            force_create=True,
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "created"
+        assert "guid" in data
+
 
 class TestSearchTransactionsTool:
     """Tests for search_transactions tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -302,6 +302,32 @@ class TestDeleteTransactionTool:
         get_result = server_module.get_transaction(guid)
         assert "error" in json.loads(get_result)
 
+    def test_delete_reconciled_rejected(self, setup_book_env):
+        """Should reject deleting a transaction with reconciled splits."""
+        transactions = json.loads(server_module.list_transactions())
+        split_guid = transactions[0]["splits"][0]["guid"]
+        server_module.set_reconcile_state(split_guid, "y")
+        guid = transactions[0]["guid"]
+
+        result = server_module.delete_transaction(guid)
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "reconciled" in data["error"].lower()
+
+    def test_delete_reconciled_force(self, setup_book_env):
+        """Should allow deleting reconciled transaction with force=True."""
+        transactions = json.loads(server_module.list_transactions())
+        split_guid = transactions[0]["splits"][0]["guid"]
+        server_module.set_reconcile_state(split_guid, "y")
+        guid = transactions[0]["guid"]
+
+        result = server_module.delete_transaction(guid, force=True)
+
+        data = json.loads(result)
+        assert data["status"] == "deleted"
+        assert data["reconciled_splits_affected"] == 1
+
     def test_delete_nonexistent_transaction(self, setup_book_env):
         """Should return error for missing transaction."""
         result = server_module.delete_transaction("nonexistent_guid_12345")
@@ -389,6 +415,50 @@ class TestUpdateTransactionTool:
         data = json.loads(result)
         assert "error" in data
         assert "balance" in data["error"].lower()
+
+    def test_update_reconciled_splits_rejected(self, setup_book_env):
+        """Should reject updating splits on a reconciled transaction."""
+        transactions = json.loads(server_module.list_transactions())
+        groceries_trans = next(
+            t for t in transactions if t["description"] == "Weekly Groceries"
+        )
+        guid = groceries_trans["guid"]
+        split_guid = groceries_trans["splits"][0]["guid"]
+        server_module.set_reconcile_state(split_guid, "y")
+
+        result = server_module.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-200.00"},
+                {"account": "Expenses:Groceries", "amount": "200.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "reconciled" in data["error"].lower()
+
+    def test_update_reconciled_force(self, setup_book_env):
+        """Should allow updating reconciled splits with force=True."""
+        transactions = json.loads(server_module.list_transactions())
+        groceries_trans = next(
+            t for t in transactions if t["description"] == "Weekly Groceries"
+        )
+        guid = groceries_trans["guid"]
+        split_guid = groceries_trans["splits"][0]["guid"]
+        server_module.set_reconcile_state(split_guid, "y")
+
+        result = server_module.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-200.00"},
+                {"account": "Expenses:Groceries", "amount": "200.00"},
+            ],
+            force=True,
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "updated"
 
 
 class TestSetReconcileStateTool:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -150,6 +150,20 @@ class TestCreateTransactionTool:
         assert "error" in data
         assert "balance" in data["error"].lower()
 
+    def test_create_transaction_placeholder_rejected(self, setup_book_env):
+        """Should reject transaction targeting placeholder account."""
+        result = server_module.create_transaction(
+            description="Bad Transaction",
+            splits=[
+                {"account": "Expenses", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "placeholder" in data["error"].lower()
+
 
 class TestSearchTransactionsTool:
     """Tests for search_transactions tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -195,6 +195,23 @@ class TestCreateTransactionTool:
         assert data["status"] == "created"
         assert "guid" in data
 
+    def test_create_transaction_dry_run(self, setup_book_env):
+        """Should return proposal without writing in dry run mode."""
+        result = server_module.create_transaction(
+            description="Dry Run Server Test",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "75.00"},
+                {"account": "Assets:Checking", "amount": "-75.00"},
+            ],
+            transaction_date="2024-03-01",
+            dry_run=True,
+        )
+
+        data = json.loads(result)
+        assert data["dry_run"] is True
+        assert data["proposed_transaction"]["description"] == "Dry Run Server Test"
+        assert "guid" not in data
+
 
 class TestSearchTransactionsTool:
     """Tests for search_transactions tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -212,6 +212,19 @@ class TestCreateTransactionTool:
         assert data["proposed_transaction"]["description"] == "Dry Run Server Test"
         assert "guid" not in data
 
+    def test_create_transaction_auto_fill(self, setup_book_env):
+        """Should auto-fill splits from matching transaction."""
+        result = server_module.create_transaction(
+            description="Weekly Groceries",
+            transaction_date="2024-03-01",
+            check_duplicates=False,
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "created"
+        assert "auto_filled_from" in data
+        assert data["auto_filled_from"]["description"] == "Weekly Groceries"
+
 
 class TestSearchTransactionsTool:
     """Tests for search_transactions tool."""


### PR DESCRIPTION
## Summary

- **Reconciled split protection**: `delete_transaction` and `update_transaction` refuse to modify transactions with reconciled splits unless `force=true`
- **Return type migration**: `create_transaction` now returns a dict (`{guid, status, warnings?, duplicates?, auto_filled_from?}`) instead of a bare GUID string
- **Placeholder account check**: Rejects splits targeting placeholder (container-only) accounts with a hint listing child accounts
- **Date and account type warnings**: Flags future dates, old dates (>365 days), negative expenses, and positive income as non-blocking warnings
- **Duplicate detection**: 3-signal scoring (description match, amount ±$1, date ±2 days) → HIGH/MEDIUM/LOW confidence. HIGH blocks creation unless `force_create=true`
- **Dry run mode**: `dry_run=true` validates everything readonly and returns a proposal without writing
- **Auto-fill from history**: Omit splits to copy them from the most recent matching transaction (bidirectional description substring match)
- **Split consistency warning**: Compares proposed categorization accounts against recent same-description transactions; warns if the pattern differs (e.g., "Recent 'Krispy Kreme' used Expenses:Dining, but this uses Expenses:Groceries")
- **Auto-fill stability warning**: When auto-fill activates, checks if recent matches agree on account pattern; warns if history is inconsistent

## Test plan

- [x] 360 tests passing (349 existing + 11 new consistency/stability tests)
- [x] Reconciled split protection: delete and update blocked, force override works
- [x] Return type migration: all call sites updated (book, tools, lots)
- [x] Placeholder rejection with child account hint
- [x] Future date, old date, negative expense, positive income warnings
- [x] Duplicate detection: HIGH blocks, MEDIUM/LOW pass through, force override, check_duplicates=false bypass
- [x] Dry run: readonly validation, proposal includes warnings and duplicates, no write
- [x] Auto-fill: description match copies splits, includes source info, no-match raises ValueError, explicit splits bypass
- [x] Split consistency: no-history clean, matching pattern clean, different pattern warns, funding account changes ignored, transfer fallback works
- [x] Auto-fill stability: stable pattern clean, unstable warns, single match clean, no false consistency+stability overlap
- [x] Live tested full pipeline with Abe (Claude Accountant) against real GnuCash book — all 10 scenarios passed