### PR TITLE
Compact output, partial GUIDs, and book summary (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ gnucash-mcp/
 - [x] Scheduled transactions
 - [x] Audit logging
 - [x] Split recategorization (`replace_splits`)
+- [x] Compact output for reduced token usage
+- [x] Partial GUID support (8+ character prefixes)
 - [ ] CSV export
 - [ ] CSV/OFX import
 - [ ] Duplicate detection

--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ Ask Claude:
 
 ## What can it do?
 
-**51 tools** across eleven categories:
+**52 tools** across twelve categories:
 
 | Category | What you can ask |
 |----------|------------------|
+| **Overview** | "Summarize the book", "What's the financial picture?", "Orient me" |
 | **Accounts** | "List my accounts", "What's my checking balance?", "Create a new expense category for subscriptions" |
 | **Transactions** | "Show recent transactions", "Record a $50 grocery purchase", "Find all Amazon transactions" |
 | **Budgets** | "Create a monthly budget", "Set grocery budget to $500", "How am I doing on my budget?" |
@@ -292,13 +293,14 @@ Example audit entry:
 
 ---
 
-## All 51 Tools
+## All 52 Tools
 
 <details>
 <summary>Click to expand full tool list</summary>
 
 | Category | Tools |
 |----------|-------|
+| Overview | `get_book_summary` |
 | Accounts | `list_accounts`, `get_account`, `get_balance`, `create_account`, `update_account`, `move_account`, `delete_account` |
 | Commodities & Prices | `list_commodities`, `create_commodity`, `create_price`, `get_prices`, `get_latest_price` |
 | Transactions | `list_transactions`, `get_transaction`, `create_transaction`, `update_transaction`, `replace_splits`, `delete_transaction`, `search_transactions`, `void_transaction`, `unvoid_transaction` |

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ gnucash-mcp/
 - [x] Partial GUID support (8+ character prefixes)
 - [ ] CSV export
 - [ ] CSV/OFX import
-- [ ] Duplicate detection
+- [x] Duplicate detection (built into `create_transaction`)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gnucash-mcp"
-version = "1.0.0"
+version = "1.0.2"
 description = "MCP server for GnuCash accounting data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gnucash_mcp/__init__.py
+++ b/src/gnucash_mcp/__init__.py
@@ -3,5 +3,5 @@
 from gnucash_mcp.book import GnuCashLockError
 from gnucash_mcp.server import main
 
-__version__ = "1.0.0"
+__version__ = "1.0.2"
 __all__ = ["main", "GnuCashLockError"]

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -85,6 +85,11 @@ def _account_to_compact_line(account: piecash.Account) -> str:
 
 def _split_to_dict(split: piecash.Split) -> dict:
     """Convert a piecash Split to a serializable dict."""
+    # Treat epoch zero (1970-01-01) as null — GnuCash stores this
+    # as the default for unreconciled splits instead of NULL
+    rec_date = split.reconcile_date
+    if rec_date and rec_date.year <= 1970:
+        rec_date = None
     return {
         "guid": split.guid,
         "account": split.account.fullname,
@@ -92,7 +97,7 @@ def _split_to_dict(split: piecash.Split) -> dict:
         "quantity": str(split.quantity),
         "memo": split.memo or "",
         "reconcile_state": split.reconcile_state,
-        "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date else None,
+        "reconcile_date": rec_date.isoformat() if rec_date else None,
         "lot_guid": split.lot.guid if split.lot else None,
     }
 
@@ -109,6 +114,110 @@ def _transaction_to_dict(transaction: piecash.Transaction) -> dict:
     if transaction.notes:
         result["notes"] = transaction.notes
     return result
+
+
+def _transaction_to_compact_line(
+    transaction: piecash.Transaction, exclude_account: str | None = None,
+) -> str:
+    """Convert a piecash Transaction to a compact one-line tab-separated string.
+
+    Format: "YYYY-MM-DD\\tabcd1234\\tDescription\\tAccount amount, Account amount"
+
+    Fields are tab-separated so descriptions can be any length without
+    truncation — important for matching. Tabs are single-token for LLMs
+    and never appear in transaction descriptions.
+
+    Args:
+        transaction: piecash Transaction object.
+        exclude_account: If set, omit the split for this account (used when
+                        listing transactions filtered by account — the AI
+                        already knows the filtered account).
+
+    Examples:
+        "2026-02-15\\ta1b2c3d4\\tSafeway\\tExpenses:Groceries 47.50, Liabilities:Visa -47.50"
+        "2026-02-14\\te5f6a7b8\\tMonthly Rent\\tExpenses:Rent 1850.00, Assets:Checking -1850.00"
+    """
+    date_str = transaction.post_date.isoformat()
+    short_guid = transaction.guid[:8]
+    desc = transaction.description
+
+    parts = []
+    for split in transaction.splits:
+        account_name = split.account.fullname
+        if exclude_account and account_name == exclude_account:
+            continue
+        amount = split.quantity
+        # For multi-currency, show both quantity and value
+        if split.quantity != split.value:
+            currency = transaction.currency.mnemonic
+            commodity = split.account.commodity.mnemonic
+            parts.append(f"{account_name} {amount} {commodity} (={split.value} {currency})")
+        else:
+            parts.append(f"{account_name} {amount}")
+
+    splits_str = ", ".join(parts)
+    line = f"{date_str}\t{short_guid}\t{desc}\t{splits_str}"
+    if transaction.notes:
+        line += f"\t{transaction.notes}"
+    return line
+
+
+def _lot_to_compact_line(lot_dict: dict) -> str:
+    """Convert a lot dict to a compact one-line tab-separated string.
+
+    Format: "short_guid\\ttitle\\tquantity shares\\tcost_basis basis\\tclosed"
+
+    Examples:
+        "a1b2c3d4\\tVTSAX 2026-01-15 purchase\\t10.0000 shares\\t2504.50 basis"
+        "e5f6a7b8\\tAAPL 2025-06-01 purchase\\t0 shares\\t0 basis\\tCLOSED"
+    """
+    short_guid = lot_dict["guid"][:8]
+    title = lot_dict["title"]
+    qty = lot_dict["quantity"]
+    basis = lot_dict["cost_basis"]
+    parts = [short_guid, title, f"{qty} shares", f"{basis} basis"]
+    if lot_dict.get("is_closed"):
+        parts.append("CLOSED")
+    return "\t".join(parts)
+
+
+def _sx_to_compact_line(sx_dict: dict) -> str:
+    """Convert a scheduled transaction dict to a compact one-line tab-separated string.
+
+    Format: "short_guid\\tname\\tfrequency\\tnext:YYYY-MM-DD"
+
+    Examples:
+        "a1b2c3d4\\tMonthly Rent\\tmonthly\\tnext:2026-03-01"
+        "e5f6a7b8\\tWeekly Groceries\\tweekly\\tnext:2026-02-22"
+        "c9d0e1f2\\tOld Subscription\\tmonthly\\tdisabled"
+    """
+    short_guid = sx_dict["guid"][:8]
+    name = sx_dict["name"]
+    freq = sx_dict["frequency"]
+    if not sx_dict.get("enabled"):
+        status = "disabled"
+    elif sx_dict.get("next_occurrence"):
+        status = f"next:{sx_dict['next_occurrence']}"
+    else:
+        status = "no upcoming"
+    return f"{short_guid}\t{name}\t{freq}\t{status}"
+
+
+def _upcoming_to_compact_line(entry: dict) -> str:
+    """Convert an upcoming transaction dict to a compact one-line tab-separated string.
+
+    Format: "short_guid\\tname\\tYYYY-MM-DD\\tN days\\tamount"
+
+    Examples:
+        "a390ebb7\\tComcast Xfinity\\t2026-02-27\\t12 days\\t149.26"
+        "b1c2d3e4\\tMonthly Rent\\t2026-03-01\\t14 days\\t1850.00"
+    """
+    short_guid = entry["guid"][:8]
+    name = entry["name"]
+    occ_date = entry["occurrence_date"]
+    days = entry["days_until"]
+    amount = entry["amount"]
+    return f"{short_guid}\t{name}\t{occ_date}\t{days} days\t{amount}"
 
 
 class GnuCashBook:
@@ -987,7 +1096,8 @@ class GnuCashBook:
         start_date: date | None = None,
         end_date: date | None = None,
         limit: int = 50,
-    ) -> list[dict]:
+        compact: bool = True,
+    ) -> list[dict] | str:
         """List transactions with optional filters.
 
         Args:
@@ -995,9 +1105,13 @@ class GnuCashBook:
             start_date: Filter transactions on or after this date.
             end_date: Filter transactions on or before this date.
             limit: Maximum number of transactions to return.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per transaction. If False, return
+                     the full list of transaction dicts.
 
         Returns:
-            List of transaction dicts, most recent first.
+            If compact: newline-separated string of transaction lines.
+            If not compact: list of transaction dicts, most recent first.
 
         Raises:
             ValueError: If specified account not found.
@@ -1027,7 +1141,12 @@ class GnuCashBook:
             # Apply limit
             filtered = filtered[:limit]
 
-            return [_transaction_to_dict(t) for t in filtered]
+            if compact:
+                lines = [_transaction_to_compact_line(t, exclude_account=account)
+                         for t in filtered]
+                return "\n".join(lines)
+            else:
+                return [_transaction_to_dict(t) for t in filtered]
 
     def get_transaction(self, guid: str) -> dict | None:
         """Get details for a specific transaction by GUID.
@@ -1715,7 +1834,9 @@ class GnuCashBook:
             result["auto_filled_from"] = auto_filled_from
         return result
 
-    def search_transactions(self, query: str, field: str = "description") -> list[dict]:
+    def search_transactions(
+        self, query: str, field: str = "description", compact: bool = True,
+    ) -> list[dict] | str:
         """Search transactions by field.
 
         Args:
@@ -1726,9 +1847,13 @@ class GnuCashBook:
                    - Range: "100-200"
             field: Field to search: 'description', 'memo', 'notes',
                    or 'amount'.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per transaction. If False, return
+                     the full list of transaction dicts.
 
         Returns:
-            List of matching transactions.
+            If compact: newline-separated string of transaction lines.
+            If not compact: list of matching transaction dicts.
 
         Raises:
             ValueError: If field is not valid.
@@ -1737,30 +1862,35 @@ class GnuCashBook:
             raise ValueError(f"Invalid search field: {field}")
 
         with self.open(readonly=True) as book:
-            results = []
+            matched = []
 
             for transaction in book.transactions:
                 if field == "description":
                     if query.lower() in transaction.description.lower():
-                        results.append(_transaction_to_dict(transaction))
+                        matched.append(transaction)
 
                 elif field == "notes":
                     if transaction.notes and query.lower() in transaction.notes.lower():
-                        results.append(_transaction_to_dict(transaction))
+                        matched.append(transaction)
 
                 elif field == "memo":
-                    # Search across all split memos
                     for split in transaction.splits:
                         if split.memo and query.lower() in split.memo.lower():
-                            results.append(_transaction_to_dict(transaction))
+                            matched.append(transaction)
                             break
 
                 elif field == "amount":
-                    # Parse amount query for ranges/comparisons
                     if self._match_amount(transaction, query):
-                        results.append(_transaction_to_dict(transaction))
+                        matched.append(transaction)
 
-            return results
+            # Sort by date descending
+            matched.sort(key=lambda t: t.post_date, reverse=True)
+
+            if compact:
+                lines = [_transaction_to_compact_line(t) for t in matched]
+                return "\n".join(lines)
+            else:
+                return [_transaction_to_dict(t) for t in matched]
 
     def _match_amount(self, transaction: piecash.Transaction, query: str) -> bool:
         """Check if any split amount matches the query.
@@ -2069,7 +2199,7 @@ class GnuCashBook:
 
             # Capture info before deletion
             result = {
-                "guid": guid,
+                "guid": transaction.guid,
                 "description": transaction.description,
                 "status": "deleted",
             }
@@ -2428,11 +2558,11 @@ class GnuCashBook:
             book.save()
 
             return {
-                "split_guid": split_guid,
+                "split_guid": split.guid,
                 "account": split.account.fullname,
                 "amount": str(split.quantity),
                 "reconcile_state": state,
-                "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date else None,
+                "reconcile_date": split.reconcile_date.isoformat() if split.reconcile_date and split.reconcile_date.year > 1970 else None,
                 "status": "updated",
             }
 
@@ -2628,7 +2758,7 @@ class GnuCashBook:
             book.save()
 
             return {
-                "guid": guid,
+                "guid": transaction.guid,
                 "description": transaction.description,
                 "void_reason": reason,
                 "status": "voided",
@@ -3459,6 +3589,26 @@ class GnuCashBook:
 
     # ============== Scheduled Transaction Methods ==============
 
+    def _find_scheduled_transaction(self, book, guid: str):
+        """Find a scheduled transaction by GUID (supports partial GUIDs, 8+ chars).
+
+        Args:
+            book: Open piecash book.
+            guid: Scheduled transaction GUID or prefix (minimum 8 characters).
+
+        Returns:
+            ScheduledTransaction if found, None otherwise.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        try:
+            full_guid = self._resolve_guid("schedxactions", guid)
+        except ValueError as e:
+            if "No schedxaction" in str(e):
+                return None
+            raise
+        return book.session.query(ScheduledTransaction).filter_by(guid=full_guid).first()
+
     def create_scheduled_transaction(
         self,
         name: str,
@@ -3621,15 +3771,20 @@ class GnuCashBook:
     def list_scheduled_transactions(
         self,
         enabled_only: bool = True,
-    ) -> list[dict]:
+        compact: bool = True,
+    ) -> list[dict] | str:
         """List all scheduled transactions.
 
         Args:
             enabled_only: If True, only show enabled schedules.
                          Default True.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per scheduled transaction. If
+                     False, return the full list of dicts.
 
         Returns:
-            List of scheduled transaction dicts.
+            If compact: newline-separated string of scheduled transaction lines.
+            If not compact: list of scheduled transaction dicts.
         """
         from piecash.core.transaction import ScheduledTransaction
 
@@ -3643,22 +3798,32 @@ class GnuCashBook:
                 if enabled_only and not sx.enabled:
                     continue
                 d = self._sx_to_dict(sx)
-                d["splits"] = self._get_sx_splits(book, sx)
+                if not compact:
+                    d["splits"] = self._get_sx_splits(book, sx)
                 results.append(d)
 
-            return results
+            if compact:
+                lines = [_sx_to_compact_line(d) for d in results]
+                return "\n".join(lines)
+            else:
+                return results
 
     def get_upcoming_transactions(
         self,
         days: int = 14,
-    ) -> list[dict]:
+        compact: bool = True,
+    ) -> list[dict] | str:
         """Get scheduled transactions due within a time window.
 
         Args:
             days: Look ahead window in days. Default 14.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per upcoming transaction. If
+                     False, return the full list of dicts with splits.
 
         Returns:
-            List of upcoming occurrences sorted by date.
+            If compact: newline-separated string of upcoming transaction lines.
+            If not compact: list of upcoming occurrence dicts sorted by date.
         """
         from piecash.core.transaction import ScheduledTransaction
 
@@ -3710,18 +3875,25 @@ class GnuCashBook:
                         if amt > 0:
                             total += amt
 
-                    upcoming.append({
+                    entry = {
                         "guid": sx.guid,
                         "name": sx.name,
                         "occurrence_date": next_occ.isoformat(),
                         "days_until": (next_occ - today).days,
                         "amount": str(total),
-                        "splits": splits,
-                    })
+                    }
+                    if not compact:
+                        entry["splits"] = splits
+                    upcoming.append(entry)
 
             # Sort by occurrence date
             upcoming.sort(key=lambda x: x["occurrence_date"])
-            return upcoming
+
+            if compact:
+                lines = [_upcoming_to_compact_line(e) for e in upcoming]
+                return "\n".join(lines)
+            else:
+                return upcoming
 
     def create_transaction_from_scheduled(
         self,
@@ -3741,12 +3913,8 @@ class GnuCashBook:
         Raises:
             ValueError: If scheduled transaction not found or disabled.
         """
-        from piecash.core.transaction import ScheduledTransaction
-
         with self.open(readonly=False) as book:
-            sx = book.session.query(
-                ScheduledTransaction
-            ).filter_by(guid=guid).first()
+            sx = self._find_scheduled_transaction(book, guid)
             if not sx:
                 raise ValueError(
                     f"Scheduled transaction not found: {guid}"
@@ -3840,12 +4008,8 @@ class GnuCashBook:
         Raises:
             ValueError: If not found.
         """
-        from piecash.core.transaction import ScheduledTransaction
-
         with self.open(readonly=False) as book:
-            sx = book.session.query(
-                ScheduledTransaction
-            ).filter_by(guid=guid).first()
+            sx = self._find_scheduled_transaction(book, guid)
             if not sx:
                 raise ValueError(
                     f"Scheduled transaction not found: {guid}"
@@ -3881,12 +4045,8 @@ class GnuCashBook:
         """
         from sqlalchemy import text
 
-        from piecash.core.transaction import ScheduledTransaction
-
         with self.open(readonly=False) as book:
-            sx = book.session.query(
-                ScheduledTransaction
-            ).filter_by(guid=guid).first()
+            sx = self._find_scheduled_transaction(book, guid)
             if not sx:
                 raise ValueError(
                     f"Scheduled transaction not found: {guid}"
@@ -3920,18 +4080,24 @@ class GnuCashBook:
     # ── Lot (Cost Basis Tracking) Methods ─────────────────────────
 
     def _find_lot(self, book: piecash.Book, guid: str):
-        """Find a lot by GUID.
+        """Find a lot by GUID (supports partial GUIDs, 8+ chars).
 
         Args:
             book: Open piecash book.
-            guid: Lot GUID.
+            guid: Lot GUID or prefix (minimum 8 characters).
 
         Returns:
             Lot if found, None otherwise.
         """
         from piecash.core.transaction import Lot
 
-        return book.session.query(Lot).filter_by(guid=guid).first()
+        try:
+            full_guid = self._resolve_guid("lots", guid)
+        except ValueError as e:
+            if "No lot" in str(e):
+                return None
+            raise
+        return book.session.query(Lot).filter_by(guid=full_guid).first()
 
     def _lot_summary(self, lot) -> dict:
         """Compute current state of a lot from its splits.
@@ -4016,16 +4182,21 @@ class GnuCashBook:
         self,
         account: str,
         include_closed: bool = False,
-    ) -> list[dict]:
+        compact: bool = True,
+    ) -> list[dict] | str:
         """List all lots for an investment account.
 
         Args:
             account: Full path of investment account.
             include_closed: If True, include fully-sold lots. Default False.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per lot. If False, return
+                     the full list of lot dicts.
 
         Returns:
-            List of lot dicts with guid, title, notes, is_closed,
-            quantity, cost_basis, cost_per_share.
+            If compact: newline-separated string of lot lines.
+            If not compact: list of lot dicts with guid, title, notes,
+            is_closed, quantity, cost_basis, cost_per_share.
 
         Raises:
             ValueError: If account not found.
@@ -4047,7 +4218,11 @@ class GnuCashBook:
                     **summary,
                 })
 
-            return results
+            if compact:
+                lines = [_lot_to_compact_line(d) for d in results]
+                return "\n".join(lines)
+            else:
+                return results
 
     def get_lot(self, guid: str) -> dict:
         """Get detailed information about a lot.
@@ -4145,8 +4320,8 @@ class GnuCashBook:
 
             return {
                 "status": "assigned",
-                "split_guid": split_guid,
-                "lot_guid": lot_guid,
+                "split_guid": split.guid,
+                "lot_guid": lot.guid,
                 **summary,
             }
 
@@ -4259,7 +4434,7 @@ class GnuCashBook:
             book.save()
 
             return {
-                "guid": guid,
+                "guid": lot.guid,
                 "title": lot.title,
                 "status": "closed",
             }

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -116,6 +116,44 @@ def _transaction_to_dict(transaction: piecash.Transaction) -> dict:
     return result
 
 
+def _commodity_to_compact_line(namespace: str, entry: dict) -> str:
+    """Convert a commodity dict to a compact one-line tab-separated string.
+
+    Format: "NAMESPACE:MNEMONIC\\tfullname\\tprice_info"
+
+    Examples:
+        "CURRENCY:USD\\tUS Dollar"
+        "FUND:VTSAX\\tVanguard Total Stock Market\\t128.75 USD (2026-02-07)"
+    """
+    prefix = f"{namespace}:{entry['mnemonic']}"
+    name = entry.get("fullname", "")
+    parts = [prefix, name]
+    lp = entry.get("latest_price")
+    if lp:
+        parts.append(f"{lp['value']} {lp['currency']} ({lp['date']})")
+    return "\t".join(parts)
+
+
+def _unreconciled_split_to_compact_line(split_dict: dict) -> str:
+    """Convert an unreconciled split dict to a compact one-line tab-separated string.
+
+    Format: "short_guid\\tYYYY-MM-DD\\tdescription\\tamount\\tstate"
+
+    The account name is omitted — the caller already knows which account
+    was queried. State is 'n' (new) or 'c' (cleared).
+
+    Examples:
+        "a1b2c3d4\\t2026-01-15\\tSafeway\\t-47.50\\tn"
+        "e5f6a7b8\\t2026-01-20\\tPayroll\\t3200.00\\tc"
+    """
+    short_guid = split_dict["guid"][:8]
+    d = split_dict["date"]
+    desc = split_dict["description"]
+    amount = split_dict["amount"]
+    state = split_dict["reconcile_state"]
+    return f"{short_guid}\t{d}\t{desc}\t{amount}\t{state}"
+
+
 def _transaction_to_compact_line(
     transaction: piecash.Transaction, exclude_account: str | None = None,
 ) -> str:
@@ -722,12 +760,16 @@ class GnuCashBook:
             return json.loads(row[0])
         return []
 
-    def list_commodities(self) -> dict:
+    def list_commodities(self, compact: bool = True) -> dict | str:
         """List all commodities in the book with latest prices.
 
+        Args:
+            compact: If True (default), return compact one-line-per-commodity
+                     string. If False, return full dict grouped by namespace.
+
         Returns:
-            Dict with commodities grouped by namespace, plus the default currency.
-            Non-currency commodities include their latest price when available.
+            If compact: newline-separated string of commodity lines.
+            If not compact: dict with commodities grouped by namespace.
         """
         with self.open(readonly=True) as book:
             by_namespace: dict[str, list[dict]] = {}
@@ -767,10 +809,19 @@ class GnuCashBook:
             for ns in by_namespace:
                 by_namespace[ns].sort(key=lambda c: c["mnemonic"])
 
-            return {
+            result = {
                 "default_currency": book.default_currency.mnemonic,
                 "commodities": by_namespace,
             }
+
+            if compact:
+                lines = []
+                for ns, entries in sorted(by_namespace.items()):
+                    for entry in entries:
+                        lines.append(_commodity_to_compact_line(ns, entry))
+                return "\n".join(lines)
+            else:
+                return result
 
     def create_commodity(
         self,
@@ -2570,15 +2621,20 @@ class GnuCashBook:
         self,
         account_name: str,
         as_of_date: date | None = None,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Get all unreconciled splits for an account.
 
         Args:
             account_name: Full account path.
             as_of_date: Only include splits on or before this date.
+            compact: If True (default), return a compact newline-separated
+                     string with one line per split plus a summary footer.
+                     If False, return the full dict with splits list.
 
         Returns:
-            Dict with account info, splits list, and running totals.
+            If compact: newline-separated string of split lines with summary.
+            If not compact: dict with account info, splits list, and totals.
 
         Raises:
             ValueError: If account not found.
@@ -2620,7 +2676,7 @@ class GnuCashBook:
                     else:
                         uncleared_total += split.quantity
 
-            return {
+            result = {
                 "account": account_name,
                 "as_of_date": as_of_date.isoformat() if as_of_date else None,
                 "splits": unreconciled,
@@ -2628,6 +2684,14 @@ class GnuCashBook:
                 "uncleared_total": str(uncleared_total),
                 "count": len(unreconciled),
             }
+
+            if compact:
+                lines = [_unreconciled_split_to_compact_line(s) for s in unreconciled]
+                footer = f"{len(unreconciled)} splits\tcleared:{cleared_total}\tuncleared:{uncleared_total}"
+                lines.append(footer)
+                return "\n".join(lines)
+            else:
+                return result
 
     def reconcile_account(
         self,

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -1062,6 +1062,171 @@ class GnuCashBook:
                 "source": latest.source,
             }
 
+    def get_book_summary(self) -> str:
+        """Return a compact text summary of the entire book.
+
+        Provides instant orientation: account structure, transaction volume,
+        key balances, commodities, and scheduled transactions — all in one call.
+
+        Returns:
+            Pre-formatted text summary string.
+        """
+        from piecash.core.transaction import ScheduledTransaction
+
+        with self.open(readonly=True) as book:
+            currency = book.default_currency.mnemonic
+
+            # --- Identify template accounts (scheduled transaction placeholders) ---
+            template_guids = set()
+            rt = book.root_template
+            if rt:
+                template_guids.add(rt.guid)
+                for child in rt.children:
+                    template_guids.add(child.guid)
+
+            # --- Collect parent GUIDs (placeholder containers) ---
+            parent_guids = set()
+            for account in book.accounts:
+                if account.parent and account.parent.type != "ROOT":
+                    parent_guids.add(account.parent.guid)
+
+            # --- Account stats ---
+            asset_types = {"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"}
+
+            # Assets: (leaf_name, balance) for non-placeholder leaf accounts
+            asset_leaves: list[tuple[str, Decimal]] = []
+            # Liabilities: (leaf_name, positive_balance) grouped by category
+            credit_cards: list[tuple[str, Decimal]] = []
+            loan_accts: list[tuple[str, Decimal]] = []
+            other_liab_accts: list[tuple[str, Decimal]] = []
+
+            income_active = 0
+            income_total = 0
+            expense_active = 0
+            expense_total = 0
+            total_accounts = 0
+
+            for account in book.accounts:
+                if account.type == "ROOT":
+                    continue
+                if account.guid in template_guids:
+                    continue
+                total_accounts += 1
+
+                has_activity = len(account.splits) > 0
+                is_leaf = account.guid not in parent_guids
+
+                # Calculate balance
+                balance = Decimal("0")
+                for split in account.splits:
+                    balance += split.quantity
+
+                leaf = account.fullname.split(":")[-1]
+
+                if account.type in asset_types:
+                    if is_leaf and balance != 0:
+                        asset_leaves.append((leaf, balance))
+                elif account.type == "CREDIT":
+                    if is_leaf:
+                        credit_cards.append((leaf, -balance))
+                elif account.type == "LIABILITY":
+                    if is_leaf:
+                        neg_balance = -balance
+                        if "loan" in account.fullname.lower():
+                            loan_accts.append((leaf, neg_balance))
+                        else:
+                            other_liab_accts.append((leaf, neg_balance))
+                elif account.type == "INCOME":
+                    income_total += 1
+                    if has_activity:
+                        income_active += 1
+                elif account.type == "EXPENSE":
+                    expense_total += 1
+                    if has_activity:
+                        expense_active += 1
+
+            # Compute totals from leaf accounts
+            def _r2(v: Decimal) -> Decimal:
+                return v.quantize(Decimal("0.01"))
+
+            assets_total = _r2(sum(b for _, b in asset_leaves) if asset_leaves else Decimal(0))
+            credit_total = _r2(sum(b for _, b in credit_cards) if credit_cards else Decimal(0))
+            loan_total = _r2(sum(b for _, b in loan_accts) if loan_accts else Decimal(0))
+            other_liab_total = _r2(sum(b for _, b in other_liab_accts) if other_liab_accts else Decimal(0))
+            liabilities_total = _r2(credit_total + loan_total + other_liab_total)
+            net_worth = _r2(assets_total - liabilities_total)
+
+            # All liability leaves sorted by balance descending for top-N
+            all_liab_leaves = credit_cards + loan_accts + other_liab_accts
+            all_liab_leaves.sort(key=lambda x: x[1], reverse=True)
+
+            # --- Transaction stats ---
+            transactions = list(book.transactions)
+            total_txns = len(transactions)
+            unreconciled_txns = 0
+            first_date = None
+            last_date = None
+
+            for txn in transactions:
+                d = txn.post_date
+                if first_date is None or d < first_date:
+                    first_date = d
+                if last_date is None or d > last_date:
+                    last_date = d
+                if any(s.reconcile_state != "y" for s in txn.splits):
+                    unreconciled_txns += 1
+
+            # --- Scheduled transactions ---
+            all_sx = book.session.query(ScheduledTransaction).all()
+            enabled_sx = sum(1 for sx in all_sx if sx.enabled)
+
+            # --- Commodities ---
+            commodity_mnemonics = sorted(set(
+                c.mnemonic for c in book.commodities
+            ))
+
+            # --- Build output ---
+            lines = []
+            lines.append(f"Book: {self.book_path}")
+            lines.append(f"Currency: {currency}")
+
+            if first_date and last_date:
+                lines.append(f"Data range: {first_date.isoformat()} to {last_date.isoformat()}")
+
+            lines.append(f"Accounts: {total_accounts} total")
+
+            # Assets section — leaf accounts with balances
+            lines.append(f"Assets: {len(asset_leaves)} accounts, {currency} {assets_total}")
+            for name, bal in sorted(asset_leaves, key=lambda x: x[1], reverse=True):
+                lines.append(f"  {name}: {currency} {_r2(bal)}")
+
+            # Liabilities section — grouped subtotals + top 3
+            liab_count = len(credit_cards) + len(loan_accts) + len(other_liab_accts)
+            lines.append(f"Liabilities: {liab_count} accounts, {currency} {liabilities_total}")
+            if credit_cards:
+                lines.append(f"  Credit cards ({len(credit_cards)}): {currency} {credit_total}")
+            if loan_accts:
+                lines.append(f"  Loans ({len(loan_accts)}): {currency} {loan_total}")
+            if other_liab_accts:
+                lines.append(f"  Other ({len(other_liab_accts)}): {currency} {other_liab_total}")
+            if len(all_liab_leaves) > 1:
+                top_n = all_liab_leaves[:3]
+                top_parts = [f"{n} {currency} {_r2(b)}" for n, b in top_n]
+                lines.append(f"  Top {len(top_n)}: {', '.join(top_parts)}")
+
+            lines.append(f"Income: {income_active} active ({income_total} total)")
+            lines.append(f"Expenses: {expense_active} active ({expense_total} total)")
+
+            lines.append(f"Transactions: {total_txns} ({unreconciled_txns} unreconciled)")
+
+            if enabled_sx > 0:
+                lines.append(f"Scheduled: {enabled_sx} recurring")
+
+            lines.append(f"Commodities: {', '.join(commodity_mnemonics)}")
+            lines.append(f"Net worth: {currency} {net_worth}")
+
+            return "\n".join(lines)
+
     def list_accounts(
         self,
         root: str | None = None,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -15,6 +15,21 @@ from mcp.server.fastmcp import FastMCP
 from gnucash_mcp.book import GnuCashBook, GnuCashLockError
 from gnucash_mcp.logging_config import audit_log, debug_log, get_audit_format, get_log_dir, setup_logging
 
+
+def _json(obj) -> str:
+    """Serialize to minified JSON, stripping noise values."""
+    return json.dumps(_strip_noise(obj), separators=(",", ":"))
+
+
+def _strip_noise(obj):
+    """Recursively remove keys with None or empty-string values from dicts."""
+    if isinstance(obj, dict):
+        return {k: _strip_noise(v) for k, v in obj.items()
+                if v is not None and v != ""}
+    if isinstance(obj, list):
+        return [_strip_noise(item) for item in obj]
+    return obj
+
 # Set up logging
 logger = logging.getLogger(__name__)
 
@@ -70,7 +85,7 @@ def safe_tool(func: Callable) -> Callable:
             return func(*args, **kwargs)
         except GnuCashLockError as e:
             logger.warning(f"Lock error in {func.__name__}: {e}")
-            return json.dumps(
+            return _json(
                 {
                     "error": str(e),
                     "error_type": "lock_error",
@@ -79,7 +94,7 @@ def safe_tool(func: Callable) -> Callable:
             )
         except FileNotFoundError as e:
             logger.error(f"File not found in {func.__name__}: {e}")
-            return json.dumps(
+            return _json(
                 {
                     "error": str(e),
                     "error_type": "file_not_found",
@@ -88,13 +103,13 @@ def safe_tool(func: Callable) -> Callable:
             )
         except ValueError as e:
             logger.warning(f"Validation error in {func.__name__}: {e}")
-            return json.dumps({"error": str(e), "error_type": "validation_error"})
+            return _json({"error": str(e), "error_type": "validation_error"})
         except Exception as e:
             # Catch-all for unexpected errors
             logger.error(
                 f"Unexpected error in {func.__name__}: {e}\n{traceback.format_exc()}"
             )
-            return json.dumps(
+            return _json(
                 {
                     "error": f"Unexpected error: {type(e).__name__}: {e}",
                     "error_type": "unexpected_error",
@@ -126,7 +141,7 @@ def list_accounts(
     book = get_book()
     result = book.list_accounts(root=root, compact=not verbose)
     if verbose:
-        return json.dumps(result, indent=2)
+        return _json(result)
     return result
 
 
@@ -140,7 +155,7 @@ def list_commodities() -> str:
     """
     book = get_book()
     result = book.list_commodities()
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -177,7 +192,7 @@ def create_commodity(
         fraction=fraction,
         cusip=cusip,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -227,7 +242,7 @@ def create_price(
         price_type=price_type,
         source=source,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -265,7 +280,7 @@ def get_prices(
         end_date=end,
         currency=currency,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -293,7 +308,7 @@ def get_latest_price(
         namespace=namespace,
         currency=currency,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -308,8 +323,8 @@ def get_account(name: str) -> str:
     book = get_book()
     result = book.get_account(name)
     if result is None:
-        return json.dumps({"error": f"Account not found: {name}"})
-    return json.dumps(result, indent=2)
+        return _json({"error": f"Account not found: {name}"})
+    return _json(result)
 
 
 @mcp.tool()
@@ -330,7 +345,7 @@ def get_balance(account_name: str, as_of_date: str | None = None) -> str:
         "balance": str(balance),
         "as_of_date": as_of_date if as_of_date else "current",
     }
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -341,20 +356,27 @@ def list_transactions(
     start_date: str | None = None,
     end_date: str | None = None,
     limit: int = 50,
+    verbose: bool = False,
 ) -> str:
     """List transactions with optional filters.
+
+    Returns a compact one-line-per-transaction format by default.
+    Use verbose=true for full JSON with GUIDs, splits, reconcile state, etc.
 
     Args:
         account: Filter by account name
         start_date: Start date in ISO format (YYYY-MM-DD)
         end_date: End date in ISO format (YYYY-MM-DD)
         limit: Maximum number of transactions to return (default 50)
+        verbose: If true, return full JSON details for each transaction.
     """
     book = get_book()
     start = date.fromisoformat(start_date) if start_date else None
     end = date.fromisoformat(end_date) if end_date else None
-    result = book.list_transactions(account, start, end, limit)
-    return json.dumps(result, indent=2)
+    result = book.list_transactions(account, start, end, limit, compact=not verbose)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -369,8 +391,8 @@ def get_transaction(guid: str) -> str:
     book = get_book()
     result = book.get_transaction(guid)
     if result is None:
-        return json.dumps({"error": f"Transaction not found: {guid}"})
-    return json.dumps(result, indent=2)
+        return _json({"error": f"Transaction not found: {guid}"})
+    return _json(result)
 
 
 @mcp.tool()
@@ -417,22 +439,28 @@ def create_transaction(
         force_create=force_create,
         dry_run=dry_run,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
 @safe_tool
 @audit_log(classification="read")
-def search_transactions(query: str, field: str = "description") -> str:
+def search_transactions(query: str, field: str = "description", verbose: bool = False) -> str:
     """Search transactions by description, memo, notes, or amount.
+
+    Returns a compact one-line-per-transaction format by default.
+    Use verbose=true for full JSON with GUIDs, splits, reconcile state, etc.
 
     Args:
         query: Search query string. For amount, supports: exact ("100"), greater (">100"), less ("<100"), range ("100-200")
         field: Field to search: 'description', 'memo', 'notes', or 'amount'
+        verbose: If true, return full JSON details for each transaction.
     """
     book = get_book()
-    result = book.search_transactions(query, field)
-    return json.dumps(result, indent=2)
+    result = book.search_transactions(query, field, compact=not verbose)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -475,7 +503,7 @@ def create_account(
         commodity=commodity,
         commodity_namespace=commodity_namespace,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -502,7 +530,7 @@ def update_account(
         description=description,
         placeholder=placeholder,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -517,7 +545,7 @@ def move_account(name: str, new_parent: str) -> str:
     """
     book = get_book()
     result = book.move_account(name=name, new_parent=new_parent)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -533,7 +561,7 @@ def delete_account(name: str) -> str:
     """
     book = get_book()
     result = book.delete_account(name=name)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -551,7 +579,7 @@ def delete_transaction(guid: str, force: bool = False) -> str:
     """
     book = get_book()
     result = book.delete_transaction(guid, force=force)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -587,7 +615,7 @@ def update_transaction(
         notes=notes,
         force=force,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -620,7 +648,7 @@ def replace_splits(
         splits=splits,
         force=force,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Reconciliation Tools ==============
@@ -648,7 +676,7 @@ def set_reconcile_state(
         state=state,
         reconcile_date=rec_date,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -670,7 +698,7 @@ def get_unreconciled_splits(
         account_name=account,
         as_of_date=date_obj,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -702,7 +730,7 @@ def reconcile_account(
         statement_balance=statement_balance,
         split_guids=split_guids,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Void Tools ==============
@@ -724,7 +752,7 @@ def void_transaction(guid: str, reason: str) -> str:
     """
     book = get_book()
     result = book.void_transaction(guid=guid, reason=reason)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -740,7 +768,7 @@ def unvoid_transaction(guid: str) -> str:
     """
     book = get_book()
     result = book.unvoid_transaction(guid=guid)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Reporting Tools ==============
@@ -767,7 +795,7 @@ def spending_by_category(
         end_date=date.fromisoformat(end_date),
         depth=depth,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -791,7 +819,7 @@ def income_by_source(
         end_date=date.fromisoformat(end_date),
         depth=depth,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -807,7 +835,7 @@ def balance_sheet(as_of_date: str) -> str:
     """
     book = get_book()
     result = book.balance_sheet(as_of_date=date.fromisoformat(as_of_date))
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -833,7 +861,7 @@ def net_worth(
         start_date=date.fromisoformat(start_date) if start_date else None,
         interval=interval,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -857,7 +885,7 @@ def cash_flow(
         end_date=date.fromisoformat(end_date),
         account=account,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Budget Tools ==============
@@ -875,7 +903,7 @@ def list_budgets() -> str:
     """
     book = get_book()
     result = book.list_budgets()
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -893,8 +921,8 @@ def get_budget(name: str) -> str:
     book = get_book()
     result = book.get_budget(name)
     if result is None:
-        return json.dumps({"error": f"Budget not found: {name}"})
-    return json.dumps(result, indent=2)
+        return _json({"error": f"Budget not found: {name}"})
+    return _json(result)
 
 
 @mcp.tool()
@@ -927,7 +955,7 @@ def create_budget(
         period_type=period_type,
         description=description,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -957,7 +985,7 @@ def set_budget_amount(
         amount=amount,
         period=period,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -988,7 +1016,7 @@ def get_budget_report(
         account=account,
         include_children=include_children,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1002,7 +1030,7 @@ def delete_budget(name: str) -> str:
     """
     book = get_book()
     result = book.delete_budget(name=name)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Scheduled Transaction Tools ==============
@@ -1047,7 +1075,7 @@ def create_scheduled_transaction(
         end_date=end_date,
         enabled=enabled,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1055,20 +1083,25 @@ def create_scheduled_transaction(
 @audit_log(classification="read")
 def list_scheduled_transactions(
     enabled_only: bool = True,
+    verbose: bool = False,
 ) -> str:
     """List all scheduled transactions.
 
+    Returns a compact one-line-per-schedule format by default.
+    Use verbose=true for full JSON with GUIDs, splits, dates, etc.
+
     Args:
         enabled_only: If True, only show enabled schedules. Default True.
-
-    Returns:
-        JSON list with guid, name, frequency, next_occurrence, enabled.
+        verbose: If true, return full JSON details for each scheduled transaction.
     """
     book = get_book()
     result = book.list_scheduled_transactions(
         enabled_only=enabled_only,
+        compact=not verbose,
     )
-    return json.dumps(result, indent=2)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -1076,6 +1109,7 @@ def list_scheduled_transactions(
 @audit_log(classification="read")
 def get_upcoming_transactions(
     days: int = 14,
+    verbose: bool = False,
 ) -> str:
     """Get scheduled transactions due within a time window.
 
@@ -1083,14 +1117,13 @@ def get_upcoming_transactions(
 
     Args:
         days: Look ahead window in days. Default 14.
-
-    Returns:
-        JSON list of upcoming occurrences:
-        [{"name": "...", "occurrence_date": "...", "amount": "...", "days_until": N}]
+        verbose: If true, return full JSON with splits. Default compact one-line format.
     """
     book = get_book()
-    result = book.get_upcoming_transactions(days=days)
-    return json.dumps(result, indent=2)
+    result = book.get_upcoming_transactions(days=days, compact=not verbose)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -1111,7 +1144,7 @@ def create_transaction_from_scheduled(
         guid=guid,
         transaction_date=transaction_date,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1135,7 +1168,7 @@ def update_scheduled_transaction(
         enabled=enabled,
         end_date=end_date,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1151,7 +1184,7 @@ def delete_scheduled_transaction(guid: str) -> str:
     """
     book = get_book()
     result = book.delete_scheduled_transaction(guid=guid)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Lot (Cost Basis) Tools ==============
@@ -1177,7 +1210,7 @@ def create_lot(
     """
     book = get_book()
     result = book.create_lot(account=account, title=title, notes=notes)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1186,23 +1219,23 @@ def create_lot(
 def list_lots(
     account: str,
     include_closed: bool = False,
+    verbose: bool = False,
 ) -> str:
     """List all lots for an investment account.
+
+    Returns a compact one-line-per-lot format by default.
+    Use verbose=true for full JSON with guid, title, notes, etc.
 
     Args:
         account: Full path of investment account.
         include_closed: If True, include fully-sold lots. Default False.
-
-    Returns:
-        JSON list of lots with:
-        - guid, title, notes, is_closed
-        - quantity (shares remaining)
-        - cost_basis (original cost of remaining shares)
-        - cost_per_share
+        verbose: If true, return full JSON details for each lot.
     """
     book = get_book()
-    result = book.list_lots(account=account, include_closed=include_closed)
-    return json.dumps(result, indent=2)
+    result = book.list_lots(account=account, include_closed=include_closed, compact=not verbose)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -1222,7 +1255,7 @@ def get_lot(guid: str) -> str:
     """
     book = get_book()
     result = book.get_lot(guid=guid)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1248,7 +1281,7 @@ def assign_split_to_lot(
     """
     book = get_book()
     result = book.assign_split_to_lot(split_guid=split_guid, lot_guid=lot_guid)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1275,7 +1308,7 @@ def calculate_lot_gain(
     result = book.calculate_lot_gain(
         lot_guid=lot_guid, shares=shares, sale_price=sale_price,
     )
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1296,7 +1329,7 @@ def close_lot(guid: str) -> str:
     """
     book = get_book()
     result = book.close_lot(guid=guid)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Account Slot Tools ==============
@@ -1320,7 +1353,7 @@ def get_account_slots(
     """
     book = get_book()
     result = book.get_account_slots(account_name=account, key=key)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1343,7 +1376,7 @@ def set_account_slot(
     """
     book = get_book()
     result = book.set_account_slot(account_name=account, key=key, value=value)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 @mcp.tool()
@@ -1361,7 +1394,7 @@ def delete_account_slot(
     """
     book = get_book()
     result = book.delete_account_slot(account_name=account, key=key)
-    return json.dumps(result, indent=2)
+    return _json(result)
 
 
 # ============== Resources ==============
@@ -1372,7 +1405,7 @@ def accounts_resource() -> str:
     """Full chart of accounts from the GnuCash book."""
     book = get_book()
     accounts = book.list_accounts(compact=False)
-    return json.dumps(accounts, indent=2)
+    return _json(accounts)
 
 
 # ============== Audit Log Tool ==============
@@ -1399,7 +1432,7 @@ def get_audit_log(
 
     log_dir = get_log_dir()
     if not log_dir:
-        return json.dumps({"error": "Logging not initialized (no book path configured)"})
+        return _json({"error": "Logging not initialized (no book path configured)"})
 
     audit_dir = log_dir / "audit"
     target_date = log_date or datetime.now().astimezone().strftime("%Y-%m-%d")
@@ -1417,7 +1450,7 @@ def get_audit_log(
 
     if not log_file.exists():
         if fmt == "json":
-            return json.dumps({"entries": [], "message": f"No audit log for {target_date}"})
+            return _json({"entries": [], "message": f"No audit log for {target_date}"})
         else:
             return f"No audit log for {target_date}"
 
@@ -1431,14 +1464,14 @@ def get_audit_log(
 
         # If user configured json but we fell back to txt, wrap in JSON with note
         if fmt == "json":
-            return json.dumps({
+            return _json({
                 "content": text_content,
                 "format": "text",
                 "note": (
                     "No .jsonl file found for this date. Returning .txt fallback. "
                     "Ensure GNUCASH_MCP_AUDIT_FORMAT=json is set when starting the server."
                 ),
-            }, indent=2)
+            })
         else:
             # User wants text, return raw text
             return text_content
@@ -1467,10 +1500,7 @@ def get_audit_log(
         return "\n".join(lines) if lines else "No entries"
 
     # User wants JSON, return JSON
-    return json.dumps(
-        {"entries": entries[-limit:], "total_count": len(entries)},
-        indent=2,
-    )
+    return _json({"entries": entries[-limit:], "total_count": len(entries)})
 
 
 # ============== Main ==============

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -127,6 +127,20 @@ def safe_tool(func: Callable) -> Callable:
 @mcp.tool()
 @safe_tool
 @audit_log(classification="read")
+def get_book_summary() -> str:
+    """Get a compact overview of the entire GnuCash book.
+
+    Returns book path, currency, account structure, transaction counts,
+    key balances, net worth, commodities, and scheduled transactions
+    in a single text response. Use this first to orient yourself.
+    """
+    book = get_book()
+    return book.get_book_summary()
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
 def list_accounts(
     root: str | None = None,
     verbose: bool = False,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -8,7 +8,9 @@ import traceback
 from datetime import date
 from functools import wraps
 from pathlib import Path
-from typing import Callable
+from typing import Annotated, Callable
+
+from pydantic import Field
 
 from mcp.server.fastmcp import FastMCP
 
@@ -148,14 +150,20 @@ def list_accounts(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="read")
-def list_commodities() -> str:
+def list_commodities(verbose: bool = False) -> str:
     """List all commodities (currencies, stocks, etc.) in the book.
 
-    Returns commodities grouped by namespace with their mnemonic, fullname, and fraction.
+    Returns a compact one-line-per-commodity format by default.
+    Use verbose=true for full JSON with fraction, latest prices, etc.
+
+    Args:
+        verbose: If true, return full JSON details for each commodity.
     """
     book = get_book()
-    result = book.list_commodities()
-    return _json(result)
+    result = book.list_commodities(compact=not verbose)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -382,11 +390,13 @@ def list_transactions(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="read")
-def get_transaction(guid: str) -> str:
+def get_transaction(
+    guid: Annotated[str, Field(description="Transaction GUID (32-character hex string, or 8+ char prefix)")],
+) -> str:
     """Get details for a specific transaction by GUID.
 
     Args:
-        guid: Transaction GUID (32-character hex string)
+        guid: Transaction GUID (32-character hex string, or 8+ char prefix)
     """
     book = get_book()
     result = book.get_transaction(guid)
@@ -567,14 +577,17 @@ def delete_account(name: str) -> str:
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="delete", entity_type="transaction")
-def delete_transaction(guid: str, force: bool = False) -> str:
+def delete_transaction(
+    guid: Annotated[str, Field(description="Transaction GUID (32-character hex string, or 8+ char prefix)")],
+    force: bool = False,
+) -> str:
     """Delete a transaction by GUID.
 
     Safeguards prevent deletion if the transaction has reconciled splits.
     Use force=true to override.
 
     Args:
-        guid: Transaction GUID (32-character hex string)
+        guid: Transaction GUID (32-character hex string, or 8+ char prefix)
         force: Allow deleting transactions with reconciled splits
     """
     book = get_book()
@@ -586,7 +599,7 @@ def delete_transaction(guid: str, force: bool = False) -> str:
 @safe_tool
 @audit_log(classification="write", operation="update", entity_type="transaction")
 def update_transaction(
-    guid: str,
+    guid: Annotated[str, Field(description="Transaction GUID to update (32-character hex string, or 8+ char prefix)")],
     description: str | None = None,
     transaction_date: str | None = None,
     splits: list[dict] | None = None,
@@ -596,7 +609,7 @@ def update_transaction(
     """Update an existing transaction.
 
     Args:
-        guid: Transaction GUID to update
+        guid: Transaction GUID to update (32-character hex string, or 8+ char prefix)
         description: New transaction description (optional)
         transaction_date: New date in ISO format YYYY-MM-DD (optional)
         splits: List of split updates with 'account' and 'amount' (optional).
@@ -622,7 +635,7 @@ def update_transaction(
 @safe_tool
 @audit_log(classification="write", operation="replace_splits", entity_type="transaction")
 def replace_splits(
-    guid: str,
+    guid: Annotated[str, Field(description="Transaction GUID (32-character hex string, or 8+ char prefix)")],
     splits: list[dict],
     force: bool = False,
 ) -> str:
@@ -633,7 +646,7 @@ def replace_splits(
     New splits must balance to zero.
 
     Args:
-        guid: Transaction GUID (32-character hex string)
+        guid: Transaction GUID (32-character hex string, or 8+ char prefix)
         splits: Complete new set of splits. Each split needs:
             - 'account' (required): Full account path
             - 'amount' (required): Value in transaction currency
@@ -658,14 +671,14 @@ def replace_splits(
 @safe_tool
 @audit_log(classification="write", operation="set_state", entity_type="split")
 def set_reconcile_state(
-    split_guid: str,
+    split_guid: Annotated[str, Field(description="GUID of the split to update (32-character hex string, or 8+ char prefix)")],
     state: str,
     reconcile_date: str | None = None,
 ) -> str:
     """Set the reconciliation state for a split.
 
     Args:
-        split_guid: GUID of the split to update
+        split_guid: GUID of the split to update (32-character hex string, or 8+ char prefix)
         state: New reconcile state: 'n' (new), 'c' (cleared), 'y' (reconciled)
         reconcile_date: Date in ISO format (YYYY-MM-DD). Required for 'y', defaults to today.
     """
@@ -685,20 +698,28 @@ def set_reconcile_state(
 def get_unreconciled_splits(
     account: str,
     as_of_date: str | None = None,
+    verbose: bool = False,
 ) -> str:
     """Get all unreconciled splits for an account.
+
+    Returns a compact one-line-per-split format by default with a summary footer.
+    Use verbose=true for full JSON with split GUIDs, amounts, and totals.
 
     Args:
         account: Full account name (e.g., 'Assets:Bank:Checking')
         as_of_date: Only include splits on or before this date (YYYY-MM-DD)
+        verbose: If true, return full JSON details. Default compact one-line format.
     """
     book = get_book()
     date_obj = date.fromisoformat(as_of_date) if as_of_date else None
     result = book.get_unreconciled_splits(
         account_name=account,
         as_of_date=date_obj,
+        compact=not verbose,
     )
-    return _json(result)
+    if verbose:
+        return _json(result)
+    return result
 
 
 @mcp.tool()
@@ -708,7 +729,7 @@ def reconcile_account(
     account: str,
     statement_date: str,
     statement_balance: str,
-    split_guids: list[str],
+    split_guids: Annotated[list[str], Field(description="List of split GUIDs to mark as reconciled (8+ char prefixes accepted)")],
 ) -> str:
     """Reconcile multiple splits against a statement balance.
 
@@ -720,7 +741,7 @@ def reconcile_account(
         account: Full account name (e.g., 'Assets:Bank:Checking')
         statement_date: Statement ending date (YYYY-MM-DD)
         statement_balance: Expected balance from statement (as string, e.g., '1234.56')
-        split_guids: List of split GUIDs to mark as reconciled
+        split_guids: List of split GUIDs to mark as reconciled (8+ char prefixes accepted)
     """
     book = get_book()
     stmt_date = date.fromisoformat(statement_date)
@@ -739,7 +760,10 @@ def reconcile_account(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="void", entity_type="transaction")
-def void_transaction(guid: str, reason: str) -> str:
+def void_transaction(
+    guid: Annotated[str, Field(description="Transaction GUID to void (32-character hex string, or 8+ char prefix)")],
+    reason: str,
+) -> str:
     """Void a transaction (proper accounting void, not delete).
 
     Voiding preserves the transaction for audit purposes but zeroes out
@@ -747,7 +771,7 @@ def void_transaction(guid: str, reason: str) -> str:
     an audit trail.
 
     Args:
-        guid: Transaction GUID to void
+        guid: Transaction GUID to void (32-character hex string, or 8+ char prefix)
         reason: Reason for voiding (required for audit trail)
     """
     book = get_book()
@@ -758,13 +782,15 @@ def void_transaction(guid: str, reason: str) -> str:
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="unvoid", entity_type="transaction")
-def unvoid_transaction(guid: str) -> str:
+def unvoid_transaction(
+    guid: Annotated[str, Field(description="Transaction GUID to unvoid (32-character hex string, or 8+ char prefix)")],
+) -> str:
     """Restore a voided transaction.
 
     Restores original split values and removes void markers.
 
     Args:
-        guid: Transaction GUID to unvoid
+        guid: Transaction GUID to unvoid (32-character hex string, or 8+ char prefix)
     """
     book = get_book()
     result = book.unvoid_transaction(guid=guid)
@@ -1130,13 +1156,13 @@ def get_upcoming_transactions(
 @safe_tool
 @audit_log(classification="write", operation="create", entity_type="transaction")
 def create_transaction_from_scheduled(
-    guid: str,
+    guid: Annotated[str, Field(description="Scheduled transaction GUID (or 8+ char prefix)")],
     transaction_date: str | None = None,
 ) -> str:
     """Create an actual transaction from a scheduled template.
 
     Args:
-        guid: Scheduled transaction GUID.
+        guid: Scheduled transaction GUID (or 8+ char prefix).
         transaction_date: Date for the transaction. Defaults to next occurrence.
     """
     book = get_book()
@@ -1151,14 +1177,14 @@ def create_transaction_from_scheduled(
 @safe_tool
 @audit_log(classification="write", operation="update", entity_type="scheduled_transaction")
 def update_scheduled_transaction(
-    guid: str,
+    guid: Annotated[str, Field(description="Scheduled transaction GUID (or 8+ char prefix)")],
     enabled: bool | None = None,
     end_date: str | None = None,
 ) -> str:
     """Update a scheduled transaction.
 
     Args:
-        guid: Scheduled transaction GUID.
+        guid: Scheduled transaction GUID (or 8+ char prefix).
         enabled: Enable or disable.
         end_date: Set end date (empty string to clear).
     """
@@ -1174,13 +1200,15 @@ def update_scheduled_transaction(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="delete", entity_type="scheduled_transaction")
-def delete_scheduled_transaction(guid: str) -> str:
+def delete_scheduled_transaction(
+    guid: Annotated[str, Field(description="Scheduled transaction GUID (or 8+ char prefix)")],
+) -> str:
     """Delete a scheduled transaction.
 
     Does not affect transactions already created from this schedule.
 
     Args:
-        guid: Scheduled transaction GUID.
+        guid: Scheduled transaction GUID (or 8+ char prefix).
     """
     book = get_book()
     result = book.delete_scheduled_transaction(guid=guid)
@@ -1241,11 +1269,13 @@ def list_lots(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="read")
-def get_lot(guid: str) -> str:
+def get_lot(
+    guid: Annotated[str, Field(description="Lot GUID (or 8+ char prefix)")],
+) -> str:
     """Get detailed information about a lot.
 
     Args:
-        guid: Lot GUID.
+        guid: Lot GUID (or 8+ char prefix).
 
     Returns:
         JSON with lot details including all splits:
@@ -1262,8 +1292,8 @@ def get_lot(guid: str) -> str:
 @safe_tool
 @audit_log(classification="write", operation="update", entity_type="lot")
 def assign_split_to_lot(
-    split_guid: str,
-    lot_guid: str,
+    split_guid: Annotated[str, Field(description="GUID of the split (from transaction's investment account). 8+ char prefix accepted.")],
+    lot_guid: Annotated[str, Field(description="GUID of the lot (or 8+ char prefix)")],
 ) -> str:
     """Assign a transaction split to a lot.
 
@@ -1271,8 +1301,8 @@ def assign_split_to_lot(
     account split to its lot for cost basis tracking.
 
     Args:
-        split_guid: GUID of the split (from transaction's investment account).
-        lot_guid: GUID of the lot.
+        split_guid: GUID of the split (from transaction's investment account). 8+ char prefix accepted.
+        lot_guid: GUID of the lot (or 8+ char prefix).
 
     Workflow:
         1. create_lot("Assets:VTSAX", "VTSAX Jan 2026")
@@ -1288,7 +1318,7 @@ def assign_split_to_lot(
 @safe_tool
 @audit_log(classification="read")
 def calculate_lot_gain(
-    lot_guid: str,
+    lot_guid: Annotated[str, Field(description="Lot GUID (or 8+ char prefix)")],
     shares: str | None = None,
     sale_price: str | None = None,
 ) -> str:
@@ -1298,7 +1328,7 @@ def calculate_lot_gain(
     Otherwise uses lot's current state and latest price.
 
     Args:
-        lot_guid: Lot GUID.
+        lot_guid: Lot GUID (or 8+ char prefix).
         shares: Optional number of shares to calculate for.
                 Defaults to all remaining shares.
         sale_price: Optional sale price per share.
@@ -1314,14 +1344,16 @@ def calculate_lot_gain(
 @mcp.tool()
 @safe_tool
 @audit_log(classification="write", operation="update", entity_type="lot")
-def close_lot(guid: str) -> str:
+def close_lot(
+    guid: Annotated[str, Field(description="Lot GUID (or 8+ char prefix)")],
+) -> str:
     """Mark a lot as closed.
 
     Use when a lot is fully sold but wasn't automatically marked closed,
     or to manually close a lot with zero shares.
 
     Args:
-        guid: Lot GUID.
+        guid: Lot GUID (or 8+ char prefix).
 
     Note:
         Lots are automatically marked closed when their quantity reaches zero

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -219,7 +219,7 @@ class TestListTransactions:
     def test_list_all_transactions(self, test_book: Path):
         """Should return all transactions."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
 
         assert len(transactions) == 3
         descriptions = {t["description"] for t in transactions}
@@ -232,7 +232,7 @@ class TestListTransactions:
         gc_book = GnuCashBook(str(test_book))
 
         # Groceries account only has one transaction
-        transactions = gc_book.list_transactions(account="Expenses:Groceries")
+        transactions = gc_book.list_transactions(account="Expenses:Groceries", compact=False)
         assert len(transactions) == 1
         assert transactions[0]["description"] == "Weekly Groceries"
 
@@ -244,6 +244,7 @@ class TestListTransactions:
         transactions = gc_book.list_transactions(
             start_date=date(2024, 1, 10),
             end_date=date(2024, 1, 18),
+            compact=False,
         )
         assert len(transactions) == 1
         assert transactions[0]["description"] == "Salary Deposit"
@@ -251,14 +252,14 @@ class TestListTransactions:
     def test_list_transactions_limit(self, test_book: Path):
         """Should respect limit parameter."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(limit=2)
+        transactions = gc_book.list_transactions(limit=2, compact=False)
 
         assert len(transactions) == 2
 
     def test_list_transactions_sorted_descending(self, test_book: Path):
         """Should return transactions sorted by date descending."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
 
         dates = [t["date"] for t in transactions]
         assert dates == sorted(dates, reverse=True)
@@ -279,7 +280,7 @@ class TestGetTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # First get a valid GUID
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         # Then fetch by GUID
@@ -710,7 +711,7 @@ class TestDryRun:
     def test_dry_run_no_write(self, test_book: Path):
         """Dry run should not create a transaction in the book."""
         gc_book = GnuCashBook(str(test_book))
-        before = gc_book.list_transactions()
+        before = gc_book.list_transactions(compact=False)
         gc_book.create_transaction(
             description="Ghost Transaction",
             splits=[
@@ -719,7 +720,7 @@ class TestDryRun:
             ],
             dry_run=True,
         )
-        after = gc_book.list_transactions()
+        after = gc_book.list_transactions(compact=False)
         assert len(after) == len(before)
 
     def test_dry_run_includes_warnings(self, test_book: Path):
@@ -1237,7 +1238,7 @@ class TestSearchTransactions:
         """Should find transactions by description."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("Salary", field="description")
+        results = gc_book.search_transactions("Salary", field="description", compact=False)
         assert len(results) == 1
         assert results[0]["description"] == "Salary Deposit"
 
@@ -1245,14 +1246,14 @@ class TestSearchTransactions:
         """Should search case-insensitively."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("salary", field="description")
+        results = gc_book.search_transactions("salary", field="description", compact=False)
         assert len(results) == 1
 
     def test_search_by_amount_exact(self, test_book: Path):
         """Should find transactions by exact amount."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("150", field="amount")
+        results = gc_book.search_transactions("150", field="amount", compact=False)
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -1260,7 +1261,7 @@ class TestSearchTransactions:
         """Should find transactions with amount greater than threshold."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions(">500", field="amount")
+        results = gc_book.search_transactions(">500", field="amount", compact=False)
         # Opening (1000) and Salary (2000) transactions
         assert len(results) == 2
 
@@ -1268,7 +1269,7 @@ class TestSearchTransactions:
         """Should find transactions with amount less than threshold."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("<200", field="amount")
+        results = gc_book.search_transactions("<200", field="amount", compact=False)
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -1276,7 +1277,7 @@ class TestSearchTransactions:
         """Should find transactions with amount in range."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("100-500", field="amount")
+        results = gc_book.search_transactions("100-500", field="amount", compact=False)
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -1294,7 +1295,7 @@ class TestSearchTransactions:
             notes="P2W1 groceries",
         )
 
-        results = gc_book.search_transactions("P2W1", field="notes")
+        results = gc_book.search_transactions("P2W1", field="notes", compact=False)
         assert len(results) == 1
         assert results[0]["description"] == "Safeway"
         assert results[0]["notes"] == "P2W1 groceries"
@@ -1303,7 +1304,7 @@ class TestSearchTransactions:
         """Should return empty list when no notes match."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("nonexistent", field="notes")
+        results = gc_book.search_transactions("nonexistent", field="notes", compact=False)
         assert len(results) == 0
 
     def test_search_invalid_field(self, test_book: Path):
@@ -1632,7 +1633,7 @@ class TestDeleteTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction to delete
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
         description = transactions[0]["description"]
 
@@ -1656,7 +1657,7 @@ class TestDeleteTransaction:
         """Should reject deletion of transaction with reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
 
@@ -1668,7 +1669,7 @@ class TestDeleteTransaction:
         """Should allow deletion with force=True despite reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
 
@@ -1687,7 +1688,7 @@ class TestUpdateTransaction:
         """Should update only the description."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -1702,7 +1703,7 @@ class TestUpdateTransaction:
         """Should update only the date."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -1718,7 +1719,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get the groceries transaction (150.00)
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -1740,7 +1741,7 @@ class TestUpdateTransaction:
         """Should update description, date, and splits together."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -1771,7 +1772,7 @@ class TestUpdateTransaction:
         """Should raise ValueError for unbalanced splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="do not balance"):
@@ -1787,7 +1788,7 @@ class TestUpdateTransaction:
         """Should raise ValueError if split account not in transaction."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="Account not found in transaction"):
@@ -1803,7 +1804,7 @@ class TestUpdateTransaction:
         """Should add notes to an existing transaction."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -1846,7 +1847,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get the groceries transaction and reconcile a split
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -1864,7 +1865,7 @@ class TestUpdateTransaction:
         """Should allow split updates with force=True despite reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -1883,7 +1884,7 @@ class TestUpdateTransaction:
         """Should allow description/date/notes changes without force on reconciled."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -1904,7 +1905,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         original_splits = transactions[0]["splits"]
 
@@ -1938,7 +1939,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         original_date = transactions[0]["date"]
         original_description = transactions[0]["description"]
@@ -1969,7 +1970,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         original_splits = transactions[0]["splits"]
 
@@ -1998,7 +1999,7 @@ class TestReplaceSplits:
         """Should reject splits that don't balance to zero."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="do not balance"):
@@ -2014,7 +2015,7 @@ class TestReplaceSplits:
         """Should reject fewer than 2 splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="At least 2 splits"):
@@ -2029,7 +2030,7 @@ class TestReplaceSplits:
         """Should reject splits with non-existent accounts."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="Account not found"):
@@ -2045,7 +2046,7 @@ class TestReplaceSplits:
         """Should reject splits to placeholder accounts."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         # Expenses is a placeholder in test_book
@@ -2076,7 +2077,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction and reconcile one of its splits
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -2095,7 +2096,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction and reconcile one of its splits
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -2223,7 +2224,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction (2 splits)
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
         assert len(transactions[0]["splits"]) == 2
 
@@ -2282,7 +2283,7 @@ class TestReplaceSplits:
         """Should preserve memo on new splits when provided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries")
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.replace_splits(
@@ -2308,7 +2309,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(multi_currency_book))
 
         # Find a USD transaction
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         # Try to replace splits to EUR account without quantity
@@ -2326,7 +2327,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(multi_currency_book))
 
         # Find a USD transaction
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         # Recategorize with proper quantity
@@ -2352,7 +2353,7 @@ class TestReplaceSplits:
         """Should reject quantity with opposite sign from amount."""
         gc_book = GnuCashBook(str(multi_currency_book))
 
-        transactions = gc_book.search_transactions("Groceries")
+        transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="same sign"):
@@ -2377,7 +2378,7 @@ class TestSetReconcileState:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a split guid
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = gc_book.set_reconcile_state(split_guid, "c")
@@ -2389,7 +2390,7 @@ class TestSetReconcileState:
         """Should set split to reconciled state with date."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = gc_book.set_reconcile_state(
@@ -2404,7 +2405,7 @@ class TestSetReconcileState:
         """Should reset split to new state."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
 
         # First set to cleared
@@ -2420,7 +2421,7 @@ class TestSetReconcileState:
         """Should raise ValueError for invalid state."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         split_guid = transactions[0]["splits"][0]["guid"]
 
         with pytest.raises(ValueError, match="Invalid reconcile state"):
@@ -2519,7 +2520,7 @@ class TestReconcileAccount:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a split from a different account
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         expense_split = None
         for split in transactions[0]["splits"]:
             if "Expenses" in split["account"]:
@@ -2544,7 +2545,7 @@ class TestVoidTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction to void
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         result = gc_book.void_transaction(guid, reason="Entered in error")
@@ -2562,7 +2563,7 @@ class TestVoidTransaction:
         """Should raise ValueError if no reason provided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="reason is required"):
@@ -2579,7 +2580,7 @@ class TestVoidTransaction:
         """Should raise ValueError if already voided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         # Void once
@@ -2598,7 +2599,7 @@ class TestUnvoidTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get original transaction values
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
         original = gc_book.get_transaction(guid)
         original_values = {s["account"]: s["value"] for s in original["splits"]}
@@ -2620,7 +2621,7 @@ class TestUnvoidTransaction:
         """Should raise ValueError if transaction is not voided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions()
+        transactions = gc_book.list_transactions(compact=False)
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="not voided"):

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -40,6 +40,45 @@ class TestGnuCashBookOpen:
             assert book is not None
 
 
+class TestGetBookSummary:
+    """Tests for get_book_summary method."""
+
+    def test_get_book_summary_returns_string(self, test_book: Path):
+        """Should return a formatted text string."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_book_summary()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_get_book_summary_contains_sections(self, test_book: Path):
+        """Should contain all expected sections."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_book_summary()
+
+        assert "Book:" in result
+        assert "Currency:" in result
+        assert "Accounts:" in result
+        assert "Assets:" in result
+        assert "Liabilities:" in result
+        assert "Income:" in result
+        assert "Expenses:" in result
+        assert "Transactions:" in result
+        assert "Commodities:" in result
+        assert "Net worth:" in result
+
+    def test_get_book_summary_currency(self, test_book: Path):
+        """Should show USD as default currency."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_book_summary()
+        assert "Currency: USD" in result
+
+    def test_get_book_summary_book_path(self, test_book: Path):
+        """Should include the book file path."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.get_book_summary()
+        assert f"Book: {test_book}" in result
+
+
 class TestListAccounts:
     """Tests for list_accounts method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -2442,7 +2442,7 @@ class TestGetUnreconciledSplits:
         """Should return unreconciled splits for account."""
         gc_book = GnuCashBook(str(test_book))
 
-        result = gc_book.get_unreconciled_splits("Assets:Checking")
+        result = gc_book.get_unreconciled_splits("Assets:Checking", compact=False)
 
         assert "splits" in result
         assert "cleared_total" in result
@@ -2457,7 +2457,7 @@ class TestGetUnreconciledSplits:
 
         # Get splits before a specific date
         result = gc_book.get_unreconciled_splits(
-            "Assets:Checking", as_of_date=date(2024, 1, 10)
+            "Assets:Checking", as_of_date=date(2024, 1, 10), compact=False,
         )
 
         # All returned splits should be on or before the date
@@ -2480,7 +2480,7 @@ class TestReconcileAccount:
         gc_book = GnuCashBook(str(test_book))
 
         # Get unreconciled splits
-        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking")
+        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking", compact=False)
 
         # Calculate what the balance should be
         total = Decimal("0")
@@ -2504,7 +2504,7 @@ class TestReconcileAccount:
         """Should raise ValueError when balance doesn't match."""
         gc_book = GnuCashBook(str(test_book))
 
-        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking")
+        unreconciled = gc_book.get_unreconciled_splits("Assets:Checking", compact=False)
         guids = [s["guid"] for s in unreconciled["splits"]]
 
         with pytest.raises(ValueError, match="Balance mismatch"):
@@ -2786,7 +2786,7 @@ class TestListCommodities:
     def test_list_commodities(self, test_book: Path):
         """Should return commodities grouped by namespace."""
         gc_book = GnuCashBook(str(test_book))
-        result = gc_book.list_commodities()
+        result = gc_book.list_commodities(compact=False)
 
         assert "default_currency" in result
         assert result["default_currency"] == "USD"
@@ -2800,7 +2800,7 @@ class TestListCommodities:
     def test_list_commodities_structure(self, test_book: Path):
         """Should return proper structure for each commodity."""
         gc_book = GnuCashBook(str(test_book))
-        result = gc_book.list_commodities()
+        result = gc_book.list_commodities(compact=False)
 
         currencies = result["commodities"]["CURRENCY"]
         for commodity in currencies:
@@ -2874,7 +2874,7 @@ class TestCreateAccountWithCurrency:
         assert result["status"] == "created"
 
         # Verify GBP is now in the commodities list
-        commodities = gc_book.list_commodities()
+        commodities = gc_book.list_commodities(compact=False)
         mnemonics = [c["mnemonic"] for c in commodities["commodities"]["CURRENCY"]]
         assert "GBP" in mnemonics
 
@@ -3126,7 +3126,7 @@ class TestCreateCommodity:
         assert result["fraction"] == 10000
 
         # Verify it appears in list_commodities
-        commodities = gc_book.list_commodities()
+        commodities = gc_book.list_commodities(compact=False)
         assert "FUND" in commodities["commodities"]
         mnemonics = [c["mnemonic"] for c in commodities["commodities"]["FUND"]]
         assert "VTSAX" in mnemonics
@@ -3166,7 +3166,7 @@ class TestCreateCommodity:
         assert result1["status"] == "created"
         assert result2["status"] == "created"
 
-        commodities = gc_book.list_commodities()
+        commodities = gc_book.list_commodities(compact=False)
         assert "FUND" in commodities["commodities"]
         assert "NASDAQ" in commodities["commodities"]
 
@@ -3580,7 +3580,7 @@ class TestInvestmentWorkflow:
             value="128.75", price_date=date(2026, 2, 7),
         )
 
-        commodities = gc_book.list_commodities()
+        commodities = gc_book.list_commodities(compact=False)
         fund_entries = commodities["commodities"]["FUND"]
         vtsax = next(c for c in fund_entries if c["mnemonic"] == "VTSAX")
 

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -90,14 +90,14 @@ class TestCreateLot:
 class TestListLots:
     def test_list_lots_empty(self, investment_book: Path):
         book = GnuCashBook(str(investment_book))
-        result = book.list_lots(account="Assets:Investments:VTSAX")
+        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
         assert result == []
 
     def test_list_lots_with_lots(self, investment_book: Path):
         book = GnuCashBook(str(investment_book))
         book.create_lot(account="Assets:Investments:VTSAX", title="Lot A")
         book.create_lot(account="Assets:Investments:VTSAX", title="Lot B")
-        result = book.list_lots(account="Assets:Investments:VTSAX")
+        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
         assert len(result) == 2
         titles = {r["title"] for r in result}
         assert titles == {"Lot A", "Lot B"}
@@ -109,12 +109,12 @@ class TestListLots:
         book.close_lot(guid=lot_b["guid"])
 
         # Default: exclude closed
-        result = book.list_lots(account="Assets:Investments:VTSAX")
+        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
         assert len(result) == 1
         assert result[0]["title"] == "Open Lot"
 
         # Include closed
-        result = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True)
+        result = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True, compact=False)
         assert len(result) == 2
 
 
@@ -330,11 +330,11 @@ class TestFullLotWorkflow:
         assert len(lot_detail["splits"]) == 2
 
         # Verify excluded from default list
-        lots = book.list_lots(account="Assets:Investments:VTSAX")
+        lots = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
         assert len(lots) == 0
 
         # Verify included when include_closed=True
-        lots = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True)
+        lots = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True, compact=False)
         assert len(lots) == 1
         assert lots[0]["is_closed"] is True
 
@@ -373,7 +373,7 @@ class TestSplitToDictLotGuid:
         txn_desc = lot_detail["splits"][0]["description"]
 
         # Search for the transaction
-        txns = book.search_transactions(query=txn_desc, field="description")
+        txns = book.search_transactions(query=txn_desc, field="description", compact=False)
         assert len(txns) > 0
         txn = book.get_transaction(txns[0]["guid"])
 

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -137,7 +137,7 @@ class TestListScheduled:
 
     def test_empty_list(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
-        result = gb.list_scheduled_transactions()
+        result = gb.list_scheduled_transactions(compact=False)
         assert result == []
 
     def test_lists_created(self, scheduled_book):
@@ -152,7 +152,7 @@ class TestListScheduled:
             start_date="2026-01-01",
             frequency="monthly",
         )
-        result = gb.list_scheduled_transactions()
+        result = gb.list_scheduled_transactions(compact=False)
         assert len(result) == 1
         assert result[0]["name"] == "Rent"
         assert result[0]["frequency"] == "monthly"
@@ -187,12 +187,12 @@ class TestListScheduled:
         gb.update_scheduled_transaction(r1["guid"], enabled=False)
 
         # Default: enabled_only=True
-        enabled = gb.list_scheduled_transactions(enabled_only=True)
+        enabled = gb.list_scheduled_transactions(enabled_only=True, compact=False)
         assert len(enabled) == 1
         assert enabled[0]["name"] == "Utils"
 
         # All
-        all_sx = gb.list_scheduled_transactions(enabled_only=False)
+        all_sx = gb.list_scheduled_transactions(enabled_only=False, compact=False)
         assert len(all_sx) == 2
 
 
@@ -216,7 +216,7 @@ class TestGetUpcoming:
             start_date=tomorrow.isoformat(),
             frequency="monthly",
         )
-        result = gb.get_upcoming_transactions(days=14)
+        result = gb.get_upcoming_transactions(days=14, compact=False)
         assert len(result) == 1
         assert result[0]["name"] == "Rent"
         assert result[0]["amount"] == "1850.00"
@@ -236,7 +236,7 @@ class TestGetUpcoming:
             start_date=future.isoformat(),
             frequency="monthly",
         )
-        result = gb.get_upcoming_transactions(days=14)
+        result = gb.get_upcoming_transactions(days=14, compact=False)
         assert len(result) == 0
 
     def test_disabled_excluded(self, scheduled_book):
@@ -253,7 +253,7 @@ class TestGetUpcoming:
             frequency="monthly",
         )
         gb.update_scheduled_transaction(r["guid"], enabled=False)
-        result = gb.get_upcoming_transactions(days=14)
+        result = gb.get_upcoming_transactions(days=14, compact=False)
         assert len(result) == 0
 
 
@@ -409,7 +409,7 @@ class TestDeleteScheduled:
         assert result["name"] == "Rent"
 
         # Verify gone
-        listed = gb.list_scheduled_transactions(enabled_only=False)
+        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)
         assert len(listed) == 0
 
     def test_delete_nonexistent_error(self, scheduled_book):
@@ -504,7 +504,7 @@ class TestScheduledIntegration:
         )
 
         # List
-        listed = gb.list_scheduled_transactions()
+        listed = gb.list_scheduled_transactions(compact=False)
         assert len(listed) == 1
         assert listed[0]["name"] == "Monthly Rent"
         assert listed[0]["enabled"] is True
@@ -532,7 +532,7 @@ class TestScheduledIntegration:
 
         # Delete
         gb.delete_scheduled_transaction(sx["guid"])
-        listed = gb.list_scheduled_transactions(enabled_only=False)
+        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)
         assert len(listed) == 0
 
     def test_multiple_frequencies(self, scheduled_book):
@@ -551,7 +551,7 @@ class TestScheduledIntegration:
                 frequency=freq,
             )
 
-        listed = gb.list_scheduled_transactions()
+        listed = gb.list_scheduled_transactions(compact=False)
         assert len(listed) == 5
         freqs = {sx["frequency"] for sx in listed}
         assert freqs == {"weekly", "biweekly", "monthly", "quarterly", "yearly"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -678,7 +678,7 @@ class TestGetUnreconciledSplitsTool:
 
     def test_get_unreconciled_splits(self, setup_book_env):
         """Should return unreconciled splits for account."""
-        result = server_module.get_unreconciled_splits("Assets:Checking")
+        result = server_module.get_unreconciled_splits("Assets:Checking", verbose=True)
 
         data = json.loads(result)
         assert "splits" in data
@@ -702,7 +702,7 @@ class TestReconcileAccountTool:
 
         # Get unreconciled splits
         unreconciled = json.loads(
-            server_module.get_unreconciled_splits("Assets:Checking")
+            server_module.get_unreconciled_splits("Assets:Checking", verbose=True)
         )
 
         # Calculate expected balance
@@ -725,7 +725,7 @@ class TestReconcileAccountTool:
     def test_reconcile_account_balance_mismatch(self, setup_book_env):
         """Should return error when balance doesn't match."""
         unreconciled = json.loads(
-            server_module.get_unreconciled_splits("Assets:Checking")
+            server_module.get_unreconciled_splits("Assets:Checking", verbose=True)
         )
         guids = [s["guid"] for s in unreconciled["splits"]]
 
@@ -973,7 +973,7 @@ class TestListCommoditiesTool:
 
     def test_list_commodities(self, setup_book_env):
         """Should return commodities grouped by namespace."""
-        result = server_module.list_commodities()
+        result = server_module.list_commodities(verbose=True)
 
         data = json.loads(result)
         assert "default_currency" in data
@@ -983,7 +983,7 @@ class TestListCommoditiesTool:
 
     def test_list_commodities_includes_usd(self, setup_book_env):
         """Should include USD in currency commodities."""
-        result = server_module.list_commodities()
+        result = server_module.list_commodities(verbose=True)
 
         data = json.loads(result)
         mnemonics = [c["mnemonic"] for c in data["commodities"]["CURRENCY"]]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -104,7 +104,7 @@ class TestListTransactionsTool:
 
     def test_list_all_transactions(self, setup_book_env):
         """Should return all transactions."""
-        result = server_module.list_transactions()
+        result = server_module.list_transactions(verbose=True)
 
         data = json.loads(result)
         assert isinstance(data, list)
@@ -112,7 +112,7 @@ class TestListTransactionsTool:
 
     def test_list_transactions_by_account(self, setup_book_env):
         """Should filter by account."""
-        result = server_module.list_transactions(account="Expenses:Groceries")
+        result = server_module.list_transactions(account="Expenses:Groceries", verbose=True)
 
         data = json.loads(result)
         assert len(data) == 1
@@ -121,7 +121,7 @@ class TestListTransactionsTool:
     def test_list_transactions_date_range(self, setup_book_env):
         """Should filter by date range."""
         result = server_module.list_transactions(
-            start_date="2024-01-10", end_date="2024-01-18"
+            start_date="2024-01-10", end_date="2024-01-18", verbose=True
         )
 
         data = json.loads(result)
@@ -254,7 +254,7 @@ class TestSearchTransactionsTool:
 
     def test_search_by_description(self, setup_book_env):
         """Should find transactions by description."""
-        result = server_module.search_transactions("Salary")
+        result = server_module.search_transactions("Salary", verbose=True)
 
         data = json.loads(result)
         assert len(data) == 1
@@ -262,7 +262,7 @@ class TestSearchTransactionsTool:
 
     def test_search_by_amount(self, setup_book_env):
         """Should find transactions by amount range."""
-        result = server_module.search_transactions(">500", field="amount")
+        result = server_module.search_transactions(">500", field="amount", verbose=True)
 
         data = json.loads(result)
         assert len(data) == 2  # Opening Balance (1000) and Salary (2000)
@@ -387,7 +387,7 @@ class TestDeleteTransactionTool:
     def test_delete_transaction(self, setup_book_env):
         """Should delete a transaction and return result."""
         # First get a transaction to delete
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.delete_transaction(guid)
@@ -402,7 +402,7 @@ class TestDeleteTransactionTool:
 
     def test_delete_reconciled_rejected(self, setup_book_env):
         """Should reject deleting a transaction with reconciled splits."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         split_guid = transactions[0]["splits"][0]["guid"]
         server_module.set_reconcile_state(split_guid, "y")
         guid = transactions[0]["guid"]
@@ -415,7 +415,7 @@ class TestDeleteTransactionTool:
 
     def test_delete_reconciled_force(self, setup_book_env):
         """Should allow deleting reconciled transaction with force=True."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         split_guid = transactions[0]["splits"][0]["guid"]
         server_module.set_reconcile_state(split_guid, "y")
         guid = transactions[0]["guid"]
@@ -440,7 +440,7 @@ class TestUpdateTransactionTool:
 
     def test_update_description(self, setup_book_env):
         """Should update transaction description."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -454,7 +454,7 @@ class TestUpdateTransactionTool:
 
     def test_update_date(self, setup_book_env):
         """Should update transaction date."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -469,7 +469,7 @@ class TestUpdateTransactionTool:
     def test_update_splits(self, setup_book_env):
         """Should update transaction split amounts."""
         # Find the groceries transaction which has known accounts
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -499,7 +499,7 @@ class TestUpdateTransactionTool:
 
     def test_update_unbalanced_splits(self, setup_book_env):
         """Should return error for unbalanced splits."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -516,7 +516,7 @@ class TestUpdateTransactionTool:
 
     def test_update_reconciled_splits_rejected(self, setup_book_env):
         """Should reject updating splits on a reconciled transaction."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -538,7 +538,7 @@ class TestUpdateTransactionTool:
 
     def test_update_reconciled_force(self, setup_book_env):
         """Should allow updating reconciled splits with force=True."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -572,7 +572,7 @@ class TestReplaceSplitsTool:
         )
 
         # Find a transaction to replace splits on
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         grocery_txn = next(
             t for t in transactions if "Groceries" in t["description"]
         )
@@ -595,7 +595,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_returns_previous_splits(self, setup_book_env):
         """Should include previous_splits for audit trail."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         grocery_txn = next(
             t for t in transactions if "Groceries" in t["description"]
         )
@@ -615,7 +615,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_unbalanced_error(self, setup_book_env):
         """Should return error for unbalanced splits."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.replace_splits(
@@ -632,7 +632,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_placeholder_error(self, setup_book_env):
         """Should return error for placeholder account."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.replace_splits(
@@ -653,7 +653,7 @@ class TestSetReconcileStateTool:
 
     def test_set_reconcile_state(self, setup_book_env):
         """Should set reconcile state on a split."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = server_module.set_reconcile_state(split_guid, "c")
@@ -664,7 +664,7 @@ class TestSetReconcileStateTool:
 
     def test_set_reconcile_state_invalid(self, setup_book_env):
         """Should return error for invalid state."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = server_module.set_reconcile_state(split_guid, "x")
@@ -746,7 +746,7 @@ class TestVoidTransactionTool:
 
     def test_void_transaction(self, setup_book_env):
         """Should void a transaction."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.void_transaction(guid, "Test void reason")
@@ -757,7 +757,7 @@ class TestVoidTransactionTool:
 
     def test_void_transaction_no_reason(self, setup_book_env):
         """Should return error if no reason provided."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.void_transaction(guid, "")
@@ -771,7 +771,7 @@ class TestUnvoidTransactionTool:
 
     def test_unvoid_transaction(self, setup_book_env):
         """Should restore a voided transaction."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         # Void first
@@ -785,7 +785,7 @@ class TestUnvoidTransactionTool:
 
     def test_unvoid_not_voided(self, setup_book_env):
         """Should return error if transaction not voided."""
-        transactions = json.loads(server_module.list_transactions())
+        transactions = json.loads(server_module.list_transactions(verbose=True))
         guid = transactions[0]["guid"]
 
         result = server_module.unvoid_transaction(guid)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,6 +20,19 @@ def setup_book_env(test_book: Path, monkeypatch):
     server_module._book = None
 
 
+class TestGetBookSummaryTool:
+    """Tests for get_book_summary tool."""
+
+    def test_get_book_summary(self, setup_book_env):
+        """Should return a text summary string."""
+        result = server_module.get_book_summary()
+        assert isinstance(result, str)
+        assert "Book:" in result
+        assert "Currency: USD" in result
+        assert "Accounts:" in result
+        assert "Net worth:" in result
+
+
 class TestListAccountsTool:
     """Tests for list_accounts tool."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "gnucash-mcp"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- **Compact output**: All listing tools (transactions, accounts, commodities, lots, scheduled transactions, unreconciled splits) default to tab-separated one-line-per-item text, with `verbose=true` for full JSON. Cuts token usage ~70%.
- **Partial GUID prefixes**: All 15 GUID-accepting tools resolve 8+ character prefixes. `Annotated[str, Field(description=...)]` on every GUID parameter so the schema exposes prefix support.
- **`get_book_summary` tool**: Single-call financial snapshot — leaf asset accounts with balances, liabilities grouped by credit cards/loans/other with top-3 triage, active vs total income/expense counts, net worth.
- **Minified JSON**: Verbose/dict outputs use `separators=(",", ":")` — no whitespace padding.
- **Bug fixes**: Multi-currency balance calculations (quantity vs value), duplicate detection checked off in roadmap.
- **Version bump**: 1.0.0 → 1.0.2, README updated to 52 tools across twelve categories.

## Test plan

- [x] 399 unit tests pass
- [x] Live tested compact output against real GnuCash book
- [x] Live tested `get_book_summary` — template accounts filtered, zero-balance assets excluded, liability grouping and top-3 verified
- [x] Verified partial GUID resolution on real transactions
- [x] Confirmed JSON schema exposes GUID prefix descriptions via FastMCP introspection