### PR TITLE
Add bimonthly frequency for scheduled transactions

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -694,13 +694,14 @@ class GnuCashBook:
     # ============== Scheduled Transaction Helpers ==============
 
     VALID_FREQUENCIES = {
-        "weekly", "biweekly", "monthly", "quarterly", "yearly",
+        "weekly", "biweekly", "monthly", "bimonthly", "quarterly", "yearly",
     }
 
     FREQUENCY_TO_RECURRENCE = {
         "weekly": ("week", 1),
         "biweekly": ("week", 2),
         "monthly": ("month", 1),
+        "bimonthly": ("month", 2),
         "quarterly": ("month", 3),
         "yearly": ("year", 1),
     }
@@ -709,6 +710,7 @@ class GnuCashBook:
         ("week", 1): "weekly",
         ("week", 2): "biweekly",
         ("month", 1): "monthly",
+        ("month", 2): "bimonthly",
         ("month", 3): "quarterly",
         ("year", 1): "yearly",
     }
@@ -742,6 +744,7 @@ class GnuCashBook:
             "weekly": relativedelta(weeks=1),
             "biweekly": relativedelta(weeks=2),
             "monthly": relativedelta(months=1),
+            "bimonthly": relativedelta(months=2),
             "quarterly": relativedelta(months=3),
             "yearly": relativedelta(years=1),
         }

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -1264,6 +1264,7 @@ def create_scheduled_transaction(
             - "weekly"
             - "biweekly" (every 2 weeks)
             - "monthly"
+            - "bimonthly" (every 2 months)
             - "quarterly" (every 3 months)
             - "yearly"
         end_date: Optional last occurrence date (YYYY-MM-DD).

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -47,6 +47,21 @@ class TestCreateScheduled:
         assert result["status"] == "created"
         assert result["frequency"] == "biweekly"
 
+    def test_bimonthly_electric(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb.create_scheduled_transaction(
+            name="Electric Bill",
+            description="Seattle City Light",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "400.00"},
+                {"account": "Assets:Checking", "amount": "-400.00"},
+            ],
+            start_date="2026-03-10",
+            frequency="bimonthly",
+        )
+        assert result["status"] == "created"
+        assert result["frequency"] == "bimonthly"
+
     def test_with_end_date(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
         result = gb.create_scheduled_transaction(


### PR DESCRIPTION
## Summary
- Adds `bimonthly` (every 2 months) as a supported frequency for scheduled transactions
- Four lookup tables updated in book.py, docstring updated in server.py
- Tested live in GnuCash — created a bimonthly Seattle City Light bill, confirmed it appears correctly

## Test plan
- [x] New test: `test_bimonthly_electric` in test_scheduled.py
- [x] Full suite passes (541 tests)
- [x] Live tested: created bimonthly scheduled transaction, verified in GnuCash UI