### PR TITLE
Add write verification for raw SQL operations

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -26,6 +26,77 @@ def _to_date(dt: date | datetime) -> date:
     return dt
 
 
+def _verify_write(session, table, guid: str, label: str) -> None:
+    """Verify a raw SQL INSERT persisted by reading back the primary key.
+
+    Must be called within the same session, before book.save().
+    Raises RuntimeError if the inserted row cannot be found.
+    """
+    from sqlalchemy import select, func
+
+    count = session.execute(
+        select(func.count()).select_from(table).where(table.c.guid == guid)
+    ).scalar()
+    if count != 1:
+        debug_logger.error(
+            f"Write verification FAILED: {label} guid={guid} count={count}"
+        )
+        raise RuntimeError(
+            f"Write verification failed: {label} with guid "
+            f"{guid} not found after INSERT (count={count})"
+        )
+
+
+def _verify_composite_write(
+    session, table, conditions: dict, label: str
+) -> None:
+    """Verify a raw SQL INSERT for a table with composite primary key.
+
+    Must be called within the same session, before book.save().
+    Raises RuntimeError if the inserted row cannot be found.
+    """
+    from sqlalchemy import select, func, and_
+
+    where_clause = and_(
+        *(table.c[col] == val for col, val in conditions.items())
+    )
+    count = session.execute(
+        select(func.count()).select_from(table).where(where_clause)
+    ).scalar()
+    if count != 1:
+        debug_logger.error(
+            f"Write verification FAILED: {label} conditions={conditions} "
+            f"count={count}"
+        )
+        raise RuntimeError(
+            f"Write verification failed: {label} not found "
+            f"after INSERT (count={count})"
+        )
+
+
+def _verify_delete(session, conditions: dict, label: str) -> None:
+    """Verify a raw SQL DELETE removed the expected row(s).
+
+    Must be called within the same session, before book.save().
+    Raises RuntimeError if matching rows still exist.
+    """
+    from sqlalchemy import text
+
+    where_parts = " AND ".join(f"{col} = :{col}" for col in conditions)
+    count = session.execute(
+        text(f"SELECT count(*) FROM slots WHERE {where_parts}"),
+        conditions,
+    ).scalar()
+    if count != 0:
+        debug_logger.error(
+            f"Delete verification FAILED: {label} still has {count} rows"
+        )
+        raise RuntimeError(
+            f"Delete verification failed: {label} still exists "
+            f"after DELETE ({count} rows remain)"
+        )
+
+
 class GnuCashLockError(Exception):
     """Raised when the GnuCash book is locked by another process."""
 
@@ -3521,6 +3592,10 @@ class GnuCashBook:
                     num_periods=num_periods,
                 )
             )
+            _verify_write(
+                book.session, Budget.__table__, budget_guid,
+                f"Budget '{name}'",
+            )
 
             book.session.execute(
                 Recurrence.__table__.insert().values(
@@ -3530,6 +3605,11 @@ class GnuCashBook:
                     recurrence_period_start=date(year, 1, 1),
                     recurrence_weekend_adjust="none",
                 )
+            )
+            _verify_composite_write(
+                book.session, Recurrence.__table__,
+                {"obj_guid": budget_guid},
+                f"Recurrence for budget '{name}'",
             )
 
             book.save()
@@ -3603,6 +3683,15 @@ class GnuCashBook:
                             amount_num=amount_num,
                             amount_denom=amount_denom,
                         )
+                    )
+                    _verify_composite_write(
+                        book.session, BudgetAmount.__table__,
+                        {
+                            "budget_guid": budget.guid,
+                            "account_guid": acct.guid,
+                            "period_num": p,
+                        },
+                        f"BudgetAmount period {p} for '{budget_name}'",
                     )
 
             book.save()
@@ -3952,6 +4041,10 @@ class GnuCashBook:
                     template_act_guid=template_acct.guid,
                 )
             )
+            _verify_write(
+                book.session, ScheduledTransaction.__table__, sx_guid,
+                f"ScheduledTransaction '{name}'",
+            )
 
             # Insert Recurrence
             book.session.execute(
@@ -3962,6 +4055,11 @@ class GnuCashBook:
                     recurrence_period_start=parsed_start,
                     recurrence_weekend_adjust="none",
                 )
+            )
+            _verify_composite_write(
+                book.session, Recurrence.__table__,
+                {"obj_guid": sx_guid},
+                f"Recurrence for scheduled transaction '{name}'",
             )
 
             # Store split templates as JSON in a slot
@@ -3980,6 +4078,11 @@ class GnuCashBook:
                     slot_type=KVP_Type.KVP_TYPE_STRING,
                     string_val=splits_json,
                 )
+            )
+            _verify_composite_write(
+                book.session, Slot.__table__,
+                {"obj_guid": sx_guid, "name": "splits-json"},
+                f"Splits slot for scheduled transaction '{name}'",
             )
 
             book.save()
@@ -4297,6 +4400,11 @@ class GnuCashBook:
                     "WHERE obj_guid = :guid AND name = :name"
                 ),
                 {"guid": sx.guid, "name": "splits-json"},
+            )
+            _verify_delete(
+                book.session,
+                {"obj_guid": sx.guid, "name": "splits-json"},
+                f"Splits slot for scheduled transaction '{result['name']}'",
             )
 
             # Delete the template account
@@ -5241,6 +5349,10 @@ class GnuCashBook:
                     cutoff=0,
                 )
             )
+            _verify_write(
+                book.session, Billterm.__table__, bt_guid,
+                f"Billterm '{name}'",
+            )
 
             book.save()
 
@@ -5357,6 +5469,10 @@ class GnuCashBook:
                     charge_amt_denom=1,
                 )
             )
+            _verify_write(
+                book.session, Invoice.__table__, inv_guid,
+                f"Invoice '{invoice_id}'",
+            )
 
             book.save()
 
@@ -5449,6 +5565,10 @@ class GnuCashBook:
                     charge_amt_num=0,
                     charge_amt_denom=1,
                 )
+            )
+            _verify_write(
+                book.session, Invoice.__table__, inv_guid,
+                f"Bill '{bill_id}'",
             )
 
             book.save()
@@ -5544,6 +5664,10 @@ class GnuCashBook:
                     billto_guid=None,
                     order_guid=None,
                 )
+            )
+            _verify_write(
+                book.session, Entry.__table__, entry_guid,
+                f"Invoice entry '{description}' on invoice {invoice_id}",
             )
 
             book.save()
@@ -5642,6 +5766,10 @@ class GnuCashBook:
                     billto_guid=None,
                     order_guid=None,
                 )
+            )
+            _verify_write(
+                book.session, Entry.__table__, entry_guid,
+                f"Bill entry '{description}' on bill {bill_id}",
             )
 
             book.save()
@@ -5805,6 +5933,11 @@ class GnuCashBook:
                 guid_val=frame_guid,
             )
         )
+        _verify_composite_write(
+            book.session, Slot.__table__,
+            {"obj_guid": obj_guid, "name": "gncInvoice"},
+            f"gncInvoice frame slot for {obj_guid[:8]}",
+        )
         book.session.execute(
             Slot.__table__.insert().values(
                 obj_guid=frame_guid,
@@ -5812,6 +5945,11 @@ class GnuCashBook:
                 slot_type=KVP_Type.KVP_TYPE_GUID,
                 guid_val=invoice_guid,
             )
+        )
+        _verify_composite_write(
+            book.session, Slot.__table__,
+            {"obj_guid": frame_guid, "name": "invoice"},
+            f"gncInvoice ref slot for frame {frame_guid[:8]}",
         )
 
     @staticmethod
@@ -5830,6 +5968,11 @@ class GnuCashBook:
                 slot_type=KVP_Type.KVP_TYPE_GDATE,
                 gdate_val=date_val,
             )
+        )
+        _verify_composite_write(
+            book.session, Slot.__table__,
+            {"obj_guid": obj_guid, "name": name},
+            f"Gdate slot '{name}' for {obj_guid[:8]}",
         )
 
     @staticmethod

--- a/tests/test_write_verification.py
+++ b/tests/test_write_verification.py
@@ -1,0 +1,299 @@
+"""Tests for write verification helpers.
+
+These tests verify that the _verify_write, _verify_composite_write,
+and _verify_delete helpers correctly detect successful and failed
+raw SQL writes.
+"""
+
+import uuid
+from pathlib import Path
+
+import piecash
+import pytest
+
+from gnucash_mcp.book import (
+    GnuCashBook,
+    _verify_composite_write,
+    _verify_delete,
+    _verify_write,
+)
+
+
+# ── _verify_write tests ──────────────────────────────────────────
+
+
+class TestVerifyWrite:
+    """Tests for _verify_write (single GUID primary key)."""
+
+    def test_passes_after_valid_insert(self, business_book: Path):
+        """Verify passes when a row exists with the given GUID."""
+        from piecash.business.invoice import Billterm
+
+        book_obj = GnuCashBook(str(business_book))
+        with book_obj.open(readonly=False) as book:
+            bt_guid = uuid.uuid4().hex
+            book.session.execute(
+                Billterm.__table__.insert().values(
+                    guid=bt_guid,
+                    name="Test Term",
+                    description="",
+                    refcount=0,
+                    invisible=0,
+                    type="GNC_TERM_TYPE_DAYS",
+                    duedays=30,
+                    discountdays=0,
+                    discount_num=0,
+                    discount_denom=1,
+                    cutoff=0,
+                )
+            )
+            # Should not raise
+            _verify_write(
+                book.session, Billterm.__table__, bt_guid,
+                "Billterm 'Test Term'",
+            )
+
+    def test_raises_for_nonexistent_guid(self, business_book: Path):
+        """Verify raises RuntimeError when GUID doesn't exist."""
+        from piecash.business.invoice import Billterm
+
+        book_obj = GnuCashBook(str(business_book))
+        with book_obj.open(readonly=False) as book:
+            fake_guid = uuid.uuid4().hex
+            with pytest.raises(RuntimeError, match="Write verification failed"):
+                _verify_write(
+                    book.session, Billterm.__table__, fake_guid,
+                    "Billterm 'Nonexistent'",
+                )
+
+
+# ── _verify_composite_write tests ────────────────────────────────
+
+
+class TestVerifyCompositeWrite:
+    """Tests for _verify_composite_write (composite primary key)."""
+
+    def test_passes_after_valid_insert(self, scheduled_book: Path):
+        """Verify passes for a composite-key insert (Recurrence)."""
+        from datetime import date
+
+        from piecash._common import Recurrence
+        from piecash.budget import Budget
+
+        book_obj = GnuCashBook(str(scheduled_book))
+        with book_obj.open(readonly=False) as book:
+            budget_guid = uuid.uuid4().hex
+            book.session.execute(
+                Budget.__table__.insert().values(
+                    guid=budget_guid,
+                    name="Test Budget",
+                    description="",
+                    num_periods=12,
+                )
+            )
+            book.session.execute(
+                Recurrence.__table__.insert().values(
+                    obj_guid=budget_guid,
+                    recurrence_mult=1,
+                    recurrence_period_type="month",
+                    recurrence_period_start=date(2026, 1, 1),
+                    recurrence_weekend_adjust="none",
+                )
+            )
+            # Should not raise
+            _verify_composite_write(
+                book.session, Recurrence.__table__,
+                {"obj_guid": budget_guid},
+                "Recurrence for test budget",
+            )
+
+    def test_raises_for_wrong_conditions(self, scheduled_book: Path):
+        """Verify raises when composite key conditions don't match."""
+        from piecash._common import Recurrence
+
+        book_obj = GnuCashBook(str(scheduled_book))
+        with book_obj.open(readonly=False) as book:
+            fake_guid = uuid.uuid4().hex
+            with pytest.raises(RuntimeError, match="Write verification failed"):
+                _verify_composite_write(
+                    book.session, Recurrence.__table__,
+                    {"obj_guid": fake_guid},
+                    "Recurrence for nonexistent",
+                )
+
+
+# ── _verify_delete tests ─────────────────────────────────────────
+
+
+class TestVerifyDelete:
+    """Tests for _verify_delete (slot deletion)."""
+
+    def test_passes_after_valid_delete(self, scheduled_book: Path):
+        """Verify passes when the slot row is successfully deleted."""
+        from piecash.kvp import KVP_Type, Slot
+        from sqlalchemy import text
+
+        book_obj = GnuCashBook(str(scheduled_book))
+        with book_obj.open(readonly=False) as book:
+            obj_guid = uuid.uuid4().hex
+            book.session.execute(
+                Slot.__table__.insert().values(
+                    obj_guid=obj_guid,
+                    name="test-slot",
+                    slot_type=KVP_Type.KVP_TYPE_STRING,
+                    string_val="test value",
+                )
+            )
+            # Delete it
+            book.session.execute(
+                text(
+                    "DELETE FROM slots "
+                    "WHERE obj_guid = :obj_guid AND name = :name"
+                ),
+                {"obj_guid": obj_guid, "name": "test-slot"},
+            )
+            # Should not raise
+            _verify_delete(
+                book.session,
+                {"obj_guid": obj_guid, "name": "test-slot"},
+                "Test slot deletion",
+            )
+
+    def test_raises_when_row_still_exists(self, scheduled_book: Path):
+        """Verify raises when the row was NOT deleted."""
+        from piecash.kvp import KVP_Type, Slot
+
+        book_obj = GnuCashBook(str(scheduled_book))
+        with book_obj.open(readonly=False) as book:
+            obj_guid = uuid.uuid4().hex
+            book.session.execute(
+                Slot.__table__.insert().values(
+                    obj_guid=obj_guid,
+                    name="still-here",
+                    slot_type=KVP_Type.KVP_TYPE_STRING,
+                    string_val="should not be deleted",
+                )
+            )
+            # Don't delete — verify should fail
+            with pytest.raises(RuntimeError, match="Delete verification failed"):
+                _verify_delete(
+                    book.session,
+                    {"obj_guid": obj_guid, "name": "still-here"},
+                    "Test slot that should still exist",
+                )
+
+
+# ── Integration: existing operations trigger verification ────────
+
+
+class TestVerificationIntegration:
+    """Verify that write operations with verification succeed end-to-end."""
+
+    def test_create_budget_with_verification(self, scheduled_book: Path):
+        """Budget creation should succeed with verification enabled."""
+        book_obj = GnuCashBook(str(scheduled_book))
+        result = book_obj.create_budget("Verified Budget", year=2026)
+        assert result["status"] == "created"
+        assert result["name"] == "Verified Budget"
+
+    def test_create_scheduled_transaction_with_verification(
+        self, scheduled_book: Path
+    ):
+        """Scheduled transaction creation should succeed with verification."""
+        book_obj = GnuCashBook(str(scheduled_book))
+        result = book_obj.create_scheduled_transaction(
+            name="Verified Rent",
+            description="Monthly rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1500.00"},
+                {"account": "Assets:Checking", "amount": "-1500.00"},
+            ],
+            start_date="2026-03-01",
+            frequency="monthly",
+        )
+        assert result["status"] == "created"
+        assert result["name"] == "Verified Rent"
+
+    def test_delete_scheduled_transaction_with_verification(
+        self, scheduled_book: Path
+    ):
+        """Scheduled transaction deletion should succeed with verification."""
+        book_obj = GnuCashBook(str(scheduled_book))
+        created = book_obj.create_scheduled_transaction(
+            name="To Delete",
+            description="Will be deleted",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "500.00"},
+                {"account": "Assets:Checking", "amount": "-500.00"},
+            ],
+            start_date="2026-03-01",
+            frequency="monthly",
+        )
+        result = book_obj.delete_scheduled_transaction(created["guid"])
+        assert result["status"] == "deleted"
+
+    def test_create_billterm_with_verification(self, business_book: Path):
+        """Billterm creation should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        result = book_obj.create_billterm("Net 30", due_days=30)
+        assert result["status"] == "created"
+
+    def test_create_invoice_with_verification(self, business_book: Path):
+        """Invoice creation should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        book_obj.create_customer("Test Client")
+        result = book_obj.create_invoice(customer_id="000001")
+        assert result["status"] == "created"
+
+    def test_create_bill_with_verification(self, business_book: Path):
+        """Bill creation should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        book_obj.create_vendor("Test Vendor")
+        result = book_obj.create_bill(vendor_id="000001")
+        assert result["status"] == "created"
+
+    def test_add_invoice_entry_with_verification(self, business_book: Path):
+        """Invoice entry addition should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        book_obj.create_customer("Entry Client")
+        inv = book_obj.create_invoice(customer_id="000001")
+        result = book_obj.add_invoice_entry(
+            invoice_id=inv["id"],
+            account="Income:Sales",
+            description="Test service",
+            quantity="1",
+            price="100.00",
+        )
+        assert result["status"] == "created"
+
+    def test_add_bill_entry_with_verification(self, business_book: Path):
+        """Bill entry addition should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        book_obj.create_vendor("Entry Vendor")
+        bill = book_obj.create_bill(vendor_id="000001")
+        result = book_obj.add_bill_entry(
+            bill_id=bill["id"],
+            account="Expenses:Office Supplies",
+            description="Test supplies",
+            quantity="1",
+            price="50.00",
+        )
+        assert result["status"] == "created"
+
+    def test_post_invoice_with_verification(self, business_book: Path):
+        """Invoice posting (slot writes) should succeed with verification."""
+        book_obj = GnuCashBook(str(business_book))
+        book_obj.create_customer("Post Client")
+        inv = book_obj.create_invoice(customer_id="000001")
+        book_obj.add_invoice_entry(
+            invoice_id=inv["id"],
+            account="Income:Sales",
+            description="Consulting",
+            quantity="10",
+            price="150.00",
+        )
+        result = book_obj.post_invoice(
+            invoice_id=inv["id"],
+            post_account="Assets:Accounts Receivable",
+        )
+        assert result["status"] == "posted"


### PR DESCRIPTION
## Summary

- Add post-write verification for all 15 raw SQL write sites that bypass piecash ORM
- Three helpers: `_verify_write` (single GUID), `_verify_composite_write` (composite key), `_verify_delete` (slot deletion)
- Verification runs within the same SQLAlchemy transaction before `book.save()`, so failures trigger automatic rollback
- Always-on with negligible overhead (one cached-page SELECT per INSERT)

## Test plan

- [x] 15 dedicated tests covering positive and negative cases for all three helpers
- [x] Full test suite passes (540 tests, 0 regressions)