### PR TITLE
fix(core): render create_transaction duplicates as TSV

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -886,6 +886,38 @@ class CoreMixin:
         )
 
     @staticmethod
+    def _duplicates_to_tsv(duplicates: list[dict]) -> str:
+        """Render the duplicate-candidates list as a compact TSV string.
+
+        Each duplicate becomes one tab-separated line in this column
+        order (no header — documented in ``create_transaction``'s
+        docstring so the LLM knows the shape without paying for a
+        header row every call)::
+
+            confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+
+        A list-of-dicts JSON response to the bookkeeper was
+        ~120 chars per candidate; the TSV form is closer to 40. The
+        rejection path emits two or three candidates typically, and
+        the savings compound when the LLM retries a mis-hit.
+
+        Returns ``""`` for empty input. ``_strip_noise`` in the
+        response serializer drops empty-string values, so callers can
+        unconditionally assign ``result["duplicates"] = _duplicates_to_tsv(...)``
+        without worrying about an empty-key leak into the output.
+
+        The internal ``_CreateSignals.duplicates`` list-of-dicts is
+        kept rich so ``has_high_duplicate`` (and any future callers
+        that need to reason about matches) can still read structured
+        fields — only the response boundary renders TSV.
+        """
+        return "\n".join(
+            f"{d['confidence']}\t{d['guid']}\t{d['date']}\t"
+            f"{d['amount']}\t{d['description']}\t{d['signals']}"
+            for d in duplicates
+        )
+
+    @staticmethod
     def _generate_warnings(
         trans_date: date,
         splits: list[dict],
@@ -980,6 +1012,15 @@ class CoreMixin:
             instead. In dry_run mode, returns 'dry_run': True with
             proposed transaction.
 
+            The 'duplicates' field, when present, is a newline-separated
+            TSV string (not a list of dicts) with columns::
+
+                confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+
+            Confidence is ``HIGH`` or ``MEDIUM``. Signals is a
+            three-char code (D/A/D for description / amount / date,
+            dash for no match). See ``_duplicates_to_tsv``.
+
         Raises:
             ValueError: If splits don't balance, fewer than 2 splits,
                        accounts don't exist, cross-currency splits
@@ -1051,7 +1092,9 @@ class CoreMixin:
             )
             duplicates = signals.duplicates
 
-            # HIGH-confidence duplicate short-circuits the write.
+            # HIGH-confidence duplicate short-circuits the write. The
+            # rejection always carries at least one candidate, so
+            # rendering TSV directly is safe (no empty-string case).
             if (
                 signals.has_high_duplicate
                 and not force_create
@@ -1060,7 +1103,7 @@ class CoreMixin:
                 return {
                     "status": "rejected",
                     "reason": "duplicate_detected",
-                    "duplicates": duplicates,
+                    "duplicates": self._duplicates_to_tsv(duplicates),
                 }
 
             # --- Validate accounts and build piecash splits ---
@@ -1163,7 +1206,7 @@ class CoreMixin:
                 result: dict = {
                     "dry_run": True,
                     "warnings": warnings,
-                    "duplicates": duplicates,
+                    "duplicates": self._duplicates_to_tsv(duplicates),
                 }
                 if auto_filled_from:
                     result["auto_filled_from"] = auto_filled_from
@@ -1189,7 +1232,7 @@ class CoreMixin:
             if warnings:
                 result["warnings"] = warnings
             if duplicates:
-                result["duplicates"] = duplicates
+                result["duplicates"] = self._duplicates_to_tsv(duplicates)
             if auto_filled_from:
                 result["auto_filled_from"] = auto_filled_from
             return result

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -168,6 +168,18 @@ def register(mcp, get_book) -> None:
         strings (e.g. "94.87") — never raw JSON numbers, which would
         lose precision on non-dyadic decimals.
 
+        When duplicate detection surfaces candidates (either rejecting
+        the write with ``status: "rejected"`` or returning alongside a
+        successful create), ``duplicates`` in the response is a
+        newline-separated TSV string, not a list of dicts. Columns::
+
+            confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+
+        Confidence is ``HIGH`` (all three signals match) or ``MEDIUM``
+        (two of three). Signals is a three-char code: position 0
+        description, position 1 amount (±$1 tolerance), position 2
+        date (±2 days); ``D``/``A``/``D`` for match, ``-`` for miss.
+
         Args:
             description: Transaction description.
             splits: List of split dicts (see above). Omit to auto-fill

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -9,6 +9,33 @@ import pytest
 from gnucash_mcp.book import GnuCashBook, GnuCashLockError
 
 
+def _parse_duplicates(tsv: str) -> list[dict]:
+    """Parse the create_transaction duplicates TSV into a list of dicts.
+
+    ``create_transaction`` emits duplicate candidates as a compact
+    newline-separated TSV (see ``_duplicates_to_tsv``). Tests were
+    written against the old list-of-dicts shape; this helper lets
+    them assert on the structured view without the response
+    actually carrying the overhead.
+
+    Empty / missing string returns ``[]``.
+    """
+    if not tsv:
+        return []
+    rows = []
+    for line in tsv.split("\n"):
+        parts = line.split("\t")
+        rows.append({
+            "confidence": parts[0],
+            "guid": parts[1],
+            "date": parts[2],
+            "amount": parts[3],
+            "description": parts[4],
+            "signals": parts[5],
+        })
+    return rows
+
+
 class TestGnuCashBookInit:
     """Tests for GnuCashBook initialization."""
 
@@ -935,8 +962,9 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "rejected"
         assert result["reason"] == "duplicate_detected"
-        assert len(result["duplicates"]) > 0
-        assert result["duplicates"][0]["confidence"] == "HIGH"
+        dups = _parse_duplicates(result["duplicates"])
+        assert len(dups) > 0
+        assert dups[0]["confidence"] == "HIGH"
 
     def test_high_duplicate_force_create(self, test_book: Path):
         """Should create when force_create overrides HIGH duplicate."""
@@ -952,7 +980,7 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "created"
         assert "guid" in result
-        assert len(result["duplicates"]) > 0
+        assert len(_parse_duplicates(result["duplicates"])) > 0
 
     def test_medium_duplicate_allowed(self, test_book: Path):
         """Should allow creation with MEDIUM confidence (2/3 signals)."""
@@ -968,7 +996,8 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "created"
         assert any(
-            d["confidence"] == "MEDIUM" for d in result.get("duplicates", [])
+            d["confidence"] == "MEDIUM"
+            for d in _parse_duplicates(result.get("duplicates", ""))
         )
 
     def test_low_duplicate_included(self, test_book: Path):
@@ -984,10 +1013,14 @@ class TestDuplicateDetection:
             trans_date=date(2024, 1, 25),
         )
         assert result["status"] == "created"
-        # Should have LOW confidence match (amount only)
+        # Should have LOW confidence match (amount only). Note: LOW is
+        # currently suppressed by _collect_create_signals (only HIGH/
+        # MEDIUM emit), so this assertion no-ops when duplicates is
+        # empty — retained for the day LOW is re-enabled.
         if result.get("duplicates"):
             assert any(
-                d["confidence"] == "LOW" for d in result["duplicates"]
+                d["confidence"] == "LOW"
+                for d in _parse_duplicates(result["duplicates"])
             )
 
     def test_check_duplicates_false_skips(self, test_book: Path):
@@ -1024,7 +1057,10 @@ class TestDuplicateDetection:
             trans_date=date(2024, 1, 20),
         )
         assert result["status"] == "rejected"
-        high = [d for d in result["duplicates"] if d["confidence"] == "HIGH"]
+        high = [
+            d for d in _parse_duplicates(result["duplicates"])
+            if d["confidence"] == "HIGH"
+        ]
         assert len(high) > 0
         # Position 0 of signals string = description match
         assert high[0]["signals"][0] == "D"
@@ -1043,7 +1079,7 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "rejected"
         # Position 1 of signals string = amount match
-        assert result["duplicates"][0]["signals"][1] == "A"
+        assert _parse_duplicates(result["duplicates"])[0]["signals"][1] == "A"
 
     def test_date_window(self, test_book: Path):
         """Date match should use ±2 day window."""
@@ -1059,7 +1095,7 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "rejected"
         # Position 2 of signals string = date match
-        assert result["duplicates"][0]["signals"][2] == "D"
+        assert _parse_duplicates(result["duplicates"])[0]["signals"][2] == "D"
 
     def test_no_duplicates_distant_date(self, test_book: Path):
         """Should find no duplicates when date is far from existing."""
@@ -1074,6 +1110,134 @@ class TestDuplicateDetection:
         )
         assert result["status"] == "created"
         assert "duplicates" not in result
+
+
+class TestDuplicatesTsvShape:
+    """The ``duplicates`` response field is a newline-separated TSV
+    string, not a list of dicts. Abe's bookkeeper thread parses it
+    column-wise to decide whether to retry with ``force_create=True``
+    or back off — compact shape matters because a rejection often
+    fires mid-conversation and the full JSON form was blowing
+    through the context budget.
+
+    Contract:
+
+        confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+
+    One row per candidate, newline-separated, no header. HIGH before
+    MEDIUM.
+    """
+
+    def test_rejected_duplicates_is_tsv_string(self, test_book: Path):
+        """The rejection path always carries duplicates; response
+        must be a str, not a list."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "rejected"
+        assert isinstance(result["duplicates"], str)
+        # No legacy leak of list-of-dicts.
+        assert not result["duplicates"].startswith("[")
+        assert "{" not in result["duplicates"]
+
+    def test_tsv_columns_and_order(self, test_book: Path):
+        """Each row is six tab-separated columns in the documented
+        order. The first row is the one with the strongest match
+        (HIGH confidence when all three signals hit)."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        first_line = result["duplicates"].split("\n")[0]
+        cols = first_line.split("\t")
+        assert len(cols) == 6
+        confidence, guid, dt, amount, description, signals = cols
+        assert confidence == "HIGH"
+        assert len(guid) >= 8  # short prefix, never a raw 32-char guid
+        assert dt == "2024-01-20"
+        # piecash's GncNumeric strips trailing zeros (150, not 150.00),
+        # so compare numerically rather than asserting exact text.
+        assert Decimal(amount) == Decimal("150")
+        assert description == "Weekly Groceries"
+        assert signals == "DAD"
+
+    def test_tsv_row_count_matches_candidates(self, test_book: Path):
+        """Number of newline-separated rows == number of unique
+        duplicate candidates returned."""
+        gc_book = GnuCashBook(str(test_book))
+        # Seed a second HIGH match to guarantee two rows.
+        gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.50"},
+                {"account": "Assets:Checking", "amount": "-150.50"},
+            ],
+            trans_date=date(2024, 1, 21),
+            force_create=True,
+        )
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        lines = result["duplicates"].split("\n")
+        # Both matches should appear as separate rows.
+        assert len(lines) >= 2
+
+    def test_success_path_drops_empty_duplicates_in_json(
+        self, test_book: Path,
+    ):
+        """When there are no duplicates on a successful create, the
+        field is absent from the response (book method returns dict
+        without the key) rather than carrying an empty string."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Totally New Description For This Book",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "7.42"},
+                {"account": "Assets:Checking", "amount": "-7.42"},
+            ],
+            trans_date=date(2025, 8, 1),
+        )
+        assert result["status"] == "created"
+        assert "duplicates" not in result
+
+    def test_tsv_shape_in_json_response(self, test_book: Path):
+        """Sanity: after ``_json`` serialization the TSV string lands
+        in the response verbatim (modulo JSON string escaping) — no
+        accidental re-listification by the serializer."""
+        import json as _json_lib
+
+        from gnucash_mcp.tools._helpers import _json
+
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.00"},
+                {"account": "Assets:Checking", "amount": "-150.00"},
+            ],
+            trans_date=date(2024, 1, 20),
+        )
+        encoded = _json(result)
+        decoded = _json_lib.loads(encoded)
+        assert isinstance(decoded["duplicates"], str)
+        # The TSV tabs survived encoding and round-trip.
+        assert "\t" in decoded["duplicates"]
 
 
 class TestDryRun:
@@ -1146,7 +1310,7 @@ class TestDryRun:
             dry_run=True,
         )
         assert result["dry_run"] is True
-        assert len(result["duplicates"]) > 0
+        assert len(_parse_duplicates(result["duplicates"])) > 0
 
     def test_dry_run_validation_errors_raised(self, test_book: Path):
         """Dry run should still raise validation errors."""


### PR DESCRIPTION
## Summary

- The ``duplicates`` field in ``create_transaction``'s response is now a compact newline-separated TSV string instead of a list-of-dicts. ~3× compression (~40 vs ~120 chars per candidate), because the bookkeeper LLM hits this response mid-conversation on a rejection and was blowing its context budget on the structured form.
- Column order, no header: ``confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals``. HIGH confidence first, MEDIUM next. Signals is a three-char code (D/A/D for description / amount / date match, dash for miss) — already the internal shape; just compacted.
- Applied at all three response sites: the HIGH-rejection branch, the dry-run result, and the success path's optional duplicates echo.
- Internal ``_CreateSignals.duplicates`` stays as list-of-dicts so ``has_high_duplicate`` and any future structured readers keep their rich view — only the response boundary renders TSV.
- Docstrings on both the book method (``book/core.py``) and the tool wrapper (``tools/core.py``) now describe the format so the LLM schema advertises it explicitly.

## Test plan

- [x] ``uv run pytest`` — 756 passed (was 751 + 5 new TSV-shape tests, 13 existing dict-based assertions updated to parse TSV)
- [x] 5 explicit TSV-shape regression tests: string type, six-column layout, row-count correspondence, absence on no-match, JSON round-trip via ``_json``
- [x] Existing 13 duplicate-assertion tests continue to assert against structured shape via a ``_parse_duplicates`` TSV→dict helper at the top of ``tests/test_book.py``
- [ ] Abe live-verification: retry the cat-tree create that originally exposed the verbose output; confirm the bookkeeper sees TSV and can parse row-by-row

## Shape example

Before (JSON, per row ~120 chars):
```json
{"confidence":"HIGH","guid":"abc123de","date":"2024-01-20","description":"Weekly Groceries","amount":"150","signals":"DAD"}
```

After (TSV, per row ~40 chars):
```
HIGH	abc123de	2024-01-20	150	Weekly Groceries	DAD
```