### PR TITLE
Add invoice and bill management tools

### DIFF
--- a/docs/BUSINESS_FEATURES_GUIDE.md
+++ b/docs/BUSINESS_FEATURES_GUIDE.md
@@ -1,0 +1,117 @@
+# GnuCash Business Features: How It All Fits Together
+
+## The Core Idea
+
+GnuCash's business features are a **layer on top of double-entry accounting**. They don't replace the ledger — they generate ledger entries. An invoice is not a transaction. An invoice is a *promise* that eventually becomes a transaction when you post it.
+
+## The Actors
+
+**Customers** owe you money. **Vendors** you owe money to. That's it. They're just address books with IDs.
+
+## The Lifecycle of an Invoice
+
+Think of it as three phases:
+
+### Phase 1: Draft — "Someone owes us money, but it's not in the books yet"
+
+- You create an invoice tied to a customer
+- You add line items (entries) — each one says "we sold X units of Y at $Z, charged to this income account"
+- Nothing touches the ledger. No transactions exist. It's a memo.
+
+### Phase 2: Post — "This is now real. Put it in the books."
+
+- Posting is the moment the invoice enters the accounting system
+- GnuCash creates a **transaction** with splits:
+  - **Debit** Accounts Receivable (someone owes you $500)
+  - **Credit** Income:Sales (you earned $500)
+- It also creates a **lot** — a container that tracks "this specific $500 that Acme owes us"
+- The A/R split gets assigned to the lot
+- The transaction gets locked (read-only) and tagged with metadata so GnuCash knows "this was generated from invoice #000001, don't let humans edit it directly"
+
+### Phase 3: Pay — "They paid us"
+
+- Payment creates another transaction:
+  - **Debit** Checking Account (money came in)
+  - **Credit** Accounts Receivable (they no longer owe us)
+- The A/R split gets assigned to the **same lot**
+- Now the lot has +$500 (posting) and -$500 (payment) = $0 balance → lot closes
+
+## Vendor Bills: The Mirror Image
+
+Identical lifecycle, flipped:
+
+- Bill entry: **Credit** Accounts Payable, **Debit** Expenses
+- Payment: **Debit** A/P, **Credit** Checking
+- Same lot mechanism for tracking "which specific bill did this payment cover"
+
+## Why Lots Matter
+
+Without lots, A/R is just a number — "$1,200 outstanding." With lots, you know:
+
+- Invoice 001: $500, fully paid
+- Invoice 002: $700, $200 paid, $500 remaining
+
+Lots connect specific invoices to specific payments. Partial payments work because a lot can have multiple payment splits.
+
+## The Metadata Web
+
+GnuCash uses **slots** (key-value metadata) to weave everything together:
+
+```
+Invoice record
+  ├── post_txn → posting transaction
+  ├── post_lot → the lot
+  └── post_acc → A/R account
+
+Posting transaction (slots)
+  ├── trans-txn-type: "I" (invoice-generated)
+  ├── trans-read-only: "Generated from an invoice..."
+  ├── trans-date-due: 2026-03-25
+  └── gncInvoice → back-pointer to invoice
+
+Lot (slots)
+  └── gncInvoice → back-pointer to invoice
+
+Payment transaction (slots)
+  └── trans-txn-type: "P" (payment-generated)
+```
+
+This web of pointers is what lets GnuCash navigate: click an invoice, see its transaction; click a transaction, jump back to the invoice; look at a lot, know which invoice it belongs to.
+
+## What the A/R Register Looks Like
+
+```
+Date       Description      Type      Debit    Credit   Balance
+2026-02-25 Bob's PTA        Invoice   $75.00            $75.00
+2026-02-25 Bob's PTA        Payment            $75.00   $0.00
+```
+
+The "Type" column comes from `split.action`. The description comes from the customer name. The transaction number is the invoice ID. All cosmetic but all expected by the UI.
+
+## Database Tables Involved
+
+| Table | Purpose |
+|-------|---------|
+| `customers` / `vendors` | Address books with IDs and currency |
+| `billterms` | Payment terms (e.g., Net 30, 2/10 Net 30) |
+| `invoices` | Invoice/bill records with linkage to posting txn, lot, and account |
+| `entries` | Line items — quantity, price, linked to income/expense accounts |
+| `transactions` | Posting and payment transactions (standard double-entry) |
+| `splits` | Transaction splits with lot assignment for payment tracking |
+| `lots` | Containers grouping an invoice's posting split with its payment splits |
+| `slots` | Metadata slots linking everything together |
+
+## The gncInvoice Slot Structure
+
+The `gncInvoice` back-pointer is stored as a two-row FRAME+GUID structure in the slots table:
+
+```
+Row 1: obj_guid=<transaction_guid>, name='gncInvoice', slot_type=9 (FRAME), guid_val=<frame_guid>
+Row 2: obj_guid=<frame_guid>, name='invoice', slot_type=5 (GUID), guid_val=<invoice_guid>
+```
+
+This same structure appears on both the posting transaction and the lot. It's how GnuCash navigates from any related object back to the originating invoice.
+
+## GnuCash Boolean Convention
+
+GnuCash uses `-1` for boolean true (not `1`). This applies to `lots.is_closed` and other boolean fields. Python treats both as truthy, but GnuCash's C code expects `-1`.

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -5777,3 +5777,665 @@ class GnuCashBook:
             if v.guid == guid:
                 return v
         return None
+
+    @staticmethod
+    def _calculate_lot_balance(lot) -> Decimal:
+        """Sum of split values in a lot.
+
+        For A/R lots: positive = outstanding receivable.
+        For A/P lots: negative = outstanding payable.
+        """
+        total = Decimal(0)
+        for split in lot.splits:
+            total += Decimal(str(split.value))
+        return total
+
+    def _get_invoice_entries_and_total(self, book, inv):
+        """Query entries for an invoice/bill and compute total.
+
+        Returns:
+            Tuple of (entries_list, per_account_totals_dict, grand_total).
+            per_account_totals maps account_guid -> Decimal total.
+        """
+        from sqlalchemy import text
+
+        is_bill = inv.owner_type == 4
+        if is_bill:
+            rows = book.session.execute(
+                text("SELECT * FROM entries WHERE bill = :guid"),
+                {"guid": inv.guid},
+            ).fetchall()
+        else:
+            rows = book.session.execute(
+                text("SELECT * FROM entries WHERE invoice = :guid"),
+                {"guid": inv.guid},
+            ).fetchall()
+
+        if not rows:
+            raise ValueError(
+                f"Cannot post: invoice {inv.id} has no entries"
+            )
+
+        # Aggregate totals per account
+        acct_totals: dict[str, Decimal] = {}
+        grand_total = Decimal(0)
+        for row in rows:
+            q_num = row.quantity_num or 0
+            q_denom = row.quantity_denom or 1
+            quantity = Decimal(q_num) / Decimal(q_denom)
+
+            if is_bill:
+                p_num = row.b_price_num or 0
+                p_denom = row.b_price_denom or 1
+                acct_guid = row.b_acct
+            else:
+                p_num = row.i_price_num or 0
+                p_denom = row.i_price_denom or 1
+                acct_guid = row.i_acct
+
+            price = Decimal(p_num) / Decimal(p_denom)
+            entry_total = quantity * price
+            grand_total += entry_total
+            acct_totals[acct_guid] = acct_totals.get(
+                acct_guid, Decimal(0)
+            ) + entry_total
+
+        return rows, acct_totals, grand_total
+
+    def post_invoice(
+        self,
+        invoice_id: str,
+        post_account: str,
+        post_date: str | None = None,
+        due_date: str | None = None,
+        description: str | None = None,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Post a customer invoice or vendor bill.
+
+        Posting creates a transaction in the A/R or A/P account, creates
+        a lot for payment tracking, and marks the invoice as posted.
+
+        Args:
+            invoice_id: Human-readable ID (e.g., '000001').
+            post_account: A/R or A/P account path.
+            post_date: ISO date (YYYY-MM-DD). Defaults to today.
+            due_date: Payment due date (YYYY-MM-DD). Optional.
+            description: Description for the posting transaction.
+            owner_type: 'customer' or 'vendor' for disambiguation.
+
+        Returns:
+            Dict with invoice details, total, transaction_guid, lot_guid.
+
+        Raises:
+            ValueError: If invoice not found, already posted, no entries,
+                        or invalid account type.
+        """
+        from piecash.business.invoice import Invoice
+        from piecash.core.transaction import Lot
+
+        ot = None
+        if owner_type == "customer":
+            ot = 2
+        elif owner_type == "vendor":
+            ot = 4
+
+        parsed_date = (
+            date.fromisoformat(post_date) if post_date
+            else date.today()
+        )
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, invoice_id, owner_type=ot)
+            if not inv:
+                raise ValueError(
+                    f"Invoice/bill not found: {invoice_id}"
+                )
+
+            if inv.date_posted is not None:
+                raise ValueError(
+                    f"Invoice {invoice_id} is already posted"
+                )
+
+            is_bill = inv.owner_type == 4
+
+            # Validate post account type
+            post_acct = self._find_account(book, post_account)
+            if not post_acct:
+                raise ValueError(
+                    f"Account not found: {post_account}"
+                )
+            expected_type = "PAYABLE" if is_bill else "RECEIVABLE"
+            if post_acct.type != expected_type:
+                raise ValueError(
+                    f"Post account must be {expected_type}, "
+                    f"got {post_acct.type}"
+                )
+
+            # Get entries and totals
+            _, acct_totals, grand_total = (
+                self._get_invoice_entries_and_total(book, inv)
+            )
+
+            # Create lot for payment tracking
+            lot = Lot(
+                title=f"Invoice {inv.id}",
+                account=post_acct,
+                is_closed=0,
+            )
+            book.session.add(lot)
+
+            # Build transaction splits
+            # For customer invoice: A/R debit (positive), income credit (negative)
+            # For vendor bill: A/P credit (negative), expense debit (positive)
+            piecash_splits = []
+
+            if is_bill:
+                # A/P split: negative (credit)
+                ar_ap_split = piecash.Split(
+                    account=post_acct,
+                    value=-grand_total,
+                    quantity=-grand_total,
+                    memo="",
+                )
+            else:
+                # A/R split: positive (debit)
+                ar_ap_split = piecash.Split(
+                    account=post_acct,
+                    value=grand_total,
+                    quantity=grand_total,
+                    memo="",
+                )
+            piecash_splits.append(ar_ap_split)
+
+            # One split per distinct entry account
+            for acct_guid, acct_total in acct_totals.items():
+                entry_acct = None
+                for a in book.accounts:
+                    if a.guid == acct_guid:
+                        entry_acct = a
+                        break
+                if not entry_acct:
+                    raise ValueError(
+                        f"Entry account not found: {acct_guid}"
+                    )
+
+                if is_bill:
+                    # Expense: positive (debit)
+                    split_value = acct_total
+                else:
+                    # Income: negative (credit)
+                    split_value = -acct_total
+
+                piecash_splits.append(
+                    piecash.Split(
+                        account=entry_acct,
+                        value=split_value,
+                        quantity=split_value,
+                        memo="",
+                    )
+                )
+
+            # Create posting transaction
+            txn_desc = description or f"Invoice {inv.id}"
+            txn = piecash.Transaction(
+                currency=inv.currency,
+                description=txn_desc,
+                post_date=parsed_date,
+                splits=piecash_splits,
+            )
+
+            # Assign A/R or A/P split to the lot
+            ar_ap_split.lot = lot
+
+            # Update invoice record with posting info via ORM
+            inv.date_posted = datetime.combine(
+                parsed_date, datetime.min.time()
+            )
+            inv.post_txn = txn
+            inv.post_lot = lot
+            inv.post_account = post_acct
+
+            book.save()
+
+            # Capture return values before session closes
+            result = {
+                "id": inv.id,
+                "type": "bill" if is_bill else "invoice",
+                "status": "posted",
+                "total": str(grand_total),
+                "post_date": str(parsed_date),
+                "transaction_guid": txn.guid,
+                "lot_guid": lot.guid,
+                "post_account": post_acct.fullname,
+            }
+
+        return result
+
+    def pay_invoice(
+        self,
+        invoice_id: str,
+        payment_account: str,
+        amount: str,
+        payment_date: str | None = None,
+        description: str | None = None,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Record a payment against a posted invoice or bill.
+
+        Creates a payment transaction and assigns the A/R or A/P split
+        to the invoice's lot for balance tracking. Partial payments
+        are supported.
+
+        Args:
+            invoice_id: Human-readable ID (e.g., '000001').
+            payment_account: Bank or cash account path.
+            amount: Payment amount as decimal string (e.g., '500.00').
+            payment_date: ISO date (YYYY-MM-DD). Defaults to today.
+            description: Description for the payment transaction.
+            owner_type: 'customer' or 'vendor' for disambiguation.
+
+        Returns:
+            Dict with payment details and remaining balance.
+
+        Raises:
+            ValueError: If invoice not found, not posted, or invalid account.
+        """
+        ot = None
+        if owner_type == "customer":
+            ot = 2
+        elif owner_type == "vendor":
+            ot = 4
+
+        payment_amount = Decimal(amount)
+        if payment_amount <= 0:
+            raise ValueError("Payment amount must be positive")
+
+        parsed_date = (
+            date.fromisoformat(payment_date) if payment_date
+            else date.today()
+        )
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, invoice_id, owner_type=ot)
+            if not inv:
+                raise ValueError(
+                    f"Invoice/bill not found: {invoice_id}"
+                )
+
+            if inv.date_posted is None:
+                raise ValueError(
+                    f"Invoice {invoice_id} is not posted — "
+                    f"post it before recording payment"
+                )
+
+            is_bill = inv.owner_type == 4
+
+            # Find payment account
+            pay_acct = self._find_account(book, payment_account)
+            if not pay_acct:
+                raise ValueError(
+                    f"Account not found: {payment_account}"
+                )
+
+            # Find the post account (A/R or A/P) from invoice
+            post_acct = None
+            post_acc_guid = inv.post_acc_guid
+            for a in book.accounts:
+                if a.guid == post_acc_guid:
+                    post_acct = a
+                    break
+            if not post_acct:
+                raise ValueError(
+                    f"Post account not found for invoice {invoice_id}"
+                )
+
+            # Find the lot
+            lot_guid = inv.post_lot_guid
+            lot_obj = None
+            for lot in post_acct.lots:
+                if lot.guid == lot_guid:
+                    lot_obj = lot
+                    break
+            if not lot_obj:
+                raise ValueError(
+                    f"Lot not found for invoice {invoice_id}"
+                )
+
+            # Build payment splits
+            if is_bill:
+                # Pay vendor bill: debit A/P (positive), credit bank (negative)
+                ar_ap_split = piecash.Split(
+                    account=post_acct,
+                    value=payment_amount,
+                    quantity=payment_amount,
+                    memo="",
+                )
+                bank_split = piecash.Split(
+                    account=pay_acct,
+                    value=-payment_amount,
+                    quantity=-payment_amount,
+                    memo="",
+                )
+            else:
+                # Receive customer payment: credit A/R (negative), debit bank (positive)
+                ar_ap_split = piecash.Split(
+                    account=post_acct,
+                    value=-payment_amount,
+                    quantity=-payment_amount,
+                    memo="",
+                )
+                bank_split = piecash.Split(
+                    account=pay_acct,
+                    value=payment_amount,
+                    quantity=payment_amount,
+                    memo="",
+                )
+
+            # Create payment transaction
+            txn_desc = (
+                description
+                or f"Payment for {'Bill' if is_bill else 'Invoice'} {inv.id}"
+            )
+            txn = piecash.Transaction(
+                currency=inv.currency,
+                description=txn_desc,
+                post_date=parsed_date,
+                splits=[ar_ap_split, bank_split],
+            )
+
+            # Assign A/R or A/P split to the invoice's lot
+            ar_ap_split.lot = lot_obj
+
+            book.save()
+
+            # Calculate remaining balance
+            remaining = self._calculate_lot_balance(lot_obj)
+
+            result = {
+                "id": inv.id,
+                "type": "bill" if is_bill else "invoice",
+                "status": "paid",
+                "amount_paid": str(payment_amount),
+                "remaining_balance": str(abs(remaining)),
+                "transaction_guid": txn.guid,
+                "payment_account": pay_acct.fullname,
+                "payment_date": str(parsed_date),
+            }
+
+        return result
+
+    def get_outstanding_invoices(
+        self,
+        owner_type: str | None = None,
+        customer_id: str | None = None,
+        vendor_id: str | None = None,
+    ) -> list[dict]:
+        """Get all posted invoices/bills with outstanding balances.
+
+        Args:
+            owner_type: Filter by 'customer' or 'vendor'. Omit for all.
+            customer_id: Filter by specific customer ID.
+            vendor_id: Filter by specific vendor ID.
+
+        Returns:
+            List of dicts with invoice details and balance info.
+        """
+        from piecash.business.invoice import Invoice
+
+        with self.open() as book:
+            query = book.session.query(Invoice).filter(
+                Invoice.date_posted.isnot(None)
+            )
+
+            if owner_type == "customer":
+                query = query.filter(Invoice.owner_type == 2)
+            elif owner_type == "vendor":
+                query = query.filter(Invoice.owner_type == 4)
+
+            # Filter by specific customer or vendor
+            if customer_id:
+                customer = None
+                for c in book.customers:
+                    if c.id == customer_id:
+                        customer = c
+                        break
+                if not customer:
+                    raise ValueError(
+                        f"Customer not found: {customer_id}"
+                    )
+                query = query.filter(
+                    Invoice.owner_guid == customer.guid
+                )
+
+            if vendor_id:
+                vendor = None
+                for v in book.vendors:
+                    if v.id == vendor_id:
+                        vendor = v
+                        break
+                if not vendor:
+                    raise ValueError(
+                        f"Vendor not found: {vendor_id}"
+                    )
+                query = query.filter(
+                    Invoice.owner_guid == vendor.guid
+                )
+
+            invoices = query.order_by(
+                Invoice.date_posted.desc()
+            ).all()
+
+            results = []
+            for inv in invoices:
+                is_bill = inv.owner_type == 4
+
+                # Find lot and calculate balance
+                post_acc_guid = inv.post_acc_guid
+                post_acct = None
+                for a in book.accounts:
+                    if a.guid == post_acc_guid:
+                        post_acct = a
+                        break
+                if not post_acct:
+                    continue
+
+                lot_obj = None
+                for lot in post_acct.lots:
+                    if lot.guid == inv.post_lot_guid:
+                        lot_obj = lot
+                        break
+                if not lot_obj:
+                    continue
+
+                balance = self._calculate_lot_balance(lot_obj)
+                # Skip fully paid (balance is zero)
+                if balance == Decimal(0):
+                    continue
+
+                # Calculate original total from entries
+                try:
+                    _, _, grand_total = (
+                        self._get_invoice_entries_and_total(book, inv)
+                    )
+                except ValueError:
+                    grand_total = abs(balance)
+
+                amount_paid = grand_total - abs(balance)
+
+                # Owner name
+                owner_name = None
+                if is_bill:
+                    v = self._find_vendor_by_guid(
+                        book, inv.owner_guid
+                    )
+                    if v:
+                        owner_name = v.name
+                else:
+                    c = self._find_customer_by_guid(
+                        book, inv.owner_guid
+                    )
+                    if c:
+                        owner_name = c.name
+
+                results.append({
+                    "id": inv.id,
+                    "type": "bill" if is_bill else "invoice",
+                    "owner_name": owner_name,
+                    "date_posted": (
+                        str(inv.date_posted.date())
+                        if inv.date_posted else None
+                    ),
+                    "original_amount": str(grand_total),
+                    "amount_paid": str(amount_paid),
+                    "amount_due": str(abs(balance)),
+                })
+
+        return results
+
+    def vendor_spending_report(
+        self,
+        start_date: str,
+        end_date: str,
+        vendor_id: str | None = None,
+    ) -> dict:
+        """Get spending breakdown by vendor for a period.
+
+        Analyzes posted vendor bills to show total billed, paid,
+        and outstanding amounts per vendor.
+
+        Args:
+            start_date: Start of period (YYYY-MM-DD).
+            end_date: End of period (YYYY-MM-DD).
+            vendor_id: Optional filter to specific vendor.
+
+        Returns:
+            Dict with per-vendor breakdown and grand totals.
+        """
+        from piecash.business.invoice import Invoice
+
+        parsed_start = date.fromisoformat(start_date)
+        parsed_end = date.fromisoformat(end_date)
+
+        with self.open() as book:
+            query = book.session.query(Invoice).filter(
+                Invoice.owner_type == 4,
+                Invoice.date_posted.isnot(None),
+            )
+
+            if vendor_id:
+                vendor = None
+                for v in book.vendors:
+                    if v.id == vendor_id:
+                        vendor = v
+                        break
+                if not vendor:
+                    raise ValueError(
+                        f"Vendor not found: {vendor_id}"
+                    )
+                query = query.filter(
+                    Invoice.owner_guid == vendor.guid
+                )
+
+            bills = query.all()
+
+            # Filter by date range (date_posted is datetime)
+            bills = [
+                b for b in bills
+                if parsed_start <= b.date_posted.date() <= parsed_end
+            ]
+
+            # Aggregate by vendor
+            vendor_data: dict[str, dict] = {}
+            for bill in bills:
+                # Get vendor name
+                v = self._find_vendor_by_guid(
+                    book, bill.owner_guid
+                )
+                v_name = v.name if v else "Unknown"
+                v_id = v.id if v else ""
+
+                if v_name not in vendor_data:
+                    vendor_data[v_name] = {
+                        "vendor_id": v_id,
+                        "vendor_name": v_name,
+                        "total_billed": Decimal(0),
+                        "total_paid": Decimal(0),
+                        "outstanding": Decimal(0),
+                        "bill_count": 0,
+                    }
+
+                # Calculate bill total from entries
+                try:
+                    _, _, total = (
+                        self._get_invoice_entries_and_total(
+                            book, bill
+                        )
+                    )
+                except ValueError:
+                    total = Decimal(0)
+
+                # Calculate outstanding from lot
+                balance = Decimal(0)
+                post_acct = None
+                for a in book.accounts:
+                    if a.guid == bill.post_acc_guid:
+                        post_acct = a
+                        break
+                if post_acct:
+                    for lot in post_acct.lots:
+                        if lot.guid == bill.post_lot_guid:
+                            balance = self._calculate_lot_balance(
+                                lot
+                            )
+                            break
+
+                outstanding = abs(balance)
+                paid = total - outstanding
+
+                vendor_data[v_name]["total_billed"] += total
+                vendor_data[v_name]["total_paid"] += paid
+                vendor_data[v_name]["outstanding"] += outstanding
+                vendor_data[v_name]["bill_count"] += 1
+
+            # Convert Decimals to strings
+            vendors_list = []
+            grand_billed = Decimal(0)
+            grand_paid = Decimal(0)
+            grand_outstanding = Decimal(0)
+
+            for vd in vendor_data.values():
+                grand_billed += vd["total_billed"]
+                grand_paid += vd["total_paid"]
+                grand_outstanding += vd["outstanding"]
+                vendors_list.append({
+                    "vendor_id": vd["vendor_id"],
+                    "vendor_name": vd["vendor_name"],
+                    "total_billed": str(vd["total_billed"]),
+                    "total_paid": str(vd["total_paid"]),
+                    "outstanding": str(vd["outstanding"]),
+                    "bill_count": vd["bill_count"],
+                })
+
+            # Sort by total billed descending
+            vendors_list.sort(
+                key=lambda x: Decimal(x["total_billed"]),
+                reverse=True,
+            )
+
+        return {
+            "period": {
+                "start": start_date,
+                "end": end_date,
+            },
+            "vendors": vendors_list,
+            "totals": {
+                "total_billed": str(grand_billed),
+                "total_paid": str(grand_paid),
+                "outstanding": str(grand_outstanding),
+                "vendor_count": len(vendors_list),
+                "bill_count": sum(
+                    v["bill_count"] for v in vendors_list
+                ),
+            },
+        }

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -4545,8 +4545,9 @@ class GnuCashBook:
             summary = self._lot_summary(lot)
 
             # Auto-close if quantity reaches zero
+            # GnuCash uses -1 for boolean true
             if Decimal(summary["quantity"]) == 0 and len(lot.splits) > 0:
-                lot.is_closed = 1
+                lot.is_closed = -1
                 book.save()
                 summary["is_closed"] = True
 
@@ -4662,7 +4663,8 @@ class GnuCashBook:
             if lot.is_closed:
                 raise ValueError("Lot is already closed")
 
-            lot.is_closed = 1
+            # GnuCash uses -1 for boolean true
+            lot.is_closed = -1
             book.save()
 
             return {
@@ -5779,6 +5781,58 @@ class GnuCashBook:
         return None
 
     @staticmethod
+    def _write_gncinvoice_slot(book, obj_guid: str, invoice_guid: str):
+        """Write a gncInvoice FRAME+GUID slot linking an object to an invoice.
+
+        GnuCash stores invoice linkage as a two-row structure:
+          Row 1: obj_guid=<parent>, name='gncInvoice', slot_type=9 (FRAME),
+                 guid_val=<frame_guid>
+          Row 2: obj_guid=<frame_guid>, name='invoice', slot_type=5 (GUID),
+                 guid_val=<invoice_guid>
+
+        This is used on both posting transactions and lots to enable
+        GnuCash UI navigation from transaction/lot back to the invoice.
+        """
+        import uuid
+        from piecash.kvp import Slot, KVP_Type
+
+        frame_guid = uuid.uuid4().hex
+        book.session.execute(
+            Slot.__table__.insert().values(
+                obj_guid=obj_guid,
+                name="gncInvoice",
+                slot_type=KVP_Type.KVP_TYPE_FRAME,
+                guid_val=frame_guid,
+            )
+        )
+        book.session.execute(
+            Slot.__table__.insert().values(
+                obj_guid=frame_guid,
+                name="invoice",
+                slot_type=KVP_Type.KVP_TYPE_GUID,
+                guid_val=invoice_guid,
+            )
+        )
+
+    @staticmethod
+    def _write_gdate_slot(book, obj_guid: str, name: str, date_val: date):
+        """Write a gdate-typed slot on an object.
+
+        Used for trans-date-due and date-posted slots on invoice
+        posting transactions.
+        """
+        from piecash.kvp import Slot, KVP_Type
+
+        book.session.execute(
+            Slot.__table__.insert().values(
+                obj_guid=obj_guid,
+                name=name,
+                slot_type=KVP_Type.KVP_TYPE_GDATE,
+                gdate_val=date_val,
+            )
+        )
+
+    @staticmethod
     def _calculate_lot_balance(lot) -> Decimal:
         """Sum of split values in a lot.
 
@@ -5925,6 +5979,22 @@ class GnuCashBook:
             )
             book.session.add(lot)
 
+            # Resolve owner name for transaction description
+            # GnuCash UI uses the customer/vendor name, not "Invoice NNNNNN"
+            if is_bill:
+                owner = self._find_vendor_by_guid(book, inv.owner_guid)
+            else:
+                owner = self._find_customer_by_guid(
+                    book, inv.owner_guid
+                )
+            owner_name = owner.name if owner else f"Invoice {inv.id}"
+            txn_desc = description or owner_name
+
+            # Parse due date if provided
+            parsed_due = (
+                date.fromisoformat(due_date) if due_date else None
+            )
+
             # Build transaction splits
             # For customer invoice: A/R debit (positive), income credit (negative)
             # For vendor bill: A/P credit (negative), expense debit (positive)
@@ -5937,6 +6007,8 @@ class GnuCashBook:
                     value=-grand_total,
                     quantity=-grand_total,
                     memo="",
+                    action="Invoice",
+                    reconcile_date=datetime(1970, 1, 1),
                 )
             else:
                 # A/R split: positive (debit)
@@ -5945,6 +6017,8 @@ class GnuCashBook:
                     value=grand_total,
                     quantity=grand_total,
                     memo="",
+                    action="Invoice",
+                    reconcile_date=datetime(1970, 1, 1),
                 )
             piecash_splits.append(ar_ap_split)
 
@@ -5977,11 +6051,12 @@ class GnuCashBook:
                 )
 
             # Create posting transaction
-            txn_desc = description or f"Invoice {inv.id}"
+            # num = invoice ID, matching GnuCash UI behavior
             txn = piecash.Transaction(
                 currency=inv.currency,
                 description=txn_desc,
                 post_date=parsed_date,
+                num=inv.id,
                 splits=piecash_splits,
             )
 
@@ -5995,6 +6070,28 @@ class GnuCashBook:
             inv.post_txn = txn
             inv.post_lot = lot
             inv.post_account = post_acct
+
+            # Flush to assign GUIDs before writing slots
+            book.flush()
+
+            # Write metadata slots matching GnuCash UI behavior.
+            # These enable GnuCash to identify invoice-generated
+            # transactions and navigate between invoices/lots/txns.
+            txn["trans-txn-type"] = "I"
+            txn["trans-read-only"] = (
+                "Generated from an invoice. "
+                "Try unposting the invoice."
+            )
+            self._write_gncinvoice_slot(
+                book, txn.guid, inv.guid
+            )
+            self._write_gncinvoice_slot(
+                book, lot.guid, inv.guid
+            )
+            if parsed_due:
+                self._write_gdate_slot(
+                    book, txn.guid, "trans-date-due", parsed_due
+                )
 
             book.save()
 
@@ -6102,6 +6199,19 @@ class GnuCashBook:
                     f"Lot not found for invoice {invoice_id}"
                 )
 
+            # Resolve owner name for transaction description
+            # GnuCash UI uses the customer/vendor name
+            if is_bill:
+                owner = self._find_vendor_by_guid(
+                    book, inv.owner_guid
+                )
+            else:
+                owner = self._find_customer_by_guid(
+                    book, inv.owner_guid
+                )
+            owner_name = owner.name if owner else ""
+            txn_desc = description or owner_name
+
             # Build payment splits
             if is_bill:
                 # Pay vendor bill: debit A/P (positive), credit bank (negative)
@@ -6110,6 +6220,7 @@ class GnuCashBook:
                     value=payment_amount,
                     quantity=payment_amount,
                     memo="",
+                    action="Payment",
                 )
                 bank_split = piecash.Split(
                     account=pay_acct,
@@ -6124,6 +6235,7 @@ class GnuCashBook:
                     value=-payment_amount,
                     quantity=-payment_amount,
                     memo="",
+                    action="Payment",
                 )
                 bank_split = piecash.Split(
                     account=pay_acct,
@@ -6133,24 +6245,29 @@ class GnuCashBook:
                 )
 
             # Create payment transaction
-            txn_desc = (
-                description
-                or f"Payment for {'Bill' if is_bill else 'Invoice'} {inv.id}"
-            )
             txn = piecash.Transaction(
                 currency=inv.currency,
                 description=txn_desc,
                 post_date=parsed_date,
+                num="",
                 splits=[ar_ap_split, bank_split],
             )
 
             # Assign A/R or A/P split to the invoice's lot
             ar_ap_split.lot = lot_obj
 
-            book.save()
+            # Flush to assign GUIDs before writing slots
+            book.flush()
 
-            # Calculate remaining balance
+            # Mark as payment transaction for GnuCash UI
+            txn["trans-txn-type"] = "P"
+
+            # Auto-close lot if fully paid
             remaining = self._calculate_lot_balance(lot_obj)
+            if remaining == Decimal(0):
+                lot_obj.is_closed = -1
+
+            book.save()
 
             result = {
                 "id": inv.id,

--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -4867,6 +4867,116 @@ class GnuCashBook:
             "discount": str(bt.discount) if bt.discount else "0",
         }
 
+    @staticmethod
+    def _decimal_to_num_denom(value: Decimal) -> tuple[int, int]:
+        """Convert a Decimal to numerator/denominator pair.
+
+        Uses the decimal's exponent to determine appropriate denominator.
+        E.g., Decimal("25.50") -> (2550, 100)
+        """
+        sign, digits, exp = value.as_tuple()
+        if exp < 0:
+            denom = 10 ** (-exp)
+            num = int(value * denom)
+        else:
+            num = int(value)
+            denom = 1
+        return num, denom
+
+    @staticmethod
+    def _find_invoice(book, invoice_id: str, owner_type: int | None = None):
+        """Find an invoice/bill by human-readable ID.
+
+        Args:
+            book: piecash Book instance.
+            invoice_id: Human-readable ID (e.g., '000001').
+            owner_type: Filter by owner type (2=customer, 4=vendor).
+                        None returns first match of either type.
+        """
+        from piecash.business.invoice import Invoice
+        query = book.session.query(Invoice).filter(Invoice.id == invoice_id)
+        if owner_type is not None:
+            query = query.filter(Invoice.owner_type == owner_type)
+        return query.first()
+
+    @staticmethod
+    def _invoice_to_dict(invoice, entries=None) -> dict:
+        """Convert a piecash Invoice to a serializable dict.
+
+        Args:
+            invoice: piecash Invoice object.
+            entries: Optional list of entry dicts. If None, entries are not included.
+        """
+        is_posted = invoice.date_posted is not None
+        result = {
+            "guid": invoice.guid,
+            "id": invoice.id,
+            "type": "bill" if invoice.owner_type == 4 else "invoice",
+            "owner_type": invoice.owner_type,
+            "owner_guid": invoice.owner_guid,
+            "date_opened": str(invoice.date_opened.date()) if invoice.date_opened else None,
+            "date_posted": str(invoice.date_posted.date()) if invoice.date_posted else None,
+            "notes": invoice.notes or "",
+            "active": bool(invoice.active),
+            "currency": invoice.currency.mnemonic if invoice.currency else None,
+            "is_posted": is_posted,
+        }
+        if entries is not None:
+            result["entries"] = entries
+        return result
+
+    @staticmethod
+    def _invoice_to_compact_line(invoice) -> str:
+        """One-line compact: 'id  type  owner_id  date_opened  status'."""
+        inv_type = "BILL" if invoice.owner_type == 4 else "INV"
+        date_str = str(invoice.date_opened.date()) if invoice.date_opened else "n/a"
+        status = "posted" if invoice.date_posted else "open"
+        return f"{invoice.id}\t{inv_type}\t{date_str}\t{status}"
+
+    @staticmethod
+    def _entry_to_dict(entry_row, is_bill: bool = False) -> dict:
+        """Convert an entry row (from raw SQL) to a serializable dict.
+
+        Args:
+            entry_row: SQLAlchemy row from entries table.
+            is_bill: If True, read b_* columns; otherwise read i_* columns.
+        """
+        # Quantity
+        q_num = entry_row.quantity_num or 0
+        q_denom = entry_row.quantity_denom or 1
+        quantity = Decimal(q_num) / Decimal(q_denom)
+
+        if is_bill:
+            p_num = entry_row.b_price_num or 0
+            p_denom = entry_row.b_price_denom or 1
+            acct_guid = entry_row.b_acct
+        else:
+            p_num = entry_row.i_price_num or 0
+            p_denom = entry_row.i_price_denom or 1
+            acct_guid = entry_row.i_acct
+
+        price = Decimal(p_num) / Decimal(p_denom)
+        total = quantity * price
+
+        # Raw SQL returns date as string; handle both str and datetime
+        raw_date = entry_row.date
+        if raw_date is None:
+            date_str = None
+        elif isinstance(raw_date, str):
+            date_str = raw_date[:10]  # "YYYY-MM-DD..."
+        else:
+            date_str = str(raw_date.date())
+
+        return {
+            "guid": entry_row.guid,
+            "date": date_str,
+            "description": entry_row.description or "",
+            "account_guid": acct_guid or "",
+            "quantity": str(quantity),
+            "price": str(price),
+            "total": str(total),
+        }
+
     def create_customer(
         self,
         name: str,
@@ -5162,3 +5272,508 @@ class GnuCashBook:
                 return "\n".join(lines)
             else:
                 return [self._billterm_to_dict(t) for t in terms]
+
+    def create_invoice(
+        self,
+        customer_id: str,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+    ) -> dict:
+        """Create a customer invoice.
+
+        Args:
+            customer_id: Customer ID (e.g., '000001').
+            date_opened: Date in ISO format. Defaults to today.
+            notes: Optional notes.
+            currency: ISO currency code. Defaults to book's default currency.
+            term: Billterm name (e.g., 'Net 30'). Optional.
+
+        Returns:
+            Dict with guid, id, customer_id, status.
+        """
+        import uuid
+        from piecash.business.invoice import Invoice, Billterm
+
+        open_date = (
+            datetime.strptime(date_opened, "%Y-%m-%d")
+            if date_opened
+            else datetime.now()
+        )
+
+        with self.open(readonly=False) as book:
+            customer = self._find_customer(book, customer_id)
+            if not customer:
+                raise ValueError(f"Customer not found: {customer_id}")
+
+            if currency:
+                currency_obj = None
+                for c in book.currencies:
+                    if c.mnemonic == currency:
+                        currency_obj = c
+                        break
+                if not currency_obj:
+                    raise ValueError(f"Currency not found: {currency}")
+                currency_guid = currency_obj.guid
+            else:
+                currency_guid = book.default_currency.guid
+
+            term_guid = None
+            if term:
+                bt = book.session.query(Billterm).filter(
+                    Billterm.name == term, Billterm.invisible == 0
+                ).first()
+                if not bt:
+                    raise ValueError(f"Billterm not found: {term}")
+                term_guid = bt.guid
+
+            cnt = book.counter_invoice + 1
+            book.counter_invoice = cnt
+            invoice_id = f"{cnt:06d}"
+            inv_guid = uuid.uuid4().hex
+
+            book.session.execute(
+                Invoice.__table__.insert().values(
+                    guid=inv_guid,
+                    id=invoice_id,
+                    date_opened=open_date,
+                    date_posted=None,
+                    notes=notes,
+                    active=1,
+                    currency=currency_guid,
+                    owner_type=2,  # Customer
+                    owner_guid=customer.guid,
+                    terms=term_guid,
+                    billing_id="",
+                    post_txn=None,
+                    post_lot=None,
+                    post_acc=None,
+                    billto_type=0,
+                    billto_guid=None,
+                    charge_amt_num=0,
+                    charge_amt_denom=1,
+                )
+            )
+
+            book.save()
+
+            return {
+                "guid": inv_guid,
+                "id": invoice_id,
+                "customer_id": customer_id,
+                "date_opened": str(open_date.date()),
+                "status": "created",
+            }
+
+    def create_bill(
+        self,
+        vendor_id: str,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+    ) -> dict:
+        """Create a vendor bill.
+
+        Args:
+            vendor_id: Vendor ID (e.g., '000001').
+            date_opened: Date in ISO format. Defaults to today.
+            notes: Optional notes.
+            currency: ISO currency code. Defaults to book's default currency.
+            term: Billterm name (e.g., 'Net 30'). Optional.
+
+        Returns:
+            Dict with guid, id, vendor_id, status.
+        """
+        import uuid
+        from piecash.business.invoice import Invoice, Billterm
+
+        open_date = (
+            datetime.strptime(date_opened, "%Y-%m-%d")
+            if date_opened
+            else datetime.now()
+        )
+
+        with self.open(readonly=False) as book:
+            vendor = self._find_vendor(book, vendor_id)
+            if not vendor:
+                raise ValueError(f"Vendor not found: {vendor_id}")
+
+            if currency:
+                currency_obj = None
+                for c in book.currencies:
+                    if c.mnemonic == currency:
+                        currency_obj = c
+                        break
+                if not currency_obj:
+                    raise ValueError(f"Currency not found: {currency}")
+                currency_guid = currency_obj.guid
+            else:
+                currency_guid = book.default_currency.guid
+
+            term_guid = None
+            if term:
+                bt = book.session.query(Billterm).filter(
+                    Billterm.name == term, Billterm.invisible == 0
+                ).first()
+                if not bt:
+                    raise ValueError(f"Billterm not found: {term}")
+                term_guid = bt.guid
+
+            cnt = book.counter_bill + 1
+            book.counter_bill = cnt
+            bill_id = f"{cnt:06d}"
+            inv_guid = uuid.uuid4().hex
+
+            book.session.execute(
+                Invoice.__table__.insert().values(
+                    guid=inv_guid,
+                    id=bill_id,
+                    date_opened=open_date,
+                    date_posted=None,
+                    notes=notes,
+                    active=1,
+                    currency=currency_guid,
+                    owner_type=4,  # Vendor
+                    owner_guid=vendor.guid,
+                    terms=term_guid,
+                    billing_id="",
+                    post_txn=None,
+                    post_lot=None,
+                    post_acc=None,
+                    billto_type=0,
+                    billto_guid=None,
+                    charge_amt_num=0,
+                    charge_amt_denom=1,
+                )
+            )
+
+            book.save()
+
+            return {
+                "guid": inv_guid,
+                "id": bill_id,
+                "vendor_id": vendor_id,
+                "date_opened": str(open_date.date()),
+                "status": "created",
+            }
+
+    def add_invoice_entry(
+        self,
+        invoice_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+    ) -> dict:
+        """Add a line item entry to a customer invoice.
+
+        Args:
+            invoice_id: Invoice ID (e.g., '000001').
+            account: Income account full path (e.g., 'Income:Sales').
+            description: Line item description.
+            quantity: Quantity as string (e.g., '1', '2.5').
+            price: Unit price as string (e.g., '100.00').
+
+        Returns:
+            Dict with guid, invoice_id, total, status.
+        """
+        import uuid
+        from piecash.business.invoice import Invoice, Entry
+
+        qty = Decimal(quantity)
+        unit_price = Decimal(price)
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, invoice_id, owner_type=2)
+            if not inv:
+                raise ValueError(f"Invoice not found: {invoice_id}")
+            if inv.owner_type != 2:
+                raise ValueError(
+                    f"'{invoice_id}' is a vendor bill, not a customer invoice. "
+                    f"Use add_bill_entry instead."
+                )
+            if inv.date_posted is not None:
+                raise ValueError(
+                    f"Invoice '{invoice_id}' is already posted. "
+                    f"Cannot add entries to posted invoices."
+                )
+
+            acct = self._find_account(book, account)
+            if not acct:
+                raise ValueError(f"Account not found: {account}")
+
+            q_num, q_denom = self._decimal_to_num_denom(qty)
+            p_num, p_denom = self._decimal_to_num_denom(unit_price)
+            entry_guid = uuid.uuid4().hex
+
+            book.session.execute(
+                Entry.__table__.insert().values(
+                    guid=entry_guid,
+                    date=datetime.now(),
+                    date_entered=datetime.now(),
+                    description=description,
+                    action="",
+                    notes="",
+                    quantity_num=q_num,
+                    quantity_denom=q_denom,
+                    i_acct=acct.guid,
+                    i_price_num=p_num,
+                    i_price_denom=p_denom,
+                    i_discount_num=0,
+                    i_discount_denom=1,
+                    invoice=inv.guid,
+                    i_disc_type="",
+                    i_disc_how="",
+                    i_taxable=0,
+                    i_taxincluded=0,
+                    i_taxtable=None,
+                    b_acct=None,
+                    b_price_num=0,
+                    b_price_denom=1,
+                    bill=None,
+                    b_taxable=0,
+                    b_taxincluded=0,
+                    b_taxtable=None,
+                    b_paytype=0,
+                    billable=0,
+                    billto_type=0,
+                    billto_guid=None,
+                    order_guid=None,
+                )
+            )
+
+            book.save()
+
+            total = qty * unit_price
+            return {
+                "guid": entry_guid,
+                "invoice_id": invoice_id,
+                "description": description,
+                "quantity": str(qty),
+                "price": str(unit_price),
+                "total": str(total),
+                "status": "created",
+            }
+
+    def add_bill_entry(
+        self,
+        bill_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+    ) -> dict:
+        """Add a line item entry to a vendor bill.
+
+        Args:
+            bill_id: Bill ID (e.g., '000001').
+            account: Expense account full path (e.g., 'Expenses:Office Supplies').
+            description: Line item description.
+            quantity: Quantity as string (e.g., '1', '2.5').
+            price: Unit price as string (e.g., '50.00').
+
+        Returns:
+            Dict with guid, bill_id, total, status.
+        """
+        import uuid
+        from piecash.business.invoice import Invoice, Entry
+
+        qty = Decimal(quantity)
+        unit_price = Decimal(price)
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, bill_id, owner_type=4)
+            if not inv:
+                raise ValueError(f"Bill not found: {bill_id}")
+            if inv.owner_type != 4:
+                raise ValueError(
+                    f"'{bill_id}' is a customer invoice, not a vendor bill. "
+                    f"Use add_invoice_entry instead."
+                )
+            if inv.date_posted is not None:
+                raise ValueError(
+                    f"Bill '{bill_id}' is already posted. "
+                    f"Cannot add entries to posted bills."
+                )
+
+            acct = self._find_account(book, account)
+            if not acct:
+                raise ValueError(f"Account not found: {account}")
+
+            q_num, q_denom = self._decimal_to_num_denom(qty)
+            p_num, p_denom = self._decimal_to_num_denom(unit_price)
+            entry_guid = uuid.uuid4().hex
+
+            book.session.execute(
+                Entry.__table__.insert().values(
+                    guid=entry_guid,
+                    date=datetime.now(),
+                    date_entered=datetime.now(),
+                    description=description,
+                    action="",
+                    notes="",
+                    quantity_num=q_num,
+                    quantity_denom=q_denom,
+                    i_acct=None,
+                    i_price_num=0,
+                    i_price_denom=1,
+                    i_discount_num=0,
+                    i_discount_denom=1,
+                    invoice=None,
+                    i_disc_type="",
+                    i_disc_how="",
+                    i_taxable=0,
+                    i_taxincluded=0,
+                    i_taxtable=None,
+                    b_acct=acct.guid,
+                    b_price_num=p_num,
+                    b_price_denom=p_denom,
+                    bill=inv.guid,
+                    b_taxable=0,
+                    b_taxincluded=0,
+                    b_taxtable=None,
+                    b_paytype=0,
+                    billable=0,
+                    billto_type=0,
+                    billto_guid=None,
+                    order_guid=None,
+                )
+            )
+
+            book.save()
+
+            total = qty * unit_price
+            return {
+                "guid": entry_guid,
+                "bill_id": bill_id,
+                "description": description,
+                "quantity": str(qty),
+                "price": str(unit_price),
+                "total": str(total),
+                "status": "created",
+            }
+
+    def list_invoices(
+        self,
+        owner_type: str | None = None,
+        status: str | None = None,
+        compact: bool = True,
+    ) -> list[dict] | str:
+        """List invoices and/or bills.
+
+        Args:
+            owner_type: Filter by type: 'customer', 'vendor', or None for all.
+            status: Filter by status: 'posted', 'open', or None for all.
+            compact: If True, return compact one-line-per-invoice string.
+
+        Returns:
+            Compact string or list of dicts.
+        """
+        from piecash.business.invoice import Invoice
+
+        with self.open() as book:
+            query = book.session.query(Invoice)
+
+            if owner_type == "customer":
+                query = query.filter(Invoice.owner_type == 2)
+            elif owner_type == "vendor":
+                query = query.filter(Invoice.owner_type == 4)
+
+            invoices = query.order_by(Invoice.date_opened.desc()).all()
+
+            if status == "posted":
+                invoices = [i for i in invoices if i.date_posted is not None]
+            elif status == "open":
+                invoices = [i for i in invoices if i.date_posted is None]
+
+            if compact:
+                lines = [self._invoice_to_compact_line(i) for i in invoices]
+                return "\n".join(lines)
+            else:
+                return [self._invoice_to_dict(i) for i in invoices]
+
+    def get_invoice(self, invoice_id: str, owner_type: str | None = None) -> dict:
+        """Get full details for an invoice or bill, including entries.
+
+        Args:
+            invoice_id: Human-readable invoice/bill ID (e.g., '000001').
+            owner_type: Filter by type: 'customer' or 'vendor'.
+                        Useful when invoice and bill share the same ID.
+
+        Returns:
+            Dict with full invoice details and entry list.
+
+        Raises:
+            ValueError: If invoice not found.
+        """
+        from piecash.business.invoice import Invoice, Entry
+        from sqlalchemy import text
+
+        ot = None
+        if owner_type == "customer":
+            ot = 2
+        elif owner_type == "vendor":
+            ot = 4
+
+        with self.open() as book:
+            inv = self._find_invoice(book, invoice_id, owner_type=ot)
+            if not inv:
+                raise ValueError(f"Invoice/bill not found: {invoice_id}")
+
+            is_bill = inv.owner_type == 4
+
+            # Get entries via raw SQL since ORM relationship doesn't
+            # work for vendor bills (bill column is VARCHAR, not FK)
+            if is_bill:
+                rows = book.session.execute(
+                    text("SELECT * FROM entries WHERE bill = :guid"),
+                    {"guid": inv.guid},
+                ).fetchall()
+            else:
+                rows = book.session.execute(
+                    text("SELECT * FROM entries WHERE invoice = :guid"),
+                    {"guid": inv.guid},
+                ).fetchall()
+
+            entries = [self._entry_to_dict(r, is_bill=is_bill) for r in rows]
+
+            # Calculate total
+            total = sum(
+                Decimal(e["quantity"]) * Decimal(e["price"])
+                for e in entries
+            )
+
+            # Look up owner name
+            owner_name = None
+            if is_bill:
+                vendor = self._find_vendor_by_guid(book, inv.owner_guid)
+                if vendor:
+                    owner_name = vendor.name
+            else:
+                customer = self._find_customer_by_guid(book, inv.owner_guid)
+                if customer:
+                    owner_name = customer.name
+
+            result = self._invoice_to_dict(inv, entries=entries)
+            result["total"] = str(total)
+            if owner_name:
+                result["owner_name"] = owner_name
+            return result
+
+    @staticmethod
+    def _find_customer_by_guid(book, guid: str):
+        """Find a customer by GUID."""
+        for c in book.customers:
+            if c.guid == guid:
+                return c
+        return None
+
+    @staticmethod
+    def _find_vendor_by_guid(book, guid: str):
+        """Find a vendor by GUID."""
+        for v in book.vendors:
+            if v.guid == guid:
+                return v
+        return None

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -548,6 +548,37 @@ def _format_audit_entry_text(entry: dict) -> str:
             lines.append(f"{time_part}  CREATE BILLTERM")
             lines.append(f'{indent}name: "{bt_name}"  due: {due_days} days')
 
+    elif entity_type == "invoice":
+        if operation == "CREATE":
+            inv_id = ""
+            customer_id = params.get("customer_id", "")
+            if after:
+                inv_id = after.get("id", "")
+                customer_id = after.get("customer_id", customer_id)
+            lines.append(f"{time_part}  CREATE INVOICE  id:{inv_id}")
+            lines.append(f'{indent}customer: {customer_id}')
+
+    elif entity_type == "bill":
+        if operation == "CREATE":
+            bill_id = ""
+            vendor_id = params.get("vendor_id", "")
+            if after:
+                bill_id = after.get("id", "")
+                vendor_id = after.get("vendor_id", vendor_id)
+            lines.append(f"{time_part}  CREATE BILL  id:{bill_id}")
+            lines.append(f'{indent}vendor: {vendor_id}')
+
+    elif entity_type == "entry":
+        if operation == "CREATE":
+            desc = params.get("description", "")
+            total = ""
+            if after:
+                desc = after.get("description", desc)
+                total = after.get("total", "")
+            inv_id = params.get("invoice_id", "") or params.get("bill_id", "")
+            lines.append(f"{time_part}  CREATE ENTRY")
+            lines.append(f'{indent}"{desc}"  total: {total}  on: {inv_id}')
+
     # Handle move_account specially (it's logged as "update" but is conceptually a move)
     if entity_type == "account" and "new_parent" in params:
         # This is actually a MOVE operation

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -557,6 +557,26 @@ def _format_audit_entry_text(entry: dict) -> str:
                 customer_id = after.get("customer_id", customer_id)
             lines.append(f"{time_part}  CREATE INVOICE  id:{inv_id}")
             lines.append(f'{indent}customer: {customer_id}')
+        elif operation == "POST":
+            inv_id = params.get("id", "")
+            post_account = params.get("post_account", "")
+            lines.append(f"{time_part}  POST INVOICE  id:{inv_id}")
+            if after:
+                total = after.get("total", "")
+                post_date = after.get("post_date", "")
+                txn_guid = (after.get("transaction_guid") or "")[:8]
+                lines.append(f'{indent}total: {total}  date: {post_date}')
+                lines.append(f'{indent}account: {post_account}  txn:{txn_guid}')
+        elif operation == "PAY":
+            inv_id = params.get("id", "")
+            lines.append(f"{time_part}  PAY INVOICE  id:{inv_id}")
+            if after:
+                amount = after.get("amount_paid", "")
+                remaining = after.get("remaining_balance", "")
+                pay_acct = params.get("payment_account", "")
+                txn_guid = (after.get("transaction_guid") or "")[:8]
+                lines.append(f'{indent}paid: {amount}  remaining: {remaining}')
+                lines.append(f'{indent}from: {pay_acct}  txn:{txn_guid}')
 
     elif entity_type == "bill":
         if operation == "CREATE":

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -117,6 +117,12 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_vendor",
         "create_billterm",
         "list_billterms",
+        "create_invoice",
+        "create_bill",
+        "add_invoice_entry",
+        "add_bill_entry",
+        "list_invoices",
+        "get_invoice",
     ],
 }
 
@@ -1778,6 +1784,172 @@ def list_billterms(
     if verbose:
         return json.dumps(result, indent=2)
     return result
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="invoice")
+def create_invoice(
+    customer_id: str,
+    date_opened: str | None = None,
+    notes: str = "",
+    currency: str | None = None,
+    term: str | None = None,
+) -> str:
+    """Create a customer invoice.
+
+    Args:
+        customer_id: Customer ID (e.g., "000001").
+        date_opened: Date in ISO format (YYYY-MM-DD). Defaults to today.
+        notes: Optional notes.
+        currency: ISO currency code. Defaults to book's default currency.
+        term: Billterm name (e.g., "Net 30"). Optional.
+    """
+    book = get_book()
+    result = book.create_invoice(
+        customer_id=customer_id, date_opened=date_opened,
+        notes=notes, currency=currency, term=term,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="bill")
+def create_bill(
+    vendor_id: str,
+    date_opened: str | None = None,
+    notes: str = "",
+    currency: str | None = None,
+    term: str | None = None,
+) -> str:
+    """Create a vendor bill.
+
+    Args:
+        vendor_id: Vendor ID (e.g., "000001").
+        date_opened: Date in ISO format (YYYY-MM-DD). Defaults to today.
+        notes: Optional notes.
+        currency: ISO currency code. Defaults to book's default currency.
+        term: Billterm name (e.g., "Net 30"). Optional.
+    """
+    book = get_book()
+    result = book.create_bill(
+        vendor_id=vendor_id, date_opened=date_opened,
+        notes=notes, currency=currency, term=term,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="entry")
+def add_invoice_entry(
+    invoice_id: str,
+    account: str,
+    description: str,
+    quantity: str,
+    price: str,
+) -> str:
+    """Add a line item to a customer invoice.
+
+    The invoice must not be posted yet. Entries represent individual
+    goods or services being billed.
+
+    Args:
+        invoice_id: Invoice ID (e.g., "000001").
+        account: Income account path (e.g., "Income:Sales").
+        description: Line item description.
+        quantity: Quantity as decimal string (e.g., "1", "2.5").
+        price: Unit price as decimal string (e.g., "100.00").
+    """
+    book = get_book()
+    result = book.add_invoice_entry(
+        invoice_id=invoice_id, account=account,
+        description=description, quantity=quantity, price=price,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="create", entity_type="entry")
+def add_bill_entry(
+    bill_id: str,
+    account: str,
+    description: str,
+    quantity: str,
+    price: str,
+) -> str:
+    """Add a line item to a vendor bill.
+
+    The bill must not be posted yet. Entries represent individual
+    goods or services being billed.
+
+    Args:
+        bill_id: Bill ID (e.g., "000001").
+        account: Expense account path (e.g., "Expenses:Office Supplies").
+        description: Line item description.
+        quantity: Quantity as decimal string (e.g., "1", "2.5").
+        price: Unit price as decimal string (e.g., "50.00").
+    """
+    book = get_book()
+    result = book.add_bill_entry(
+        bill_id=bill_id, account=account,
+        description=description, quantity=quantity, price=price,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def list_invoices(
+    owner_type: str | None = None,
+    status: str | None = None,
+    verbose: bool = False,
+) -> str:
+    """List invoices and/or vendor bills.
+
+    Returns a compact one-line-per-invoice format by default.
+    Use verbose=true for full JSON with GUIDs, dates, notes, etc.
+
+    Args:
+        owner_type: Filter by type: "customer" for invoices,
+                    "vendor" for bills, or omit for all.
+        status: Filter by status: "posted" or "open", or omit for all.
+        verbose: If true, return full JSON details.
+    """
+    book = get_book()
+    result = book.list_invoices(
+        owner_type=owner_type, status=status, compact=not verbose,
+    )
+    if verbose:
+        return json.dumps(result, indent=2)
+    return result
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_invoice(
+    id: str,
+    owner_type: str | None = None,
+) -> str:
+    """Get full details for an invoice or bill, including line items.
+
+    Works for both customer invoices and vendor bills. Returns all
+    entries with quantities, prices, and totals.
+
+    Args:
+        id: Invoice or bill ID (e.g., "000001"). This is the
+            human-readable ID, not the internal GUID.
+        owner_type: Filter by type: "customer" for invoices,
+                    "vendor" for bills. Useful when an invoice and
+                    bill share the same ID (independent counters).
+    """
+    book = get_book()
+    result = book.get_invoice(invoice_id=id, owner_type=owner_type)
+    return _json(result)
 
 
 # ============== Resources ==============

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -123,6 +123,10 @@ TOOL_MODULES: dict[str, list[str]] = {
         "add_bill_entry",
         "list_invoices",
         "get_invoice",
+        "post_invoice",
+        "pay_invoice",
+        "get_outstanding_invoices",
+        "vendor_spending_report",
     ],
 }
 
@@ -1949,6 +1953,129 @@ def get_invoice(
     """
     book = get_book()
     result = book.get_invoice(invoice_id=id, owner_type=owner_type)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="post", entity_type="invoice")
+def post_invoice(
+    id: str,
+    post_account: str,
+    post_date: str | None = None,
+    due_date: str | None = None,
+    description: str | None = None,
+    owner_type: str | None = None,
+) -> str:
+    """Post a customer invoice or vendor bill.
+
+    Posting creates a transaction in the A/R or A/P account and makes
+    the invoice official. Once posted, entries cannot be added.
+
+    Args:
+        id: Invoice or bill ID (e.g., "000001").
+        post_account: A/R or A/P account path (e.g., "Assets:Accounts Receivable").
+        post_date: Date in ISO format (YYYY-MM-DD). Defaults to today.
+        due_date: Payment due date (YYYY-MM-DD). Optional.
+        description: Description for the posting transaction. Optional.
+        owner_type: "customer" or "vendor" for disambiguation when IDs collide.
+    """
+    book = get_book()
+    result = book.post_invoice(
+        invoice_id=id,
+        post_account=post_account,
+        post_date=post_date,
+        due_date=due_date,
+        description=description,
+        owner_type=owner_type,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="pay", entity_type="invoice")
+def pay_invoice(
+    id: str,
+    payment_account: str,
+    amount: str,
+    payment_date: str | None = None,
+    description: str | None = None,
+    owner_type: str | None = None,
+) -> str:
+    """Record a payment against a posted invoice or bill.
+
+    Creates a payment transaction from the specified bank/cash account
+    to the invoice's A/R or A/P account. Partial payments are supported.
+
+    Args:
+        id: Invoice or bill ID (e.g., "000001").
+        payment_account: Bank or cash account for payment (e.g., "Assets:Checking").
+        amount: Payment amount as decimal string (e.g., "500.00").
+        payment_date: Payment date (YYYY-MM-DD). Defaults to today.
+        description: Description for the payment transaction. Optional.
+        owner_type: "customer" or "vendor" for disambiguation.
+    """
+    book = get_book()
+    result = book.pay_invoice(
+        invoice_id=id,
+        payment_account=payment_account,
+        amount=amount,
+        payment_date=payment_date,
+        description=description,
+        owner_type=owner_type,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def get_outstanding_invoices(
+    owner_type: str | None = None,
+    customer_id: str | None = None,
+    vendor_id: str | None = None,
+) -> str:
+    """Get all posted invoices/bills with outstanding balances.
+
+    Args:
+        owner_type: Filter by "customer" or "vendor". Omit for all.
+        customer_id: Filter by specific customer ID.
+        vendor_id: Filter by specific vendor ID.
+    """
+    book = get_book()
+    result = book.get_outstanding_invoices(
+        owner_type=owner_type,
+        customer_id=customer_id,
+        vendor_id=vendor_id,
+    )
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="read")
+def vendor_spending_report(
+    start_date: str,
+    end_date: str,
+    vendor_id: str | None = None,
+) -> str:
+    """Get spending breakdown by vendor for a period.
+
+    Analyzes posted vendor bills to show total billed, total paid,
+    and outstanding amounts per vendor.
+
+    Args:
+        start_date: Start of period (YYYY-MM-DD).
+        end_date: End of period (YYYY-MM-DD).
+        vendor_id: Optional filter to a specific vendor.
+    """
+    book = get_book()
+    result = book.vendor_spending_report(
+        start_date=start_date,
+        end_date=end_date,
+        vendor_id=vendor_id,
+    )
     return _json(result)
 
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -834,6 +834,124 @@ class TestPostInvoice:
         )
         assert result["status"] == "posted"
 
+    def test_post_sets_transaction_metadata(self, business_book):
+        """Posting transaction has GnuCash-compatible metadata."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            due_date="2026-04-01",
+        )
+        txn_guid = result["transaction_guid"]
+        lot_guid = result["lot_guid"]
+
+        # Read slots from the database directly
+        conn = sqlite3.connect(str(business_book))
+        try:
+            # Transaction num should be invoice ID
+            txn = conn.execute(
+                "SELECT num, description FROM transactions "
+                "WHERE guid = ?",
+                (txn_guid,),
+            ).fetchone()
+            assert txn[0] == "000001", "transaction.num should be invoice ID"
+            assert txn[1] == "Acme Corp", (
+                "description should be customer name"
+            )
+
+            # A/R split should have action='Invoice'
+            ar_split = conn.execute(
+                "SELECT action, reconcile_date FROM splits "
+                "WHERE tx_guid = ? AND action = 'Invoice'",
+                (txn_guid,),
+            ).fetchone()
+            assert ar_split is not None, "A/R split should have action=Invoice"
+
+            # Check transaction slots
+            slots = conn.execute(
+                "SELECT name, slot_type, string_val, guid_val, gdate_val "
+                "FROM slots WHERE obj_guid = ?",
+                (txn_guid,),
+            ).fetchall()
+            slot_dict = {s[0]: s for s in slots}
+
+            assert "trans-txn-type" in slot_dict, "missing trans-txn-type slot"
+            assert slot_dict["trans-txn-type"][2] == "I"
+
+            assert "trans-read-only" in slot_dict, "missing trans-read-only slot"
+            assert "invoice" in slot_dict["trans-read-only"][2].lower()
+
+            # gncInvoice frame slot on transaction
+            assert "gncInvoice" in slot_dict, (
+                "missing gncInvoice slot on transaction"
+            )
+            frame_guid = slot_dict["gncInvoice"][3]
+            assert frame_guid is not None
+
+            # Child GUID slot inside the frame
+            child = conn.execute(
+                "SELECT name, slot_type, guid_val FROM slots "
+                "WHERE obj_guid = ? AND name = 'invoice'",
+                (frame_guid,),
+            ).fetchone()
+            assert child is not None, "missing gncInvoice/invoice child slot"
+            assert child[1] == 5, "child slot should be GUID type (5)"
+
+            # Due date slot
+            assert "trans-date-due" in slot_dict, "missing trans-date-due slot"
+            assert slot_dict["trans-date-due"][1] == 10, (
+                "trans-date-due should be GDATE type (10)"
+            )
+
+            # gncInvoice frame slot on lot
+            lot_slots = conn.execute(
+                "SELECT name, slot_type, guid_val FROM slots "
+                "WHERE obj_guid = ?",
+                (lot_guid,),
+            ).fetchall()
+            lot_slot_dict = {s[0]: s for s in lot_slots}
+            assert "gncInvoice" in lot_slot_dict, (
+                "missing gncInvoice slot on lot"
+            )
+        finally:
+            conn.close()
+
+    def test_post_bill_sets_metadata(self, business_book):
+        """Vendor bill posting also sets correct metadata."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        self._setup_bill(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        txn_guid = result["transaction_guid"]
+
+        conn = sqlite3.connect(str(business_book))
+        try:
+            txn = conn.execute(
+                "SELECT description FROM transactions WHERE guid = ?",
+                (txn_guid,),
+            ).fetchone()
+            assert txn[0] == "Office Depot", (
+                "bill description should be vendor name"
+            )
+
+            slots = conn.execute(
+                "SELECT name, string_val FROM slots "
+                "WHERE obj_guid = ? AND slot_type = 4",
+                (txn_guid,),
+            ).fetchall()
+            slot_dict = {s[0]: s[1] for s in slots}
+            assert slot_dict.get("trans-txn-type") == "I"
+        finally:
+            conn.close()
+
 
 # ============== Pay Invoice Tests ==============
 
@@ -982,6 +1100,102 @@ class TestPayInvoice:
             description="Wire transfer payment",
         )
         assert result["status"] == "paid"
+
+    def test_payment_sets_transaction_metadata(self, business_book):
+        """Payment transaction has GnuCash-compatible metadata."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+        txn_guid = result["transaction_guid"]
+
+        conn = sqlite3.connect(str(business_book))
+        try:
+            # Description should be customer name
+            txn = conn.execute(
+                "SELECT description FROM transactions WHERE guid = ?",
+                (txn_guid,),
+            ).fetchone()
+            assert txn[0] == "Acme Corp", (
+                "payment description should be customer name"
+            )
+
+            # A/R split should have action='Payment'
+            pay_split = conn.execute(
+                "SELECT action FROM splits "
+                "WHERE tx_guid = ? AND action = 'Payment'",
+                (txn_guid,),
+            ).fetchone()
+            assert pay_split is not None, (
+                "A/R split should have action=Payment"
+            )
+
+            # trans-txn-type slot should be 'P'
+            slot = conn.execute(
+                "SELECT string_val FROM slots "
+                "WHERE obj_guid = ? AND name = 'trans-txn-type'",
+                (txn_guid,),
+            ).fetchone()
+            assert slot is not None, "missing trans-txn-type slot on payment"
+            assert slot[0] == "P"
+        finally:
+            conn.close()
+
+    def test_full_payment_closes_lot(self, business_book):
+        """Full payment auto-closes the lot with GnuCash boolean -1."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        post_result = gb.get_invoice("000001")
+
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+
+        # Check lot is_closed = -1 in the database
+        conn = sqlite3.connect(str(business_book))
+        try:
+            lots = conn.execute(
+                "SELECT is_closed FROM lots WHERE account_guid IN "
+                "(SELECT guid FROM accounts WHERE name = 'Accounts Receivable')"
+            ).fetchall()
+            assert any(
+                row[0] == -1 for row in lots
+            ), "lot should be closed with is_closed=-1"
+        finally:
+            conn.close()
+
+    def test_partial_payment_does_not_close_lot(self, business_book):
+        """Partial payment leaves lot open."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+
+        conn = sqlite3.connect(str(business_book))
+        try:
+            lots = conn.execute(
+                "SELECT is_closed FROM lots WHERE account_guid IN "
+                "(SELECT guid FROM accounts WHERE name = 'Accounts Receivable')"
+            ).fetchall()
+            assert all(
+                row[0] == 0 for row in lots
+            ), "lot should remain open after partial payment"
+        finally:
+            conn.close()
 
 
 # ============== Outstanding Invoices Tests ==============

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -655,3 +655,692 @@ class TestInvoiceBillIdCollision:
         assert inv["type"] == "invoice"
         bill = gb.get_invoice("000001", owner_type="vendor")
         assert bill["type"] == "bill"
+
+
+# ============== Post Invoice Tests ==============
+
+
+class TestPostInvoice:
+    """Tests for post_invoice."""
+
+    def _setup_invoice(self, gb, amount="500.00"):
+        """Create customer + invoice + entry, return invoice ID."""
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        return "000001"
+
+    def _setup_bill(self, gb, amount="50.00"):
+        """Create vendor + bill + entry, return bill ID."""
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price=amount,
+        )
+        return "000001"
+
+    def test_basic_post(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert result["status"] == "posted"
+        assert Decimal(result["total"]) == Decimal("500")
+        assert len(result["transaction_guid"]) == 32
+        assert len(result["lot_guid"]) == 32
+        assert result["post_account"] == "Assets:Accounts Receivable"
+
+    def test_post_marks_invoice_posted(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        inv = gb.get_invoice("000001")
+        assert inv["is_posted"] is True
+        assert inv["date_posted"] is not None
+
+    def test_post_with_multiple_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="2",
+            price="150.00",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Consulting",
+            description="Advisory",
+            quantity="1",
+            price="200.00",
+        )
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert Decimal(result["total"]) == Decimal("500")
+
+    def test_post_same_account_entries_aggregated(self, business_book):
+        """Entries to the same income account produce one split."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Item A",
+            quantity="1",
+            price="300.00",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Item B",
+            quantity="1",
+            price="200.00",
+        )
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert Decimal(result["total"]) == Decimal("500")
+
+    def test_post_already_posted_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        with pytest.raises(ValueError, match="already posted"):
+            gb.post_invoice(
+                invoice_id="000001",
+                post_account="Assets:Accounts Receivable",
+            )
+
+    def test_post_no_entries_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="no entries"):
+            gb.post_invoice(
+                invoice_id="000001",
+                post_account="Assets:Accounts Receivable",
+            )
+
+    def test_post_not_found_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.post_invoice(
+                invoice_id="999999",
+                post_account="Assets:Accounts Receivable",
+            )
+
+    def test_post_wrong_account_type_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        with pytest.raises(ValueError, match="RECEIVABLE"):
+            gb.post_invoice(
+                invoice_id="000001",
+                post_account="Assets:Checking",
+            )
+
+    def test_post_vendor_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_bill(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        assert result["status"] == "posted"
+        assert result["type"] == "bill"
+        assert Decimal(result["total"]) == Decimal("50")
+
+    def test_post_with_custom_date(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-03-15",
+        )
+        assert result["post_date"] == "2026-03-15"
+
+    def test_post_with_description(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._setup_invoice(gb)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            description="Q1 consulting services",
+        )
+        assert result["status"] == "posted"
+
+
+# ============== Pay Invoice Tests ==============
+
+
+class TestPayInvoice:
+    """Tests for pay_invoice."""
+
+    def _post_invoice(self, gb, amount="500.00"):
+        """Create customer + invoice + entry + post, return invoice ID."""
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        return "000001"
+
+    def _post_bill(self, gb, amount="50.00"):
+        """Create vendor + bill + entry + post, return bill ID."""
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        return "000001"
+
+    def test_full_payment(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+        assert result["status"] == "paid"
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+
+    def test_partial_payment(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        assert Decimal(result["remaining_balance"]) == Decimal("300")
+
+    def test_multiple_payments(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="300",
+        )
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+
+    def test_pay_unposted_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100.00",
+        )
+        with pytest.raises(ValueError, match="not posted"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="100",
+            )
+
+    def test_pay_not_found_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.pay_invoice(
+                invoice_id="999999",
+                payment_account="Assets:Checking",
+                amount="100",
+            )
+
+    def test_pay_zero_amount_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        with pytest.raises(ValueError, match="must be positive"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="0",
+            )
+
+    def test_pay_vendor_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_bill(gb, "50.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="50",
+            owner_type="vendor",
+        )
+        assert result["type"] == "bill"
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+
+    def test_pay_with_custom_date(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+            payment_date="2026-04-01",
+        )
+        assert result["payment_date"] == "2026-04-01"
+
+    def test_pay_with_description(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb)
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+            description="Wire transfer payment",
+        )
+        assert result["status"] == "paid"
+
+
+# ============== Outstanding Invoices Tests ==============
+
+
+class TestGetOutstandingInvoices:
+    """Tests for get_outstanding_invoices."""
+
+    def test_empty_when_none_posted(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.get_outstanding_invoices()
+        assert result == []
+
+    def test_shows_posted_unpaid(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        result = gb.get_outstanding_invoices()
+        assert len(result) == 1
+        assert result[0]["id"] == "000001"
+        assert Decimal(result[0]["amount_due"]) == Decimal("500")
+
+    def test_excludes_fully_paid(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+        result = gb.get_outstanding_invoices()
+        assert len(result) == 0
+
+    def test_partially_paid_shows_correct_amounts(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        result = gb.get_outstanding_invoices()
+        assert len(result) == 1
+        assert Decimal(result[0]["amount_due"]) == Decimal("300")
+        assert Decimal(result[0]["amount_paid"]) == Decimal("200")
+
+    def test_filter_by_customer(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_customer(name="Beta Inc")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="For Acme",
+            quantity="1",
+            price="100.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        gb.create_invoice(customer_id="000002")
+        gb.add_invoice_entry(
+            invoice_id="000002",
+            account="Income:Sales",
+            description="For Beta",
+            quantity="1",
+            price="200.00",
+        )
+        gb.post_invoice(
+            invoice_id="000002",
+            post_account="Assets:Accounts Receivable",
+        )
+        result = gb.get_outstanding_invoices(customer_id="000001")
+        assert len(result) == 1
+        assert result[0]["owner_name"] == "Acme Corp"
+
+    def test_filter_by_vendor(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        result = gb.get_outstanding_invoices(owner_type="vendor")
+        assert len(result) == 1
+        assert result[0]["type"] == "bill"
+
+
+# ============== Vendor Spending Report Tests ==============
+
+
+class TestVendorSpendingReport:
+    """Tests for vendor_spending_report."""
+
+    def test_basic_report(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-02-15",
+        )
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+        )
+        assert len(result["vendors"]) == 1
+        assert result["vendors"][0]["vendor_name"] == "Office Depot"
+        assert Decimal(result["vendors"][0]["total_billed"]) == Decimal("50")
+        assert result["totals"]["bill_count"] == 1
+
+    def test_multiple_vendors(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_vendor(name="Staples")
+        # Bill 1 for Office Depot
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-02-15",
+        )
+        # Bill 2 for Staples
+        gb.create_bill(vendor_id="000002")
+        gb.add_bill_entry(
+            bill_id="000002",
+            account="Expenses:Office Supplies",
+            description="Pens",
+            quantity="1",
+            price="30.00",
+        )
+        gb.post_invoice(
+            invoice_id="000002",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-02-20",
+        )
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+        )
+        assert result["totals"]["vendor_count"] == 2
+        assert Decimal(result["totals"]["total_billed"]) == Decimal("80")
+
+    def test_date_filter(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-06-15",
+        )
+        # Query range that excludes the bill
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-03-31",
+        )
+        assert len(result["vendors"]) == 0
+
+    def test_filter_by_vendor_id(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_vendor(name="Staples")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-02-15",
+        )
+        gb.create_bill(vendor_id="000002")
+        gb.add_bill_entry(
+            bill_id="000002",
+            account="Expenses:Office Supplies",
+            description="Pens",
+            quantity="1",
+            price="30.00",
+        )
+        gb.post_invoice(
+            invoice_id="000002",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-02-20",
+        )
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+            vendor_id="000001",
+        )
+        assert len(result["vendors"]) == 1
+        assert result["vendors"][0]["vendor_name"] == "Office Depot"
+
+
+# ============== End-to-End Lifecycle Tests ==============
+
+
+class TestInvoiceLifecycle:
+    """End-to-end invoice and bill lifecycle tests."""
+
+    def test_full_invoice_lifecycle(self, business_book):
+        """Customer invoice: create -> add entries -> post -> pay."""
+        gb = GnuCashBook(str(business_book))
+        # Create customer and invoice
+        gb.create_customer(name="Acme Corp")
+        inv = gb.create_invoice(customer_id="000001")
+        assert inv["status"] == "created"
+
+        # Add entries
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="10",
+            price="100.00",
+        )
+
+        # Post
+        post_result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert post_result["status"] == "posted"
+        assert Decimal(post_result["total"]) == Decimal("1000")
+
+        # Verify outstanding
+        outstanding = gb.get_outstanding_invoices()
+        assert len(outstanding) == 1
+        assert Decimal(outstanding[0]["amount_due"]) == Decimal("1000")
+
+        # Pay in full
+        pay_result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="1000",
+        )
+        assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
+
+        # Verify no longer outstanding
+        outstanding = gb.get_outstanding_invoices()
+        assert len(outstanding) == 0
+
+    def test_full_bill_lifecycle(self, business_book):
+        """Vendor bill: create -> add entries -> post -> pay."""
+        gb = GnuCashBook(str(business_book))
+        # Create vendor and bill
+        gb.create_vendor(name="Office Depot")
+        bill = gb.create_bill(vendor_id="000001")
+        assert bill["status"] == "created"
+
+        # Add entry
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="5",
+            price="20.00",
+        )
+
+        # Post
+        post_result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        assert post_result["status"] == "posted"
+        assert Decimal(post_result["total"]) == Decimal("100")
+
+        # Verify outstanding
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor")
+        assert len(outstanding) == 1
+
+        # Pay
+        pay_result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="100",
+            owner_type="vendor",
+        )
+        assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
+
+        # Verify cleared
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor")
+        assert len(outstanding) == 0

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1,6 +1,7 @@
-"""Tests for business tools: customers, vendors, billterms."""
+"""Tests for business tools: customers, vendors, billterms, invoices, bills."""
 
 import json
+from decimal import Decimal
 import pytest
 from gnucash_mcp.book import GnuCashBook
 
@@ -285,3 +286,372 @@ class TestReceivablePayableAccountTypes:
         assert result["status"] == "created"
         acct = gb.get_account("Liabilities:AP Other")
         assert acct["type"] == "PAYABLE"
+
+
+# ============== Invoice Tests ==============
+
+
+class TestCreateInvoice:
+    """Tests for create_invoice."""
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.create_invoice(customer_id="000001")
+        assert result["status"] == "created"
+        assert result["id"] == "000001"
+        assert result["customer_id"] == "000001"
+        assert len(result["guid"]) == 32
+
+    def test_auto_id_increments(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        r1 = gb.create_invoice(customer_id="000001")
+        r2 = gb.create_invoice(customer_id="000001")
+        assert r1["id"] == "000001"
+        assert r2["id"] == "000002"
+
+    def test_with_date(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.create_invoice(
+            customer_id="000001", date_opened="2026-01-15",
+        )
+        assert result["date_opened"] == "2026-01-15"
+
+    def test_with_notes(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.create_invoice(
+            customer_id="000001", notes="Q1 consulting",
+        )
+        assert result["status"] == "created"
+        # Verify notes via get_invoice
+        inv = gb.get_invoice(result["id"])
+        assert inv["notes"] == "Q1 consulting"
+
+    def test_with_billterm(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_billterm(name="Net 30", due_days=30)
+        result = gb.create_invoice(
+            customer_id="000001", term="Net 30",
+        )
+        assert result["status"] == "created"
+
+    def test_invalid_customer(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Customer not found"):
+            gb.create_invoice(customer_id="999999")
+
+    def test_invalid_billterm(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        with pytest.raises(ValueError, match="Billterm not found"):
+            gb.create_invoice(customer_id="000001", term="Nonexistent")
+
+
+class TestCreateBill:
+    """Tests for create_bill."""
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.create_bill(vendor_id="000001")
+        assert result["status"] == "created"
+        assert result["id"] == "000001"
+        assert result["vendor_id"] == "000001"
+
+    def test_bill_counter_independent_from_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        inv = gb.create_invoice(customer_id="000001")
+        bill = gb.create_bill(vendor_id="000001")
+        # Both should be 000001 — independent counters
+        assert inv["id"] == "000001"
+        assert bill["id"] == "000001"
+
+    def test_invalid_vendor(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Vendor not found"):
+            gb.create_bill(vendor_id="999999")
+
+
+class TestAddInvoiceEntry:
+    """Tests for add_invoice_entry."""
+
+    def test_basic_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        result = gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting services",
+            quantity="1",
+            price="500.00",
+        )
+        assert result["status"] == "created"
+        assert Decimal(result["total"]) == Decimal("500")
+        assert result["invoice_id"] == "000001"
+
+    def test_fractional_quantity(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        result = gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Hours",
+            quantity="2.5",
+            price="100.00",
+        )
+        assert Decimal(result["total"]) == Decimal("250")
+
+    def test_multiple_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Item 1", quantity="1", price="100.00",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="Item 2", quantity="2", price="75.00",
+        )
+        inv = gb.get_invoice("000001")
+        assert len(inv["entries"]) == 2
+        assert Decimal(inv["total"]) == Decimal("250")
+
+    def test_invalid_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Invoice not found"):
+            gb.add_invoice_entry(
+                invoice_id="999999", account="Income:Sales",
+                description="Test", quantity="1", price="10",
+            )
+
+    def test_wrong_type_rejects_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        with pytest.raises(ValueError, match="Invoice not found"):
+            gb.add_invoice_entry(
+                invoice_id="000001", account="Income:Sales",
+                description="Test", quantity="1", price="10",
+            )
+
+    def test_invalid_account(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="Account not found"):
+            gb.add_invoice_entry(
+                invoice_id="000001", account="Income:Nonexistent",
+                description="Test", quantity="1", price="10",
+            )
+
+
+class TestAddBillEntry:
+    """Tests for add_bill_entry."""
+
+    def test_basic_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        result = gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Printer paper",
+            quantity="10",
+            price="5.00",
+        )
+        assert result["status"] == "created"
+        assert Decimal(result["total"]) == Decimal("50")
+        assert result["bill_id"] == "000001"
+
+    def test_wrong_type_rejects_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="Bill not found"):
+            gb.add_bill_entry(
+                bill_id="000001", account="Expenses:Office Supplies",
+                description="Test", quantity="1", price="10",
+            )
+
+
+class TestListInvoices:
+    """Tests for list_invoices."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.list_invoices()
+        assert result == ""
+
+    def test_compact_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001", date_opened="2026-01-15")
+        result = gb.list_invoices()
+        assert "000001" in result
+        assert "INV" in result
+        assert "open" in result
+
+    def test_verbose_format(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        result = gb.list_invoices(compact=False)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["type"] == "invoice"
+
+    def test_filter_by_customer_type(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        gb.create_bill(vendor_id="000001")
+        result = gb.list_invoices(owner_type="customer", compact=False)
+        assert len(result) == 1
+        assert result[0]["type"] == "invoice"
+
+    def test_filter_by_vendor_type(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        gb.create_bill(vendor_id="000001")
+        result = gb.list_invoices(owner_type="vendor", compact=False)
+        assert len(result) == 1
+        assert result[0]["type"] == "bill"
+
+    def test_filter_by_status(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        # All invoices are open (not posted)
+        result = gb.list_invoices(status="open", compact=False)
+        assert len(result) == 1
+        result = gb.list_invoices(status="posted", compact=False)
+        assert len(result) == 0
+
+
+class TestGetInvoice:
+    """Tests for get_invoice."""
+
+    def test_get_customer_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        result = gb.get_invoice("000001")
+        assert result["type"] == "invoice"
+        assert result["is_posted"] is False
+        assert len(result["entries"]) == 1
+        assert Decimal(result["total"]) == Decimal("500")
+        assert result["owner_name"] == "Acme Corp"
+
+    def test_get_vendor_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="10", price="5.00",
+        )
+        result = gb.get_invoice("000001")
+        assert result["type"] == "bill"
+        assert len(result["entries"]) == 1
+        assert Decimal(result["total"]) == Decimal("50")
+        assert result["owner_name"] == "Office Depot"
+
+    def test_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.get_invoice("999999")
+
+    def test_entries_have_correct_fields(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Widget", quantity="3", price="25.00",
+        )
+        result = gb.get_invoice("000001")
+        entry = result["entries"][0]
+        assert "guid" in entry
+        assert entry["description"] == "Widget"
+        assert Decimal(entry["quantity"]) == Decimal("3")
+        assert Decimal(entry["price"]) == Decimal("25")
+        assert Decimal(entry["total"]) == Decimal("75")
+
+
+class TestInvoiceBillIdCollision:
+    """Tests for ID collision between invoices and bills.
+
+    Invoice and bill IDs come from independent counters, so both
+    start at 000001. The lookup must filter by owner_type to avoid
+    returning the wrong record.
+    """
+
+    def test_add_invoice_entry_with_collision(self, business_book):
+        """add_invoice_entry targets the invoice, not the bill."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")  # ID 000001
+        gb.create_bill(vendor_id="000001")        # ID 000001
+        # Should target the customer invoice, not the vendor bill
+        result = gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="100",
+        )
+        assert result["status"] == "created"
+        inv = gb.get_invoice("000001")
+        assert inv["type"] == "invoice"
+        assert len(inv["entries"]) == 1
+
+    def test_add_bill_entry_with_collision(self, business_book):
+        """add_bill_entry targets the bill, not the invoice."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")  # ID 000001
+        gb.create_bill(vendor_id="000001")        # ID 000001
+        # Should target the vendor bill, not the customer invoice
+        result = gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="1", price="50",
+        )
+        assert result["status"] == "created"
+
+    def test_get_invoice_with_collision_defaults_to_first(self, business_book):
+        """get_invoice without owner_type returns first match."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        gb.create_bill(vendor_id="000001")
+        result = gb.get_invoice("000001")
+        # Returns whichever was created first (invoice)
+        assert result["type"] in ("invoice", "bill")
+
+    def test_get_invoice_with_owner_type_filter(self, business_book):
+        """get_invoice with owner_type disambiguates colliding IDs."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        gb.create_bill(vendor_id="000001")
+        inv = gb.get_invoice("000001", owner_type="customer")
+        assert inv["type"] == "invoice"
+        bill = gb.get_invoice("000001", owner_type="vendor")
+        assert bill["type"] == "bill"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -36,9 +36,9 @@ class TestToolModulesMapping:
         assert len(TOOL_MODULES["core"]) == 15
 
     def test_total_tool_count(self):
-        """Total tools across all modules should be 60."""
+        """Total tools across all modules should be 66."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 60
+        assert total == 66
 
     def test_expected_modules_exist(self):
         """All expected module names should be present."""
@@ -68,9 +68,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 60 tools."""
+        """--modules=all should keep all 66 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 60
+        assert len(self._tool_names()) == 66
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag should default to core only."""
@@ -97,12 +97,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 60
+        assert len(self._tool_names()) == 66
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 60 tools."""
+        """'all' mixed with other modules should keep all 66 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 60
+        assert len(self._tool_names()) == 66
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -38,7 +38,7 @@ class TestToolModulesMapping:
     def test_total_tool_count(self):
         """Total tools across all modules should be 66."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 66
+        assert total == 70
 
     def test_expected_modules_exist(self):
         """All expected module names should be present."""
@@ -70,7 +70,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 66 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 66
+        assert len(self._tool_names()) == 70
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag should default to core only."""
@@ -97,12 +97,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 66
+        assert len(self._tool_names()) == 70
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 66 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 66
+        assert len(self._tool_names()) == 70
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

- Add invoice and bill CRUD: create invoices (customers) and bills (vendors), add line item entries to each
- Add invoice posting and payment: post invoices/bills to A/R or A/P accounts, record payments against posted invoices with partial payment support
- Add reporting tools: list invoices with status/owner filters, get invoice details with line items, get outstanding invoices, vendor spending report
- Add GnuCash-compatible metadata to posted invoices (date-posted, posted-to slots) for native GnuCash UI compatibility

## Test plan

- [x] Unit tests for invoice/bill creation, entry addition, posting, and payment (1275+ lines in test_business.py)
- [x] Duplicate invoice ID detection across customers and vendors
- [x] Posting validation (must have entries, can't double-post)
- [x] Payment validation (must be posted, correct owner type)
- [x] Outstanding invoice filtering by owner type, customer, and vendor
- [x] Vendor spending report with date filtering
- [x] Live testing with real GnuCash book