### PR TITLE
Add business delete tools, custom invoice/bill IDs, and default currency fix

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -492,6 +492,29 @@ class GnuCashBook:
                 return transaction
         return None
 
+    @staticmethod
+    def _require_default_currency(book: piecash.Book) -> piecash.Commodity:
+        """Get the book's default currency, raising a clear error if missing.
+
+        Args:
+            book: Open piecash book.
+
+        Returns:
+            The default currency Commodity.
+
+        Raises:
+            ValueError: If the book has no default currency set.
+        """
+        dc = book.default_currency
+        if dc is None:
+            raise ValueError(
+                "Book has no default currency set. In GnuCash desktop, "
+                "set the default currency under Preferences > Accounts "
+                "(Edit menu on Linux/Windows, GnuCash menu on macOS), "
+                "or pass the currency parameter explicitly."
+            )
+        return dc
+
     def _find_commodity(
         self, book: piecash.Book, mnemonic: str, namespace: str = "CURRENCY"
     ) -> piecash.Commodity | None:
@@ -885,7 +908,7 @@ class GnuCashBook:
                 by_namespace[ns].sort(key=lambda c: c["mnemonic"])
 
             result = {
-                "default_currency": book.default_currency.mnemonic,
+                "default_currency": self._require_default_currency(book).mnemonic,
                 "commodities": by_namespace,
             }
 
@@ -1149,7 +1172,7 @@ class GnuCashBook:
         from piecash.core.transaction import ScheduledTransaction
 
         with self.open(readonly=True) as book:
-            currency = book.default_currency.mnemonic
+            currency = self._require_default_currency(book).mnemonic
 
             # --- Identify template accounts (scheduled transaction placeholders) ---
             template_guids = set()
@@ -1904,7 +1927,7 @@ class GnuCashBook:
         with self.open(readonly=False) as book:
             # Determine transaction currency
             if currency is None:
-                trans_currency = book.default_currency
+                trans_currency = self._require_default_currency(book)
             else:
                 trans_currency = self._get_or_create_currency(book, currency)
 
@@ -2032,7 +2055,7 @@ class GnuCashBook:
         with self.open(readonly=True) as book:
             # Determine transaction currency (readonly — no creation)
             if currency is None:
-                trans_currency = book.default_currency
+                trans_currency = self._require_default_currency(book)
                 currency_mnemonic = trans_currency.mnemonic
             else:
                 trans_currency = self._find_commodity(book, currency)
@@ -2296,7 +2319,7 @@ class GnuCashBook:
 
             # Determine commodity
             if commodity is None:
-                account_commodity = book.default_currency
+                account_commodity = self._require_default_currency(book)
             elif commodity_namespace == "CURRENCY":
                 account_commodity = self._get_or_create_currency(book, commodity)
             else:
@@ -4020,7 +4043,7 @@ class GnuCashBook:
                 name=name,
                 type="BANK",
                 parent=book.root_template,
-                commodity=book.default_currency,
+                commodity=self._require_default_currency(book),
             )
             book.session.add(template_acct)
             book.session.flush()
@@ -5121,7 +5144,7 @@ class GnuCashBook:
                 if not currency_obj:
                     raise ValueError(f"Currency not found: {currency}")
             else:
-                currency_obj = book.default_currency
+                currency_obj = self._require_default_currency(book)
 
             addr = None
             if address:
@@ -5226,7 +5249,7 @@ class GnuCashBook:
                 if not currency_obj:
                     raise ValueError(f"Currency not found: {currency}")
             else:
-                currency_obj = book.default_currency
+                currency_obj = self._require_default_currency(book)
 
             addr = None
             if address:
@@ -5397,6 +5420,7 @@ class GnuCashBook:
         notes: str = "",
         currency: str | None = None,
         term: str | None = None,
+        invoice_id: str | None = None,
     ) -> dict:
         """Create a customer invoice.
 
@@ -5406,6 +5430,8 @@ class GnuCashBook:
             notes: Optional notes.
             currency: ISO currency code. Defaults to book's default currency.
             term: Billterm name (e.g., 'Net 30'). Optional.
+            invoice_id: Custom invoice number. If omitted, auto-generates
+                from the book's invoice counter.
 
         Returns:
             Dict with guid, id, customer_id, status.
@@ -5434,7 +5460,7 @@ class GnuCashBook:
                     raise ValueError(f"Currency not found: {currency}")
                 currency_guid = currency_obj.guid
             else:
-                currency_guid = book.default_currency.guid
+                currency_guid = self._require_default_currency(book).guid
 
             term_guid = None
             if term:
@@ -5445,9 +5471,18 @@ class GnuCashBook:
                     raise ValueError(f"Billterm not found: {term}")
                 term_guid = bt.guid
 
-            cnt = book.counter_invoice + 1
-            book.counter_invoice = cnt
-            invoice_id = f"{cnt:06d}"
+            if invoice_id is not None:
+                if not invoice_id.strip():
+                    raise ValueError("invoice_id must not be blank")
+                existing = self._find_invoice(book, invoice_id, owner_type=2)
+                if existing:
+                    raise ValueError(
+                        f"Invoice with ID '{invoice_id}' already exists"
+                    )
+            else:
+                cnt = book.counter_invoice + 1
+                book.counter_invoice = cnt
+                invoice_id = f"{cnt:06d}"
             inv_guid = uuid.uuid4().hex
 
             book.session.execute(
@@ -5494,6 +5529,7 @@ class GnuCashBook:
         notes: str = "",
         currency: str | None = None,
         term: str | None = None,
+        bill_id: str | None = None,
     ) -> dict:
         """Create a vendor bill.
 
@@ -5503,6 +5539,8 @@ class GnuCashBook:
             notes: Optional notes.
             currency: ISO currency code. Defaults to book's default currency.
             term: Billterm name (e.g., 'Net 30'). Optional.
+            bill_id: Custom bill number. If omitted, auto-generates
+                from the book's bill counter.
 
         Returns:
             Dict with guid, id, vendor_id, status.
@@ -5531,7 +5569,7 @@ class GnuCashBook:
                     raise ValueError(f"Currency not found: {currency}")
                 currency_guid = currency_obj.guid
             else:
-                currency_guid = book.default_currency.guid
+                currency_guid = self._require_default_currency(book).guid
 
             term_guid = None
             if term:
@@ -5542,9 +5580,18 @@ class GnuCashBook:
                     raise ValueError(f"Billterm not found: {term}")
                 term_guid = bt.guid
 
-            cnt = book.counter_bill + 1
-            book.counter_bill = cnt
-            bill_id = f"{cnt:06d}"
+            if bill_id is not None:
+                if not bill_id.strip():
+                    raise ValueError("bill_id must not be blank")
+                existing = self._find_invoice(book, bill_id, owner_type=4)
+                if existing:
+                    raise ValueError(
+                        f"Bill with ID '{bill_id}' already exists"
+                    )
+            else:
+                cnt = book.counter_bill + 1
+                book.counter_bill = cnt
+                bill_id = f"{cnt:06d}"
             inv_guid = uuid.uuid4().hex
 
             book.session.execute(
@@ -6427,6 +6474,191 @@ class GnuCashBook:
             }
 
         return result
+
+    def delete_invoice(self, invoice_id: str) -> dict:
+        """Delete an unposted customer invoice.
+
+        Automatically removes associated entries. Posted invoices cannot
+        be deleted — void them or issue a credit note instead.
+
+        Args:
+            invoice_id: Invoice ID (e.g., '000001' or 'INV-2026-001').
+
+        Returns:
+            Dict with id, guid, entries_deleted, status.
+
+        Raises:
+            ValueError: If invoice not found or is posted.
+        """
+        return self._delete_invoice_or_bill(invoice_id, owner_type=2)
+
+    def delete_bill(self, bill_id: str) -> dict:
+        """Delete an unposted vendor bill.
+
+        Automatically removes associated entries. Posted bills cannot
+        be deleted — void them or issue a credit note instead.
+
+        Args:
+            bill_id: Bill ID (e.g., '000001' or 'BILL-2026-001').
+
+        Returns:
+            Dict with id, guid, entries_deleted, status.
+
+        Raises:
+            ValueError: If bill not found or is posted.
+        """
+        return self._delete_invoice_or_bill(bill_id, owner_type=4)
+
+    def _delete_invoice_or_bill(self, doc_id: str, owner_type: int) -> dict:
+        """Shared implementation for delete_invoice and delete_bill."""
+        from sqlalchemy import text
+        from piecash.business.invoice import Invoice
+
+        type_label = "Bill" if owner_type == 4 else "Invoice"
+        entry_fk = "bill" if owner_type == 4 else "invoice"
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, doc_id, owner_type=owner_type)
+            if not inv:
+                raise ValueError(f"{type_label} not found: {doc_id}")
+
+            if inv.date_posted is not None:
+                raise ValueError(
+                    f"Cannot delete posted {type_label.lower()} '{doc_id}'. "
+                    f"Void it or issue a credit note instead."
+                )
+
+            inv_guid = inv.guid
+
+            # Delete entries
+            entry_count = book.session.execute(
+                text(f"SELECT count(*) FROM entries WHERE {entry_fk} = :guid"),
+                {"guid": inv_guid},
+            ).scalar()
+            if entry_count:
+                book.session.execute(
+                    text(f"DELETE FROM entries WHERE {entry_fk} = :guid"),
+                    {"guid": inv_guid},
+                )
+
+            # Delete the invoice row
+            book.session.execute(
+                text("DELETE FROM invoices WHERE guid = :guid"),
+                {"guid": inv_guid},
+            )
+
+            book.save()
+
+            return {
+                "id": doc_id,
+                "guid": inv_guid,
+                "type": type_label.lower(),
+                "entries_deleted": entry_count,
+                "status": "deleted",
+            }
+
+    def delete_customer(self, customer_id: str) -> dict:
+        """Delete a customer with no invoices.
+
+        Customers with any invoices (posted or unposted) cannot be deleted.
+        Delete the invoices first, or void posted ones.
+
+        Args:
+            customer_id: Customer ID (e.g., '000001').
+
+        Returns:
+            Dict with id, guid, name, status.
+
+        Raises:
+            ValueError: If customer not found or has invoices.
+        """
+        return self._delete_customer_or_vendor(customer_id, is_vendor=False)
+
+    def delete_vendor(self, vendor_id: str) -> dict:
+        """Delete a vendor with no bills.
+
+        Vendors with any bills (posted or unposted) cannot be deleted.
+        Delete the bills first, or void posted ones.
+
+        Args:
+            vendor_id: Vendor ID (e.g., '000001').
+
+        Returns:
+            Dict with id, guid, name, status.
+
+        Raises:
+            ValueError: If vendor not found or has bills.
+        """
+        return self._delete_customer_or_vendor(vendor_id, is_vendor=True)
+
+    def _delete_customer_or_vendor(self, entity_id: str, is_vendor: bool) -> dict:
+        """Shared implementation for delete_customer and delete_vendor."""
+        from sqlalchemy import text
+        from piecash.business.invoice import Invoice
+
+        if is_vendor:
+            type_label = "Vendor"
+            owner_type = 4
+            doc_label = "bills"
+        else:
+            type_label = "Customer"
+            owner_type = 2
+            doc_label = "invoices"
+
+        with self.open(readonly=False) as book:
+            if is_vendor:
+                entity = self._find_vendor(book, entity_id)
+            else:
+                entity = self._find_customer(book, entity_id)
+
+            if not entity:
+                raise ValueError(f"{type_label} not found: {entity_id}")
+
+            entity_guid = entity.guid
+            entity_name = entity.name
+
+            # Check for any invoices/bills
+            invoices = book.session.query(Invoice).filter(
+                Invoice.owner_guid == entity_guid,
+                Invoice.owner_type == owner_type,
+            ).all()
+
+            if invoices:
+                posted = [i for i in invoices if i.date_posted is not None]
+                unposted = [i for i in invoices if i.date_posted is None]
+
+                if posted:
+                    posted_ids = ", ".join(i.id for i in posted)
+                    raise ValueError(
+                        f"Cannot delete {type_label.lower()} with posted "
+                        f"{doc_label}: {posted_ids}. "
+                        f"Void them or issue credit notes first."
+                    )
+                else:
+                    unposted_ids = ", ".join(i.id for i in unposted)
+                    raise ValueError(
+                        f"Cannot delete {type_label.lower()} with "
+                        f"{doc_label}: {unposted_ids}. "
+                        f"Delete the {doc_label} first."
+                    )
+
+            # Delete slots for this entity
+            book.session.execute(
+                text("DELETE FROM slots WHERE obj_guid = :guid"),
+                {"guid": entity_guid},
+            )
+
+            # Delete the entity
+            book.session.delete(entity)
+            book.save()
+
+            return {
+                "id": entity_id,
+                "guid": entity_guid,
+                "name": entity_name,
+                "type": type_label.lower(),
+                "status": "deleted",
+            }
 
     def get_outstanding_invoices(
         self,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -524,6 +524,13 @@ def _format_audit_entry_text(entry: dict) -> str:
             if after:
                 currency = after.get("currency", currency) or ""
             lines.append(f'{indent}name: "{cust_name}"  currency: {currency}')
+        elif operation == "DELETE":
+            cust_id = params.get("customer_id", "")
+            lines.append(f"{time_part}  DELETE CUSTOMER  id:{cust_id}")
+            if after:
+                cust_name = after.get("name", "")
+                if cust_name:
+                    lines.append(f'{indent}name: "{cust_name}"')
 
     elif entity_type == "vendor":
         if operation == "CREATE":
@@ -537,6 +544,13 @@ def _format_audit_entry_text(entry: dict) -> str:
             if after:
                 currency = after.get("currency", currency) or ""
             lines.append(f'{indent}name: "{vend_name}"  currency: {currency}')
+        elif operation == "DELETE":
+            vend_id = params.get("vendor_id", "")
+            lines.append(f"{time_part}  DELETE VENDOR  id:{vend_id}")
+            if after:
+                vend_name = after.get("name", "")
+                if vend_name:
+                    lines.append(f'{indent}name: "{vend_name}"')
 
     elif entity_type == "billterm":
         if operation == "CREATE":
@@ -557,6 +571,13 @@ def _format_audit_entry_text(entry: dict) -> str:
                 customer_id = after.get("customer_id", customer_id)
             lines.append(f"{time_part}  CREATE INVOICE  id:{inv_id}")
             lines.append(f'{indent}customer: {customer_id}')
+        elif operation == "DELETE":
+            inv_id = params.get("invoice_id", "")
+            lines.append(f"{time_part}  DELETE INVOICE  id:{inv_id}")
+            if after:
+                entries = after.get("entries_deleted", 0)
+                if entries:
+                    lines.append(f"{indent}entries removed: {entries}")
         elif operation == "POST":
             inv_id = params.get("id", "")
             post_account = params.get("post_account", "")
@@ -587,6 +608,13 @@ def _format_audit_entry_text(entry: dict) -> str:
                 vendor_id = after.get("vendor_id", vendor_id)
             lines.append(f"{time_part}  CREATE BILL  id:{bill_id}")
             lines.append(f'{indent}vendor: {vendor_id}')
+        elif operation == "DELETE":
+            bill_id = params.get("bill_id", "")
+            lines.append(f"{time_part}  DELETE BILL  id:{bill_id}")
+            if after:
+                entries = after.get("entries_deleted", 0)
+                if entries:
+                    lines.append(f"{indent}entries removed: {entries}")
 
     elif entity_type == "entry":
         if operation == "CREATE":

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -125,6 +125,10 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_invoice",
         "post_invoice",
         "pay_invoice",
+        "delete_invoice",
+        "delete_bill",
+        "delete_customer",
+        "delete_vendor",
         "get_outstanding_invoices",
         "vendor_spending_report",
     ],
@@ -1800,6 +1804,7 @@ def create_invoice(
     notes: str = "",
     currency: str | None = None,
     term: str | None = None,
+    invoice_id: str | None = None,
 ) -> str:
     """Create a customer invoice.
 
@@ -1809,11 +1814,14 @@ def create_invoice(
         notes: Optional notes.
         currency: ISO currency code. Defaults to book's default currency.
         term: Billterm name (e.g., "Net 30"). Optional.
+        invoice_id: Custom invoice number (e.g., "INV-2026-001"). If omitted,
+            auto-generates from the book's invoice counter.
     """
     book = get_book()
     result = book.create_invoice(
         customer_id=customer_id, date_opened=date_opened,
         notes=notes, currency=currency, term=term,
+        invoice_id=invoice_id,
     )
     return _json(result)
 
@@ -1827,6 +1835,7 @@ def create_bill(
     notes: str = "",
     currency: str | None = None,
     term: str | None = None,
+    bill_id: str | None = None,
 ) -> str:
     """Create a vendor bill.
 
@@ -1836,11 +1845,14 @@ def create_bill(
         notes: Optional notes.
         currency: ISO currency code. Defaults to book's default currency.
         term: Billterm name (e.g., "Net 30"). Optional.
+        bill_id: Custom bill number (e.g., "BILL-2026-001"). If omitted,
+            auto-generates from the book's bill counter.
     """
     book = get_book()
     result = book.create_bill(
         vendor_id=vendor_id, date_opened=date_opened,
         notes=notes, currency=currency, term=term,
+        bill_id=bill_id,
     )
     return _json(result)
 
@@ -2031,6 +2043,74 @@ def pay_invoice(
 
 @mcp.tool()
 @safe_tool
+@audit_log(classification="write", operation="delete", entity_type="invoice")
+def delete_invoice(invoice_id: str) -> str:
+    """Delete an unposted customer invoice.
+
+    Automatically removes associated entries (line items). Posted invoices
+    cannot be deleted — void them or issue a credit note instead.
+
+    Args:
+        invoice_id: Invoice ID (e.g., "000001" or "INV-2026-001").
+    """
+    book = get_book()
+    result = book.delete_invoice(invoice_id=invoice_id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete", entity_type="bill")
+def delete_bill(bill_id: str) -> str:
+    """Delete an unposted vendor bill.
+
+    Automatically removes associated entries (line items). Posted bills
+    cannot be deleted — void them or issue a credit note instead.
+
+    Args:
+        bill_id: Bill ID (e.g., "000001" or "BILL-2026-001").
+    """
+    book = get_book()
+    result = book.delete_bill(bill_id=bill_id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete", entity_type="customer")
+def delete_customer(customer_id: str) -> str:
+    """Delete a customer with no invoices.
+
+    Customers with any invoices (posted or unposted) cannot be deleted.
+    Delete the invoices first, then delete the customer.
+
+    Args:
+        customer_id: Customer ID (e.g., "000001").
+    """
+    book = get_book()
+    result = book.delete_customer(customer_id=customer_id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
+@audit_log(classification="write", operation="delete", entity_type="vendor")
+def delete_vendor(vendor_id: str) -> str:
+    """Delete a vendor with no bills.
+
+    Vendors with any bills (posted or unposted) cannot be deleted.
+    Delete the bills first, then delete the vendor.
+
+    Args:
+        vendor_id: Vendor ID (e.g., "000001").
+    """
+    book = get_book()
+    result = book.delete_vendor(vendor_id=vendor_id)
+    return _json(result)
+
+
+@mcp.tool()
+@safe_tool
 @audit_log(classification="read")
 def get_outstanding_invoices(
     owner_type: str | None = None,
@@ -2204,6 +2284,9 @@ def _get_server_config_impl() -> str:
         f"Debug mode: {str(_server_state.get('debug', False)).lower()}",
         f"Version: {__version__}",
     ]
+    dc_ok = _server_state.get("default_currency_ok")
+    if dc_ok is False:
+        lines.append("Warning: Book has no default currency set")
     return "\n".join(lines)
 
 
@@ -2286,6 +2369,27 @@ Logs are stored alongside the book file:
     _validate_tool_modules()
     loaded_modules = _apply_module_filter(modules_value)
 
+    # Check book health (non-fatal)
+    currency_ok = None
+    if book_path:
+        try:
+            b = get_book()
+            with b.open(readonly=True) as bk:
+                dc = bk.default_currency
+                if dc is None:
+                    currency_ok = False
+                    print(
+                        "Warning: Book has no default currency. "
+                        "Set one in GnuCash under Preferences > Accounts "
+                        "(Edit menu on Linux/Windows, GnuCash menu on macOS), "
+                        "or pass the currency parameter explicitly to each tool.",
+                        file=sys.stderr,
+                    )
+                else:
+                    currency_ok = True
+        except Exception:
+            pass  # Book may be locked — don't block startup
+
     # Populate runtime state and conditionally register debug tool
     tool_count = len(mcp._tool_manager._tools)
     modules_display = ", ".join(loaded_modules)
@@ -2294,6 +2398,7 @@ Logs are stored alongside the book file:
         "tool_count": tool_count,
         "book_path": book_path or "not set",
         "debug": debug_flag,
+        "default_currency_ok": currency_ok,
     })
 
     if debug_flag:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -79,6 +79,56 @@ class TestGetBookSummary:
         assert f"Book: {test_book}" in result
 
 
+class TestMissingDefaultCurrency:
+    """Tests for books with no default currency."""
+
+    def _corrupt_book_currency(self, book_path: Path):
+        """Null out the default currency GUID in the books table."""
+        import sqlite3
+        conn = sqlite3.connect(str(book_path))
+        conn.execute(
+            "UPDATE books SET root_template_guid = root_template_guid"
+        )  # no-op to ensure we can write
+        # Delete the commodity referenced by the book
+        conn.execute(
+            "DELETE FROM commodities WHERE namespace = 'CURRENCY'"
+        )
+        conn.commit()
+        conn.close()
+
+    def test_get_book_summary_clear_error(self, test_book: Path):
+        self._corrupt_book_currency(test_book)
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="no default currency"):
+            gc_book.get_book_summary()
+
+    def test_create_transaction_clear_error(self, test_book: Path):
+        self._corrupt_book_currency(test_book)
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="no default currency"):
+            gc_book.create_transaction(
+                description="Test",
+                splits=[
+                    {"account": "Assets:Checking", "amount": "100"},
+                    {"account": "Income:Salary", "amount": "-100"},
+                ],
+            )
+
+    def test_explicit_currency_bypasses_error(self, test_book: Path):
+        """Passing currency explicitly should work even without default."""
+        # Don't corrupt — just verify the workaround path works
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Test with explicit currency",
+            currency="USD",
+            splits=[
+                {"account": "Assets:Checking", "amount": "50"},
+                {"account": "Income:Salary", "amount": "-50"},
+            ],
+        )
+        assert result["guid"]
+
+
 class TestListAccounts:
     """Tests for list_accounts method."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -190,6 +190,85 @@ class TestGetVendor:
             gb.get_vendor("999999")
 
 
+class TestDeleteCustomer:
+    """Tests for delete_customer."""
+
+    def test_delete_customer_no_invoices(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Temp Customer")
+        result = gb.delete_customer(customer_id="000001")
+        assert result["status"] == "deleted"
+        assert result["name"] == "Temp Customer"
+        assert result["type"] == "customer"
+
+    def test_delete_customer_with_unposted_invoice_blocked(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="Delete the invoices first"):
+            gb.delete_customer(customer_id="000001")
+
+    def test_delete_customer_after_invoice_deleted(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.delete_invoice(invoice_id="000001")
+        result = gb.delete_customer(customer_id="000001")
+        assert result["status"] == "deleted"
+
+    def test_delete_customer_with_posted_invoice_blocked(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Work", quantity="1", price="100.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        with pytest.raises(ValueError, match="posted invoices"):
+            gb.delete_customer(customer_id="000001")
+
+    def test_delete_nonexistent_customer(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Customer not found"):
+            gb.delete_customer(customer_id="999999")
+
+
+class TestDeleteVendor:
+    """Tests for delete_vendor."""
+
+    def test_delete_vendor_no_bills(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Temp Vendor")
+        result = gb.delete_vendor(vendor_id="000001")
+        assert result["status"] == "deleted"
+        assert result["name"] == "Temp Vendor"
+        assert result["type"] == "vendor"
+
+    def test_delete_vendor_with_unposted_bill_blocked(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        with pytest.raises(ValueError, match="Delete the bills first"):
+            gb.delete_vendor(vendor_id="000001")
+
+    def test_delete_vendor_after_bill_deleted(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.delete_bill(bill_id="000001")
+        result = gb.delete_vendor(vendor_id="000001")
+        assert result["status"] == "deleted"
+
+    def test_delete_nonexistent_vendor(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Vendor not found"):
+            gb.delete_vendor(vendor_id="999999")
+
+
 class TestCreateBillterm:
     """Tests for create_billterm."""
 
@@ -339,6 +418,36 @@ class TestCreateInvoice:
         )
         assert result["status"] == "created"
 
+    def test_custom_invoice_id(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        result = gb.create_invoice(
+            customer_id="000001", invoice_id="INV-2026-001",
+        )
+        assert result["id"] == "INV-2026-001"
+        assert result["status"] == "created"
+
+    def test_custom_id_does_not_increment_counter(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001", invoice_id="CUSTOM-1")
+        # Next auto-generated ID should still be 000001 (counter untouched)
+        r2 = gb.create_invoice(customer_id="000001")
+        assert r2["id"] == "000001"
+
+    def test_duplicate_invoice_id_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001", invoice_id="DUP-001")
+        with pytest.raises(ValueError, match="already exists"):
+            gb.create_invoice(customer_id="000001", invoice_id="DUP-001")
+
+    def test_blank_invoice_id_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        with pytest.raises(ValueError, match="must not be blank"):
+            gb.create_invoice(customer_id="000001", invoice_id="  ")
+
     def test_invalid_customer(self, business_book):
         gb = GnuCashBook(str(business_book))
         with pytest.raises(ValueError, match="Customer not found"):
@@ -372,10 +481,137 @@ class TestCreateBill:
         assert inv["id"] == "000001"
         assert bill["id"] == "000001"
 
+    def test_custom_bill_id(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.create_bill(
+            vendor_id="000001", bill_id="BILL-2026-001",
+        )
+        assert result["id"] == "BILL-2026-001"
+        assert result["status"] == "created"
+
+    def test_custom_id_does_not_increment_counter(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001", bill_id="CUSTOM-1")
+        # Next auto-generated ID should still be 000001 (counter untouched)
+        r2 = gb.create_bill(vendor_id="000001")
+        assert r2["id"] == "000001"
+
+    def test_duplicate_bill_id_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001", bill_id="DUP-001")
+        with pytest.raises(ValueError, match="already exists"):
+            gb.create_bill(vendor_id="000001", bill_id="DUP-001")
+
     def test_invalid_vendor(self, business_book):
         gb = GnuCashBook(str(business_book))
         with pytest.raises(ValueError, match="Vendor not found"):
             gb.create_bill(vendor_id="999999")
+
+
+class TestDeleteInvoice:
+    """Tests for delete_invoice."""
+
+    def test_delete_unposted_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        inv = gb.create_invoice(customer_id="000001")
+        result = gb.delete_invoice(invoice_id=inv["id"])
+        assert result["status"] == "deleted"
+        assert result["id"] == inv["id"]
+        assert result["type"] == "invoice"
+        # Verify it's gone
+        with pytest.raises(ValueError, match="not found"):
+            gb.get_invoice(inv["id"])
+
+    def test_delete_invoice_with_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        result = gb.delete_invoice(invoice_id="000001")
+        assert result["status"] == "deleted"
+        assert result["entries_deleted"] == 1
+
+    def test_delete_posted_invoice_blocked(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-15",
+        )
+        with pytest.raises(ValueError, match="Cannot delete posted"):
+            gb.delete_invoice(invoice_id="000001")
+
+    def test_delete_nonexistent_invoice(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.delete_invoice(invoice_id="NOPE")
+
+    def test_delete_with_custom_id(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001", invoice_id="INV-DEL-001")
+        result = gb.delete_invoice(invoice_id="INV-DEL-001")
+        assert result["status"] == "deleted"
+        assert result["id"] == "INV-DEL-001"
+
+
+class TestDeleteBill:
+    """Tests for delete_bill."""
+
+    def test_delete_unposted_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        bill = gb.create_bill(vendor_id="000001")
+        result = gb.delete_bill(bill_id=bill["id"])
+        assert result["status"] == "deleted"
+        assert result["id"] == bill["id"]
+        assert result["type"] == "bill"
+
+    def test_delete_bill_with_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="10", price="5.00",
+        )
+        result = gb.delete_bill(bill_id="000001")
+        assert result["status"] == "deleted"
+        assert result["entries_deleted"] == 1
+
+    def test_delete_posted_bill_blocked(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="10", price="5.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        with pytest.raises(ValueError, match="Cannot delete posted"):
+            gb.delete_bill(bill_id="000001")
+
+    def test_delete_nonexistent_bill(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.delete_bill(bill_id="NOPE")
 
 
 class TestAddInvoiceEntry:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -38,7 +38,7 @@ class TestToolModulesMapping:
     def test_total_tool_count(self):
         """Total tools across all modules should be 66."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 70
+        assert total == 74
 
     def test_expected_modules_exist(self):
         """All expected module names should be present."""
@@ -70,7 +70,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 66 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 70
+        assert len(self._tool_names()) == 74
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag should default to core only."""
@@ -97,12 +97,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 70
+        assert len(self._tool_names()) == 74
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 66 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 70
+        assert len(self._tool_names()) == 74
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

- **Custom invoice/bill IDs**: Optional `invoice_id`/`bill_id` parameters on `create_invoice`/`create_bill` for user-supplied document numbers. Counter is skipped when a custom ID is provided; duplicates and blank values are rejected.
- **Delete tools** (4 new): `delete_invoice`, `delete_bill`, `delete_customer`, `delete_vendor` with accounting safeguards — posted invoices/bills cannot be deleted, customers/vendors with any invoices/bills are blocked.
- **Default currency fix**: All 10 `book.default_currency` access sites now raise a clear `ValueError` with platform-specific GnuCash Preferences path instead of crashing with `NoneType` attribute errors. Startup detection warns via stderr and `get_server_config`.
- Audit log formatters for all new delete operations.
- Tool count: 70 → 74.

## Test plan

- [x] `uv run pytest` — 569 passed, 0 failed
- [x] Custom invoice ID used verbatim, counter unaffected, duplicates rejected, blanks rejected
- [x] Custom bill ID same pattern
- [x] Delete unposted invoice/bill succeeds, entries auto-cascade
- [x] Delete posted invoice/bill blocked with clear error
- [x] Delete customer/vendor with no invoices/bills succeeds
- [x] Delete customer/vendor with invoices/bills blocked, error lists IDs
- [x] Corrupted book (no default currency) raises clear error on `get_book_summary` and `create_transaction`
- [x] Explicit `currency` parameter bypasses missing default currency
- [x] Live tested custom IDs and delete tools via Claude Desktop against real book