### PR TITLE
feat: get_budget_report rolls child actuals up to budgeted parents

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -494,6 +494,8 @@ class BudgetsMixin:
 
             # Gather budgeted amounts
             budgeted: dict[str, Decimal] = {}
+            # Keep a handle to each budgeted account for descendant walking.
+            budgeted_accounts: dict[str, object] = {}
             for ba in budget.amounts:
                 if ba.period_num not in report_periods:
                     continue
@@ -503,6 +505,29 @@ class BudgetsMixin:
                 budgeted[acct_name] = budgeted.get(
                     acct_name, Decimal("0")
                 ) + ba.amount
+                budgeted_accounts[acct_name] = ba.account
+
+            # Roll-up map: descendant-account-fullname → nearest-ancestor-
+            # fullname that is itself budgeted. Lets budgets set on a
+            # placeholder parent (e.g. Expenses:Utilities) sum the actuals
+            # from all its non-budgeted children (Electric, Gas, Water...).
+            # A child that is itself separately budgeted is NOT rolled up —
+            # its actuals stay on its own line to avoid double-counting.
+            rollup_map: dict[str, str] = {}
+            for acct_name, budgeted_acct in budgeted_accounts.items():
+                rollup_map.setdefault(acct_name, acct_name)
+                descendants: set = set()
+                self._collect_descendants(budgeted_acct, descendants)
+                for desc in descendants:
+                    if desc.fullname in budgeted:
+                        continue  # separately budgeted — don't roll up
+                    # If multiple budgeted ancestors cover this descendant
+                    # (nested parents), keep the nearest one (the deepest
+                    # budgeted ancestor). A simple proxy: prefer the longer
+                    # ancestor path.
+                    existing = rollup_map.get(desc.fullname)
+                    if existing is None or len(acct_name) > len(existing):
+                        rollup_map[desc.fullname] = acct_name
 
             # Calculate actuals from transactions
             actuals: dict[str, Decimal] = {}
@@ -511,16 +536,17 @@ class BudgetsMixin:
                     continue
                 for split in transaction.splits:
                     acct_name = split.account.fullname
-                    if acct_name not in budgeted:
+                    rollup_target = rollup_map.get(acct_name)
+                    if rollup_target is None:
                         continue
                     amount = split.quantity
                     if split.account.type == "EXPENSE" and amount > 0:
-                        actuals[acct_name] = actuals.get(
-                            acct_name, Decimal("0")
+                        actuals[rollup_target] = actuals.get(
+                            rollup_target, Decimal("0")
                         ) + amount
                     elif split.account.type == "INCOME" and amount < 0:
-                        actuals[acct_name] = actuals.get(
-                            acct_name, Decimal("0")
+                        actuals[rollup_target] = actuals.get(
+                            rollup_target, Decimal("0")
                         ) + (-amount)
 
             accounts_result = []

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -418,6 +418,138 @@ class TestGetBudgetReport:
         assert Decimal(report["totals"]["actual"]) == Decimal("650")
         assert Decimal(report["totals"]["remaining"]) == Decimal("150")
 
+    def test_parent_placeholder_rolls_up_children_actuals(
+        self, budget_book: Path
+    ):
+        """Budget set on a parent placeholder sums children's actuals.
+
+        Adds `Expenses:Utilities` (placeholder) with children
+        `Electric` + `Gas`. Budget $450 on the parent only. Post a
+        $95 charge to Electric and $65 to Gas. Report should show
+        `Expenses:Utilities` actual = $160 — not $0.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gc = GnuCashBook(str(budget_book))
+        with gc.open(readonly=False) as b:
+            usd = b.default_currency
+            expenses = next(a for a in b.accounts if a.fullname == "Expenses")
+            checking = next(a for a in b.accounts if a.fullname == "Assets:Checking")
+            utilities = piecash.Account(
+                name="Utilities", type="EXPENSE", parent=expenses,
+                commodity=usd, placeholder=True,
+            )
+            electric = piecash.Account(
+                name="Electric", type="EXPENSE", parent=utilities,
+                commodity=usd,
+            )
+            gas = piecash.Account(
+                name="Gas", type="EXPENSE", parent=utilities,
+                commodity=usd,
+            )
+            piecash.Transaction(
+                currency=usd, description="Electric bill",
+                post_date=_date(2026, 1, 15),
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("-95")),
+                    piecash.Split(account=electric, value=Decimal("95")),
+                ],
+            )
+            piecash.Transaction(
+                currency=usd, description="Gas bill",
+                post_date=_date(2026, 1, 20),
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("-65")),
+                    piecash.Split(account=gas, value=Decimal("65")),
+                ],
+            )
+            b.save()
+
+        gc.create_budget(name="Util Budget", year=2026, num_periods=12)
+        gc.set_budget_amount(
+            budget_name="Util Budget",
+            account="Expenses:Utilities",
+            amount="450.00",
+            period=0,
+        )
+
+        report = gc.get_budget_report(
+            budget_name="Util Budget",
+            period=0,
+        )
+        util_line = next(
+            a for a in report["accounts"]
+            if a["account"] == "Expenses:Utilities"
+        )
+        assert Decimal(util_line["budgeted"]) == Decimal("450")
+        assert Decimal(util_line["actual"]) == Decimal("160")
+        assert Decimal(util_line["remaining"]) == Decimal("290")
+
+    def test_separately_budgeted_child_does_not_double_count(
+        self, budget_book: Path
+    ):
+        """When both a parent and a child are budgeted, the child's
+        actuals stay on its own line — the parent only collects
+        actuals from its *non-budgeted* descendants.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gc = GnuCashBook(str(budget_book))
+        with gc.open(readonly=False) as b:
+            usd = b.default_currency
+            expenses = next(a for a in b.accounts if a.fullname == "Expenses")
+            checking = next(a for a in b.accounts if a.fullname == "Assets:Checking")
+            utilities = piecash.Account(
+                name="Utilities", type="EXPENSE", parent=expenses,
+                commodity=usd, placeholder=True,
+            )
+            electric = piecash.Account(
+                name="Electric", type="EXPENSE", parent=utilities,
+                commodity=usd,
+            )
+            gas = piecash.Account(
+                name="Gas", type="EXPENSE", parent=utilities,
+                commodity=usd,
+            )
+            piecash.Transaction(
+                currency=usd, description="Electric",
+                post_date=_date(2026, 1, 15),
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("-95")),
+                    piecash.Split(account=electric, value=Decimal("95")),
+                ],
+            )
+            piecash.Transaction(
+                currency=usd, description="Gas",
+                post_date=_date(2026, 1, 20),
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("-65")),
+                    piecash.Split(account=gas, value=Decimal("65")),
+                ],
+            )
+            b.save()
+
+        gc.create_budget(name="Mixed Budget", year=2026, num_periods=12)
+        # Parent budget of $450 + child Electric explicitly budgeted $100.
+        # Electric's $95 actual should stay on Electric, not roll up.
+        # Only Gas's $65 should roll up to the parent.
+        gc.set_budget_amount(
+            budget_name="Mixed Budget",
+            account="Expenses:Utilities", amount="450", period=0,
+        )
+        gc.set_budget_amount(
+            budget_name="Mixed Budget",
+            account="Expenses:Utilities:Electric", amount="100", period=0,
+        )
+        report = gc.get_budget_report(
+            budget_name="Mixed Budget", period=0,
+        )
+        by_acct = {a["account"]: a for a in report["accounts"]}
+        assert Decimal(by_acct["Expenses:Utilities"]["actual"]) == Decimal("65")
+        assert Decimal(by_acct["Expenses:Utilities:Electric"]["actual"]) == Decimal("95")
+
     def test_report_nonexistent_budget_raises(self, budget_book: Path):
         """Reporting on nonexistent budget raises ValueError."""
         book = GnuCashBook(str(budget_book))


### PR DESCRIPTION
## Summary

Closes a long-standing deficiency in `get_budget_report`: budgets set on a parent placeholder account (e.g. `Expenses:Utilities`, `Expenses:Pet`) showed 0% used because the aggregation only matched splits against exact budgeted-account names.

On Alex's synthetic book, the \$5,400 Utilities budget showed 0 actual despite 12 months of electric / gas / water / internet / phone bills — \$5,220 of real spending invisible to the report.

### Fix

Build a rollup map from non-budgeted descendants → nearest budgeted ancestor, then use that map when aggregating splits. A descendant that is itself separately budgeted is NOT rolled up (no double-counting when parent and child are both budgeted).

**Before:**
```
Expenses:Utilities    budgeted=5400  actual=0     used=0.0%
Expenses:Pet          budgeted= 840  actual=0     used=0.0%
```

**After:**
```
Expenses:Utilities    budgeted=5400  actual=5219.88  used=96.7%
Expenses:Pet          budgeted= 840  actual=1597.47  used=190.2% (over — vet visits)
```

## Test plan

- [x] `uv run pytest` passes (**720 / 720**, +2 new tests)
- [x] `test_parent_placeholder_rolls_up_children_actuals` — basic parent rollup
- [x] `test_separately_budgeted_child_does_not_double_count` — child with its own budget stays independent, parent only collects non-budgeted siblings
- [x] Existing 30 TestGetBudgetReport cases unchanged
- [x] Verified in-process against Alex's book: Utilities now reports 96.7%, Pet 190.2%
- [ ] Tester validation on develop