### PR TITLE
fix(core): drop float precision leak in split amount validation

### DIFF
--- a/src/gnucash_mcp/book/__init__.py
+++ b/src/gnucash_mcp/book/__init__.py
@@ -18,6 +18,7 @@ import importlib
 from gnucash_mcp.book._base import (
     BaseGnuCashBook,
     GnuCashLockError,
+    _to_decimal,
     _verify_composite_write,
     _verify_delete,
     _verify_write,
@@ -110,6 +111,7 @@ __all__ = [
     "GnuCashLockError",
     "build_book_class",
     "extracted_modules",
+    "_to_decimal",
     "_verify_write",
     "_verify_composite_write",
     "_verify_delete",

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -48,6 +48,32 @@ def _to_date(dt: date | datetime) -> date:
     return dt
 
 
+def _to_decimal(value) -> Decimal:
+    """Safe Decimal construction for user-supplied monetary values.
+
+    Routes through ``Decimal(str(value))`` so a ``float`` that slipped
+    past the pydantic boundary (e.g. because the MCP client sent a bare
+    JSON number instead of the advertised string) decimalizes via
+    Python's shortest-repr algorithm — `str(94.87) == "94.87"` —
+    instead of directly via ``Decimal(float)``, which would embed the
+    IEEE-754 epsilon (`0.8699999999999999955591...`) in the result and
+    break the sum-to-zero balance check.
+
+    Exact-decimal inputs (``str``, ``int``, ``Decimal``) round-trip
+    unchanged; only ``float`` is rescued.
+
+    Use everywhere a user-supplied monetary value hits ``Decimal(...)``.
+    This is belt-and-suspenders against the boundary contract: even
+    when the pydantic schema enforces ``str`` at the tool layer,
+    direct callers (tests, scripts) bypass that coercion, and the
+    book methods themselves should never corrupt storage if someone
+    hands them a float.
+    """
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
 def _verify_write(session, table, guid: str, label: str) -> None:
     """Verify a raw SQL INSERT persisted by reading back the primary key.
 

--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 import piecash
 
 from gnucash_mcp.book._base import (
+    _to_decimal,
     _unique_prefix,
     _verify_composite_write,
     _verify_write,
@@ -356,7 +357,7 @@ class BudgetsMixin:
         """
         from piecash.budget import BudgetAmount
 
-        amount_decimal = Decimal(amount)
+        amount_decimal = _to_decimal(amount)
 
         with self.open(readonly=False) as book:
             budget = self._find_budget(book, budget_name)

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -19,7 +19,12 @@ from decimal import Decimal
 
 import piecash
 
-from gnucash_mcp.book._base import _to_date, _verify_composite_write, _verify_write
+from gnucash_mcp.book._base import (
+    _to_date,
+    _to_decimal,
+    _verify_composite_write,
+    _verify_write,
+)
 
 
 class BusinessMixin:
@@ -868,7 +873,7 @@ class BusinessMixin:
         import uuid
         from piecash.business.invoice import Billterm
 
-        discount = Decimal(discount_percent)
+        discount = _to_decimal(discount_percent)
         disc_str = str(discount)
         if "." in disc_str:
             decimals = len(disc_str.split(".")[1])
@@ -1181,8 +1186,8 @@ class BusinessMixin:
         import uuid
         from piecash.business.invoice import Invoice, Entry
 
-        qty = Decimal(quantity)
-        unit_price = Decimal(price)
+        qty = _to_decimal(quantity)
+        unit_price = _to_decimal(price)
 
         with self.open(readonly=False) as book:
             inv = self._find_invoice(book, invoice_id, owner_type=2)
@@ -1283,8 +1288,8 @@ class BusinessMixin:
         import uuid
         from piecash.business.invoice import Invoice, Entry
 
-        qty = Decimal(quantity)
-        unit_price = Decimal(price)
+        qty = _to_decimal(quantity)
+        unit_price = _to_decimal(price)
 
         with self.open(readonly=False) as book:
             inv = self._find_invoice(book, bill_id, owner_type=4)
@@ -1733,7 +1738,7 @@ class BusinessMixin:
         elif owner_type == "vendor":
             ot = 4
 
-        payment_amount = Decimal(amount)
+        payment_amount = _to_decimal(amount)
         if payment_amount <= 0:
             raise ValueError("Payment amount must be positive")
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -36,6 +36,7 @@ from gnucash_mcp.book._base import (
     _guid_prefix_map,
     _split_to_compact_dict,
     _split_to_dict,
+    _to_decimal,
     _transaction_to_compact_line,
     _transaction_to_dict,
     _unique_prefix,
@@ -920,7 +921,7 @@ class CoreMixin:
             })
 
         for split_data, account in zip(splits, accounts):
-            amount = Decimal(split_data["amount"])
+            amount = _to_decimal(split_data["amount"])
             if account.type == "EXPENSE" and amount < 0:
                 warnings.append({
                     "type": "negative_expense",
@@ -1026,13 +1027,16 @@ class CoreMixin:
                 raise ValueError("Transaction must have at least 2 splits")
 
             # Validate balance (using "amount" as transaction-currency value).
+            # _to_decimal routes through str() so a float that slipped past
+            # the pydantic boundary decimalizes via shortest-repr instead of
+            # embedding IEEE-754 epsilon in the sum.
             total = Decimal("0")
             for split in splits:
-                total += Decimal(split["amount"])
+                total += _to_decimal(split["amount"])
             if total != Decimal("0"):
                 raise ValueError(f"Splits do not balance: total is {total}")
 
-            proposed_amounts = [abs(Decimal(s["amount"])) for s in splits]
+            proposed_amounts = [abs(_to_decimal(s["amount"])) for s in splits]
 
             # --- Preflight pass 2: duplicates + recent matches ---
             signals = self._collect_create_signals(
@@ -1093,14 +1097,14 @@ class CoreMixin:
                     )
 
                 resolved_accounts.append(account)
-                value = Decimal(split["amount"])
+                value = _to_decimal(split["amount"])
 
                 # Determine quantity (same-currency: equals value;
                 # cross-currency: caller must provide and sign-match).
                 if account.commodity == trans_currency:
                     quantity = value
                 elif "quantity" in split:
-                    quantity = Decimal(split["quantity"])
+                    quantity = _to_decimal(split["quantity"])
                     if quantity * value < 0:
                         raise ValueError(
                             f"Split for '{split['account']}': quantity and value "
@@ -1770,7 +1774,7 @@ class CoreMixin:
                 # Validate splits balance to zero
                 total = Decimal("0")
                 for split in splits:
-                    total += Decimal(split["amount"])
+                    total += _to_decimal(split["amount"])
                 if total != Decimal("0"):
                     raise ValueError(f"Splits do not balance: total is {total}")
 
@@ -1784,14 +1788,14 @@ class CoreMixin:
                     account_name = split.account.fullname
                     if account_name in split_updates:
                         update = split_updates[account_name]
-                        new_value = Decimal(update["amount"])
+                        new_value = _to_decimal(update["amount"])
                         split.value = new_value
 
                         # Determine quantity
                         if split.account.commodity == trans_currency:
                             split.quantity = new_value
                         elif "quantity" in update:
-                            new_quantity = Decimal(update["quantity"])
+                            new_quantity = _to_decimal(update["quantity"])
                             if new_quantity * new_value < 0:
                                 raise ValueError(
                                     f"Split for '{account_name}': quantity and value "
@@ -1873,8 +1877,9 @@ class CoreMixin:
         if len(splits) < 2:
             raise ValueError("At least 2 splits required")
 
-        # Validate balance upfront
-        total = sum(Decimal(s["amount"]) for s in splits)
+        # Validate balance upfront. _to_decimal guards against float input
+        # slipping past the pydantic boundary (see tools/_helpers.SplitInput).
+        total = sum((_to_decimal(s["amount"]) for s in splits), Decimal("0"))
         if total != Decimal("0"):
             raise ValueError(f"Splits do not balance: total is {total}")
 
@@ -1949,13 +1954,13 @@ class CoreMixin:
             # 7. Create new splits
             trans_currency = transaction.currency
             for account, split_data in resolved_accounts:
-                amount = Decimal(split_data["amount"])
+                amount = _to_decimal(split_data["amount"])
 
                 # Determine quantity
                 if account.commodity == trans_currency:
                     quantity = amount
                 elif "quantity" in split_data:
-                    quantity = Decimal(split_data["quantity"])
+                    quantity = _to_decimal(split_data["quantity"])
                     if quantity * amount < 0:
                         raise ValueError(
                             f"Split for '{account.fullname}': quantity and "

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -22,6 +22,7 @@ from gnucash_mcp.book._base import (
     _guid_prefix_map,
     _lot_to_compact_line,
     _to_date,
+    _to_decimal,
     _unique_prefix,
 )
 
@@ -197,7 +198,7 @@ class InvestmentsMixin:
                     break
 
             if existing:
-                existing.value = Decimal(value)
+                existing.value = _to_decimal(value)
                 existing.type = price_type
             else:
                 # piecash expects datetime.date, not datetime.datetime
@@ -205,7 +206,7 @@ class InvestmentsMixin:
                     commodity=comm,
                     currency=curr,
                     date=price_date,
-                    value=Decimal(value),
+                    value=_to_decimal(value),
                     type=price_type,
                     source=source,
                 )
@@ -613,7 +614,7 @@ class InvestmentsMixin:
                 raise ValueError("Lot has no remaining shares")
 
             if shares is not None:
-                shares_to_sell = Decimal(shares)
+                shares_to_sell = _to_decimal(shares)
                 if shares_to_sell > remaining:
                     raise ValueError(
                         f"Cannot sell {shares_to_sell}; lot has {remaining} shares"
@@ -622,7 +623,7 @@ class InvestmentsMixin:
                 shares_to_sell = remaining
 
             if sale_price is not None:
-                price = Decimal(sale_price)
+                price = _to_decimal(sale_price)
             else:
                 # Look up latest price inline (we're inside an open session)
                 commodity = lot.account.commodity

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 from gnucash_mcp.book._base import (
     _guid_prefix_map,
     _split_to_compact_dict,
+    _to_decimal,
     _transaction_to_dict,
     _unique_prefix,
     _unreconciled_split_to_compact_line,
@@ -217,7 +218,7 @@ class ReconciliationMixin:
         Raises:
             ValueError: If account not found, split not found, or balance mismatch.
         """
-        expected_balance = Decimal(statement_balance)
+        expected_balance = _to_decimal(statement_balance)
 
         with self.open(readonly=False) as book:
             account = self._find_account(book, account_name)

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -26,6 +26,8 @@ from decimal import Decimal, InvalidOperation
 
 import piecash
 
+from gnucash_mcp.book._base import _to_decimal
+
 # Account-type groups used across the reports. Defined at module level
 # so the SQL IN() clauses share a single canonical definition rather
 # than drifting across methods.
@@ -703,11 +705,15 @@ class ReportingMixin:
             ValueError: If no debt accounts found, budget invalid, or budget
                         less than sum of minimum payments.
         """
-        budget = Decimal(monthly_budget)
+        budget = _to_decimal(monthly_budget)
         if budget <= 0:
             raise ValueError("monthly_budget must be a positive number")
 
-        purchase_amount = Decimal(additional_purchase) if additional_purchase else Decimal("1.00")
+        purchase_amount = (
+            _to_decimal(additional_purchase)
+            if additional_purchase
+            else Decimal("1.00")
+        )
         if purchase_amount <= 0:
             raise ValueError("additional_purchase must be a positive number")
 

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -22,6 +22,7 @@ import piecash
 from gnucash_mcp.book._base import (
     _guid_prefix_map,
     _sx_to_compact_line,
+    _to_decimal,
     _unique_prefix,
     _upcoming_to_compact_line,
     _verify_composite_write,
@@ -226,9 +227,12 @@ class SchedulingMixin:
             date.fromisoformat(end_date) if end_date else None
         )
 
+        # _to_decimal routes any stray float (direct caller bypassing the
+        # tool-layer SplitInput model) through Python's shortest-repr so
+        # the balance check doesn't fail on IEEE-754 noise.
         total = Decimal("0")
         for s in splits:
-            total += Decimal(s["amount"])
+            total += _to_decimal(s["amount"])
         if total != 0:
             raise ValueError(
                 f"Splits must balance to zero (total: {total})"
@@ -306,11 +310,16 @@ class SchedulingMixin:
                 f"Recurrence for scheduled transaction '{name}'",
             )
 
-            # Store split templates as JSON in a slot
+            # Store split templates as JSON in a slot. Normalize `amount`
+            # through _to_decimal → str so the persisted JSON is always a
+            # clean decimal string, even if the caller handed us a float.
+            # Otherwise a float would survive json.dumps as a numeric
+            # literal, and every future instantiation would replay the
+            # IEEE-754 epsilon.
             splits_json = json.dumps([
                 {
                     "account": s["account"],
-                    "amount": s["amount"],
+                    "amount": str(_to_decimal(s["amount"])),
                     "memo": s.get("memo", ""),
                 }
                 for s in splits
@@ -450,10 +459,12 @@ class SchedulingMixin:
                 if next_occ and next_occ <= window_end:
                     splits = self._get_sx_splits(book, sx)
 
-                    # Calculate total amount (sum of positive splits)
+                    # Calculate total amount (sum of positive splits).
+                    # _to_decimal is defensive for any legacy slots whose
+                    # pre-fix JSON may still carry a numeric literal.
                     total = Decimal("0")
                     for s in splits:
-                        amt = Decimal(s["amount"])
+                        amt = _to_decimal(s["amount"])
                         if amt > 0:
                             total += amt
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -829,6 +829,33 @@ def _format_audit_entry_text(entry: dict) -> str:
     return "\n".join(lines) if lines else ""
 
 
+def _normalize_for_audit(value):
+    """Recursively convert pydantic models to plain dicts/primitives.
+
+    The audit decorator captures the tool's ``kwargs`` into
+    ``entry["params"]`` and also stringifies them into the debug log
+    via ``json.dumps``. When a tool declares a pydantic model in its
+    signature (e.g. ``splits: list[SplitInput]`` on
+    ``create_transaction``), FastMCP hands us live model instances —
+    not JSON-serializable, and the audit text formatters expect the
+    raw dict shape (``split.get("account")``, etc.).
+
+    This normalizer walks the kwargs once and produces an equivalent
+    value with every pydantic model replaced by ``model_dump
+    (exclude_none=True)``. Plain dicts, lists, and scalars pass
+    through untouched (``exclude_none`` preserves the
+    "key present iff value set" contract the book methods depend
+    on — ``"quantity" in split`` keeps working).
+    """
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=True)
+    if isinstance(value, list):
+        return [_normalize_for_audit(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalize_for_audit(v) for k, v in value.items()}
+    return value
+
+
 def _extract_after_state(result: str, entity_type: str | None) -> dict | None:
     """Extract entity state from tool result JSON.
 
@@ -881,11 +908,17 @@ def audit_log(
             debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
             timestamp = datetime.now().astimezone().isoformat()
 
+            # Normalize up front so pydantic models (e.g. list[SplitInput]
+            # from the transaction-creating tools) become plain dicts before
+            # they hit json.dumps in the debug line or the text-audit
+            # formatters that read from entry["params"].
+            normalized_kwargs = _normalize_for_audit(kwargs)
+
             entry = {
                 "timestamp": timestamp,
                 "tool": func.__name__,
                 "classification": classification,
-                "params": kwargs,
+                "params": normalized_kwargs,
             }
 
             if classification == "write":
@@ -893,7 +926,8 @@ def audit_log(
                 entry["entity_type"] = entity_type
 
             debug_logger.debug(
-                f"MCP request: tool={func.__name__} params={json.dumps(kwargs)}"
+                f"MCP request: tool={func.__name__} "
+                f"params={json.dumps(normalized_kwargs)}"
             )
 
             # Before the first write of each process, give the backup

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -10,7 +10,7 @@ import traceback
 from functools import wraps
 from typing import Annotated, Callable
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from gnucash_mcp.book import GnuCashLockError
 
@@ -38,6 +38,97 @@ ScheduledTransactionGuid = Annotated[
     str,
     Field(description="Scheduled transaction GUID (32-char hex or 8+ char prefix)"),
 ]
+
+
+# ── Split payload schema ──────────────────────────────────────────
+#
+# Transaction-creating tools (create_transaction, update_transaction,
+# replace_splits, create_scheduled_transaction) all take a list of
+# split dicts. Before this model existed, the tool signature was
+# ``splits: list[dict]`` — pydantic doesn't descend into bare ``dict``,
+# so the inner ``amount`` / ``quantity`` values round-tripped through
+# whatever type the JSON parser produced. When a client sent a bare
+# JSON number (``"amount": 94.87``), the parser emitted a float, and
+# ``Decimal(split["amount"])`` inside the book method inherited the
+# IEEE-754 epsilon ( ``0.8699999999999999955591...`` ) — causing
+# spurious "splits do not balance" errors on non-dyadic decimals.
+#
+# ``SplitInput`` enforces ``amount`` / ``quantity`` as strings at the
+# MCP boundary. With ``coerce_numbers_to_str=True`` pydantic routes a
+# stray JSON number through Python's ``str()`` (shortest-repr) before
+# we ever construct a Decimal — so ``94.87`` becomes ``"94.87"``, not
+# a noisy float. Internal book methods also wrap every
+# user-derived ``Decimal(...)`` call with ``_to_decimal(...)`` as
+# belt-and-suspenders for direct callers (tests, scripts) that
+# bypass this layer.
+
+
+class SplitInput(BaseModel):
+    """One split in a transaction-creating tool call.
+
+    Fields mirror the dict shape the book methods already consume:
+    ``account`` (required), ``amount`` (required, string, in
+    transaction currency), ``quantity`` (optional, string, required
+    only when the account commodity differs from the transaction
+    currency), and ``memo`` (optional).
+    """
+
+    model_config = ConfigDict(
+        coerce_numbers_to_str=True,
+        extra="ignore",
+    )
+
+    account: Annotated[str, Field(description="Full account path (e.g. 'Expenses:Rent')")]
+    amount: Annotated[
+        str,
+        Field(description="Value in transaction currency, as a decimal string (e.g. '94.87')"),
+    ]
+    quantity: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Amount in the account's commodity, as a decimal string. Required "
+                "when the account's commodity differs from the transaction currency."
+            ),
+        ),
+    ] = None
+    memo: Annotated[
+        str | None,
+        Field(default=None, description="Optional split memo."),
+    ] = None
+
+
+def _splits_to_dicts(
+    splits: list | None,
+) -> list[dict] | None:
+    """Normalize a splits list to plain dicts the book methods expect.
+
+    In production the MCP layer decodes each entry through
+    ``SplitInput`` (pydantic) and we receive a list of models. Tests
+    call the tool callable directly with raw dicts and never hit
+    pydantic. Accept both: models go through ``model_dump``, dicts
+    are coerced through ``SplitInput`` so the test path gets the same
+    ``amount`` / ``quantity`` stringification the production path
+    does.
+
+    ``exclude_none=True`` preserves the "key present iff value set"
+    contract — so ``"quantity" in split`` and ``split.get("memo", "")``
+    keep behaving the way they did when splits arrived as loose dicts.
+
+    ``None`` passes through unchanged (auto-fill path in
+    ``create_transaction``).
+    """
+    if splits is None:
+        return None
+    result: list[dict] = []
+    for s in splits:
+        if isinstance(s, SplitInput):
+            model = s
+        else:
+            model = SplitInput.model_validate(s)
+        result.append(model.model_dump(exclude_none=True))
+    return result
 
 
 def _strip_noise(obj):

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -10,8 +10,10 @@ from datetime import date
 
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
+    SplitInput,
     TransactionGuid,
     _json,
+    _splits_to_dicts,
     safe_tool,
 )
 
@@ -149,7 +151,7 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="write", operation="create", entity_type="transaction")
     def create_transaction(
         description: str,
-        splits: list[dict] | None = None,
+        splits: list[SplitInput] | None = None,
         transaction_date: str | None = None,
         currency: str | None = None,
         notes: str | None = None,
@@ -162,7 +164,9 @@ def register(mcp, get_book) -> None:
         Each split: ``account`` (full path, required), ``amount``
         (required, in transaction currency), ``quantity`` (required
         when account commodity differs from transaction currency),
-        ``memo`` (optional).
+        ``memo`` (optional). ``amount`` and ``quantity`` are decimal
+        strings (e.g. "94.87") — never raw JSON numbers, which would
+        lose precision on non-dyadic decimals.
 
         Args:
             description: Transaction description.
@@ -179,7 +183,7 @@ def register(mcp, get_book) -> None:
         trans_date = date.fromisoformat(transaction_date) if transaction_date else None
         result = book.create_transaction(
             description=description,
-            splits=splits,
+            splits=_splits_to_dicts(splits),
             trans_date=trans_date,
             currency=currency,
             notes=notes,
@@ -347,7 +351,7 @@ def register(mcp, get_book) -> None:
         guid: TransactionGuid,
         description: str | None = None,
         transaction_date: str | None = None,
-        splits: list[dict] | None = None,
+        splits: list[SplitInput] | None = None,
         notes: str | None = None,
         force: bool = False,
     ) -> str:
@@ -360,6 +364,7 @@ def register(mcp, get_book) -> None:
             splits: List of split updates with 'account' and 'amount' (optional).
                     Must match existing splits by account name and balance to zero.
                     For cross-currency splits, include 'quantity' (amount in account's commodity).
+                    ``amount``/``quantity`` are decimal strings (e.g. "94.87").
             notes: New transaction notes (optional). Pass empty string to clear.
             force: Allow modifying transactions with reconciled splits
         """
@@ -369,7 +374,7 @@ def register(mcp, get_book) -> None:
             guid=guid,
             description=description,
             trans_date=trans_date,
-            splits=splits,
+            splits=_splits_to_dicts(splits),
             notes=notes,
             force=force,
         )
@@ -380,7 +385,7 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="write", operation="replace_splits", entity_type="transaction")
     def replace_splits(
         guid: TransactionGuid,
-        splits: list[dict],
+        splits: list[SplitInput],
         force: bool = False,
     ) -> str:
         """Replace all splits in a transaction with a new set.
@@ -393,8 +398,8 @@ def register(mcp, get_book) -> None:
             guid: Transaction GUID (32-character hex string, or 8+ char prefix)
             splits: Complete new set of splits. Each split needs:
                 - 'account' (required): Full account path
-                - 'amount' (required): Value in transaction currency
-                - 'quantity' (optional): Amount in account's commodity.
+                - 'amount' (required): Value in transaction currency, as a decimal string
+                - 'quantity' (optional): Amount in account's commodity, as a decimal string.
                   Required if account commodity differs from transaction currency.
                 - 'memo' (optional): Split memo
             force: Allow replacing reconciled splits or splits in lots
@@ -402,7 +407,7 @@ def register(mcp, get_book) -> None:
         book = get_book()
         result = book.replace_splits(
             guid=guid,
-            splits=splits,
+            splits=_splits_to_dicts(splits),
             force=force,
         )
         return _json(result)

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -3,7 +3,9 @@
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     ScheduledTransactionGuid,
+    SplitInput,
     _json,
+    _splits_to_dicts,
     safe_tool,
 )
 
@@ -17,7 +19,7 @@ def register(mcp, get_book) -> None:
     def create_scheduled_transaction(
         name: str,
         description: str,
-        splits: list[dict],
+        splits: list[SplitInput],
         start_date: str,
         frequency: str,
         end_date: str | None = None,
@@ -30,6 +32,7 @@ def register(mcp, get_book) -> None:
             description: Transaction description at instantiation.
             splits: Same format as create_transaction, e.g.
                 ``[{"account": "Expenses:Rent", "amount": "1850.00"}, ...]``.
+                ``amount`` / ``quantity`` must be decimal strings.
             start_date: First occurrence (YYYY-MM-DD).
             frequency: "weekly", "biweekly" (2w), "monthly",
                 "bimonthly" (2mo), "quarterly" (3mo), or "yearly".
@@ -40,7 +43,7 @@ def register(mcp, get_book) -> None:
         result = book.create_scheduled_transaction(
             name=name,
             description=description,
-            splits=splits,
+            splits=_splits_to_dicts(splits),
             start_date=start_date,
             frequency=frequency,
             end_date=end_date,

--- a/tests/test_float_precision.py
+++ b/tests/test_float_precision.py
@@ -1,0 +1,473 @@
+"""Regression tests for the float/Decimal precision bug.
+
+Filed as ``docs/float-precision-bug.md`` — `create_transaction`
+rejected balanced payloads like $94.87 because `0.87` has no exact
+binary representation and the IEEE-754 epsilon leaked from a
+``float`` into ``Decimal(...)`` before the sum-to-zero check.
+
+Two protections now guard the boundary:
+
+1. ``tools._helpers.SplitInput`` — pydantic model with
+   ``coerce_numbers_to_str=True`` that stringifies any stray JSON
+   number via Python's shortest-repr before it reaches the book
+   method.
+2. ``book._base._to_decimal`` — belt-and-suspenders ``Decimal(str(x))``
+   used at every user-facing ``Decimal(...)`` site. Catches direct
+   callers (tests, scripts) that bypass the pydantic layer.
+
+These tests exercise both protections with the specific non-dyadic
+amounts the bug report identified plus the multi-currency/penny
+edge cases.
+"""
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+from gnucash_mcp.book._base import _to_decimal
+from gnucash_mcp.tools._helpers import SplitInput, _splits_to_dicts
+
+
+# ── _to_decimal helper ──────────────────────────────────────────────
+
+
+class TestToDecimalHelper:
+    """Contract tests for the belt-and-suspenders helper."""
+
+    def test_float_94_87_round_trips_cleanly(self):
+        """The canonical bug: Decimal(0.87) carries IEEE noise;
+        _to_decimal routes through str() and loses it."""
+        assert _to_decimal(94.87) == Decimal("94.87")
+        # Sanity: the direct-Decimal-of-float path is still broken,
+        # which is why we need this helper.
+        assert Decimal(94.87) != Decimal("94.87")
+
+    def test_string_passes_through(self):
+        assert _to_decimal("94.87") == Decimal("94.87")
+
+    def test_decimal_passes_through(self):
+        # Identity for Decimal inputs — no stringify round-trip needed.
+        d = Decimal("94.87")
+        assert _to_decimal(d) is d
+
+    def test_integer_coerces(self):
+        assert _to_decimal(42) == Decimal("42")
+
+    def test_sum_of_non_dyadic_floats_balances(self):
+        """The exact scenario from Abe's report: three non-dyadic
+        floats + one float negation sum to zero."""
+        amounts = [6.25, 5.75, 3.87, -15.87]
+        total = sum((_to_decimal(a) for a in amounts), Decimal("0"))
+        assert total == Decimal("0")
+
+
+# ── SplitInput pydantic coercion ────────────────────────────────────
+
+
+class TestSplitInputCoercion:
+    """The boundary model converts stray JSON numbers to strings so
+    `Decimal(...)` downstream never sees a float."""
+
+    def test_bare_float_coerced_to_string(self):
+        split = SplitInput(account="Assets:Checking", amount=94.87)
+        assert split.amount == "94.87"
+        # And the string itself round-trips exactly to the right Decimal.
+        assert Decimal(split.amount) == Decimal("94.87")
+
+    def test_string_passes_through(self):
+        split = SplitInput(account="Assets:Checking", amount="94.87")
+        assert split.amount == "94.87"
+
+    def test_quantity_optional(self):
+        split = SplitInput(account="Assets:Checking", amount="94.87")
+        assert split.quantity is None
+        # exclude_none drops it from the dict so `"quantity" in split`
+        # keeps working.
+        assert "quantity" not in split.model_dump(exclude_none=True)
+
+    def test_quantity_bare_float_coerced(self):
+        split = SplitInput(
+            account="Assets:Euro Savings", amount="110.00", quantity=100.0,
+        )
+        assert split.quantity == "100.0"
+        assert Decimal(split.quantity) == Decimal("100.0")
+
+    def test_extras_ignored(self):
+        # Passing an unexpected key doesn't raise — existing callers
+        # that emit extra fields keep working.
+        split = SplitInput(
+            account="Assets:Checking", amount="1.00", unknown_key="x",
+        )
+        assert not hasattr(split, "unknown_key")
+
+    def test_splits_to_dicts_converts_list(self):
+        inputs = [
+            SplitInput(account="Assets:Checking", amount=94.87),
+            SplitInput(account="Expenses:Groceries", amount=-94.87),
+        ]
+        dicts = _splits_to_dicts(inputs)
+        assert dicts == [
+            {"account": "Assets:Checking", "amount": "94.87"},
+            {"account": "Expenses:Groceries", "amount": "-94.87"},
+        ]
+
+    def test_splits_to_dicts_none_passthrough(self):
+        # create_transaction's auto-fill path passes None; must survive.
+        assert _splits_to_dicts(None) is None
+
+
+# ── book.create_transaction — the primary bug site ────────────────────
+
+
+class TestCreateTransactionNonDyadic:
+    """Direct-call tests against the book method. Feeding floats
+    directly exercises the ``_to_decimal`` guard inside the book
+    layer, independent of the pydantic boundary.
+    """
+
+    def test_94_87_balanced_via_float(self, test_book: Path):
+        """Canonical failing case from the bug report."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Cat tree",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": 94.87},
+                {"account": "Assets:Checking", "amount": -94.87},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+    def test_94_87_balanced_via_string(self, test_book: Path):
+        """Same amounts as strings — the documented happy path."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Cat tree (str)",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "94.87"},
+                {"account": "Assets:Checking", "amount": "-94.87"},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+    def test_three_way_non_dyadic_split(self, test_book: Path):
+        """6.25 + 5.75 + 3.87 against -15.87 — the three-leg case the
+        spec calls out. Each leg non-dyadic; the sum is exact."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Three-way split",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": 6.25},
+                {"account": "Expenses:Groceries", "amount": 5.75},
+                {"account": "Expenses:Groceries", "amount": 3.87},
+                {"account": "Assets:Checking", "amount": -15.87},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+    def test_penny_split(self, test_book: Path):
+        """$0.01 — smallest representable cent. Non-dyadic in binary."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Penny",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": 0.01},
+                {"account": "Assets:Checking", "amount": -0.01},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+    def test_100_divided_three_ways_rounded(self, test_book: Path):
+        """$100 split three ways rounded to cents: 33.33 + 33.33 + 33.34
+        balanced against -100. The third leg carries the rounding error."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Split three ways",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "33.33"},
+                {"account": "Expenses:Groceries", "amount": "33.33"},
+                {"account": "Expenses:Groceries", "amount": "33.34"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+    def test_unbalanced_floats_still_rejected(self, test_book: Path):
+        """Belt-and-suspenders must not mask real balance errors. A
+        genuine off-by-a-cent still raises."""
+        gc = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="do not balance"):
+            gc.create_transaction(
+                description="Bad math",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": 10.00},
+                    {"account": "Assets:Checking", "amount": -10.01},
+                ],
+                trans_date=date(2026, 4, 23),
+                check_duplicates=False,
+            )
+
+
+# ── book.replace_splits and update_transaction ────────────────────────
+
+
+class TestReplaceSplitsNonDyadic:
+    """replace_splits shares the same Decimal(split["amount"]) pattern
+    as create; the guard applies there too."""
+
+    def test_replace_with_non_dyadic_floats(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        # Seed a transaction we can then replace.
+        created = gc.create_transaction(
+            description="To replace",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        result = gc.replace_splits(
+            guid=created["guid"],
+            splits=[
+                {"account": "Expenses:Groceries", "amount": 42.29},
+                {"account": "Assets:Checking", "amount": -42.29},
+            ],
+        )
+        assert result["status"] == "splits_replaced"
+
+
+class TestUpdateTransactionNonDyadic:
+    """update_transaction also re-validates balance on split updates."""
+
+    def test_update_splits_with_non_dyadic_floats(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        created = gc.create_transaction(
+            description="To update",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+            trans_date=date(2026, 4, 23),
+            check_duplicates=False,
+        )
+        # update_transaction matches by account fullname, so the split
+        # accounts must stay the same — only amounts change.
+        result = gc.update_transaction(
+            guid=created["guid"],
+            splits=[
+                {"account": "Expenses:Groceries", "amount": 18.10},
+                {"account": "Assets:Checking", "amount": -18.10},
+            ],
+        )
+        assert result["status"] == "updated"
+
+
+# ── Scheduled transactions — persisted-float protection ───────────────
+
+
+class TestScheduledSplitsPersistedAsStrings:
+    """The splits-json slot must never store a JSON numeric literal.
+    If a float slips through the schema layer, the write-side
+    normalization re-routes it through str(Decimal(str(x))) so every
+    future instantiation reads a clean decimal string."""
+
+    def test_slot_stores_string_amounts(self, scheduled_book: Path):
+        import json
+        from sqlalchemy import text
+
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="Cat Tree Subscription",
+            description="Rolling non-dyadic charge",
+            splits=[
+                {"account": "Expenses:Rent", "amount": 94.87},
+                {"account": "Assets:Checking", "amount": -94.87},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+
+        # Read the slot raw to confirm the stored JSON is strings.
+        with gc.open(readonly=True) as book:
+            rows = book.session.execute(
+                text(
+                    "SELECT string_val FROM slots WHERE name = :name"
+                ),
+                {"name": "splits-json"},
+            ).fetchall()
+        assert len(rows) == 1
+        payload = json.loads(rows[0][0])
+        # json.loads preserves types: if amount were a float, it would
+        # parse as float, not str.
+        assert all(isinstance(s["amount"], str) for s in payload)
+        # And the values round-trip through Decimal exactly.
+        total = sum(
+            (Decimal(s["amount"]) for s in payload), Decimal("0"),
+        )
+        assert total == Decimal("0")
+
+    def test_instantiation_balances(self, scheduled_book: Path):
+        """End-to-end: create a schedule with float amounts, then
+        instantiate it; the real transaction must balance."""
+        gc = GnuCashBook(str(scheduled_book))
+        sx = gc.create_scheduled_transaction(
+            name="Cat Tree Monthly",
+            description="Monthly charge",
+            splits=[
+                {"account": "Expenses:Rent", "amount": 94.87},
+                {"account": "Assets:Checking", "amount": -94.87},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+        result = gc.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-05-01",
+        )
+        assert result["status"] == "created"
+
+
+# ── Multi-currency: 4-decimal FX rate precision ───────────────────────
+
+
+class TestCrossCurrencyFourDecimalRate:
+    """Spec asks for a multi-currency split where converted amounts
+    involve 4-decimal FX rates. `create_transaction` with an explicit
+    quantity exercises the quantity-side `_to_decimal` guard too."""
+
+    def test_cross_currency_float_quantity(self, multi_currency_book: Path):
+        """USD invoice, EUR savings side: value in USD (transaction
+        currency), quantity in EUR. Both non-dyadic floats through
+        a 4-decimal FX rate."""
+        gc = GnuCashBook(str(multi_currency_book))
+        # $118.75 at rate 1.0825 = 109.70 EUR.
+        result = gc.create_transaction(
+            description="FX transfer with rate 1.0825",
+            splits=[
+                {"account": "Assets:Checking", "amount": -118.75, "quantity": -118.75},
+                {"account": "Assets:Euro Savings", "amount": 118.75, "quantity": 109.70},
+            ],
+            trans_date=date(2026, 4, 23),
+            currency="USD",
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+
+
+# ── Scalar-param tools: belt-and-suspenders via _to_decimal ───────────
+
+
+class TestAuditLogNormalizesPydanticModels:
+    """Live-test regression: when FastMCP decodes a tool call, it
+    hands ``create_transaction`` live ``SplitInput`` instances — not
+    dicts. The audit decorator used to capture those raw kwargs into
+    ``entry["params"]`` and then ``json.dumps`` them for the debug
+    log, which crashed with ``TypeError: Object of type SplitInput is
+    not JSON serializable``. The normalizer inside ``@audit_log``
+    must convert models to plain dicts before any serialization.
+
+    These tests simulate the production path by calling the tool
+    callable with ``SplitInput`` instances.
+    """
+
+    def _create_tool(self, book_path):
+        """Register the core tools against a fresh FastMCP instance
+        pointed at the given book, then hand back the
+        create_transaction callable. Mirrors the production wiring:
+        FastMCP → @audit_log → @safe_tool → @mcp.tool-registered
+        function → book.create_transaction.
+        """
+        from mcp.server.fastmcp import FastMCP
+
+        from gnucash_mcp.tools.core import register
+
+        mcp = FastMCP("test-float")
+        gc = GnuCashBook(str(book_path))
+        register(mcp, lambda: gc)
+        # FastMCP stores the registered tools with their wrapped
+        # function as ``.fn``. Reach in so we can exercise the full
+        # decorator stack without actually speaking MCP.
+        return mcp._tool_manager._tools["create_transaction"].fn
+
+    def test_create_with_splitinput_instances(self, test_book: Path):
+        """SplitInput models from the MCP layer must round-trip
+        through @audit_log + @safe_tool without serialization errors,
+        and produce a real transaction."""
+        import json as _json_lib
+
+        create = self._create_tool(test_book)
+        result_json = create(
+            description="Non-dyadic via MCP path",
+            splits=[
+                SplitInput(account="Expenses:Groceries", amount=94.87),
+                SplitInput(account="Assets:Checking", amount=-94.87),
+            ],
+            transaction_date="2026-04-23",
+            check_duplicates=False,
+        )
+        result = _json_lib.loads(result_json)
+        # If the pydantic leak regressed, result would carry
+        # {"error": "... SplitInput is not JSON serializable"}.
+        assert "error" not in result, result
+        assert result["status"] == "created"
+
+    def test_dry_run_with_splitinput_instances(self, test_book: Path):
+        """The live-test report specifically said dry-run also failed
+        — the crash was upstream of the write. Guard that path too."""
+        import json as _json_lib
+
+        create = self._create_tool(test_book)
+        result_json = create(
+            description="Dry run via MCP path",
+            splits=[
+                SplitInput(account="Expenses:Groceries", amount=94.87),
+                SplitInput(account="Assets:Checking", amount=-94.87),
+            ],
+            transaction_date="2026-04-23",
+            dry_run=True,
+            check_duplicates=False,
+        )
+        result = _json_lib.loads(result_json)
+        assert "error" not in result, result
+        assert result.get("dry_run") is True
+
+
+class TestScalarAmountsAcceptFloat:
+    """The scalar monetary params (amount, price, quantity,
+    statement_balance, etc.) are declared str at the tool layer, so
+    pydantic will coerce in practice. But direct callers can still
+    hand the book method a float — `_to_decimal` guards those too."""
+
+    def test_set_budget_amount_accepts_float(self, budget_book: Path):
+        gc = GnuCashBook(str(budget_book))
+        gc.create_budget(name="TestBudget", year=2026, num_periods=12)
+        result = gc.set_budget_amount(
+            budget_name="TestBudget",
+            account="Expenses:Groceries",
+            amount=94.87,  # bare float
+            period=0,
+        )
+        assert result["status"] == "updated"
+
+    def test_create_price_accepts_float(self, investment_book: Path):
+        gc = GnuCashBook(str(investment_book))
+        result = gc.create_price(
+            commodity="VTSAX",
+            namespace="FUND",
+            value=128.33,  # bare float — historical NAV
+            currency="USD",
+            price_date=date(2026, 3, 15),
+        )
+        assert result["status"] in ("created", "updated")


### PR DESCRIPTION
## Summary

- Non-dyadic split amounts (e.g. `94.87`) rejected `create_transaction` with IEEE-754 noise like `total is -4.6411895751953125E-27` when the client sent a bare JSON number instead of a decimal string. `Decimal(0.87)` embeds `0.8699999999999999955591...`, and the sum-to-zero check fails by an epsilon.
- Fix protects at two layers: `SplitInput` pydantic model at the MCP boundary (`coerce_numbers_to_str=True`), and `_to_decimal(x)` belt-and-suspenders at every user-facing `Decimal(...)` site in the book methods.
- Scheduled-transaction slot writes normalize `amount` through `str(_to_decimal(x))` so float contamination cannot persist across future instantiations.
- `_normalize_for_audit` in `logging_config` converts pydantic models to plain dicts before `json.dumps` — closes a live-test regression where `SplitInput` instances leaked into the audit text formatter.
- 27 regression tests in `tests/test_float_precision.py` cover non-dyadic splits via create/update/replace_splits, penny amounts, `100/3` rounding, cross-currency 4-decimal FX, scheduled slot persistence, and the pydantic-via-MCP audit path.

## Test plan

- [x] `uv run pytest` — 751 passed (was 724 + 27 new)
- [x] Abe's canonical failing case: `$94.87` balanced against `-$94.87` via `create_transaction` — now succeeds
- [x] Three-way non-dyadic split `6.25 + 5.75 + 3.87` vs `-15.87` — balances
- [x] `100/3` rounded to cents `33.33 + 33.33 + 33.34` vs `-100` — balances
- [x] Penny-level `$0.01` split — balances
- [x] Cross-currency with 4-decimal FX rate via explicit `quantity` — balances
- [x] Scheduled-transaction slot JSON persists `amount` as string; instantiation balances
- [x] Live-test regression: `SplitInput` instances via MCP path no longer crash `@audit_log`'s `json.dumps`
- [ ] Abe live-verification on Alex's book (pending)