### PR TITLE
feat: market-value reports for cross-commodity balances

### DIFF
--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -63,6 +63,83 @@ class ReportingMixin:
             return account
         return path[target_depth]
 
+    # ── Cross-commodity conversion helpers ────────────────────────────
+    #
+    # For reports that aggregate asset balances across accounts with
+    # different commodities (e.g. USD Checking + VTSAX shares + EUR
+    # Savings), split.quantity lives in each account's own commodity
+    # and can't be summed directly. Convert each account's quantity
+    # to the book's default currency at the latest user-supplied
+    # market price before aggregating. Fallback: split.value (which
+    # is in the transaction currency, generally the book default for
+    # USD-denominated investment buys) is used when no price is on
+    # file — that yields cost basis, which is a reasonable default
+    # when no market price has been loaded.
+
+    def _latest_market_rates(
+        self, book: piecash.Book
+    ) -> dict[str, Decimal]:
+        """Return {commodity_guid: Decimal} — latest user-supplied
+        price for each non-default-currency commodity in the book
+        currency. Skips piecash's auto-created ``type='transaction'``
+        prices (they capture the effective rate of a cross-currency
+        txn; we want explicit market prices).
+        """
+        default_currency = self._require_default_currency(book)
+        latest: dict[str, tuple] = {}  # guid → (date, Decimal rate)
+        for p in book.prices:
+            if p.currency != default_currency:
+                continue
+            if p.type == "transaction":
+                continue
+            p_date = p.date
+            if hasattr(p_date, "date") and callable(p_date.date):
+                p_date = p_date.date()
+            key = p.commodity.guid
+            existing = latest.get(key)
+            if existing is None or p_date > existing[0]:
+                latest[key] = (p_date, Decimal(str(p.value)))
+        return {guid: rate for guid, (_date, rate) in latest.items()}
+
+    def _account_conversion_factors(
+        self, book: piecash.Book
+    ) -> dict[str, Decimal | None]:
+        """Return {account_guid: Decimal factor or None}.
+
+        ``factor * split.quantity = amount in default currency``.
+        A factor of 1 means the account is already in the default
+        currency. ``None`` means no rate is available — callers
+        should fall back to ``split.value`` (transaction-currency
+        amount), which correctly reflects cost basis for USD-
+        denominated investment buys.
+        """
+        default_currency = self._require_default_currency(book)
+        rates = self._latest_market_rates(book)
+        factors: dict[str, Decimal | None] = {}
+        for acct in book.accounts:
+            if acct.commodity == default_currency:
+                factors[acct.guid] = Decimal("1")
+            else:
+                factors[acct.guid] = rates.get(acct.commodity.guid)
+        return factors
+
+    @staticmethod
+    def _split_in_default_currency(
+        split,
+        account,
+        factor: Decimal | None,
+    ) -> Decimal:
+        """Value a single split in the book's default currency.
+
+        Uses ``factor * quantity`` when a factor is available. Falls
+        back to ``split.value`` otherwise — correct for STOCK/MUTUAL
+        splits whose transaction currency is the book default, and a
+        reasonable cost-basis approximation for other cases.
+        """
+        if factor is not None:
+            return Decimal(str(split.quantity)) * factor
+        return Decimal(str(split.value))
+
     # ── SQL-filtered split iterator ───────────────────────────────────
 
     def _query_filtered_splits(
@@ -275,6 +352,7 @@ class ReportingMixin:
             _ASSET_TYPES | _LIABILITY_TYPES | _EQUITY_TYPES | _NET_INCOME_TYPES
         )
         with self.open(readonly=True) as book:
+            factors = self._account_conversion_factors(book)
             rows = self._query_filtered_splits(
                 book,
                 end_date=as_of_date,
@@ -284,16 +362,23 @@ class ReportingMixin:
             balances: dict[str, tuple[str, Decimal]] = {}
             net_income = Decimal("0")
             for split, _txn, account in rows:
+                # Value the split in the book's default currency so
+                # investment shares (VTSAX @ $128, etc.) and foreign-
+                # currency holdings contribute their market/USD value
+                # to balance-sheet totals rather than raw share counts.
+                amt = self._split_in_default_currency(
+                    split, account, factors.get(account.guid)
+                )
                 if account.type in _NET_INCOME_TYPES:
                     # Income is stored negative, expenses positive; net
                     # income = revenues - expenses = -(sum of both).
-                    net_income -= split.quantity
+                    net_income -= amt
                     continue
                 key = account.fullname
                 current_type, current_bal = balances.get(
                     key, (account.type, Decimal("0"))
                 )
-                balances[key] = (current_type, current_bal + split.quantity)
+                balances[key] = (current_type, current_bal + amt)
 
             assets: dict[str, Decimal] = {}
             liabilities: dict[str, Decimal] = {}
@@ -367,6 +452,8 @@ class ReportingMixin:
         nw_types = _ASSET_TYPES | _LIABILITY_TYPES
 
         with self.open(readonly=True) as book:
+            factors = self._account_conversion_factors(book)
+
             # --- Point-in-time: one filtered SQL query, sum in Python.
             if not start_date or not interval:
                 rows = self._query_filtered_splits(
@@ -375,10 +462,15 @@ class ReportingMixin:
                     account_types=nw_types,
                 )
                 total = Decimal("0")
-                for split, _txn, _account in rows:
-                    # Liabilities are stored negative, so adding
-                    # quantity directly gives assets - liabilities.
-                    total += split.quantity
+                for split, _txn, account in rows:
+                    # Liabilities are stored negative, so adding the
+                    # converted amount directly gives assets minus
+                    # liabilities. Investments and foreign-currency
+                    # holdings are valued in the book's default
+                    # currency via their latest market price.
+                    total += self._split_in_default_currency(
+                        split, account, factors.get(account.guid)
+                    )
                 return {
                     "as_of_date": end_date.isoformat(),
                     "net_worth": str(total),
@@ -424,7 +516,7 @@ class ReportingMixin:
             running = Decimal("0")
             b_idx = 0
 
-            for split, txn, _account in rows:
+            for split, txn, account in rows:
                 # For each boundary that sits before this split's
                 # post_date, the running total is already correct —
                 # snapshot it and advance.
@@ -437,7 +529,9 @@ class ReportingMixin:
                         "net_worth": str(running),
                     })
                     b_idx += 1
-                running += split.quantity
+                running += self._split_in_default_currency(
+                    split, account, factors.get(account.guid)
+                )
 
             # Drain any boundaries past the last split — they all see
             # the final running total.
@@ -493,13 +587,17 @@ class ReportingMixin:
                     account_types=_CASH_TYPES,
                 )
 
+            factors = self._account_conversion_factors(book)
             inflows = Decimal("0")
             outflows = Decimal("0")
-            for split, _txn, _account in rows:
-                if split.quantity > 0:
-                    inflows += split.quantity
-                else:
-                    outflows += -split.quantity
+            for split, _txn, acct in rows:
+                amt = self._split_in_default_currency(
+                    split, acct, factors.get(acct.guid)
+                )
+                if amt > 0:
+                    inflows += amt
+                elif amt < 0:
+                    outflows += -amt
 
             # period is input echo (LLM supplied dates), net is derivable
             # (inflows - outflows). Both dropped.

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3618,31 +3618,71 @@ class TestMultiCurrencyBalances:
         # 5000 (opening) + 3000 (salary) - 1100 (transfer) - 200 (groceries)
         assert balance == Decimal("6700")
 
-    def test_balance_sheet_uses_quantity(self, multi_currency_book: Path):
-        """Balance sheet should report account balances in their own commodity."""
+    def test_balance_sheet_values_foreign_currency_at_cost_basis_without_price(
+        self, multi_currency_book: Path
+    ):
+        """Without a EUR/USD price on file, balance_sheet falls back
+        to cost basis (split.value, in transaction currency) for the
+        EUR account. The fixture's FX transfer booked value=1100 USD
+        on the EUR side, so cost basis = $1,100.
+        """
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
-
         asset_accounts = {
             a["account"]: Decimal(a["balance"])
             for a in result["assets"]["accounts"]
         }
         assert asset_accounts["Assets:Checking"] == Decimal("6700")
-        # EUR savings should show 1000 (EUR quantity), not 1100 (USD value)
-        assert asset_accounts["Assets:Euro Savings"] == Decimal("1000")
+        # Cost-basis fallback in the default currency
+        assert asset_accounts["Assets:Euro Savings"] == Decimal("1100")
 
-    def test_net_worth_uses_quantity(self, multi_currency_book: Path):
-        """Net worth should use quantity for each account."""
+    def test_balance_sheet_values_foreign_currency_at_market_with_price(
+        self, multi_currency_book: Path
+    ):
+        """With an EUR/USD price on file, balance_sheet values the EUR
+        savings account at shares × rate = 1000 × 1.20 = $1,200.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gc_book = GnuCashBook(str(multi_currency_book))
+        with gc_book.open(readonly=False) as b:
+            usd = b.default_currency
+            eur = next(c for c in b.commodities if c.mnemonic == "EUR")
+            b.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2024, 12, 31),
+                value="1.20", source="user:test", type="nav",
+            ))
+            b.save()
+
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        asset_accounts = {
+            a["account"]: Decimal(a["balance"])
+            for a in result["assets"]["accounts"]
+        }
+        assert asset_accounts["Assets:Euro Savings"] == Decimal("1200")
+
+    def test_net_worth_converts_foreign_currency(
+        self, multi_currency_book: Path
+    ):
+        """Net worth uses market value (or cost-basis fallback) for
+        non-default-currency accounts rather than summing raw
+        quantities as if they were USD.
+        """
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.net_worth(end_date=date(2024, 12, 31))
         net = Decimal(result["net_worth"])
-        # Assets: Checking 6700 + Euro Savings 1000 = 7700
-        # (Note: mixing currencies, but that's the current behavior —
-        # the important thing is we use quantity, not value)
-        assert net == Decimal("7700")
+        # Without a price: Checking 6700 + Euro Savings 1100 (cost basis)
+        assert net == Decimal("7800")
 
-    def test_cash_flow_uses_quantity(self, multi_currency_book: Path):
-        """Cash flow should use quantity for account splits."""
+    def test_cash_flow_converts_foreign_currency(
+        self, multi_currency_book: Path
+    ):
+        """Cash flow aggregates USD-equivalent amounts across cash
+        and bank accounts (using cost basis as fallback when no
+        market rate is on file).
+        """
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.cash_flow(
             start_date=date(2024, 1, 1),
@@ -3652,8 +3692,8 @@ class TestMultiCurrencyBalances:
         outflows = Decimal(result["outflows"])
         # Checking inflows: 5000 + 3000 = 8000
         # Checking outflows: 1100 + 200 = 1300
-        # EUR Savings inflows: 1000 (quantity, not 1100 value)
-        assert inflows == Decimal("9000")
+        # EUR Savings inflow at cost basis (no price): 1100
+        assert inflows == Decimal("9100")
         assert outflows == Decimal("1300")
 
     def test_spending_by_category_uses_quantity(self, multi_currency_book: Path):


### PR DESCRIPTION
## Summary

Extends the investment-valuation fix from PR #41 (which covered only `get_book_summary`) to the other reports that aggregate asset balances across commodities: **balance_sheet**, **net_worth** (point-in-time + time-series), and **cash_flow**.

### The problem

The three reports summed `split.quantity` across accounts of different commodities. An investment account holding 230.76 VTSAX shares contributed "230.76 USD" to totals — raw share counts as default-currency dollars. A foreign-currency BANK/CASH account contributed its EUR/GBP balance as USD. Totals were nonsense for any book with investments or foreign cash.

### The fix

Three shared helpers on `ReportingMixin`:

- **`_latest_market_rates(book)`** — `{commodity_guid: Decimal}` latest user-supplied price per non-default-currency commodity. Skips piecash's auto-created `type='transaction'` rates so they can't mask a missing real price.
- **`_account_conversion_factors(book)`** — `{account_guid: Decimal | None}` computed once per call. Factor of 1 for default-currency accounts; latest rate for foreign-commodity accounts; `None` when no rate is available.
- **`_split_in_default_currency(split, account, factor)`** — per-split conversion. When factor is present: `quantity × factor`. Otherwise falls back to `split.value` (transaction-currency amount) — correct cost basis for USD-denominated investment purchases and a graceful degradation for foreign-currency holdings without prices.

All three reports now go through these helpers.

### Verified against Alex's book

Net worth at Dec 31: **\$308,531.64** (was summing raw share counts as USD before, badly wrong).

Investments valued at Phase 1 Dec prices:
- VTSAX 180 × \$128 = \$23,040
- AAPL 25 × \$220 = \$5,500
- ETH 2.5 × \$3,200 = \$8,000
- MSFT 15 × \$420 = \$6,300
- VBTLX 500 × \$10.80 = \$5,400

## Test plan

- [x] `uv run pytest` passes (**719 / 719**)
- [x] `TestMultiCurrencyBalances` tests updated — the old pass criteria asserted the old "less wrong" raw-quantity sums; replaced with correctness criteria for both fallback (no price) and full-rate paths
- [x] New test: `test_balance_sheet_values_foreign_currency_at_market_with_price` covers the rate-applied path end-to-end
- [x] `test_cash_flow_specific_account` (which had the variable shadowing regression) fixed and passing
- [x] Verified live against Alex's book: investment values + net worth correct at market
- [ ] Tester validation on develop

## Companion to PR #46

This PR + PR #46 (budget parent rollup) together close the "accountant-sad" report issues Abe flagged. Both are independent; either can merge first.