### PR TITLE
fix: resolved currency in create_customer/vendor/employee result dicts

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -555,6 +555,7 @@ class BusinessMixin:
             "guid": entity.guid,
             "id": entity.id,
             "name": entity.name,
+            "currency": currency_obj.mnemonic,
             "status": "created",
         }
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -29,6 +29,19 @@ class TestCreateCustomer:
         result = gb.create_customer(name="Acme Corp", currency="USD")
         assert result["status"] == "created"
 
+    def test_result_includes_resolved_currency(self, business_book):
+        """Result dict always reports the resolved currency so the audit
+        log formatter renders ``currency: USD`` instead of an empty field
+        when the caller didn't supply currency explicitly.
+        """
+        gb = GnuCashBook(str(business_book))
+        # Explicit currency
+        r1 = gb.create_customer(name="Explicit", currency="USD")
+        assert r1["currency"] == "USD"
+        # Defaulted currency (caller omits) — still populated
+        r2 = gb.create_customer(name="Defaulted")
+        assert r2["currency"] == "USD"
+
     def test_invalid_currency(self, business_book):
         gb = GnuCashBook(str(business_book))
         with pytest.raises(ValueError, match="Currency not found"):


### PR DESCRIPTION
## Summary

Pre-release fix #5 from `docs/PRE_RELEASE_FIXES.md` (cosmetic). The audit log rendered an empty `currency:` field on business-entity creates when the caller didn't pass `currency` explicitly:

```
CREATE CUSTOMER  id:000004
    name: "TEST CUSTOMER"  currency:
```

### Root cause
`_create_business_person` returned `{guid, id, name, status}` — no `currency` key. The audit formatter reads `after_state["currency"]` first, gets None, falls through to `params.get("currency")`, which is also None when the caller relied on the default. Result: empty field.

### Fix
Include `currency_obj.mnemonic` in the returned dict. The resolution already happens (via `_require_default_currency` when caller omits), so this is a zero-cost addition.

After:
```
CREATE CUSTOMER  id:000004
    name: "TEST"  currency: USD
```

## Test plan

- [x] `uv run pytest` passes (707 / 707, +1 new test)
- [x] `test_result_includes_resolved_currency` covers both explicit and defaulted paths
- [x] Existing 144 TestCreate*/TestDelete* tests still pass (additive change)
- [ ] Tester creates a customer without passing currency; audit log shows `currency: USD`