### PR TITLE
feat(scheduling): respect last_occur to prevent duplicate instantiation

### DIFF
--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -64,6 +64,7 @@ class SchedulingMixin:
         frequency: str,
         after: date | None = None,
         end_date: date | None = None,
+        last_occur: date | None = None,
     ) -> date | None:
         """Calculate the next occurrence of a scheduled transaction.
 
@@ -72,6 +73,11 @@ class SchedulingMixin:
             frequency: One of VALID_FREQUENCIES.
             after: Find next occurrence after this date. Defaults to today.
             end_date: If set, return None if next occurrence past this date.
+            last_occur: Last instantiation date. If set and greater than
+                        `after`, the search threshold is raised to
+                        `last_occur` so already-instantiated occurrences
+                        aren't returned (e.g., when GnuCash desktop has
+                        run the schedule ahead).
 
         Returns:
             Next occurrence date, or None if past end_date.
@@ -80,6 +86,9 @@ class SchedulingMixin:
 
         if after is None:
             after = date.today()
+
+        if last_occur is not None and last_occur > after:
+            after = last_occur
 
         delta_map = {
             "weekly": relativedelta(weeks=1),
@@ -126,7 +135,7 @@ class SchedulingMixin:
 
         next_occ = self._next_occurrence(
             start, frequency, after=date.today() - timedelta(days=1),
-            end_date=end,
+            end_date=end, last_occur=last,
         ) if frequency != "unknown" else None
 
         return {
@@ -450,10 +459,14 @@ class SchedulingMixin:
                 if isinstance(end, datetime):
                     end = end.date()
 
+                last = sx.last_occur
+                if isinstance(last, datetime):
+                    last = last.date()
+
                 next_occ = self._next_occurrence(
                     start, frequency,
                     after=today - timedelta(days=1),
-                    end_date=end,
+                    end_date=end, last_occur=last,
                 )
 
                 if next_occ and next_occ <= window_end:
@@ -541,18 +554,34 @@ class SchedulingMixin:
             if isinstance(end, datetime):
                 end = end.date()
 
+            last = sx.last_occur
+            if isinstance(last, datetime):
+                last = last.date()
+
             if transaction_date:
                 txn_date = date.fromisoformat(transaction_date)
             else:
                 txn_date = self._next_occurrence(
                     start, frequency,
                     after=date.today() - timedelta(days=1),
-                    end_date=end,
+                    end_date=end, last_occur=last,
                 )
                 if not txn_date:
                     raise ValueError(
                         "No upcoming occurrence (past end date)"
                     )
+
+            # Preflight: refuse to instantiate an occurrence on or before
+            # last_occur. GnuCash desktop's "Since Last Run" updates
+            # last_occur when it auto-creates transactions; running this
+            # tool with a prior date would silently create a duplicate.
+            if last and txn_date <= last:
+                raise ValueError(
+                    f"Transaction date {txn_date.isoformat()} is not "
+                    f"after last occurrence {last.isoformat()}. The "
+                    f"schedule has already been run through that date "
+                    f"(possibly by GnuCash desktop). Use a later date."
+                )
 
             splits = self._get_sx_splits(book, sx)
             if not splits:
@@ -561,7 +590,9 @@ class SchedulingMixin:
                     "transaction"
                 )
 
-            sx.last_occur = txn_date
+            # Never rewind last_occur. If desktop pre-created ahead and
+            # we're backfilling an earlier gap, keep the later marker.
+            sx.last_occur = max(last, txn_date) if last else txn_date
             sx.instance_count += 1
 
             sx_name = sx.name

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -352,6 +352,56 @@ class TestCreateFromScheduled:
                 transaction_date="2026-02-01",
             )
 
+    def test_duplicate_occurrence_rejected(self, scheduled_book):
+        """Cannot instantiate the same date twice.
+
+        Guards against double-billing when the bookkeeper thread and
+        GnuCash desktop both try to run the same occurrence.
+        """
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        with pytest.raises(ValueError, match="not after last occurrence"):
+            gb.create_transaction_from_scheduled(
+                guid=sx["guid"], transaction_date="2026-02-01",
+            )
+
+    def test_backfill_before_last_occur_rejected(self, scheduled_book):
+        """Cannot instantiate a date earlier than last_occur.
+
+        Desktop's adv_creation may create occurrences months ahead;
+        backfilling a gap that's already been run would duplicate.
+        """
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-03-01",
+        )
+        with pytest.raises(ValueError, match="not after last occurrence"):
+            gb.create_transaction_from_scheduled(
+                guid=sx["guid"], transaction_date="2026-02-01",
+            )
+
 
 # ── Update ──────────────────────────────────────────────────
 
@@ -494,6 +544,34 @@ class TestNextOccurrence:
             after=date(2026, 6, 1),
         )
         assert result == date(2027, 1, 1)
+
+    def test_last_occur_raises_threshold(self, scheduled_book):
+        """last_occur past `after` pushes the search forward.
+
+        Prevents returning an occurrence that desktop (or a prior run)
+        has already instantiated.
+        """
+        gb = GnuCashBook(str(scheduled_book))
+        # Without last_occur: after=2026-03-15 → next monthly is 2026-04-01.
+        # With last_occur=2026-05-15 (desktop ran ahead): next is 2026-06-01.
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 1),
+            frequency="monthly",
+            after=date(2026, 3, 15),
+            last_occur=date(2026, 5, 15),
+        )
+        assert result == date(2026, 6, 1)
+
+    def test_last_occur_earlier_than_after_ignored(self, scheduled_book):
+        """last_occur older than `after` doesn't lower the threshold."""
+        gb = GnuCashBook(str(scheduled_book))
+        result = gb._next_occurrence(
+            start_date=date(2026, 1, 1),
+            frequency="monthly",
+            after=date(2026, 3, 15),
+            last_occur=date(2026, 2, 1),
+        )
+        assert result == date(2026, 4, 1)
 
 
 # ── Integration ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Prevents scheduled-transaction double-billing when GnuCash desktop and the MCP bookkeeper both try to run the same occurrence. Desktop's "Since Last Run" auto-creates transactions and advances ``last_occur``; our code was ignoring that field.
- ``_next_occurrence`` now takes a ``last_occur`` parameter. When set and later than ``after``, the search threshold is raised so already-instantiated occurrences no longer surface as "next."
- ``create_transaction_from_scheduled`` preflights ``txn_date > last_occur`` and refuses any on-or-before date with a clear error message pointing at desktop's "Since Last Run."
- ``last_occur`` never rewinds on instantiation (``max(last, txn_date) if last else txn_date``) — if desktop pre-ran ahead to May and you backfill February, the May marker stays intact.
- ``list_scheduled_transactions`` and ``get_upcoming_transactions`` now thread ``last_occur`` into their ``_next_occurrence`` calls so surfaced "next" dates match what instantiation will actually produce.

## Test plan

- [x] ``uv run pytest`` — 760 passed (756 + 4 new scheduling regressions)
- [x] ``test_duplicate_occurrence_rejected`` — instantiating the same date twice fails with "not after last occurrence"
- [x] ``test_backfill_before_last_occur_rejected`` — desktop ran March 1, LLM tries to backfill February 1 → rejected
- [x] ``test_last_occur_raises_threshold`` — ``_next_occurrence`` honors the new parameter
- [x] ``test_last_occur_earlier_than_after_ignored`` — older ``last_occur`` doesn't lower the threshold
- [x] Rebased cleanly onto current develop (post-merge of #48 float fix and #49 duplicates-TSV); the combined state runs the full suite green
- [ ] Live-verify: run a schedule through GnuCash desktop, then attempt the same date via MCP → confirm hard reject