### PR TITLE
Add modular tool loading and debug config tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,35 @@ This server **writes to your GnuCash book**. Before first use:
 | Variable | Description |
 |----------|-------------|
 | `GNUCASH_BOOK_PATH` | Path to your GnuCash SQLite book (required) |
+| `GNUCASH_MCP_MODULES` | Tool modules to load (e.g., `core,reporting`). Default: `core` |
 | `GNUCASH_MCP_DEBUG` | Set to `1` for debug logging |
 | `GNUCASH_MCP_NOAUDIT` | Set to `1` to disable audit logging |
 | `GNUCASH_MCP_AUDIT_FORMAT` | `text` (default) or `json` |
+
+### Tool Modules
+
+By default, only the **core** module (15 tools) is loaded to minimize context usage. Load additional modules as needed:
+
+```bash
+# Default: core only (15 tools — accounts, transactions, book summary)
+gnucash-mcp
+
+# All 52 tools
+gnucash-mcp --modules=all
+
+# Mix and match
+gnucash-mcp --modules=core,reporting,reconciliation
+```
+
+| Module | Tools | Description |
+|--------|-------|-------------|
+| `core` | 15 | Accounts, transactions, book summary (always loaded) |
+| `reconciliation` | 5 | Unreconciled splits, reconcile, void/unvoid |
+| `reporting` | 5 | Spending, income, balance sheet, net worth, cash flow |
+| `budgets` | 6 | Budget CRUD and variance reports |
+| `scheduling` | 6 | Recurring transactions and upcoming bills |
+| `investments` | 11 | Commodities, prices, lots, cost basis |
+| `admin` | 4 | Account metadata slots, audit log |
 
 ### Claude Code
 
@@ -252,7 +278,7 @@ claude mcp add-json gnucash \
   '{"command":"uv","args":["run","--directory","/path/to/gnucash-mcp","python","-m","gnucash_mcp"],"env":{"GNUCASH_BOOK_PATH":"/path/to/your/book.gnucash"}}'
 ```
 
-Replace both paths with your actual paths. Add `"--debug"` or `"--audit-format=text"` to the args array as needed.
+Replace both paths with your actual paths. Add `"--modules=all"`, `"--debug"`, or `"--audit-format=text"` to the args array as needed.
 
 ### Other MCP Clients
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ gnucash-mcp --modules=core,reporting,reconciliation
 | `investments` | 11 | Commodities, prices, lots, cost basis |
 | `admin` | 4 | Account metadata slots, audit log |
 
+When `--debug` is set, an additional `get_server_config` diagnostic tool is registered. It reports loaded modules, tool count, book path, debug mode, and version — useful for verifying what the server actually loaded.
+
 ### Claude Code
 
 Run this command to add the server (use `--scope user` for all projects, or `--scope project` for the current project only):
@@ -367,6 +369,59 @@ gnucash-mcp/
 
 ---
 
+## Changelog
+
+### v1.1.0 — Modular Tool Loading
+
+The context-efficiency release. Previous versions advertised all tools to every client, consuming system prompt tokens whether you needed investments or not.
+
+- **Tool modules** (`--modules=`): Load only the tool categories you need. Seven modules (core, reconciliation, reporting, budgets, scheduling, investments, admin) let you go from 52 tools down to as few as 15. Core is always loaded; `all` loads everything.
+- **`get_server_config` debug tool**: When `--debug` is set, a diagnostic tool reports loaded modules, tool count, book path, and version. Clients can verify their own inventory instead of guessing.
+- **`GNUCASH_MCP_MODULES` env var**: Configure modules without CLI flags — useful for Claude Desktop configs.
+- **Version**: 1.1.0 (424 tests)
+
+### v1.0.2 — Compact Output
+
+Reduced token usage on the *response* side. Every read tool that returned verbose JSON by default now returns compact one-line-per-item text instead.
+
+- **Compact default output** for list_transactions, list_commodities, list_scheduled_transactions, get_unreconciled_splits, list_lots — verbose JSON available via `verbose=true`
+- **`get_book_summary`**: Single-call financial snapshot — book path, account structure, key balances, net worth, commodities, and scheduled transactions in one text response
+- **Minified JSON**: Stripped null/empty values and whitespace from all JSON responses
+- **Partial GUID support**: 8+ character prefixes accepted for transactions, splits, lots, and scheduled transactions
+- **Version**: 1.0.2 (399 tests)
+
+### v1.0.0 — Stable Release
+
+Feature-complete with write safety and audit trail.
+
+- **`replace_splits`**: Wholesale split replacement on existing transactions (recategorization without void/recreate)
+- **Transaction pipeline**: Duplicate detection, dry run mode, auto-fill from prior transactions, date sanity checks, placeholder account warnings
+- **`list_accounts` compact mode**: One-line-per-account default with `root` filter
+- **Account metadata slots**: Custom key-value pairs on accounts (APR, credit limits, reward rates)
+- **Audit log text format**: Human-readable audit trail alongside JSON option
+- **Version**: 1.0.0 (394 tests)
+
+### v0.9.0 — Feature Build-out
+
+From basic CRUD to a full accounting toolkit.
+
+- **Investments**: Commodities, prices, lot-based cost basis tracking, capital gain calculation
+- **Scheduled transactions**: Recurring templates, upcoming bills, one-click instantiation
+- **Budgets**: Create budgets, set targets by period/quarter, variance reporting
+- **Multi-currency**: Cross-currency transactions with quantity/value split handling
+- **Reporting**: Spending by category, income by source, balance sheet, net worth, cash flow
+- **Reconciliation**: Statement reconciliation, void/unvoid with audit trail
+- **Audit logging**: Automatic write-operation logging alongside the book file
+- **Version**: 0.9.0 (187 tests)
+
+### v0.1.0 — Initial Release
+
+- Account listing, balances, transaction CRUD, search
+- MCP server with FastMCP, Claude Desktop integration
+- piecash SQLite interface with error handling
+
+---
+
 ## Roadmap
 
 - [x] Full account management
@@ -379,9 +434,10 @@ gnucash-mcp/
 - [x] Split recategorization (`replace_splits`)
 - [x] Compact output for reduced token usage
 - [x] Partial GUID support (8+ character prefixes)
+- [x] Duplicate detection (built into `create_transaction`)
+- [x] Modular tool loading (`--modules=`)
 - [ ] CSV export
 - [ ] CSV/OFX import
-- [x] Duplicate detection (built into `create_transaction`)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gnucash-mcp"
-version = "1.0.2"
+version = "1.1.0"
 description = "MCP server for GnuCash accounting data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gnucash_mcp/__init__.py
+++ b/src/gnucash_mcp/__init__.py
@@ -3,5 +3,5 @@
 from gnucash_mcp.book import GnuCashLockError
 from gnucash_mcp.server import main
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 __all__ = ["main", "GnuCashLockError"]

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -38,6 +38,140 @@ logger = logging.getLogger(__name__)
 # Create FastMCP server
 mcp = FastMCP("gnucash-mcp")
 
+# ---------------------------------------------------------------------------
+# Tool module definitions — controls which tools are advertised via --modules
+# ---------------------------------------------------------------------------
+TOOL_MODULES: dict[str, list[str]] = {
+    "core": [
+        "get_book_summary",
+        "list_accounts",
+        "get_account",
+        "get_balance",
+        "create_account",
+        "update_account",
+        "move_account",
+        "delete_account",
+        "list_transactions",
+        "get_transaction",
+        "create_transaction",
+        "update_transaction",
+        "delete_transaction",
+        "replace_splits",
+        "search_transactions",
+    ],
+    "reconciliation": [
+        "get_unreconciled_splits",
+        "set_reconcile_state",
+        "reconcile_account",
+        "void_transaction",
+        "unvoid_transaction",
+    ],
+    "reporting": [
+        "spending_by_category",
+        "income_by_source",
+        "balance_sheet",
+        "net_worth",
+        "cash_flow",
+    ],
+    "budgets": [
+        "list_budgets",
+        "get_budget",
+        "create_budget",
+        "set_budget_amount",
+        "get_budget_report",
+        "delete_budget",
+    ],
+    "scheduling": [
+        "create_scheduled_transaction",
+        "list_scheduled_transactions",
+        "get_upcoming_transactions",
+        "create_transaction_from_scheduled",
+        "update_scheduled_transaction",
+        "delete_scheduled_transaction",
+    ],
+    "investments": [
+        "list_commodities",
+        "create_commodity",
+        "create_price",
+        "get_prices",
+        "get_latest_price",
+        "create_lot",
+        "list_lots",
+        "get_lot",
+        "assign_split_to_lot",
+        "calculate_lot_gain",
+        "close_lot",
+    ],
+    "admin": [
+        "get_account_slots",
+        "set_account_slot",
+        "delete_account_slot",
+        "get_audit_log",
+    ],
+}
+
+
+def _validate_tool_modules() -> None:
+    """Verify every registered tool belongs to exactly one module.
+
+    Developer guard — catches the case where a tool is added but not
+    placed in TOOL_MODULES, or a module lists a tool that doesn't exist.
+    """
+    all_mapped: set[str] = set()
+    for tools in TOOL_MODULES.values():
+        all_mapped.update(tools)
+
+    registered = set(mcp._tool_manager._tools.keys())
+    unmapped = registered - all_mapped
+    if unmapped:
+        raise RuntimeError(
+            f"Tools registered but not in TOOL_MODULES: {sorted(unmapped)}. "
+            f"Add them to the appropriate module."
+        )
+    phantom = all_mapped - registered
+    if phantom:
+        raise RuntimeError(
+            f"Tools in TOOL_MODULES but not registered: {sorted(phantom)}. "
+            f"Remove them from TOOL_MODULES or register the tools."
+        )
+
+
+def _apply_module_filter(modules_str: str | None) -> None:
+    """Remove tools not in the selected modules from the FastMCP registry.
+
+    Args:
+        modules_str: Comma-separated module names, "all", or None (core only).
+    """
+    if modules_str is None:
+        enabled_modules = {"core"}
+    else:
+        enabled_modules = {m.strip() for m in modules_str.split(",")}
+        if "all" in enabled_modules:
+            return  # Keep everything
+        # Validate module names
+        unknown = enabled_modules - set(TOOL_MODULES.keys())
+        if unknown:
+            print(
+                f"Warning: Unknown module(s): {', '.join(sorted(unknown))}. "
+                f"Available: {', '.join(sorted(TOOL_MODULES.keys()))}, all",
+                file=sys.stderr,
+            )
+        # core is always included
+        enabled_modules.add("core")
+
+    # Build the set of tool names to keep
+    keep: set[str] = set()
+    for mod_name in enabled_modules:
+        if mod_name in TOOL_MODULES:
+            keep.update(TOOL_MODULES[mod_name])
+
+    # Remove tools not in the keep set
+    all_registered = list(mcp._tool_manager._tools.keys())
+    for tool_name in all_registered:
+        if tool_name not in keep:
+            mcp.remove_tool(tool_name)
+
+
 # Global book instance - initialized on first use
 _book: GnuCashBook | None = None
 
@@ -1561,13 +1695,18 @@ def main() -> None:
 Usage: gnucash-mcp [OPTIONS]
 
 Options:
-  --debug                Enable debug logging (MCP protocol traffic, timing)
-  --noaudit              Disable audit logging
+  --modules=MODULES    Tool modules to load (comma-separated).
+                       Default: core (15 tools). Use "all" for all 52 tools.
+                       Available: core, reconciliation, reporting, budgets,
+                       scheduling, investments, admin
+  --debug              Enable debug logging (MCP protocol traffic, timing)
+  --noaudit            Disable audit logging
   --audit-format=FORMAT  Audit log format: "text" (default) or "json"
-  -h, --help             Show this help message
+  -h, --help           Show this help message
 
 Environment variables:
   GNUCASH_BOOK_PATH          Path to GnuCash SQLite book (required)
+  GNUCASH_MCP_MODULES        Tool modules to load (e.g., "core,reporting")
   GNUCASH_MCP_DEBUG=1        Enable debug logging
   GNUCASH_MCP_NOAUDIT=1      Disable audit logging
   GNUCASH_MCP_AUDIT_FORMAT   Audit format: "text" or "json"
@@ -1584,17 +1723,25 @@ Logs are stored alongside the book file:
     debug_flag = "--debug" in sys.argv
     noaudit_flag = "--noaudit" in sys.argv
     audit_format = "text"  # default
+    modules_value = None
 
-    # Parse --audit-format=json or --audit-format=text
+    # Parse --key=value flags
     for arg in sys.argv[:]:
         if arg.startswith("--audit-format="):
             audit_format = arg.split("=", 1)[1]
+            sys.argv.remove(arg)
+        elif arg.startswith("--modules="):
+            modules_value = arg.split("=", 1)[1]
             sys.argv.remove(arg)
 
     if "--debug" in sys.argv:
         sys.argv.remove("--debug")
     if "--noaudit" in sys.argv:
         sys.argv.remove("--noaudit")
+
+    # Env var fallback for modules (CLI flag takes precedence)
+    if modules_value is None:
+        modules_value = os.environ.get("GNUCASH_MCP_MODULES")
 
     # Re-init logging if CLI flags override env vars
     if debug_flag or noaudit_flag or audit_format != "text":
@@ -1610,6 +1757,14 @@ Logs are stored alongside the book file:
             if debug_flag:
                 debug_log(f"Server starting via CLI. Book: {book_path}")
                 debug_log(f"Debug logging enabled, audit={'enabled' if audit_enabled else 'disabled'}, format={audit_format}")
+
+    # Validate and apply module filter
+    _validate_tool_modules()
+    _apply_module_filter(modules_value)
+
+    if debug_flag:
+        debug_log(f"Modules: {modules_value or 'core (default)'}")
+        debug_log(f"Tools loaded: {len(mcp._tool_manager._tools)}")
 
     mcp.run()
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -136,18 +136,21 @@ def _validate_tool_modules() -> None:
         )
 
 
-def _apply_module_filter(modules_str: str | None) -> None:
+def _apply_module_filter(modules_str: str | None) -> list[str]:
     """Remove tools not in the selected modules from the FastMCP registry.
 
     Args:
         modules_str: Comma-separated module names, "all", or None (core only).
+
+    Returns:
+        Sorted list of module names that were actually loaded.
     """
     if modules_str is None:
         enabled_modules = {"core"}
     else:
         enabled_modules = {m.strip() for m in modules_str.split(",")}
         if "all" in enabled_modules:
-            return  # Keep everything
+            return sorted(TOOL_MODULES.keys())
         # Validate module names
         unknown = enabled_modules - set(TOOL_MODULES.keys())
         if unknown:
@@ -161,9 +164,11 @@ def _apply_module_filter(modules_str: str | None) -> None:
 
     # Build the set of tool names to keep
     keep: set[str] = set()
-    for mod_name in enabled_modules:
+    valid_modules: list[str] = []
+    for mod_name in sorted(enabled_modules):
         if mod_name in TOOL_MODULES:
             keep.update(TOOL_MODULES[mod_name])
+            valid_modules.append(mod_name)
 
     # Remove tools not in the keep set
     all_registered = list(mcp._tool_manager._tools.keys())
@@ -171,6 +176,11 @@ def _apply_module_filter(modules_str: str | None) -> None:
         if tool_name not in keep:
             mcp.remove_tool(tool_name)
 
+    return valid_modules
+
+
+# Runtime server state — populated by main(), read by get_server_config tool
+_server_state: dict = {}
 
 # Global book instance - initialized on first use
 _book: GnuCashBook | None = None
@@ -1683,6 +1693,27 @@ def get_audit_log(
     return _json({"entries": entries[-limit:], "total_count": len(entries)})
 
 
+# ============== Debug Tool (conditionally registered) ==============
+
+
+def _get_server_config_impl() -> str:
+    """Return current server configuration and runtime state.
+
+    Only available when the server is started with --debug.
+    Reports loaded modules, tool count, book path, and version
+    so the client can verify its own tool inventory.
+    """
+    from gnucash_mcp import __version__
+    lines = [
+        f"Modules loaded: {_server_state.get('modules', 'unknown')}",
+        f"Tools available: {_server_state.get('tool_count', 'unknown')}",
+        f"Book path: {_server_state.get('book_path', 'not set')}",
+        f"Debug mode: {str(_server_state.get('debug', False)).lower()}",
+        f"Version: {__version__}",
+    ]
+    return "\n".join(lines)
+
+
 # ============== Main ==============
 
 
@@ -1760,11 +1791,39 @@ Logs are stored alongside the book file:
 
     # Validate and apply module filter
     _validate_tool_modules()
-    _apply_module_filter(modules_value)
+    loaded_modules = _apply_module_filter(modules_value)
+
+    # Populate runtime state and conditionally register debug tool
+    tool_count = len(mcp._tool_manager._tools)
+    modules_display = ", ".join(loaded_modules)
+    _server_state.update({
+        "modules": modules_display,
+        "tool_count": tool_count,
+        "book_path": book_path or "not set",
+        "debug": debug_flag,
+    })
 
     if debug_flag:
-        debug_log(f"Modules: {modules_value or 'core (default)'}")
-        debug_log(f"Tools loaded: {len(mcp._tool_manager._tools)}")
+        # Register the debug-only diagnostic tool
+        @mcp.tool()
+        @safe_tool
+        def get_server_config() -> str:
+            """Get the server's loaded configuration.
+
+            Returns loaded modules, tool count, book path, debug mode,
+            and version. Only available when server is started with --debug.
+            Use this to verify which tools are available in this session.
+            """
+            return _get_server_config_impl()
+
+        # Update tool count to include the newly registered tool
+        _server_state["tool_count"] = len(mcp._tool_manager._tools)
+        debug_log(f"Modules: {modules_display}")
+        debug_log(f"Tools loaded: {_server_state['tool_count']}")
+    else:
+        if _debug_mode:
+            debug_log(f"Modules: {modules_display}")
+            debug_log(f"Tools loaded: {tool_count}")
 
     mcp.run()
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,8 +1,15 @@
-"""Tests for tool module filtering."""
+"""Tests for tool module filtering and server configuration."""
 
 import pytest
 
-from gnucash_mcp.server import TOOL_MODULES, _apply_module_filter, _validate_tool_modules, mcp
+from gnucash_mcp.server import (
+    TOOL_MODULES,
+    _apply_module_filter,
+    _get_server_config_impl,
+    _server_state,
+    _validate_tool_modules,
+    mcp,
+)
 
 
 class TestToolModulesMapping:
@@ -136,3 +143,82 @@ class TestApplyModuleFilter:
         registered = set(dict(mcp._tool_manager._tools).keys())
         # All remaining tools should be valid registered tools
         assert remaining == registered
+
+    def test_returns_loaded_modules_sorted(self):
+        """Return value should be sorted list of actually loaded modules."""
+        result = _apply_module_filter("reporting,budgets")
+        # core is always added, result should be sorted
+        assert result == ["budgets", "core", "reporting"]
+
+    def test_returns_all_modules_for_all(self):
+        """'all' should return all module names sorted."""
+        result = _apply_module_filter("all")
+        assert result == sorted(TOOL_MODULES.keys())
+
+    def test_returns_core_for_none(self):
+        """None should return just core."""
+        result = _apply_module_filter(None)
+        assert result == ["core"]
+
+    def test_returns_excludes_unknown_modules(self):
+        """Unknown module names should not appear in return value."""
+        result = _apply_module_filter("reporting,nonexistent")
+        assert "nonexistent" not in result
+        assert "core" in result
+        assert "reporting" in result
+
+
+class TestGetServerConfig:
+    """Tests for the debug-only get_server_config tool."""
+
+    @pytest.fixture(autouse=True)
+    def save_and_restore_state(self):
+        """Save server state before test, restore after."""
+        original = dict(_server_state)
+        yield
+        _server_state.clear()
+        _server_state.update(original)
+
+    def test_impl_returns_all_fields(self):
+        """Output should contain all five diagnostic fields."""
+        _server_state.update({
+            "modules": "core,reporting",
+            "tool_count": 20,
+            "book_path": "/tmp/test.gnucash",
+            "debug": True,
+        })
+        output = _get_server_config_impl()
+        assert "Modules loaded: core,reporting" in output
+        assert "Tools available: 20" in output
+        assert "Book path: /tmp/test.gnucash" in output
+        assert "Debug mode: true" in output
+        assert "Version:" in output
+
+    def test_impl_defaults_when_state_empty(self):
+        """Output should handle missing state gracefully."""
+        _server_state.clear()
+        output = _get_server_config_impl()
+        assert "Modules loaded: unknown" in output
+        assert "Tools available: unknown" in output
+        assert "Book path: not set" in output
+        assert "Debug mode: false" in output
+
+    def test_impl_output_is_plain_text(self):
+        """Output should be plain text, not JSON."""
+        _server_state.update({
+            "modules": "all",
+            "tool_count": 53,
+            "book_path": "/tmp/test.gnucash",
+            "debug": True,
+        })
+        output = _get_server_config_impl()
+        assert not output.startswith("{")
+        lines = output.strip().split("\n")
+        assert len(lines) == 5
+
+    def test_not_registered_by_default(self):
+        """get_server_config should not be in TOOL_MODULES or registered at import time."""
+        all_module_tools = set()
+        for tools in TOOL_MODULES.values():
+            all_module_tools.update(tools)
+        assert "get_server_config" not in all_module_tools

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,138 @@
+"""Tests for tool module filtering."""
+
+import pytest
+
+from gnucash_mcp.server import TOOL_MODULES, _apply_module_filter, _validate_tool_modules, mcp
+
+
+class TestToolModulesMapping:
+    """Tests for the TOOL_MODULES constant."""
+
+    def test_all_registered_tools_are_mapped(self):
+        """Every registered tool must appear in TOOL_MODULES."""
+        all_mapped = set()
+        for tools in TOOL_MODULES.values():
+            all_mapped.update(tools)
+        registered = set(mcp._tool_manager._tools.keys())
+        assert all_mapped == registered
+
+    def test_no_duplicate_tools_across_modules(self):
+        """No tool should appear in more than one module."""
+        seen = set()
+        for tools in TOOL_MODULES.values():
+            for tool in tools:
+                assert tool not in seen, f"{tool} appears in multiple modules"
+                seen.add(tool)
+
+    def test_core_module_count(self):
+        """Core module should have 15 tools."""
+        assert len(TOOL_MODULES["core"]) == 15
+
+    def test_total_tool_count(self):
+        """Total tools across all modules should be 52."""
+        total = sum(len(tools) for tools in TOOL_MODULES.values())
+        assert total == 52
+
+    def test_expected_modules_exist(self):
+        """All expected module names should be present."""
+        expected = {
+            "core", "reconciliation", "reporting", "budgets",
+            "scheduling", "investments", "admin",
+        }
+        assert set(TOOL_MODULES.keys()) == expected
+
+    def test_validate_tool_modules_passes(self):
+        """Validation should pass with the current mapping."""
+        _validate_tool_modules()  # Should not raise
+
+
+class TestApplyModuleFilter:
+    """Tests for _apply_module_filter."""
+
+    @pytest.fixture(autouse=True)
+    def save_and_restore_tools(self):
+        """Save tool state before test, restore after."""
+        original = dict(mcp._tool_manager._tools)
+        yield
+        mcp._tool_manager._tools.clear()
+        mcp._tool_manager._tools.update(original)
+
+    def _tool_names(self):
+        return set(mcp._tool_manager._tools.keys())
+
+    def test_all_keeps_everything(self):
+        """--modules=all should keep all 52 tools."""
+        _apply_module_filter("all")
+        assert len(self._tool_names()) == 52
+
+    def test_none_defaults_to_core_only(self):
+        """No --modules flag should default to core only."""
+        _apply_module_filter(None)
+        remaining = self._tool_names()
+        assert remaining == set(TOOL_MODULES["core"])
+        assert len(remaining) == 15
+
+    def test_core_plus_reporting(self):
+        """--modules=core,reporting should load both modules."""
+        _apply_module_filter("core,reporting")
+        remaining = self._tool_names()
+        expected = set(TOOL_MODULES["core"]) | set(TOOL_MODULES["reporting"])
+        assert remaining == expected
+
+    def test_core_always_included(self):
+        """Even if only 'reporting' is specified, core is always included."""
+        _apply_module_filter("reporting")
+        remaining = self._tool_names()
+        assert set(TOOL_MODULES["core"]).issubset(remaining)
+        assert set(TOOL_MODULES["reporting"]).issubset(remaining)
+
+    def test_all_modules_combined(self):
+        """Specifying every module individually should equal 'all'."""
+        all_names = ",".join(TOOL_MODULES.keys())
+        _apply_module_filter(all_names)
+        assert len(self._tool_names()) == 52
+
+    def test_all_in_list_keeps_everything(self):
+        """'all' mixed with other modules should keep all 52 tools."""
+        _apply_module_filter("scheduling,reconciliation,all")
+        assert len(self._tool_names()) == 52
+
+    def test_unknown_module_warns(self, capsys):
+        """Unknown module names should produce a warning on stderr."""
+        _apply_module_filter("core,nonexistent")
+        captured = capsys.readouterr()
+        assert "nonexistent" in captured.err
+        assert "Unknown module" in captured.err
+
+    def test_unknown_module_still_loads_core(self, capsys):
+        """Unknown modules should not prevent core from loading."""
+        _apply_module_filter("nonexistent")
+        remaining = self._tool_names()
+        assert set(TOOL_MODULES["core"]).issubset(remaining)
+
+    def test_whitespace_in_module_names(self):
+        """Whitespace around module names should be stripped."""
+        _apply_module_filter("core , reporting")
+        remaining = self._tool_names()
+        expected = set(TOOL_MODULES["core"]) | set(TOOL_MODULES["reporting"])
+        assert remaining == expected
+
+    def test_investments_module_tools(self):
+        """Investments module should include commodity and lot tools."""
+        _apply_module_filter("investments")
+        remaining = self._tool_names()
+        assert "list_commodities" in remaining
+        assert "create_lot" in remaining
+        assert "calculate_lot_gain" in remaining
+        # Core should also be present
+        assert "list_accounts" in remaining
+        # Non-selected modules should not be present
+        assert "spending_by_category" not in remaining
+
+    def test_filter_is_subtractive(self):
+        """Filtering should only remove tools, never add non-existent ones."""
+        _apply_module_filter("core")
+        remaining = self._tool_names()
+        registered = set(dict(mcp._tool_manager._tools).keys())
+        # All remaining tools should be valid registered tools
+        assert remaining == registered

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "gnucash-mcp"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- **`--modules=` flag** with 7 modules (core, reconciliation, reporting, budgets, scheduling, investments, admin) to control which of 52 tools are advertised — reduces system prompt token usage
- **`get_server_config` debug tool** registered only when `--debug` is set — reports loaded modules, tool count, book path, version
- **`_apply_module_filter` returns resolved module list** — sorted, with implicit core, excluding unknowns
- **Version 1.1.0** with changelog covering v0.1 through v1.1
- **25 module/config tests** (424 total)

## Test plan

- [x] All 424 tests pass
- [x] Each module tested individually via Claude Desktop
- [x] `get_server_config` returns correct output with `--debug`
- [x] Tool not registered without `--debug`
- [x] Unknown modules warn without crashing
- [x] `all` works standalone and in comma-separated list
- [x] Core always included even if not specified