### PR TITLE
Release v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gnucash-mcp"
-version = "0.9.0"
+version = "1.0.0"
 description = "MCP server for GnuCash accounting data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gnucash_mcp/__init__.py
+++ b/src/gnucash_mcp/__init__.py
@@ -3,5 +3,5 @@
 from gnucash_mcp.book import GnuCashLockError
 from gnucash_mcp.server import main
 
-__version__ = "0.9.0"
+__version__ = "1.0.0"
 __all__ = ["main", "GnuCashLockError"]

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -2144,6 +2144,151 @@ class GnuCashBook:
 
             return _transaction_to_dict(transaction) | {"status": "updated"}
 
+    def recategorize_transaction(
+        self,
+        guid: str,
+        splits: list[dict],
+        force: bool = False,
+    ) -> dict:
+        """Replace all splits in a transaction with a new set.
+
+        Use this to change which accounts a transaction affects (recategorize).
+        The transaction's currency, description, date, and notes are preserved.
+        New splits must balance to zero.
+
+        Args:
+            guid: Transaction GUID.
+            splits: Complete new set of splits. Each split needs:
+                - 'account' (required): Full account path
+                - 'amount' (required): Value in transaction currency
+                - 'quantity' (optional): Amount in account's commodity.
+                  Required if account commodity differs from transaction currency.
+                - 'memo' (optional): Split memo
+            force: Required if existing splits are reconciled ('y') or
+                   assigned to lots.
+
+        Returns:
+            Dict with updated transaction details, previous splits for audit
+            trail, status, and any warnings.
+
+        Raises:
+            ValueError: If transaction not found, splits don't balance,
+                       account not found, placeholder account used,
+                       cross-currency split missing quantity, or has
+                       reconciled/lot splits without force.
+        """
+        # Validate split count upfront
+        if len(splits) < 2:
+            raise ValueError("At least 2 splits required")
+
+        # Validate balance upfront
+        total = sum(Decimal(s["amount"]) for s in splits)
+        if total != Decimal("0"):
+            raise ValueError(f"Splits do not balance: total is {total}")
+
+        with self.open(readonly=False) as book:
+            warnings = []
+
+            # 1. Find transaction
+            transaction = self._find_transaction(book, guid)
+            if not transaction:
+                raise ValueError(f"Transaction not found: {guid}")
+
+            # 2. Capture previous splits for audit trail (before deletion)
+            previous_splits = [_split_to_dict(s) for s in transaction.splits]
+
+            # 3. Resolve and validate all accounts upfront
+            resolved_accounts = []
+            for split_data in splits:
+                account_name = split_data["account"]
+                account = self._find_account(book, account_name)
+                if not account:
+                    raise ValueError(f"Account not found: {account_name}")
+                if account.placeholder:
+                    raise ValueError(
+                        f"Cannot use placeholder account: {account_name}"
+                    )
+                resolved_accounts.append((account, split_data))
+
+            # 4. Check reconciled splits
+            reconciled = [
+                s for s in transaction.splits if s.reconcile_state == "y"
+            ]
+            if reconciled and not force:
+                names = ", ".join(s.account.fullname for s in reconciled)
+                raise ValueError(
+                    f"Transaction has reconciled splits in: {names}. "
+                    f"Use force=true to override."
+                )
+            if reconciled:
+                names = ", ".join(s.account.fullname for s in reconciled)
+                warnings.append(f"Replaced reconciled splits in: {names}")
+
+            # 5. Check lot assignments
+            in_lots = [s for s in transaction.splits if s.lot is not None]
+            if in_lots and not force:
+                names = ", ".join(s.account.fullname for s in in_lots)
+                raise ValueError(
+                    f"Transaction has splits in lots: {names}. "
+                    f"Use force=true to override."
+                )
+            if in_lots:
+                lot_info = ", ".join(
+                    f"{s.lot.title} ({s.account.fullname})" for s in in_lots
+                )
+                warnings.append(
+                    f"Removed splits from lots: {lot_info}. "
+                    f"Cost basis tracking affected."
+                )
+
+            # 6. Delete existing splits
+            for split in list(transaction.splits):
+                book.delete(split)
+
+            # 7. Create new splits
+            trans_currency = transaction.currency
+            for account, split_data in resolved_accounts:
+                amount = Decimal(split_data["amount"])
+
+                # Determine quantity
+                if account.commodity == trans_currency:
+                    quantity = amount
+                elif "quantity" in split_data:
+                    quantity = Decimal(split_data["quantity"])
+                    if quantity * amount < 0:
+                        raise ValueError(
+                            f"Split for '{account.fullname}': quantity and "
+                            f"value must have same sign "
+                            f"(got value={amount}, quantity={quantity})"
+                        )
+                else:
+                    raise ValueError(
+                        f"Split for '{account.fullname}' requires 'quantity' "
+                        f"because account commodity "
+                        f"({account.commodity.mnemonic}) differs from "
+                        f"transaction currency ({trans_currency.mnemonic})"
+                    )
+
+                piecash.Split(
+                    account=account,
+                    value=amount,
+                    quantity=quantity,
+                    memo=split_data.get("memo", ""),
+                    transaction=transaction,
+                )
+
+            # 8. Save
+            book.save()
+
+            # 9. Build response
+            result = _transaction_to_dict(transaction)
+            result["previous_splits"] = previous_splits
+            result["status"] = "recategorized"
+            if warnings:
+                result["warnings"] = warnings
+
+            return result
+
     def _find_split(self, book: piecash.Book, guid: str) -> piecash.Split | None:
         """Find a split by GUID.
 

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -2144,7 +2144,7 @@ class GnuCashBook:
 
             return _transaction_to_dict(transaction) | {"status": "updated"}
 
-    def recategorize_transaction(
+    def replace_splits(
         self,
         guid: str,
         splits: list[dict],
@@ -2152,7 +2152,7 @@ class GnuCashBook:
     ) -> dict:
         """Replace all splits in a transaction with a new set.
 
-        Use this to change which accounts a transaction affects (recategorize).
+        Replace all splits in a transaction with a completely new set.
         The transaction's currency, description, date, and notes are preserved.
         New splits must balance to zero.
 
@@ -2283,7 +2283,7 @@ class GnuCashBook:
             # 9. Build response
             result = _transaction_to_dict(transaction)
             result["previous_splits"] = previous_splits
-            result["status"] = "recategorized"
+            result["status"] = "splits_replaced"
             if warnings:
                 result["warnings"] = warnings
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -403,8 +403,8 @@ def _format_audit_entry_text(entry: dict) -> str:
                 if before.get("splits"):
                     lines.append(_format_splits_text(before["splits"], indent + "  "))
 
-        elif operation == "RECATEGORIZE":
-            lines.append(f"{time_part}  RECATEGORIZE TRANSACTION  guid:{guid_short}")
+        elif operation == "REPLACE_SPLITS":
+            lines.append(f"{time_part}  REPLACE SPLITS  guid:{guid_short}")
             if after:
                 desc = after.get("description", "")
                 date_str = after.get("date", "")

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -403,6 +403,28 @@ def _format_audit_entry_text(entry: dict) -> str:
                 if before.get("splits"):
                     lines.append(_format_splits_text(before["splits"], indent + "  "))
 
+        elif operation == "RECATEGORIZE":
+            lines.append(f"{time_part}  RECATEGORIZE TRANSACTION  guid:{guid_short}")
+            if after:
+                desc = after.get("description", "")
+                date_str = after.get("date", "")
+                lines.append(f'{indent}"{desc}" ({date_str})')
+                # Show before splits (from previous_splits in the response)
+                prev_splits = after.get("previous_splits", [])
+                if prev_splits:
+                    lines.append(f"{indent}Splits (before):")
+                    lines.append(_format_splits_text(prev_splits, indent + "  "))
+                # Show after splits
+                new_splits = after.get("splits", [])
+                if new_splits:
+                    lines.append(f"{indent}Splits (after):")
+                    lines.append(_format_splits_text(new_splits, indent + "  "))
+                # Show warnings if any
+                warnings = after.get("warnings", [])
+                if warnings:
+                    for w in warnings:
+                        lines.append(f"{indent}Warning: {w}")
+
     elif entity_type == "account":
         if operation == "CREATE":
             lines.append(f"{time_part}  CREATE ACCOUNT")

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -592,15 +592,15 @@ def update_transaction(
 
 @mcp.tool()
 @safe_tool
-@audit_log(classification="write", operation="recategorize", entity_type="transaction")
-def recategorize_transaction(
+@audit_log(classification="write", operation="replace_splits", entity_type="transaction")
+def replace_splits(
     guid: str,
     splits: list[dict],
     force: bool = False,
 ) -> str:
     """Replace all splits in a transaction with a new set.
 
-    Use this to change which accounts a transaction affects (recategorize).
+    Replace all splits in a transaction with a completely new set.
     The transaction's currency, description, date, and notes are preserved.
     New splits must balance to zero.
 
@@ -615,7 +615,7 @@ def recategorize_transaction(
         force: Allow replacing reconciled splits or splits in lots
     """
     book = get_book()
-    result = book.recategorize_transaction(
+    result = book.replace_splits(
         guid=guid,
         splits=splits,
         force=force,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -590,6 +590,39 @@ def update_transaction(
     return json.dumps(result, indent=2)
 
 
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="recategorize", entity_type="transaction")
+def recategorize_transaction(
+    guid: str,
+    splits: list[dict],
+    force: bool = False,
+) -> str:
+    """Replace all splits in a transaction with a new set.
+
+    Use this to change which accounts a transaction affects (recategorize).
+    The transaction's currency, description, date, and notes are preserved.
+    New splits must balance to zero.
+
+    Args:
+        guid: Transaction GUID (32-character hex string)
+        splits: Complete new set of splits. Each split needs:
+            - 'account' (required): Full account path
+            - 'amount' (required): Value in transaction currency
+            - 'quantity' (optional): Amount in account's commodity.
+              Required if account commodity differs from transaction currency.
+            - 'memo' (optional): Split memo
+        force: Allow replacing reconciled splits or splits in lots
+    """
+    book = get_book()
+    result = book.recategorize_transaction(
+        guid=guid,
+        splits=splits,
+        force=force,
+    )
+    return json.dumps(result, indent=2)
+
+
 # ============== Reconciliation Tools ==============
 
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1896,10 +1896,10 @@ class TestUpdateTransaction:
         assert result["description"] == "Updated Groceries"
 
 
-class TestRecategorizeTransaction:
-    """Tests for recategorize_transaction method."""
+class TestReplaceSplits:
+    """Tests for replace_splits method."""
 
-    def test_basic_recategorize(self, test_book: Path):
+    def test_basic_replace_splits(self, test_book: Path):
         """Should replace splits with new accounts."""
         gc_book = GnuCashBook(str(test_book))
 
@@ -1912,7 +1912,7 @@ class TestRecategorizeTransaction:
         original_accounts = {s["account"] for s in original_splits}
         assert "Expenses:Groceries" in original_accounts
 
-        # Create a Dining account to recategorize to
+        # Create a Dining account to replace splits with
         gc_book.create_account(
             name="Dining",
             account_type="EXPENSE",
@@ -1920,7 +1920,7 @@ class TestRecategorizeTransaction:
         )
 
         # Recategorize: Groceries -> Dining
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Dining", "amount": "150.00"},
@@ -1928,7 +1928,7 @@ class TestRecategorizeTransaction:
             ],
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         new_accounts = {s["account"] for s in result["splits"]}
         assert "Expenses:Dining" in new_accounts
         assert "Expenses:Groceries" not in new_accounts
@@ -1951,7 +1951,7 @@ class TestRecategorizeTransaction:
         )
 
         # Recategorize
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Dining", "amount": "150.00"},
@@ -1981,7 +1981,7 @@ class TestRecategorizeTransaction:
         )
 
         # Recategorize
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Dining", "amount": "150.00"},
@@ -2002,7 +2002,7 @@ class TestRecategorizeTransaction:
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="do not balance"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Expenses:Groceries", "amount": "150.00"},
@@ -2018,7 +2018,7 @@ class TestRecategorizeTransaction:
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="At least 2 splits"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Expenses:Groceries", "amount": "0.00"},
@@ -2033,7 +2033,7 @@ class TestRecategorizeTransaction:
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="Account not found"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Expenses:NonExistent", "amount": "150.00"},
@@ -2050,7 +2050,7 @@ class TestRecategorizeTransaction:
 
         # Expenses is a placeholder in test_book
         with pytest.raises(ValueError, match="placeholder account"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Expenses", "amount": "150.00"},
@@ -2063,7 +2063,7 @@ class TestRecategorizeTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         with pytest.raises(ValueError, match="Transaction not found"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid="00000000000000000000000000000000",
                 splits=[
                     {"account": "Expenses:Groceries", "amount": "150.00"},
@@ -2082,7 +2082,7 @@ class TestRecategorizeTransaction:
         gc_book.set_reconcile_state(split_guid, "y")
 
         with pytest.raises(ValueError, match="reconciled splits"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Expenses:Groceries", "amount": "150.00"},
@@ -2107,7 +2107,7 @@ class TestRecategorizeTransaction:
             parent="Expenses",
         )
 
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Dining", "amount": "150.00"},
@@ -2116,7 +2116,7 @@ class TestRecategorizeTransaction:
             force=True,
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         assert "warnings" in result
         assert any("reconciled" in w.lower() for w in result["warnings"])
 
@@ -2153,9 +2153,9 @@ class TestRecategorizeTransaction:
         )
         gc_book.assign_split_to_lot(inv_split["guid"], lot_guid)
 
-        # Try to recategorize without force
+        # Try to replace splits without force
         with pytest.raises(ValueError, match="splits in lots"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=txn_guid,
                 splits=[
                     {
@@ -2201,7 +2201,7 @@ class TestRecategorizeTransaction:
         gc_book.assign_split_to_lot(inv_split["guid"], lot_guid)
 
         # Recategorize with force
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=txn_guid,
             splits=[
                 {
@@ -2214,7 +2214,7 @@ class TestRecategorizeTransaction:
             force=True,
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         assert "warnings" in result
         assert any("lot" in w.lower() for w in result["warnings"])
 
@@ -2235,7 +2235,7 @@ class TestRecategorizeTransaction:
         )
 
         # Recategorize to 3 splits
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Groceries", "amount": "100.00"},
@@ -2244,7 +2244,7 @@ class TestRecategorizeTransaction:
             ],
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         assert len(result["splits"]) == 3
 
     def test_reduce_to_two_splits(self, budget_book: Path):
@@ -2267,7 +2267,7 @@ class TestRecategorizeTransaction:
         assert len(txn["splits"]) == 3
 
         # Recategorize to 2 splits
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Groceries", "amount": "80.00"},
@@ -2275,7 +2275,7 @@ class TestRecategorizeTransaction:
             ],
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         assert len(result["splits"]) == 2
 
     def test_preserves_memo(self, test_book: Path):
@@ -2285,7 +2285,7 @@ class TestRecategorizeTransaction:
         transactions = gc_book.search_transactions("Weekly Groceries")
         guid = transactions[0]["guid"]
 
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {
@@ -2297,7 +2297,7 @@ class TestRecategorizeTransaction:
             ],
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         groceries_split = next(
             s for s in result["splits"] if s["account"] == "Expenses:Groceries"
         )
@@ -2311,9 +2311,9 @@ class TestRecategorizeTransaction:
         transactions = gc_book.search_transactions("Groceries")
         guid = transactions[0]["guid"]
 
-        # Try to recategorize to EUR account without quantity
+        # Try to replace splits to EUR account without quantity
         with pytest.raises(ValueError, match="requires 'quantity'"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {"account": "Assets:Euro Savings", "amount": "200.00"},
@@ -2330,7 +2330,7 @@ class TestRecategorizeTransaction:
         guid = transactions[0]["guid"]
 
         # Recategorize with proper quantity
-        result = gc_book.recategorize_transaction(
+        result = gc_book.replace_splits(
             guid=guid,
             splits=[
                 {
@@ -2342,7 +2342,7 @@ class TestRecategorizeTransaction:
             ],
         )
 
-        assert result["status"] == "recategorized"
+        assert result["status"] == "splits_replaced"
         eur_split = next(
             s for s in result["splits"] if s["account"] == "Assets:Euro Savings"
         )
@@ -2356,7 +2356,7 @@ class TestRecategorizeTransaction:
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="same sign"):
-            gc_book.recategorize_transaction(
+            gc_book.replace_splits(
                 guid=guid,
                 splits=[
                     {

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1896,6 +1896,479 @@ class TestUpdateTransaction:
         assert result["description"] == "Updated Groceries"
 
 
+class TestRecategorizeTransaction:
+    """Tests for recategorize_transaction method."""
+
+    def test_basic_recategorize(self, test_book: Path):
+        """Should replace splits with new accounts."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Find the grocery transaction
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        original_splits = transactions[0]["splits"]
+
+        # Get original accounts for verification
+        original_accounts = {s["account"] for s in original_splits}
+        assert "Expenses:Groceries" in original_accounts
+
+        # Create a Dining account to recategorize to
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        # Recategorize: Groceries -> Dining
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        assert result["status"] == "recategorized"
+        new_accounts = {s["account"] for s in result["splits"]}
+        assert "Expenses:Dining" in new_accounts
+        assert "Expenses:Groceries" not in new_accounts
+
+    def test_preserves_transaction_identity(self, test_book: Path):
+        """Should preserve transaction GUID, description, date, notes."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Find the grocery transaction
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        original_date = transactions[0]["date"]
+        original_description = transactions[0]["description"]
+
+        # Create a Dining account
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        # Recategorize
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        # Identity preserved
+        assert result["guid"] == guid
+        assert result["date"] == original_date
+        assert result["description"] == original_description
+
+    def test_returns_previous_splits(self, test_book: Path):
+        """Should include previous_splits in response for audit trail."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Find the grocery transaction
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        original_splits = transactions[0]["splits"]
+
+        # Create a Dining account
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        # Recategorize
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        assert "previous_splits" in result
+        assert len(result["previous_splits"]) == len(original_splits)
+        previous_accounts = {s["account"] for s in result["previous_splits"]}
+        assert "Expenses:Groceries" in previous_accounts
+
+    def test_requires_balanced_splits(self, test_book: Path):
+        """Should reject splits that don't balance to zero."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="do not balance"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-140.00"},  # Wrong
+                ],
+            )
+
+    def test_requires_two_splits(self, test_book: Path):
+        """Should reject fewer than 2 splits."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="At least 2 splits"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "0.00"},
+                ],
+            )
+
+    def test_account_not_found(self, test_book: Path):
+        """Should reject splits with non-existent accounts."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="Account not found"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:NonExistent", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+            )
+
+    def test_placeholder_rejected(self, test_book: Path):
+        """Should reject splits to placeholder accounts."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+
+        # Expenses is a placeholder in test_book
+        with pytest.raises(ValueError, match="placeholder account"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+            )
+
+    def test_transaction_not_found(self, test_book: Path):
+        """Should reject non-existent transaction GUID."""
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Transaction not found"):
+            gc_book.recategorize_transaction(
+                guid="00000000000000000000000000000000",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+            )
+
+    def test_reconciled_requires_force(self, test_book: Path):
+        """Should reject recategorizing reconciled splits without force."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a transaction and reconcile one of its splits
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        with pytest.raises(ValueError, match="reconciled splits"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "150.00"},
+                    {"account": "Assets:Checking", "amount": "-150.00"},
+                ],
+            )
+
+    def test_reconciled_with_force(self, test_book: Path):
+        """Should allow recategorizing reconciled splits with force."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Get a transaction and reconcile one of its splits
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        split_guid = transactions[0]["splits"][0]["guid"]
+        gc_book.set_reconcile_state(split_guid, "y")
+
+        # Create a Dining account
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            force=True,
+        )
+
+        assert result["status"] == "recategorized"
+        assert "warnings" in result
+        assert any("reconciled" in w.lower() for w in result["warnings"])
+
+    def test_lot_requires_force(self, investment_book: Path):
+        """Should reject recategorizing splits in lots without force."""
+        gc_book = GnuCashBook(str(investment_book))
+
+        # Create an investment purchase with a lot
+        lot_result = gc_book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="Test Lot",
+        )
+        lot_guid = lot_result["guid"]
+
+        # Create a buy transaction
+        result = gc_book.create_transaction(
+            description="Buy VTSAX",
+            splits=[
+                {
+                    "account": "Assets:Investments:VTSAX",
+                    "amount": "1250.00",
+                    "quantity": "10",
+                },
+                {"account": "Assets:Checking", "amount": "-1250.00"},
+            ],
+        )
+        txn_guid = result["guid"]
+
+        # Get the investment split and assign to lot
+        txn = gc_book.get_transaction(txn_guid)
+        inv_split = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Investments:VTSAX"
+        )
+        gc_book.assign_split_to_lot(inv_split["guid"], lot_guid)
+
+        # Try to recategorize without force
+        with pytest.raises(ValueError, match="splits in lots"):
+            gc_book.recategorize_transaction(
+                guid=txn_guid,
+                splits=[
+                    {
+                        "account": "Assets:Investments:VTSAX",
+                        "amount": "1250.00",
+                        "quantity": "10",
+                    },
+                    {"account": "Assets:Checking", "amount": "-1250.00"},
+                ],
+            )
+
+    def test_lot_with_force(self, investment_book: Path):
+        """Should allow recategorizing splits in lots with force and warning."""
+        gc_book = GnuCashBook(str(investment_book))
+
+        # Create an investment purchase with a lot
+        lot_result = gc_book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="Test Lot For Force",
+        )
+        lot_guid = lot_result["guid"]
+
+        # Create a buy transaction
+        result = gc_book.create_transaction(
+            description="Buy VTSAX for force test",
+            splits=[
+                {
+                    "account": "Assets:Investments:VTSAX",
+                    "amount": "1250.00",
+                    "quantity": "10",
+                },
+                {"account": "Assets:Checking", "amount": "-1250.00"},
+            ],
+        )
+        txn_guid = result["guid"]
+
+        # Get the investment split and assign to lot
+        txn = gc_book.get_transaction(txn_guid)
+        inv_split = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Investments:VTSAX"
+        )
+        gc_book.assign_split_to_lot(inv_split["guid"], lot_guid)
+
+        # Recategorize with force
+        result = gc_book.recategorize_transaction(
+            guid=txn_guid,
+            splits=[
+                {
+                    "account": "Assets:Investments:VTSAX",
+                    "amount": "1250.00",
+                    "quantity": "10",
+                },
+                {"account": "Assets:Checking", "amount": "-1250.00"},
+            ],
+            force=True,
+        )
+
+        assert result["status"] == "recategorized"
+        assert "warnings" in result
+        assert any("lot" in w.lower() for w in result["warnings"])
+
+    def test_three_way_split(self, test_book: Path):
+        """Should allow recategorizing to more splits than original."""
+        gc_book = GnuCashBook(str(test_book))
+
+        # Find the grocery transaction (2 splits)
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+        assert len(transactions[0]["splits"]) == 2
+
+        # Create additional accounts
+        gc_book.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        # Recategorize to 3 splits
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "100.00"},
+                {"account": "Expenses:Dining", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        assert result["status"] == "recategorized"
+        assert len(result["splits"]) == 3
+
+    def test_reduce_to_two_splits(self, budget_book: Path):
+        """Should allow recategorizing to fewer splits than original."""
+        gc_book = GnuCashBook(str(budget_book))
+
+        # Create a 3-way split transaction
+        result = gc_book.create_transaction(
+            description="Multi-category purchase",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Expenses:Dining", "amount": "30.00"},
+                {"account": "Assets:Checking", "amount": "-80.00"},
+            ],
+        )
+        guid = result["guid"]
+
+        # Get the transaction to verify 3 splits
+        txn = gc_book.get_transaction(guid)
+        assert len(txn["splits"]) == 3
+
+        # Recategorize to 2 splits
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "80.00"},
+                {"account": "Assets:Checking", "amount": "-80.00"},
+            ],
+        )
+
+        assert result["status"] == "recategorized"
+        assert len(result["splits"]) == 2
+
+    def test_preserves_memo(self, test_book: Path):
+        """Should preserve memo on new splits when provided."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions("Weekly Groceries")
+        guid = transactions[0]["guid"]
+
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {
+                    "account": "Expenses:Groceries",
+                    "amount": "150.00",
+                    "memo": "Updated memo",
+                },
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        assert result["status"] == "recategorized"
+        groceries_split = next(
+            s for s in result["splits"] if s["account"] == "Expenses:Groceries"
+        )
+        assert groceries_split["memo"] == "Updated memo"
+
+    def test_cross_currency_requires_quantity(self, multi_currency_book: Path):
+        """Should require quantity for cross-currency splits."""
+        gc_book = GnuCashBook(str(multi_currency_book))
+
+        # Find a USD transaction
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        # Try to recategorize to EUR account without quantity
+        with pytest.raises(ValueError, match="requires 'quantity'"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {"account": "Assets:Euro Savings", "amount": "200.00"},
+                    {"account": "Assets:Checking", "amount": "-200.00"},
+                ],
+            )
+
+    def test_cross_currency_with_quantity(self, multi_currency_book: Path):
+        """Should allow cross-currency splits when quantity provided."""
+        gc_book = GnuCashBook(str(multi_currency_book))
+
+        # Find a USD transaction
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        # Recategorize with proper quantity
+        result = gc_book.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {
+                    "account": "Assets:Euro Savings",
+                    "amount": "200.00",
+                    "quantity": "182.00",  # EUR equivalent
+                },
+                {"account": "Assets:Checking", "amount": "-200.00"},
+            ],
+        )
+
+        assert result["status"] == "recategorized"
+        eur_split = next(
+            s for s in result["splits"] if s["account"] == "Assets:Euro Savings"
+        )
+        assert Decimal(eur_split["quantity"]) == Decimal("182.00")
+
+    def test_quantity_sign_mismatch(self, multi_currency_book: Path):
+        """Should reject quantity with opposite sign from amount."""
+        gc_book = GnuCashBook(str(multi_currency_book))
+
+        transactions = gc_book.search_transactions("Groceries")
+        guid = transactions[0]["guid"]
+
+        with pytest.raises(ValueError, match="same sign"):
+            gc_book.recategorize_transaction(
+                guid=guid,
+                splits=[
+                    {
+                        "account": "Assets:Euro Savings",
+                        "amount": "200.00",
+                        "quantity": "-182.00",  # Wrong sign
+                    },
+                    {"account": "Assets:Checking", "amount": "-200.00"},
+                ],
+            )
+
+
 class TestSetReconcileState:
     """Tests for set_reconcile_state method."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -266,6 +266,45 @@ class TestTextFormat:
         assert "test_read" not in content
         assert "balance" not in content
 
+    def test_text_format_logs_recategorize_with_splits(self, temp_book_path, temp_log_dir):
+        """Verify text format logs recategorize with before and after splits."""
+        setup_logging(book_path=str(temp_book_path), debug=False, audit_format="text")
+
+        @audit_log(classification="write", operation="recategorize", entity_type="transaction")
+        def test_recategorize(guid: str, splits: list) -> str:
+            return json.dumps({
+                "guid": guid,
+                "description": "Test Transaction",
+                "date": "2026-02-14",
+                "splits": [
+                    {"account": "Expenses:Dining", "value": "50.00"},
+                    {"account": "Assets:Checking", "value": "-50.00"},
+                ],
+                "previous_splits": [
+                    {"account": "Expenses:Groceries", "value": "50.00"},
+                    {"account": "Assets:Checking", "value": "-50.00"},
+                ],
+                "status": "recategorized",
+            })
+
+        test_recategorize(
+            guid="abc12345",
+            splits=[
+                {"account": "Expenses:Dining", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+        )
+
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        txt_file = temp_log_dir / "audit" / f"{today}.txt"
+        content = txt_file.read_text()
+
+        assert "RECATEGORIZE TRANSACTION" in content
+        assert "Splits (before):" in content
+        assert "Splits (after):" in content
+        assert "Groceries" in content  # Old split (formatted as leaf name)
+        assert "Dining" in content  # New split (formatted as leaf name)
+
 
 class TestAuditLogIntegration:
     """Integration tests for the complete audit trail."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -266,12 +266,12 @@ class TestTextFormat:
         assert "test_read" not in content
         assert "balance" not in content
 
-    def test_text_format_logs_recategorize_with_splits(self, temp_book_path, temp_log_dir):
-        """Verify text format logs recategorize with before and after splits."""
+    def test_text_format_logs_replace_splits(self, temp_book_path, temp_log_dir):
+        """Verify text format logs replace_splits with before and after splits."""
         setup_logging(book_path=str(temp_book_path), debug=False, audit_format="text")
 
-        @audit_log(classification="write", operation="recategorize", entity_type="transaction")
-        def test_recategorize(guid: str, splits: list) -> str:
+        @audit_log(classification="write", operation="replace_splits", entity_type="transaction")
+        def test_replace_splits(guid: str, splits: list) -> str:
             return json.dumps({
                 "guid": guid,
                 "description": "Test Transaction",
@@ -284,10 +284,10 @@ class TestTextFormat:
                     {"account": "Expenses:Groceries", "value": "50.00"},
                     {"account": "Assets:Checking", "value": "-50.00"},
                 ],
-                "status": "recategorized",
+                "status": "splits_replaced",
             })
 
-        test_recategorize(
+        test_replace_splits(
             guid="abc12345",
             splits=[
                 {"account": "Expenses:Dining", "amount": "50.00"},
@@ -299,7 +299,7 @@ class TestTextFormat:
         txt_file = temp_log_dir / "audit" / f"{today}.txt"
         content = txt_file.read_text()
 
-        assert "RECATEGORIZE TRANSACTION" in content
+        assert "REPLACE SPLITS" in content
         assert "Splits (before):" in content
         assert "Splits (after):" in content
         assert "Groceries" in content  # Old split (formatted as leaf name)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -559,11 +559,11 @@ class TestUpdateTransactionTool:
         assert data["status"] == "updated"
 
 
-class TestRecategorizeTransactionTool:
-    """Tests for recategorize_transaction tool."""
+class TestReplaceSplitsTool:
+    """Tests for replace_splits tool."""
 
-    def test_recategorize_basic(self, setup_book_env):
-        """Should recategorize a transaction to different accounts."""
+    def test_replace_splits_basic(self, setup_book_env):
+        """Should replace splits on a transaction with different accounts."""
         # Create a Dining account first
         server_module.create_account(
             name="Dining",
@@ -571,15 +571,15 @@ class TestRecategorizeTransactionTool:
             parent="Expenses",
         )
 
-        # Find a transaction to recategorize
+        # Find a transaction to replace splits on
         transactions = json.loads(server_module.list_transactions())
         grocery_txn = next(
             t for t in transactions if "Groceries" in t["description"]
         )
         guid = grocery_txn["guid"]
 
-        # Recategorize
-        result = server_module.recategorize_transaction(
+        # Replace splits
+        result = server_module.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Dining", "amount": "150.00"},
@@ -588,12 +588,12 @@ class TestRecategorizeTransactionTool:
         )
 
         data = json.loads(result)
-        assert data["status"] == "recategorized"
+        assert data["status"] == "splits_replaced"
         accounts = {s["account"] for s in data["splits"]}
         assert "Expenses:Dining" in accounts
         assert "Expenses:Groceries" not in accounts
 
-    def test_recategorize_returns_previous_splits(self, setup_book_env):
+    def test_replace_splits_returns_previous_splits(self, setup_book_env):
         """Should include previous_splits for audit trail."""
         transactions = json.loads(server_module.list_transactions())
         grocery_txn = next(
@@ -601,7 +601,7 @@ class TestRecategorizeTransactionTool:
         )
         guid = grocery_txn["guid"]
 
-        result = server_module.recategorize_transaction(
+        result = server_module.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Groceries", "amount": "150.00"},
@@ -613,12 +613,12 @@ class TestRecategorizeTransactionTool:
         assert "previous_splits" in data
         assert len(data["previous_splits"]) == 2
 
-    def test_recategorize_unbalanced_error(self, setup_book_env):
+    def test_replace_splits_unbalanced_error(self, setup_book_env):
         """Should return error for unbalanced splits."""
         transactions = json.loads(server_module.list_transactions())
         guid = transactions[0]["guid"]
 
-        result = server_module.recategorize_transaction(
+        result = server_module.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses:Groceries", "amount": "150.00"},
@@ -630,12 +630,12 @@ class TestRecategorizeTransactionTool:
         assert "error" in data
         assert "balance" in data["error"].lower()
 
-    def test_recategorize_placeholder_error(self, setup_book_env):
+    def test_replace_splits_placeholder_error(self, setup_book_env):
         """Should return error for placeholder account."""
         transactions = json.loads(server_module.list_transactions())
         guid = transactions[0]["guid"]
 
-        result = server_module.recategorize_transaction(
+        result = server_module.replace_splits(
             guid=guid,
             splits=[
                 {"account": "Expenses", "amount": "150.00"},

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -559,6 +559,95 @@ class TestUpdateTransactionTool:
         assert data["status"] == "updated"
 
 
+class TestRecategorizeTransactionTool:
+    """Tests for recategorize_transaction tool."""
+
+    def test_recategorize_basic(self, setup_book_env):
+        """Should recategorize a transaction to different accounts."""
+        # Create a Dining account first
+        server_module.create_account(
+            name="Dining",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+
+        # Find a transaction to recategorize
+        transactions = json.loads(server_module.list_transactions())
+        grocery_txn = next(
+            t for t in transactions if "Groceries" in t["description"]
+        )
+        guid = grocery_txn["guid"]
+
+        # Recategorize
+        result = server_module.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Dining", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert data["status"] == "recategorized"
+        accounts = {s["account"] for s in data["splits"]}
+        assert "Expenses:Dining" in accounts
+        assert "Expenses:Groceries" not in accounts
+
+    def test_recategorize_returns_previous_splits(self, setup_book_env):
+        """Should include previous_splits for audit trail."""
+        transactions = json.loads(server_module.list_transactions())
+        grocery_txn = next(
+            t for t in transactions if "Groceries" in t["description"]
+        )
+        guid = grocery_txn["guid"]
+
+        result = server_module.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "previous_splits" in data
+        assert len(data["previous_splits"]) == 2
+
+    def test_recategorize_unbalanced_error(self, setup_book_env):
+        """Should return error for unbalanced splits."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "balance" in data["error"].lower()
+
+    def test_recategorize_placeholder_error(self, setup_book_env):
+        """Should return error for placeholder account."""
+        transactions = json.loads(server_module.list_transactions())
+        guid = transactions[0]["guid"]
+
+        result = server_module.recategorize_transaction(
+            guid=guid,
+            splits=[
+                {"account": "Expenses", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+        )
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "placeholder" in data["error"].lower()
+
+
 class TestSetReconcileStateTool:
     """Tests for set_reconcile_state tool."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "gnucash-mcp"
-version = "0.9.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Add `replace_splits` tool for wholesale split replacement on existing transactions
- Add audit logging for replace_splits operations
- Bump version to v1.0.0

## Test plan
- [x] Run full test suite (`uv run pytest`)
- [x] Live test replace_splits via MCP
- [x] Verify audit log entries for replace_splits