### PR TITLE
Add business module: customers, vendors, billterms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gnucash-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "MCP server for GnuCash accounting data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gnucash_mcp/__init__.py
+++ b/src/gnucash_mcp/__init__.py
@@ -3,5 +3,5 @@
 from gnucash_mcp.book import GnuCashLockError
 from gnucash_mcp.server import main
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __all__ = ["main", "GnuCashLockError"]

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -279,6 +279,7 @@ class GnuCashBook:
     _GUID_TABLES = frozenset({
         "transactions", "splits", "accounts", "lots",
         "schedxactions", "commodities", "budgets",
+        "customers", "vendors", "invoices",
     })
 
     def _resolve_guid(self, table: str, partial: str) -> str:
@@ -2164,6 +2165,8 @@ class GnuCashBook:
         "INCOME",
         "LIABILITY",
         "MUTUAL",
+        "PAYABLE",
+        "RECEIVABLE",
         "STOCK",
     }
 
@@ -4776,3 +4779,386 @@ class GnuCashBook:
                 "key": key,
                 "status": "deleted",
             }
+
+    # ------------------------------------------------------------------
+    # Business: Customer / Vendor / Billterm
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_customer(book, customer_id: str):
+        """Find a customer by their human-readable ID (e.g., '000001')."""
+        for c in book.customers:
+            if c.id == customer_id:
+                return c
+        return None
+
+    @staticmethod
+    def _find_vendor(book, vendor_id: str):
+        """Find a vendor by their human-readable ID (e.g., '000001')."""
+        for v in book.vendors:
+            if v.id == vendor_id:
+                return v
+        return None
+
+    @staticmethod
+    def _customer_to_dict(customer) -> dict:
+        """Convert a piecash Customer to a serializable dict."""
+        return {
+            "guid": customer.guid,
+            "id": customer.id,
+            "name": customer.name,
+            "currency": customer.currency.mnemonic if customer.currency else None,
+            "notes": customer.notes or "",
+            "active": bool(customer.active),
+            "address": {
+                "name": customer.addr_name or "",
+                "addr1": customer.addr_addr1 or "",
+                "addr2": customer.addr_addr2 or "",
+                "addr3": customer.addr_addr3 or "",
+                "addr4": customer.addr_addr4 or "",
+                "phone": customer.addr_phone or "",
+                "fax": customer.addr_fax or "",
+                "email": customer.addr_email or "",
+            },
+        }
+
+    @staticmethod
+    def _vendor_to_dict(vendor) -> dict:
+        """Convert a piecash Vendor to a serializable dict."""
+        return {
+            "guid": vendor.guid,
+            "id": vendor.id,
+            "name": vendor.name,
+            "currency": vendor.currency.mnemonic if vendor.currency else None,
+            "notes": vendor.notes or "",
+            "active": bool(vendor.active),
+            "address": {
+                "name": vendor.addr_name or "",
+                "addr1": vendor.addr_addr1 or "",
+                "addr2": vendor.addr_addr2 or "",
+                "addr3": vendor.addr_addr3 or "",
+                "addr4": vendor.addr_addr4 or "",
+                "phone": vendor.addr_phone or "",
+                "fax": vendor.addr_fax or "",
+                "email": vendor.addr_email or "",
+            },
+        }
+
+    @staticmethod
+    def _customer_to_compact_line(customer) -> str:
+        """One-line compact: 'id  name  currency'."""
+        return f"{customer.id}\t{customer.name}\t{customer.currency.mnemonic}"
+
+    @staticmethod
+    def _vendor_to_compact_line(vendor) -> str:
+        """One-line compact: 'id  name  currency'."""
+        return f"{vendor.id}\t{vendor.name}\t{vendor.currency.mnemonic}"
+
+    @staticmethod
+    def _billterm_to_dict(bt) -> dict:
+        """Convert a Billterm to a serializable dict."""
+        return {
+            "guid": bt.guid,
+            "name": bt.name,
+            "description": bt.description or "",
+            "type": bt.type,
+            "due_days": bt.duedays,
+            "discount_days": bt.discountdays if bt.discountdays else 0,
+            "discount": str(bt.discount) if bt.discount else "0",
+        }
+
+    def create_customer(
+        self,
+        name: str,
+        currency: str | None = None,
+        notes: str = "",
+        address: dict | None = None,
+    ) -> dict:
+        """Create a new customer.
+
+        Args:
+            name: Customer name.
+            currency: ISO currency code. Defaults to book's default currency.
+            notes: Optional notes.
+            address: Optional address dict with keys: name, addr1, addr2,
+                     addr3, addr4, phone, fax, email.
+
+        Returns:
+            Dict with guid, id, name, status.
+        """
+        from piecash.business.person import Customer, Address
+
+        with self.open(readonly=False) as book:
+            if currency:
+                currency_obj = None
+                for c in book.currencies:
+                    if c.mnemonic == currency:
+                        currency_obj = c
+                        break
+                if not currency_obj:
+                    raise ValueError(f"Currency not found: {currency}")
+            else:
+                currency_obj = book.default_currency
+
+            addr = None
+            if address:
+                addr = Address(
+                    name=address.get("name", name),
+                    addr1=address.get("addr1", ""),
+                    addr2=address.get("addr2", ""),
+                    addr3=address.get("addr3", ""),
+                    addr4=address.get("addr4", ""),
+                    phone=address.get("phone", ""),
+                    fax=address.get("fax", ""),
+                    email=address.get("email", ""),
+                )
+
+            customer = Customer(
+                name=name,
+                currency=currency_obj,
+                notes=notes,
+                address=addr,
+                book=book,
+            )
+            book.save()
+
+            return {
+                "guid": customer.guid,
+                "id": customer.id,
+                "name": customer.name,
+                "status": "created",
+            }
+
+    def list_customers(
+        self,
+        active_only: bool = True,
+        compact: bool = True,
+    ) -> list[dict] | str:
+        """List all customers.
+
+        Args:
+            active_only: If True, only return active customers.
+            compact: If True, return compact one-line-per-customer string.
+
+        Returns:
+            Compact string or list of dicts.
+        """
+        with self.open() as book:
+            customers = sorted(book.customers, key=lambda c: c.name)
+            if active_only:
+                customers = [c for c in customers if c.active]
+
+            if compact:
+                lines = [self._customer_to_compact_line(c) for c in customers]
+                return "\n".join(lines)
+            else:
+                return [self._customer_to_dict(c) for c in customers]
+
+    def get_customer(self, customer_id: str) -> dict:
+        """Get customer details by ID.
+
+        Args:
+            customer_id: Human-readable customer ID (e.g., '000001').
+
+        Returns:
+            Dict with full customer details.
+
+        Raises:
+            ValueError: If customer not found.
+        """
+        with self.open() as book:
+            customer = self._find_customer(book, customer_id)
+            if not customer:
+                raise ValueError(f"Customer not found: {customer_id}")
+            return self._customer_to_dict(customer)
+
+    def create_vendor(
+        self,
+        name: str,
+        currency: str | None = None,
+        notes: str = "",
+        address: dict | None = None,
+    ) -> dict:
+        """Create a new vendor.
+
+        Args:
+            name: Vendor name.
+            currency: ISO currency code. Defaults to book's default currency.
+            notes: Optional notes.
+            address: Optional address dict with keys: name, addr1, addr2,
+                     addr3, addr4, phone, fax, email.
+
+        Returns:
+            Dict with guid, id, name, status.
+        """
+        from piecash.business.person import Vendor, Address
+
+        with self.open(readonly=False) as book:
+            if currency:
+                currency_obj = None
+                for c in book.currencies:
+                    if c.mnemonic == currency:
+                        currency_obj = c
+                        break
+                if not currency_obj:
+                    raise ValueError(f"Currency not found: {currency}")
+            else:
+                currency_obj = book.default_currency
+
+            addr = None
+            if address:
+                addr = Address(
+                    name=address.get("name", name),
+                    addr1=address.get("addr1", ""),
+                    addr2=address.get("addr2", ""),
+                    addr3=address.get("addr3", ""),
+                    addr4=address.get("addr4", ""),
+                    phone=address.get("phone", ""),
+                    fax=address.get("fax", ""),
+                    email=address.get("email", ""),
+                )
+
+            vendor = Vendor(
+                name=name,
+                currency=currency_obj,
+                notes=notes,
+                address=addr,
+                book=book,
+            )
+            book.save()
+
+            return {
+                "guid": vendor.guid,
+                "id": vendor.id,
+                "name": vendor.name,
+                "status": "created",
+            }
+
+    def list_vendors(
+        self,
+        active_only: bool = True,
+        compact: bool = True,
+    ) -> list[dict] | str:
+        """List all vendors.
+
+        Args:
+            active_only: If True, only return active vendors.
+            compact: If True, return compact one-line-per-vendor string.
+
+        Returns:
+            Compact string or list of dicts.
+        """
+        with self.open() as book:
+            vendors = sorted(book.vendors, key=lambda v: v.name)
+            if active_only:
+                vendors = [v for v in vendors if v.active]
+
+            if compact:
+                lines = [self._vendor_to_compact_line(v) for v in vendors]
+                return "\n".join(lines)
+            else:
+                return [self._vendor_to_dict(v) for v in vendors]
+
+    def get_vendor(self, vendor_id: str) -> dict:
+        """Get vendor details by ID.
+
+        Args:
+            vendor_id: Human-readable vendor ID (e.g., '000001').
+
+        Returns:
+            Dict with full vendor details.
+
+        Raises:
+            ValueError: If vendor not found.
+        """
+        with self.open() as book:
+            vendor = self._find_vendor(book, vendor_id)
+            if not vendor:
+                raise ValueError(f"Vendor not found: {vendor_id}")
+            return self._vendor_to_dict(vendor)
+
+    def create_billterm(
+        self,
+        name: str,
+        due_days: int = 30,
+        description: str = "",
+        discount_days: int = 0,
+        discount_percent: str = "0",
+    ) -> dict:
+        """Create a new billing term.
+
+        Args:
+            name: Billterm name (e.g., 'Net 30').
+            due_days: Number of days until payment is due.
+            description: Optional description.
+            discount_days: Days within which early discount applies.
+            discount_percent: Early payment discount percentage.
+
+        Returns:
+            Dict with guid, name, due_days, status.
+        """
+        import uuid
+        from piecash.business.invoice import Billterm
+
+        discount = Decimal(discount_percent)
+        # Convert discount to num/denom
+        disc_str = str(discount)
+        if "." in disc_str:
+            decimals = len(disc_str.split(".")[1])
+            disc_denom = 10 ** decimals
+            disc_num = int(discount * disc_denom)
+        else:
+            disc_num = int(discount)
+            disc_denom = 1
+
+        with self.open(readonly=False) as book:
+            bt_guid = uuid.uuid4().hex
+
+            book.session.execute(
+                Billterm.__table__.insert().values(
+                    guid=bt_guid,
+                    name=name,
+                    description=description,
+                    refcount=0,
+                    invisible=0,
+                    type="GNC_TERM_TYPE_DAYS",
+                    duedays=due_days,
+                    discountdays=discount_days,
+                    discount_num=disc_num,
+                    discount_denom=disc_denom,
+                    cutoff=0,
+                )
+            )
+
+            book.save()
+
+            return {
+                "guid": bt_guid,
+                "name": name,
+                "due_days": due_days,
+                "status": "created",
+            }
+
+    def list_billterms(self, compact: bool = True) -> list[dict] | str:
+        """List all billing terms.
+
+        Args:
+            compact: If True, return compact one-line-per-term string.
+
+        Returns:
+            Compact string or list of dicts.
+        """
+        from piecash.business.invoice import Billterm
+
+        with self.open() as book:
+            terms = book.session.query(Billterm).filter(
+                Billterm.invisible == 0
+            ).order_by(Billterm.name).all()
+
+            if compact:
+                lines = []
+                for t in terms:
+                    lines.append(f"{t.name}\t{t.duedays} days")
+                return "\n".join(lines)
+            else:
+                return [self._billterm_to_dict(t) for t in terms]

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -512,6 +512,42 @@ def _format_audit_entry_text(entry: dict) -> str:
             lines.append(f"{time_part}  DELETE ACCOUNT SLOT  account:{account}")
             lines.append(f'{indent}key: "{key}"')
 
+    elif entity_type == "customer":
+        if operation == "CREATE":
+            cust_id = ""
+            cust_name = params.get("name", "")
+            if after:
+                cust_id = after.get("id", "")
+                cust_name = after.get("name", cust_name)
+            lines.append(f"{time_part}  CREATE CUSTOMER  id:{cust_id}")
+            currency = params.get("currency", "")
+            if after:
+                currency = after.get("currency", currency) or ""
+            lines.append(f'{indent}name: "{cust_name}"  currency: {currency}')
+
+    elif entity_type == "vendor":
+        if operation == "CREATE":
+            vend_id = ""
+            vend_name = params.get("name", "")
+            if after:
+                vend_id = after.get("id", "")
+                vend_name = after.get("name", vend_name)
+            lines.append(f"{time_part}  CREATE VENDOR  id:{vend_id}")
+            currency = params.get("currency", "")
+            if after:
+                currency = after.get("currency", currency) or ""
+            lines.append(f'{indent}name: "{vend_name}"  currency: {currency}')
+
+    elif entity_type == "billterm":
+        if operation == "CREATE":
+            bt_name = params.get("name", "")
+            due_days = params.get("due_days", "")
+            if after:
+                bt_name = after.get("name", bt_name)
+                due_days = after.get("due_days", due_days)
+            lines.append(f"{time_part}  CREATE BILLTERM")
+            lines.append(f'{indent}name: "{bt_name}"  due: {due_days} days')
+
     # Handle move_account specially (it's logged as "update" but is conceptually a move)
     if entity_type == "account" and "new_parent" in params:
         # This is actually a MOVE operation

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -108,6 +108,16 @@ TOOL_MODULES: dict[str, list[str]] = {
         "delete_account_slot",
         "get_audit_log",
     ],
+    "business": [
+        "create_customer",
+        "list_customers",
+        "get_customer",
+        "create_vendor",
+        "list_vendors",
+        "get_vendor",
+        "create_billterm",
+        "list_billterms",
+    ],
 }
 
 
@@ -647,7 +657,7 @@ def create_account(
 
     Args:
         name: Account name (e.g., "AI Subscriptions")
-        account_type: GnuCash account type (ASSET, BANK, CASH, CREDIT, EQUITY, EXPENSE, INCOME, LIABILITY, MUTUAL, STOCK)
+        account_type: GnuCash account type (ASSET, BANK, CASH, CREDIT, EQUITY, EXPENSE, INCOME, LIABILITY, MUTUAL, STOCK, RECEIVABLE, PAYABLE)
         parent: Full path of parent account (e.g., "Expenses:Online Services")
         description: Optional description
         placeholder: If true, account is container-only. Default: false
@@ -1585,6 +1595,189 @@ def delete_account_slot(
     book = get_book()
     result = book.delete_account_slot(account_name=account, key=key)
     return _json(result)
+
+
+# ============== Business Tools ==============
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="customer")
+def create_customer(
+    name: str,
+    currency: str | None = None,
+    notes: str = "",
+    address: dict | None = None,
+) -> str:
+    """Create a new customer.
+
+    Args:
+        name: Customer name (e.g., "Acme Corp").
+        currency: ISO currency code (e.g., "USD", "EUR").
+                  Defaults to book's default currency.
+        notes: Optional notes.
+        address: Optional address with keys: name, addr1, addr2,
+                 addr3, addr4, phone, fax, email.
+    """
+    book = get_book()
+    result = book.create_customer(
+        name=name, currency=currency, notes=notes, address=address,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_customers(
+    active_only: bool = True,
+    verbose: bool = False,
+) -> str:
+    """List all customers.
+
+    Returns a compact one-line-per-customer format by default.
+    Use verbose=true for full JSON with guid, address, notes, etc.
+
+    Args:
+        active_only: If True, only show active customers. Default True.
+        verbose: If true, return full JSON details for each customer.
+    """
+    book = get_book()
+    result = book.list_customers(active_only=active_only, compact=not verbose)
+    if verbose:
+        return json.dumps(result, indent=2)
+    return result
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_customer(
+    id: str,
+) -> str:
+    """Get details for a specific customer by ID.
+
+    Args:
+        id: Customer ID (e.g., "000001"). This is the human-readable
+            ID shown in GnuCash, not the internal GUID.
+    """
+    book = get_book()
+    result = book.get_customer(customer_id=id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="vendor")
+def create_vendor(
+    name: str,
+    currency: str | None = None,
+    notes: str = "",
+    address: dict | None = None,
+) -> str:
+    """Create a new vendor.
+
+    Args:
+        name: Vendor name (e.g., "Office Depot").
+        currency: ISO currency code (e.g., "USD", "EUR").
+                  Defaults to book's default currency.
+        notes: Optional notes.
+        address: Optional address with keys: name, addr1, addr2,
+                 addr3, addr4, phone, fax, email.
+    """
+    book = get_book()
+    result = book.create_vendor(
+        name=name, currency=currency, notes=notes, address=address,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_vendors(
+    active_only: bool = True,
+    verbose: bool = False,
+) -> str:
+    """List all vendors.
+
+    Returns a compact one-line-per-vendor format by default.
+    Use verbose=true for full JSON with guid, address, notes, etc.
+
+    Args:
+        active_only: If True, only show active vendors. Default True.
+        verbose: If true, return full JSON details for each vendor.
+    """
+    book = get_book()
+    result = book.list_vendors(active_only=active_only, compact=not verbose)
+    if verbose:
+        return json.dumps(result, indent=2)
+    return result
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_vendor(
+    id: str,
+) -> str:
+    """Get details for a specific vendor by ID.
+
+    Args:
+        id: Vendor ID (e.g., "000001"). This is the human-readable
+            ID shown in GnuCash, not the internal GUID.
+    """
+    book = get_book()
+    result = book.get_vendor(vendor_id=id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="billterm")
+def create_billterm(
+    name: str,
+    due_days: int = 30,
+    description: str = "",
+    discount_days: int = 0,
+    discount_percent: str = "0",
+) -> str:
+    """Create a new billing term.
+
+    Args:
+        name: Billterm name (e.g., "Net 30").
+        due_days: Number of days until payment is due. Default 30.
+        description: Optional description.
+        discount_days: Days within which early discount applies.
+        discount_percent: Early payment discount percentage (e.g., "2" for 2%).
+    """
+    book = get_book()
+    result = book.create_billterm(
+        name=name, due_days=due_days, description=description,
+        discount_days=discount_days, discount_percent=discount_percent,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_billterms(
+    verbose: bool = False,
+) -> str:
+    """List all billing terms.
+
+    Returns a compact one-line-per-term format by default.
+    Use verbose=true for full JSON with guid, discount details, etc.
+
+    Args:
+        verbose: If true, return full JSON details for each billing term.
+    """
+    book = get_book()
+    result = book.list_billterms(compact=not verbose)
+    if verbose:
+        return json.dumps(result, indent=2)
+    return result
 
 
 # ============== Resources ==============

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -727,3 +727,120 @@ def investment_book(tmp_path: Path) -> Path:
     book.close()
 
     return book_path
+
+
+@pytest.fixture
+def business_book(tmp_path: Path) -> Path:
+    """Create a GnuCash book with business-ready accounts.
+
+    Creates a USD-default book with:
+    - Assets:Checking (BANK, USD)
+    - Assets:Accounts Receivable (RECEIVABLE, USD)
+    - Liabilities:Accounts Payable (PAYABLE, USD)
+    - Income:Sales, Income:Consulting (INCOME, USD)
+    - Expenses:Office Supplies, Expenses:Services (EXPENSE, USD)
+    - Equity:Opening Balance (EQUITY, USD)
+    - Opening balance: $10000 in checking
+
+    No pre-existing customers/vendors — tests create their own.
+    """
+    book_path = tmp_path / "business_test.gnucash"
+
+    book = piecash.create_book(
+        str(book_path),
+        currency="USD",
+        overwrite=True,
+    )
+
+    root = book.root_account
+    usd = book.default_currency
+
+    assets = piecash.Account(
+        name="Assets", type="ASSET", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(assets)
+
+    checking = piecash.Account(
+        name="Checking", type="BANK", parent=assets, commodity=usd,
+    )
+    book.session.add(checking)
+
+    ar = piecash.Account(
+        name="Accounts Receivable", type="RECEIVABLE", parent=assets,
+        commodity=usd,
+    )
+    book.session.add(ar)
+
+    liabilities = piecash.Account(
+        name="Liabilities", type="LIABILITY", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(liabilities)
+
+    ap = piecash.Account(
+        name="Accounts Payable", type="PAYABLE", parent=liabilities,
+        commodity=usd,
+    )
+    book.session.add(ap)
+
+    income = piecash.Account(
+        name="Income", type="INCOME", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(income)
+
+    sales = piecash.Account(
+        name="Sales", type="INCOME", parent=income, commodity=usd,
+    )
+    book.session.add(sales)
+
+    consulting = piecash.Account(
+        name="Consulting", type="INCOME", parent=income, commodity=usd,
+    )
+    book.session.add(consulting)
+
+    expenses = piecash.Account(
+        name="Expenses", type="EXPENSE", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(expenses)
+
+    office_supplies = piecash.Account(
+        name="Office Supplies", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(office_supplies)
+
+    services = piecash.Account(
+        name="Services", type="EXPENSE", parent=expenses, commodity=usd,
+    )
+    book.session.add(services)
+
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", parent=root,
+        commodity=usd, placeholder=True,
+    )
+    book.session.add(equity)
+
+    opening = piecash.Account(
+        name="Opening Balance", type="EQUITY", parent=equity, commodity=usd,
+    )
+    book.session.add(opening)
+
+    book.save()
+
+    t0 = piecash.Transaction(
+        currency=usd,
+        description="Opening Balance",
+        post_date=date(2025, 12, 31),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("10000")),
+            piecash.Split(account=opening, value=Decimal("-10000")),
+        ],
+    )
+    book.session.add(t0)
+
+    book.save()
+    book.close()
+
+    return book_path

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1,0 +1,287 @@
+"""Tests for business tools: customers, vendors, billterms."""
+
+import json
+import pytest
+from gnucash_mcp.book import GnuCashBook
+
+
+class TestCreateCustomer:
+    """Tests for create_customer."""
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_customer(name="Acme Corp")
+        assert result["status"] == "created"
+        assert result["name"] == "Acme Corp"
+        assert result["id"] == "000001"
+        assert len(result["guid"]) == 32
+
+    def test_auto_id_increments(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        r1 = gb.create_customer(name="Customer A")
+        r2 = gb.create_customer(name="Customer B")
+        assert r1["id"] == "000001"
+        assert r2["id"] == "000002"
+
+    def test_with_currency(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_customer(name="Acme Corp", currency="USD")
+        assert result["status"] == "created"
+
+    def test_invalid_currency(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Currency not found"):
+            gb.create_customer(name="Acme Corp", currency="XYZ")
+
+    def test_with_notes(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp", notes="Important client")
+        result = gb.get_customer("000001")
+        assert result["notes"] == "Important client"
+
+    def test_with_address(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        addr = {
+            "name": "Acme Corp",
+            "addr1": "123 Main St",
+            "addr2": "Suite 100",
+            "phone": "555-1234",
+            "email": "billing@acme.com",
+        }
+        gb.create_customer(name="Acme Corp", address=addr)
+        result = gb.get_customer("000001")
+        assert result["address"]["addr1"] == "123 Main St"
+        assert result["address"]["phone"] == "555-1234"
+        assert result["address"]["email"] == "billing@acme.com"
+
+    def test_duplicate_name_allowed(self, business_book):
+        """GnuCash allows duplicate customer names."""
+        gb = GnuCashBook(str(business_book))
+        r1 = gb.create_customer(name="Acme Corp")
+        r2 = gb.create_customer(name="Acme Corp")
+        assert r1["id"] != r2["id"]
+
+
+class TestListCustomers:
+    """Tests for list_customers."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.list_customers()
+        assert result == ""
+
+    def test_compact_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Beta Corp")
+        gb.create_customer(name="Alpha Inc")
+        result = gb.list_customers()
+        lines = result.strip().split("\n")
+        assert len(lines) == 2
+        # Sorted by name
+        assert "Alpha Inc" in lines[0]
+        assert "Beta Corp" in lines[1]
+
+    def test_verbose_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.list_customers(compact=False)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "Acme Corp"
+        assert "guid" in result[0]
+        assert "address" in result[0]
+
+
+class TestGetCustomer:
+    """Tests for get_customer."""
+
+    def test_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.get_customer("000001")
+        assert result["name"] == "Acme Corp"
+        assert result["id"] == "000001"
+        assert result["active"] is True
+
+    def test_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Customer not found"):
+            gb.get_customer("999999")
+
+
+class TestCreateVendor:
+    """Tests for create_vendor."""
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_vendor(name="Office Depot")
+        assert result["status"] == "created"
+        assert result["name"] == "Office Depot"
+        assert result["id"] == "000001"
+        assert len(result["guid"]) == 32
+
+    def test_auto_id_increments(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        r1 = gb.create_vendor(name="Vendor A")
+        r2 = gb.create_vendor(name="Vendor B")
+        assert r1["id"] == "000001"
+        assert r2["id"] == "000002"
+
+    def test_with_address(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        addr = {"name": "Office Depot", "addr1": "456 Commerce Blvd"}
+        gb.create_vendor(name="Office Depot", address=addr)
+        result = gb.get_vendor("000001")
+        assert result["address"]["addr1"] == "456 Commerce Blvd"
+
+    def test_vendor_counter_independent_from_customer(self, business_book):
+        """Customer and vendor counters are independent."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Customer A")
+        gb.create_vendor(name="Vendor A")
+        # Both should get ID 000001 from their independent counters
+        cust = gb.get_customer("000001")
+        vend = gb.get_vendor("000001")
+        assert cust["name"] == "Customer A"
+        assert vend["name"] == "Vendor A"
+
+
+class TestListVendors:
+    """Tests for list_vendors."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.list_vendors()
+        assert result == ""
+
+    def test_compact_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Zeta Supply")
+        gb.create_vendor(name="Alpha Parts")
+        result = gb.list_vendors()
+        lines = result.strip().split("\n")
+        assert len(lines) == 2
+        assert "Alpha Parts" in lines[0]
+        assert "Zeta Supply" in lines[1]
+
+    def test_verbose_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.list_vendors(compact=False)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "Office Depot"
+
+
+class TestGetVendor:
+    """Tests for get_vendor."""
+
+    def test_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.get_vendor("000001")
+        assert result["name"] == "Office Depot"
+        assert result["active"] is True
+
+    def test_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Vendor not found"):
+            gb.get_vendor("999999")
+
+
+class TestCreateBillterm:
+    """Tests for create_billterm."""
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_billterm(name="Net 30")
+        assert result["status"] == "created"
+        assert result["name"] == "Net 30"
+        assert result["due_days"] == 30
+        assert len(result["guid"]) == 32
+
+    def test_custom_due_days(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_billterm(name="Net 60", due_days=60)
+        assert result["due_days"] == 60
+
+    def test_with_discount(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_billterm(
+            name="2/10 Net 30",
+            due_days=30,
+            discount_days=10,
+            discount_percent="2",
+        )
+        assert result["status"] == "created"
+
+    def test_read_back_via_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_billterm(name="Net 30")
+        gb.create_billterm(name="Net 60", due_days=60)
+        result = gb.list_billterms(compact=False)
+        assert len(result) == 2
+        names = {bt["name"] for bt in result}
+        assert names == {"Net 30", "Net 60"}
+
+
+class TestListBillterms:
+    """Tests for list_billterms."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.list_billterms()
+        assert result == ""
+
+    def test_compact_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_billterm(name="Net 30")
+        result = gb.list_billterms()
+        assert "Net 30" in result
+        assert "30 days" in result
+
+    def test_verbose_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_billterm(name="Net 30", due_days=30, description="Standard terms")
+        result = gb.list_billterms(compact=False)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "Net 30"
+        assert result[0]["due_days"] == 30
+        assert result[0]["description"] == "Standard terms"
+
+
+class TestReceivablePayableAccountTypes:
+    """Tests for RECEIVABLE and PAYABLE account type support."""
+
+    def test_receivable_account_in_fixture(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        acct = gb.get_account("Assets:Accounts Receivable")
+        assert acct["type"] == "RECEIVABLE"
+
+    def test_payable_account_in_fixture(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        acct = gb.get_account("Liabilities:Accounts Payable")
+        assert acct["type"] == "PAYABLE"
+
+    def test_create_receivable_account(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_account(
+            name="AR Other",
+            account_type="RECEIVABLE",
+            parent="Assets",
+        )
+        assert result["status"] == "created"
+        acct = gb.get_account("Assets:AR Other")
+        assert acct["type"] == "RECEIVABLE"
+
+    def test_create_payable_account(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.create_account(
+            name="AP Other",
+            account_type="PAYABLE",
+            parent="Liabilities",
+        )
+        assert result["status"] == "created"
+        acct = gb.get_account("Liabilities:AP Other")
+        assert acct["type"] == "PAYABLE"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -36,15 +36,15 @@ class TestToolModulesMapping:
         assert len(TOOL_MODULES["core"]) == 15
 
     def test_total_tool_count(self):
-        """Total tools across all modules should be 52."""
+        """Total tools across all modules should be 60."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 52
+        assert total == 60
 
     def test_expected_modules_exist(self):
         """All expected module names should be present."""
         expected = {
             "core", "reconciliation", "reporting", "budgets",
-            "scheduling", "investments", "admin",
+            "scheduling", "investments", "admin", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
 
@@ -68,9 +68,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 52 tools."""
+        """--modules=all should keep all 60 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 52
+        assert len(self._tool_names()) == 60
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag should default to core only."""
@@ -97,12 +97,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 52
+        assert len(self._tool_names()) == 60
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 52 tools."""
+        """'all' mixed with other modules should keep all 60 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 52
+        assert len(self._tool_names()) == 60
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "gnucash-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- 8 new tools in `business` module: create/list/get for customers and vendors, create/list for billterms
- Customer and vendor use piecash ORM with auto-ID generation from independent counters
- Billterm uses raw SQL insert (blocked constructor pattern)
- Add RECEIVABLE and PAYABLE to valid account types
- Audit log handlers for customer, vendor, and billterm operations
- Version bump to 1.2.0
- 32 new tests (456 total)

## Test plan

- [x] All 456 tests pass
- [x] Live tested all 8 tools against real GnuCash book
- [x] Customer and vendor ID sequences are independent
- [x] Billterm creation with standard and discount terms
- [x] Compact and verbose output formats verified