### PR TITLE
Add account type changes and optional root-level account creation

### DIFF
--- a/src/gnucash_mcp/book.py
+++ b/src/gnucash_mcp/book.py
@@ -2271,7 +2271,7 @@ class GnuCashBook:
         self,
         name: str,
         account_type: str,
-        parent: str,
+        parent: str | None = None,
         description: str = "",
         placeholder: bool = False,
         commodity: str | None = None,
@@ -2283,6 +2283,7 @@ class GnuCashBook:
             name: Account name (e.g., "AI Subscriptions").
             account_type: GnuCash account type (ASSET, EXPENSE, etc.).
             parent: Full path of parent account (e.g., "Expenses:Online Services").
+                    If omitted, creates a top-level account at the book root.
             description: Optional description.
             placeholder: If True, account is container-only. Default False.
             commodity: ISO currency code (e.g., "USD", "EUR") or commodity mnemonic.
@@ -2291,7 +2292,8 @@ class GnuCashBook:
                                 Default "CURRENCY".
 
         Returns:
-            Dict with guid, fullname, and status.
+            Dict with guid, fullname, and status. Includes a warning if
+            created at root level.
 
         Raises:
             ValueError: If parent not found, invalid type, duplicate name,
@@ -2305,16 +2307,22 @@ class GnuCashBook:
             )
 
         with self.open(readonly=False) as book:
-            # Find parent account
-            parent_account = self._find_account(book, parent)
-            if not parent_account:
-                raise ValueError(f"Parent account not found: {parent}")
+            # Determine parent account
+            is_root_level = parent is None
+            if is_root_level:
+                parent_account = book.root_account
+                parent_label = "root"
+            else:
+                parent_account = self._find_account(book, parent)
+                if not parent_account:
+                    raise ValueError(f"Parent account not found: {parent}")
+                parent_label = parent
 
             # Check for duplicate - same name under same parent
             for child in parent_account.children:
                 if child.name == name:
                     raise ValueError(
-                        f"Account '{name}' already exists under '{parent}'"
+                        f"Account '{name}' already exists under '{parent_label}'"
                     )
 
             # Determine commodity
@@ -2343,11 +2351,36 @@ class GnuCashBook:
 
             book.save()
 
-            return {
+            result = {
                 "guid": new_account.guid,
                 "fullname": new_account.fullname,
                 "status": "created",
             }
+            if is_root_level:
+                result["warning"] = (
+                    "Account created at root level, outside the standard "
+                    "account hierarchy (Assets, Liabilities, Equity, Income, "
+                    "Expenses). This may affect reports and balance sheet "
+                    "calculations."
+                )
+            return result
+
+    # Polarity groups for account type change validation.
+    # Types within the same group can be freely converted.
+    _ACCOUNT_TYPE_POLARITY = {
+        "ASSET": "debit_asset",
+        "BANK": "debit_asset",
+        "CASH": "debit_asset",
+        "RECEIVABLE": "debit_asset",
+        "LIABILITY": "credit_liability",
+        "CREDIT": "credit_liability",
+        "PAYABLE": "credit_liability",
+        "INCOME": "credit_income",
+        "EXPENSE": "debit_expense",
+        "EQUITY": "credit_equity",
+        "STOCK": "debit_investment",
+        "MUTUAL": "debit_investment",
+    }
 
     def update_account(
         self,
@@ -2355,6 +2388,7 @@ class GnuCashBook:
         new_name: str | None = None,
         description: str | None = None,
         placeholder: bool | None = None,
+        account_type: str | None = None,
     ) -> dict:
         """Update an existing account's properties.
 
@@ -2363,12 +2397,16 @@ class GnuCashBook:
             new_name: New name for the account (just the name, not full path).
             description: New description.
             placeholder: New placeholder status.
+            account_type: New account type (e.g., "CREDIT", "BANK"). Only
+                changes within the same debit/credit polarity family are
+                allowed (e.g., LIABILITY to CREDIT, ASSET to BANK).
 
         Returns:
             Dict with updated account details.
 
         Raises:
-            ValueError: If account not found or new name conflicts.
+            ValueError: If account not found, new name conflicts, or type
+                change would flip debit/credit polarity.
         """
         with self.open(readonly=False) as book:
             account = self._find_account(book, name)
@@ -2391,6 +2429,29 @@ class GnuCashBook:
 
             if placeholder is not None:
                 account.placeholder = placeholder
+
+            if account_type is not None:
+                new_type = account_type.upper()
+                old_type = account.type
+
+                if new_type not in self.VALID_ACCOUNT_TYPES:
+                    raise ValueError(
+                        f"Invalid account type: {new_type}. "
+                        f"Valid types: {', '.join(sorted(self.VALID_ACCOUNT_TYPES))}"
+                    )
+
+                if new_type != old_type:
+                    old_polarity = self._ACCOUNT_TYPE_POLARITY.get(old_type)
+                    new_polarity = self._ACCOUNT_TYPE_POLARITY.get(new_type)
+
+                    if old_polarity != new_polarity:
+                        raise ValueError(
+                            f"Cannot change account type from {old_type} to "
+                            f"{new_type} — this would flip the debit/credit "
+                            f"polarity and corrupt existing transaction balances."
+                        )
+
+                    account.type = new_type
 
             book.save()
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -661,7 +661,7 @@ def search_transactions(query: str, field: str = "description", verbose: bool = 
 def create_account(
     name: str,
     account_type: str,
-    parent: str,
+    parent: str | None = None,
     description: str = "",
     placeholder: bool = False,
     commodity: str | None = None,
@@ -672,7 +672,8 @@ def create_account(
     Args:
         name: Account name (e.g., "AI Subscriptions")
         account_type: GnuCash account type (ASSET, BANK, CASH, CREDIT, EQUITY, EXPENSE, INCOME, LIABILITY, MUTUAL, STOCK, RECEIVABLE, PAYABLE)
-        parent: Full path of parent account (e.g., "Expenses:Online Services")
+        parent: Full path of parent account (e.g., "Expenses:Online Services").
+            If omitted, creates a top-level account at the book root.
         description: Optional description
         placeholder: If true, account is container-only. Default: false
         commodity: Symbol for the account's commodity:
@@ -706,6 +707,7 @@ def update_account(
     new_name: str | None = None,
     description: str | None = None,
     placeholder: bool | None = None,
+    account_type: str | None = None,
 ) -> str:
     """Update an existing account's properties.
 
@@ -714,6 +716,10 @@ def update_account(
         new_name: New name for the account (just the leaf name, not full path)
         description: New description
         placeholder: New placeholder status (true = container only)
+        account_type: New account type (e.g., "CREDIT", "BANK"). Only changes
+            within the same debit/credit polarity are allowed — e.g.,
+            LIABILITY to CREDIT, ASSET to BANK. Cross-polarity changes
+            (e.g., ASSET to LIABILITY) are blocked.
     """
     book = get_book()
     result = book.update_account(
@@ -721,6 +727,7 @@ def update_account(
         new_name=new_name,
         description=description,
         placeholder=placeholder,
+        account_type=account_type,
     )
     return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1516,6 +1516,50 @@ class TestCreateAccount:
 
         assert result["status"] == "created"
 
+    def test_create_root_level_account(self, test_book: Path):
+        """Should create account at root level when parent is omitted."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_account(
+            name="Testing",
+            account_type="ASSET",
+        )
+        assert result["status"] == "created"
+        assert result["fullname"] == "Testing"
+        assert "warning" in result
+        assert "root level" in result["warning"]
+
+    def test_root_level_account_no_warning_with_parent(self, test_book: Path):
+        """Should not include warning when parent is provided."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_account(
+            name="Normal Child",
+            account_type="EXPENSE",
+            parent="Expenses",
+        )
+        assert result["status"] == "created"
+        assert "warning" not in result
+
+    def test_root_level_account_in_list(self, test_book: Path):
+        """Root-level account should appear in list_accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(name="TopLevel", account_type="ASSET")
+        result = gc_book.list_accounts()
+        assert "TopLevel" in result
+
+    def test_root_level_account_get_balance(self, test_book: Path):
+        """get_balance should work on a root-level account."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(name="TopLevel", account_type="ASSET")
+        balance = gc_book.get_balance("TopLevel")
+        assert balance == 0
+
+    def test_root_level_duplicate_blocked(self, test_book: Path):
+        """Should block duplicate root-level accounts."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(name="UniqueRoot", account_type="ASSET")
+        with pytest.raises(ValueError, match="already exists"):
+            gc_book.create_account(name="UniqueRoot", account_type="ASSET")
+
 
 class TestUpdateAccount:
     """Tests for update_account method."""
@@ -1588,6 +1632,88 @@ class TestUpdateAccount:
                 name="Expenses:Groceries",
                 new_name="Dining",
             )
+
+
+    def test_update_account_type_liability_to_credit(self, test_book: Path):
+        """Should allow changing LIABILITY to CREDIT (same polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="CareCredit", account_type="LIABILITY", parent="Liabilities",
+        )
+        result = gc_book.update_account(
+            name="Liabilities:CareCredit", account_type="CREDIT",
+        )
+        assert result["status"] == "updated"
+        assert result["type"] == "CREDIT"
+
+    def test_update_account_type_credit_to_liability(self, test_book: Path):
+        """Should allow changing CREDIT to LIABILITY (reverse, same polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Store Card", account_type="CREDIT", parent="Liabilities",
+        )
+        result = gc_book.update_account(
+            name="Liabilities:Store Card", account_type="LIABILITY",
+        )
+        assert result["status"] == "updated"
+        assert result["type"] == "LIABILITY"
+
+    def test_update_account_type_asset_to_bank(self, test_book: Path):
+        """Should allow changing ASSET to BANK (same polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Savings", account_type="ASSET", parent="Assets",
+        )
+        result = gc_book.update_account(
+            name="Assets:Savings", account_type="BANK",
+        )
+        assert result["status"] == "updated"
+        assert result["type"] == "BANK"
+
+    def test_update_account_type_stock_to_mutual(self, test_book: Path):
+        """Should allow changing STOCK to MUTUAL (same polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Index Fund", account_type="STOCK", parent="Assets",
+        )
+        result = gc_book.update_account(
+            name="Assets:Index Fund", account_type="MUTUAL",
+        )
+        assert result["status"] == "updated"
+        assert result["type"] == "MUTUAL"
+
+    def test_update_account_type_cross_polarity_blocked(self, test_book: Path):
+        """Should block ASSET to LIABILITY (cross-polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="flip the debit/credit polarity"):
+            gc_book.update_account(
+                name="Assets:Checking", account_type="LIABILITY",
+            )
+
+    def test_update_account_type_expense_to_income_blocked(self, test_book: Path):
+        """Should block EXPENSE to INCOME (cross-polarity)."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="flip the debit/credit polarity"):
+            gc_book.update_account(
+                name="Expenses:Groceries", account_type="INCOME",
+            )
+
+    def test_update_account_type_invalid_type(self, test_book: Path):
+        """Should reject invalid account types."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Invalid account type"):
+            gc_book.update_account(
+                name="Assets:Checking", account_type="NONSENSE",
+            )
+
+    def test_update_account_type_same_type_noop(self, test_book: Path):
+        """Changing to the same type should succeed without error."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.update_account(
+            name="Assets:Checking", account_type="BANK",
+        )
+        assert result["status"] == "updated"
+        assert result["type"] == "BANK"
 
 
 class TestMoveAccount:


### PR DESCRIPTION
## Summary

- **`update_account` type changes**: New `account_type` parameter allows changing account types within the same debit/credit polarity family (e.g., LIABILITY to CREDIT, ASSET to BANK, STOCK to MUTUAL). Cross-polarity changes are blocked with a clear error message.
- **`create_account` optional parent**: `parent` parameter is now optional. When omitted, creates a top-level account at the book root with a warning in the response. Matches GnuCash desktop behavior.

## Test plan

- [x] `uv run pytest` — 582 passed, 0 failed
- [x] LIABILITY → CREDIT (same polarity) — succeeds
- [x] CREDIT → LIABILITY (reverse) — succeeds
- [x] CREDIT → ASSET (cross-polarity) — blocked with clear error
- [x] EXPENSE → INCOME (cross-polarity) — blocked with clear error
- [x] STOCK → MUTUAL — succeeds
- [x] Root-level account creation — succeeds with warning
- [x] Normal account creation — no warning
- [x] Root-level get_balance — works
- [x] Root-level duplicate — blocked
- [x] Live tested via Claude Desktop against real book (8/8 passed, no artifacts)