### PR TITLE
feat: recognize realized FX gain/loss on cross-currency pay_invoice

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -59,6 +59,79 @@ class BusinessMixin:
                 return v
         return None
 
+    # Path for the auto-created realized-FX-gain/loss income account.
+    # Single credit-natural account: positive balance = net gain, negative
+    # = net loss across the period. Named to match GAAP convention
+    # ("Foreign Exchange Gain (Loss)") while staying one account for
+    # simplicity.
+    FX_GAIN_LOSS_PATH = "Income:Foreign Exchange Gain/Loss"
+
+    def _get_or_create_fx_account(self, book):
+        """Find or lazily create ``Income:Foreign Exchange Gain/Loss``.
+
+        Created on first cross-currency pay whose post-date rate
+        differs from its pay-date rate, so books without foreign-
+        currency activity never accumulate an unused account.
+
+        Raises:
+            ValueError: If the parent ``Income`` account doesn't exist.
+                Caller must create it first — we won't auto-create a
+                top-level account.
+        """
+        fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
+        if fx_acct is not None:
+            return fx_acct
+
+        income = self._find_account(book, "Income")
+        if income is None:
+            raise ValueError(
+                "Realized FX gain/loss on cross-currency payment needs "
+                "an Income parent account, but none exists. Create "
+                "Income (type=INCOME, placeholder) first."
+            )
+
+        default_currency = self._require_default_currency(book)
+        # Construct — piecash.Account auto-adds to the session via the
+        # parent linkage. Don't flush here: the caller is still building
+        # the payment transaction, and orphan Split objects already in
+        # the session would trip a NOT NULL on splits.tx_guid. The
+        # final book.save() at the end of pay_invoice flushes everything
+        # together with their now-set tx_guids.
+        fx_acct = piecash.Account(
+            name="Foreign Exchange Gain/Loss",
+            type="INCOME",
+            parent=income,
+            commodity=default_currency,
+            description=(
+                "Realized gains and losses from cross-currency "
+                "invoice settlements (rate drift between post-date "
+                "and pay-date). Auto-created on first use."
+            ),
+        )
+        return fx_acct
+
+    @staticmethod
+    def _rate_from_post_transaction(post_txn, invoice_currency):
+        """Derive the exchange rate that was applied at invoice-posting.
+
+        Inspects the posting transaction's splits for one whose account
+        commodity differs from the invoice currency (the income, expense,
+        or A/R side that received the rate). The ratio of |quantity|
+        (account commodity) to |value| (transaction currency) is the
+        rate that was in force at posting.
+
+        Returns the Decimal rate, or None if no cross-currency split
+        is present (same-currency post, or post predates the rate fix).
+        """
+        for s in post_txn.splits:
+            if s.account.commodity == invoice_currency:
+                continue
+            s_value = abs(Decimal(str(s.value)))
+            s_quantity = abs(Decimal(str(s.quantity)))
+            if s_value > 0:
+                return s_quantity / s_value
+        return None
+
     @staticmethod
     def _find_exchange_rate(book, from_commodity, to_commodity, as_of: date):
         """Look up an exchange rate from book.prices for a cross-currency
@@ -1786,12 +1859,62 @@ class BusinessMixin:
                     memo="",
                 )
 
+            # Realized FX gain/loss: when cross-currency and the rate
+            # moved between post-date and pay-date, the USD actually
+            # received/spent differs from what was originally recorded
+            # as income/expense. That delta is taxable FX gain (or
+            # loss); book it to an auto-created Income:FX Gain/Loss
+            # account. The split has value=0 in the transaction
+            # currency (so EUR/GBP/etc. balance is preserved) but
+            # non-zero quantity in the book's default currency. Same
+            # account for both directions; sign determines gain vs
+            # loss.
+            splits = [ar_ap_split, bank_split]
+            fx_gain_loss = None
+            fx_diff = Decimal("0")
+            fx_acct = None
+            if exchange_rate is not None:
+                rate_at_post = self._rate_from_post_transaction(
+                    inv.post_txn, inv.currency
+                )
+                if rate_at_post is not None:
+                    expected_at_post = (
+                        payment_amount * rate_at_post
+                    ).quantize(Decimal("0.01"))
+                    fx_diff = pay_quantity - expected_at_post
+                    if abs(fx_diff) >= Decimal("0.01"):
+                        fx_acct = self._get_or_create_fx_account(book)
+                        # Customer (is_bill=False): we received MORE
+                        # USD than income recorded → gain → credit
+                        # income account (quantity = -fx_diff for a
+                        # gain, +|fx_diff| for a loss).
+                        # Vendor bill (is_bill=True): we spent MORE
+                        # USD than expense recorded → loss → debit
+                        # income account (quantity = +fx_diff for a
+                        # loss, -|fx_diff| for a gain).
+                        quantity_sign = 1 if is_bill else -1
+                        is_loss = (is_bill and fx_diff > 0) or (
+                            not is_bill and fx_diff < 0
+                        )
+                        fx_gain_loss = piecash.Split(
+                            account=fx_acct,
+                            value=Decimal("0"),
+                            quantity=quantity_sign * fx_diff,
+                            memo=(
+                                f"FX {'loss' if is_loss else 'gain'} "
+                                f"on invoice {inv.id}: post-rate "
+                                f"{rate_at_post:.4f}, pay-rate "
+                                f"{exchange_rate}"
+                            ),
+                        )
+                        splits.append(fx_gain_loss)
+
             txn = piecash.Transaction(
                 currency=inv.currency,
                 description=txn_desc,
                 post_date=parsed_date,
                 num="",
-                splits=[ar_ap_split, bank_split],
+                splits=splits,
             )
 
             ar_ap_split.lot = lot_obj
@@ -1821,6 +1944,17 @@ class BusinessMixin:
                 result["payment_account_amount"] = str(pay_quantity)
                 result["invoice_currency"] = inv.currency.mnemonic
                 result["payment_account_currency"] = pay_acct.commodity.mnemonic
+                if fx_gain_loss is not None:
+                    direction = (
+                        "loss" if (is_bill and fx_diff > 0)
+                        or (not is_bill and fx_diff < 0)
+                        else "gain"
+                    )
+                    result["fx_realized"] = {
+                        "amount": str(abs(fx_diff).quantize(Decimal("0.01"))),
+                        "direction": direction,
+                        "account": fx_acct.fullname,
+                    }
 
         return result
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1797,6 +1797,151 @@ class TestPayInvoice:
         # Business book opens with $10,000 in checking per the fixture
         assert checking_balance == Decimal("14950.00")
 
+    def _add_eur_ar_and_price(self, gb, rate_date, rate_value):
+        """Helper: add EUR commodity, EUR A/R subaccount, and a EUR/USD price."""
+        import piecash
+        from datetime import date as _date
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = None
+            for c in book.commodities:
+                if c.mnemonic == "EUR":
+                    eur = c
+                    break
+            if eur is None:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+            if not any(a.fullname == "Assets:Accounts Receivable EUR"
+                       for a in book.accounts):
+                assets = next(a for a in book.accounts if a.fullname == "Assets")
+                book.session.add(piecash.Account(
+                    name="Accounts Receivable EUR", type="RECEIVABLE",
+                    parent=assets, commodity=eur,
+                ))
+            parsed = rate_date if isinstance(rate_date, _date) else _date.fromisoformat(rate_date)
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd, date=parsed,
+                value=str(rate_value), source="user:test", type="nav",
+            ))
+            book.save()
+
+    def test_cross_currency_fx_gain_on_customer_payment(self, business_book):
+        """When the pay-date rate is higher than the post-date rate, the
+        extra USD received is recognized as FX gain.
+
+        Post Mar 10 at 1.10 (income $4,950). Pay Mar 20 at 1.12
+        ($5,040 received). Gain = $90, booked to
+        Income:Foreign Exchange Gain/Loss with value=0 and
+        quantity=-90 (credit to credit-natural income account).
+        """
+        import piecash
+        gb = GnuCashBook(str(business_book))
+
+        # Two prices: post-date and pay-date rates.
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.12")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(invoice_id="000001",
+                             account="Income:Consulting",
+                             description="EUR services",
+                             quantity="1", price="4500.00")
+        gb.post_invoice(invoice_id="000001",
+                        post_account="Assets:Accounts Receivable EUR",
+                        post_date="2026-03-10")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+
+        # Checking credited at pay-date rate
+        assert Decimal(result["payment_account_amount"]) == Decimal("5040.00")
+        # FX realized: gain of $90
+        assert "fx_realized" in result
+        assert result["fx_realized"]["direction"] == "gain"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("90.00")
+        assert result["fx_realized"]["account"] == "Income:Foreign Exchange Gain/Loss"
+
+        # FX account balance: credit of $90 (income earned)
+        fx_balance = gb.get_balance(account_name="Income:Foreign Exchange Gain/Loss")
+        # Income is credit-natural; credit balance stored as negative.
+        assert fx_balance == Decimal("-90")
+        # Consulting income unchanged at post-date rate
+        consulting = gb.get_balance(account_name="Income:Consulting")
+        assert consulting == Decimal("-4950")
+        # Checking holds full $5,040 + $10,000 opening
+        checking = gb.get_balance(account_name="Assets:Checking")
+        assert checking == Decimal("15040.00")
+        # Net income (Consulting + FX) matches cash received
+        assert -consulting + -fx_balance == checking - Decimal("10000")
+
+    def test_cross_currency_fx_loss_on_customer_payment(self, business_book):
+        """Pay-date rate lower than post-date rate → FX loss.
+
+        Post at 1.12 ($5,040 income). Pay at 1.10 ($4,950 received).
+        Loss = $90, split has positive quantity = +90 (debit to
+        credit-natural income = loss recognized).
+        """
+        gb = GnuCashBook(str(business_book))
+
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.12")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.10")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(invoice_id="000001",
+                             account="Income:Consulting",
+                             description="EUR services",
+                             quantity="1", price="4500.00")
+        gb.post_invoice(invoice_id="000001",
+                        post_account="Assets:Accounts Receivable EUR",
+                        post_date="2026-03-10")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+
+        assert Decimal(result["payment_account_amount"]) == Decimal("4950.00")
+        assert result["fx_realized"]["direction"] == "loss"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("90.00")
+        # FX Gain/Loss has a debit = positive stored value (credit-natural
+        # account with a debit shows as positive).
+        fx_balance = gb.get_balance(account_name="Income:Foreign Exchange Gain/Loss")
+        assert fx_balance == Decimal("90")
+
+    def test_cross_currency_same_rate_no_fx_split(self, business_book):
+        """Post and pay at the identical rate → no FX split, no FX account."""
+        gb = GnuCashBook(str(business_book))
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(invoice_id="000001",
+                             account="Income:Consulting",
+                             description="EUR services",
+                             quantity="1", price="4500.00")
+        gb.post_invoice(invoice_id="000001",
+                        post_account="Assets:Accounts Receivable EUR",
+                        post_date="2026-03-10")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-10",
+        )
+
+        assert "fx_realized" not in result
+        # FX account wasn't auto-created since no FX drift.
+        assert gb.get_account(name="Income:Foreign Exchange Gain/Loss") is None
+
     def test_cross_currency_payment_to_matching_currency_account(self, business_book):
         """When the payment account's commodity matches the invoice
         currency, no rate lookup is needed (same-currency payment on a


### PR DESCRIPTION
## Summary

Closes the last open item from the known-limitations list: cross-currency invoice payments now recognize realized foreign-exchange gain (or loss) when the post-date rate differs from the pay-date rate.

### Background

After the multi-currency fix in PR #39-era (post/pay_invoice applying exchange rates), a subtle issue remained: if the rate moved between when an invoice was posted and when it was paid, the USD actually deposited differed from the USD originally recognized as income. The difference silently inflated (or deflated) the payment account's USD balance with no corresponding income entry.

**Concrete example on Alex's book:** Berlin Digital billed €4,500 on Mar 10 (rate 1.09 → $4,905 income), paid on Apr 9 (rate 1.095 → $4,927.50 received). The $22.50 difference is realized FX gain — taxable income — but had no home in the books. An accountant reviewing the P&L would see income shy of cash by $22.50 per invoice and have to reconstruct the gain manually.

### Fix

`pay_invoice` now emits a third split when the rate drift is material (≥ \$0.01):

- **value = 0** in the invoice's currency (EUR/GBP/etc.), so the transaction still balances at the transaction-currency level.
- **quantity = ±fx_diff** in the book's default currency (USD), booked to `Income:Foreign Exchange Gain/Loss`.
- Sign flips between customer (gain on rate rise) and vendor (loss on rate rise) paths.

The FX account is **auto-created on first use** under `Income` (with a clear error if the `Income` parent doesn't exist). Books without cross-currency activity never see the account.

Result dict gains an `fx_realized` sub-dict: `{amount, direction: gain|loss, account}`.

### Verified against Alex's synthetic book

Re-running Phase 7 on the live book produced:

- `Income:Foreign Exchange Gain/Loss`: **−\$31** (credit = $31 of realized gain)
- `Income:LLC Revenue`: **−\$102,618** (unchanged, booked at posting-date rates)
- `Assets:Checking`: **\$145,044.85** (unchanged, cash at payment-date rates)

Cash received now equals income recognized: \$102,618 + \$31 = \$102,649.

## Test plan

- [x] `uv run pytest` passes (**721 / 721**, +3 new tests)
- [x] Three new tests: customer FX gain, customer FX loss, same-rate no-op (verifies FX account is not auto-created)
- [x] Existing 14 `TestPayInvoice` tests unchanged — same-currency and cross-currency-without-drift paths behave identically
- [x] Live verification on Alex's book: \$31 FX gain correctly recognized
- [x] Bill path (vendor) covered by symmetric sign logic; manually traced rate-up/rate-down cases
- [ ] Tester validation on develop before release

## Related

Extends the multi-currency work from PR that landed in develop earlier (commit `0623081`). Together, these complete the GAAP-clean cross-currency invoicing story.