### PR TITLE
fix(core): duplicate-detection cleanup + hide template accounts

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -814,8 +814,21 @@ class BaseGnuCashBook:
             raise last_error
 
     def _find_account(self, book: piecash.Book, fullname: str) -> piecash.Account | None:
-        """Find an account by its full name path."""
+        """Find an account by its full name path.
+
+        Scheduled-transaction template accounts (under
+        ``book.root_template``) are never returned — they're GnuCash
+        internals, not part of the user's chart of accounts. Callers
+        that legitimately need to touch a template (currently only
+        ``create_scheduled_transaction`` / ``delete_scheduled_transaction``)
+        access it through piecash's typed relationships
+        (``sx.template_account``, ``book.root_template.children``),
+        not by name.
+        """
+        template_guids = self._template_account_guids(book)
         for account in book.accounts:
+            if account.guid in template_guids:
+                continue
             if account.fullname == fullname:
                 return account
         return None
@@ -912,3 +925,28 @@ class BaseGnuCashBook:
         for child in account.children:
             result.add(child)
             self._collect_descendants(child, result)
+
+    def _template_account_guids(self, book: piecash.Book) -> set[str]:
+        """GUIDs for every account in the scheduled-transaction
+        template subtree (``book.root_template`` and all descendants).
+
+        GnuCash persists scheduled-transaction split templates as real
+        Account rows rooted at ``root_template``. Piecash surfaces
+        them in ``book.accounts`` alongside the user's chart of
+        accounts, but they're bookkeeping scaffolding — not
+        transactions the user posts to or a balance they care about.
+        Every user-facing account iteration path should filter this
+        set out before serving results.
+
+        Returns an empty set when the book has no template root
+        (books created by very old GnuCash versions, or freshly-created
+        books that haven't materialized the template root yet).
+        """
+        rt = book.root_template
+        if rt is None:
+            return set()
+        guids = {rt.guid}
+        descendants: set = set()
+        self._collect_descendants(rt, descendants)
+        guids.update(a.guid for a in descendants)
+        return guids

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -751,6 +751,19 @@ class CoreMixin:
             else {}
         )
 
+        # Template-account GUID set — used to skip scheduled-transaction
+        # template transactions. GnuCash persists each SX's split
+        # template as a real Transaction row whose splits post to
+        # accounts under book.root_template. Those are recipes, not
+        # events — a user entering a mortgage payment for the first
+        # time would otherwise always see the Mortgage template as a
+        # "duplicate" candidate via description + date match, even
+        # with a stale template amount that kills the A signal.
+        # Filtering at the iteration boundary blocks leakage into
+        # every bucket the collector fills: auto-fill, stability,
+        # duplicates, and recent-matches.
+        template_guids = self._template_account_guids(book)
+
         # Proposed primary — the headline amount (max abs split value)
         # used by the duplicate amount-signal. Computed once; when
         # ``want_duplicates`` is False the caller passed ``[]`` and
@@ -773,6 +786,17 @@ class CoreMixin:
         )
 
         for txn in sorted_txns:
+            # Skip scheduled-transaction template rows — their splits
+            # post to Template Accounts, they have no bearing on the
+            # user's chart, and they'd otherwise fire D-D matches on
+            # every near-cadence description (mortgage, HOA, auto
+            # loans, etc.), training the user to ignore the
+            # duplicate warning.
+            if template_guids and any(
+                s.account.guid in template_guids for s in txn.splits
+            ):
+                continue
+
             txn_desc_lower = txn.description.lower()
             desc_match = (
                 desc_lower in txn_desc_lower

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -745,6 +745,13 @@ class CoreMixin:
             else {}
         )
 
+        # Proposed primary — the headline amount (max abs split value)
+        # used by the duplicate amount-signal. Computed once; when
+        # ``want_duplicates`` is False the caller passed ``[]`` and
+        # this stays zero (harmless — the amount-signal branch never
+        # runs on that code path).
+        proposed_primary = max(proposed_amounts) if proposed_amounts else Decimal("0")
+
         # Local accumulators — each bucket is independent. We finalize
         # them into the returned _CreateSignals after the loop.
         auto_fill_source = None  # piecash.Transaction
@@ -793,17 +800,25 @@ class CoreMixin:
                 want_duplicates
                 and dup_start <= txn.post_date <= dup_end
             ):
-                # Signal 2: any proposed amount within ±$1.00 of any
-                # split's absolute value.
-                amount_match = False
-                txn_amounts = [abs(s.value) for s in txn.splits]
-                for proposed_amt in proposed_amounts:
-                    for txn_amt in txn_amounts:
-                        if abs(proposed_amt - txn_amt) <= Decimal("1.00"):
-                            amount_match = True
-                            break
-                    if amount_match:
-                        break
+                # Signal 2: proposed PRIMARY amount (max abs split
+                # value) within ±$1.00 of candidate's primary amount.
+                #
+                # Earlier iterations compared any-to-any across every
+                # split pair. On multi-split transactions (paychecks
+                # with 10+ deduction splits) that produced
+                # false-positive MEDIUM matches whenever a tiny
+                # deduction happened to land within ±$1 of a
+                # candidate's amount — e.g. a paycheck-vs-coffee-shop
+                # match because some $5-ish union/medicare deduction
+                # sat near the coffee's $5.67 total. "Primary" means
+                # the headline number a human reading the register
+                # uses to recognize a transaction; matching on that
+                # kills the noise without losing real duplicates
+                # (paycheck-vs-paycheck still matches on gross).
+                primary_amount = max(abs(s.value) for s in txn.splits)
+                amount_match = (
+                    abs(proposed_primary - primary_amount) <= Decimal("1.00")
+                )
 
                 # Signal 3: date within ±2 days of trans_date (tighter
                 # than the window filter — window is for "worth
@@ -818,9 +833,6 @@ class CoreMixin:
                         + ("A" if amount_match else "-")
                         + ("D" if date_match else "-")
                     )
-                    # Primary amount: max absolute split value — enough
-                    # context for the LLM to recognize the duplicate.
-                    primary_amount = max(abs(s.value) for s in txn.splits)
                     duplicates.append({
                         "confidence": confidence,
                         "guid": txn_prefixes[txn.guid],

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -116,13 +116,12 @@ class CoreMixin:
             default_currency = self._require_default_currency(book)
             currency = default_currency.mnemonic
 
-            # --- Identify template accounts (scheduled transaction placeholders) ---
-            template_guids = set()
-            rt = book.root_template
-            if rt:
-                template_guids.add(rt.guid)
-                for child in rt.children:
-                    template_guids.add(child.guid)
+            # Identify template accounts (scheduled-transaction scaffolding).
+            # Shared helper on BaseGnuCashBook walks the whole subtree; the
+            # old inline version only captured root_template + direct
+            # children, which worked because create_scheduled_transaction
+            # creates flat templates — but tolerates deeper nesting now.
+            template_guids = self._template_account_guids(book)
 
             # --- Collect parent GUIDs (placeholder containers) ---
             parent_guids = set()
@@ -396,9 +395,16 @@ class CoreMixin:
             If not compact: flat list of account dicts with full paths.
         """
         with self.open(readonly=True) as book:
+            # Hide scheduled-transaction template accounts — they live
+            # under book.root_template as real Account rows (piecash
+            # surfaces them in book.accounts), but they're GnuCash
+            # internals, not part of the user's chart of accounts.
+            template_guids = self._template_account_guids(book)
             filtered = []
             for account in book.accounts:
                 if account.type == "ROOT":
+                    continue
+                if account.guid in template_guids:
                     continue
                 if root is not None:
                     fn = account.fullname

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -371,6 +371,110 @@ class TestGetAccount:
         assert account is None
 
 
+class TestTemplateAccountsHidden:
+    """Scheduled transactions persist their split templates as real
+    Account rows under ``book.root_template``. piecash surfaces those
+    in ``book.accounts`` alongside the user's chart of accounts, but
+    they're GnuCash internals — not transactions the user posts to
+    or a balance they care about. Every user-facing lookup path
+    filters them out.
+
+    Exercising this end-to-end: create a scheduled transaction
+    (which creates a template account with the same name), then
+    verify ``list_accounts`` and ``get_account`` both hide it.
+    """
+
+    def test_list_accounts_hides_template(self, scheduled_book: Path):
+        """The template account created by ``create_scheduled_transaction``
+        must not surface in ``list_accounts``."""
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="MonthlyRentTemplate",
+            description="Monthly Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+        # Compact and verbose paths must both hide the template.
+        compact = gc.list_accounts()
+        assert "MonthlyRentTemplate" not in compact
+
+        verbose = gc.list_accounts(compact=False)
+        names = {a["fullname"] for a in verbose}
+        assert not any("MonthlyRentTemplate" in n for n in names)
+        # User's chart of accounts still appears normally.
+        assert "Assets:Checking" in {a["fullname"] for a in verbose}
+        assert "Expenses:Rent" in {a["fullname"] for a in verbose}
+
+    def test_get_account_hides_template(self, scheduled_book: Path):
+        """Looking up a template account by name returns None, same
+        shape as a missing account."""
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="AnotherTemplate",
+            description="Whatever",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "100.00"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+        # Whatever piecash's fullname for the template happens to be,
+        # neither the bare name nor any plausible templated path
+        # should resolve.
+        assert gc.get_account("AnotherTemplate") is None
+        assert gc.get_account("Template Root:AnotherTemplate") is None
+
+    def test_scheduled_instantiation_still_works(
+        self, scheduled_book: Path,
+    ):
+        """Canary: filtering templates from the user-facing lookup
+        paths must not break the scheduled-transaction instantiation
+        path, which reaches templates through piecash relationships
+        (``sx.template_account``), not by name."""
+        gc = GnuCashBook(str(scheduled_book))
+        sx = gc.create_scheduled_transaction(
+            name="RentToInstantiate",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+        result = gc.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-05-01",
+        )
+        assert result["status"] == "created"
+
+    def test_root_filter_does_not_surface_templates(
+        self, scheduled_book: Path,
+    ):
+        """Even with an aggressive ``root=`` filter that could
+        conceivably match the template subtree name, templates stay
+        hidden. Belt-and-suspenders for edge-case GnuCash namings."""
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="TemplatedThing",
+            description="x",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "100.00"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+            start_date="2026-05-01",
+            frequency="monthly",
+        )
+        # Any list_accounts call, filtered or not, omits templates.
+        for root in (None, "Assets", "Expenses", "Template Root"):
+            result = gc.list_accounts(root=root)
+            assert "TemplatedThing" not in result
+
+
 class TestGetBalance:
     """Tests for get_balance method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -4,9 +4,58 @@ from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 
+import piecash
 import pytest
 
 from gnucash_mcp.book import GnuCashBook, GnuCashLockError
+
+
+def _seed_template_transaction(
+    gc: GnuCashBook,
+    description: str,
+    amount: str,
+    trans_date: date,
+) -> str:
+    """Seed a GnuCash-style scheduled-transaction TEMPLATE as a real
+    Transaction whose splits post to accounts under root_template.
+
+    GnuCash persists each scheduled-transaction's split recipe as a
+    Transaction row whose splits reference accounts rooted at
+    ``book.root_template``. Our MCP creates schedules via a
+    ``splits-json`` Slot instead (see ``create_scheduled_transaction``)
+    so the MCP never produces these rows directly — but books
+    touched by the GnuCash desktop UI are full of them, and the
+    bookkeeper hit exactly that on Alex's mortgage backfill. Tests
+    fabricate one via piecash directly to exercise the filter.
+
+    Returns the transaction's GUID so tests can assert it never
+    resurfaces in user-facing output.
+    """
+    with gc.open(readonly=False) as book:
+        template_acct = piecash.Account(
+            name=f"{description} Template",
+            type="BANK",
+            parent=book.root_template,
+            commodity=book.default_currency,
+        )
+        book.session.add(template_acct)
+        book.flush()
+        txn = piecash.Transaction(
+            currency=book.default_currency,
+            description=description,
+            post_date=trans_date,
+            splits=[
+                piecash.Split(
+                    account=template_acct, value=Decimal(amount),
+                ),
+                piecash.Split(
+                    account=template_acct, value=-Decimal(amount),
+                ),
+            ],
+        )
+        book.session.add(txn)
+        book.save()
+        return txn.guid
 
 
 def _parse_duplicates(tsv: str) -> list[dict]:
@@ -1332,6 +1381,140 @@ class TestDuplicateAmountPrimaryOnly:
         dups = _parse_duplicates(result["duplicates"])
         assert dups[0]["confidence"] == "HIGH"
         assert dups[0]["signals"] == "DAD"
+
+
+class TestTemplateTransactionsExcluded:
+    """Scheduled-transaction template rows are recipes, not events.
+    GnuCash desktop persists each SX's splits as a real Transaction
+    whose splits post to accounts under ``root_template``. The
+    duplicate-detection scan must filter those out — otherwise a
+    user entering a mortgage payment for the first time would always
+    see the mortgage template as a "duplicate" candidate (D-D
+    typically, since template amounts drift from reality but
+    descriptions and cadence match), training them to ignore the
+    duplicate warning.
+
+    Regression for Abe's 2026-04-23 filing, which surfaced $2,485
+    mortgage-template MEDIUM matches against $2,850 real-world
+    payments on Alex's book.
+    """
+
+    def test_template_transaction_never_surfaces_as_duplicate(
+        self, test_book: Path,
+    ):
+        """The exact bookkeeper scenario: a template transaction for
+        'Mortgage Payment' at a stale $2,485 must not appear in the
+        duplicates list when the user enters a real mortgage payment
+        at $2,850."""
+        gc = GnuCashBook(str(test_book))
+        template_guid = _seed_template_transaction(
+            gc,
+            description="Mortgage Payment",
+            amount="2485",
+            trans_date=date(2025, 1, 1),
+        )
+        result = gc.create_transaction(
+            description="Mortgage Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "2850.00"},
+                {"account": "Assets:Checking", "amount": "-2850.00"},
+            ],
+            trans_date=date(2026, 1, 1),
+            check_duplicates=True,
+        )
+        assert result["status"] == "created"
+        dups_tsv = result.get("duplicates", "")
+        # The template's short-guid prefix must not appear anywhere
+        # in the TSV response.
+        assert template_guid[:8] not in dups_tsv
+
+    def test_real_transaction_still_surfaces_even_with_template_present(
+        self, test_book: Path,
+    ):
+        """Having a template on file doesn't suppress legitimate
+        duplicate detection against real user transactions that share
+        the same description."""
+        gc = GnuCashBook(str(test_book))
+        _seed_template_transaction(
+            gc,
+            description="Mortgage Payment",
+            amount="2485",
+            trans_date=date(2025, 1, 1),
+        )
+        # A real, user-posted mortgage transaction (not in the
+        # template subtree).
+        real = gc.create_transaction(
+            description="Mortgage Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "2850.00"},
+                {"account": "Assets:Checking", "amount": "-2850.00"},
+            ],
+            trans_date=date(2026, 1, 1),
+            check_duplicates=False,
+        )
+        # Now try to enter the same mortgage payment again → should
+        # flag the REAL one (HIGH, all three signals), not the
+        # template.
+        result = gc.create_transaction(
+            description="Mortgage Payment",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "2850.00"},
+                {"account": "Assets:Checking", "amount": "-2850.00"},
+            ],
+            trans_date=date(2026, 1, 1),
+            check_duplicates=True,
+        )
+        assert result["status"] == "rejected"
+        dups = _parse_duplicates(result["duplicates"])
+        assert dups[0]["confidence"] == "HIGH"
+        # Short-guid of the real transaction, not the template.
+        assert dups[0]["guid"] == real["guid"]
+
+    def test_template_not_used_for_auto_fill(self, test_book: Path):
+        """Auto-fill pulls the most-recent matching-description
+        transaction's splits when the user omits ``splits``. A
+        template row near the top of the sorted list by date could
+        hijack auto-fill and poison the created transaction with
+        template-account splits — verify the filter keeps it clear."""
+        gc = GnuCashBook(str(test_book))
+        # Seed a template in 2026 (most recent by date) and a real
+        # transaction earlier. If the filter misses, auto-fill grabs
+        # the template; if it holds, auto-fill uses the real one.
+        _seed_template_transaction(
+            gc,
+            description="Utility Bill",
+            amount="500",
+            trans_date=date(2026, 3, 1),
+        )
+        gc.create_transaction(
+            description="Utility Bill",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "120.50"},
+                {"account": "Assets:Checking", "amount": "-120.50"},
+            ],
+            trans_date=date(2026, 1, 15),
+            check_duplicates=False,
+        )
+        # Omit splits — force auto-fill.
+        result = gc.create_transaction(
+            description="Utility Bill",
+            trans_date=date(2026, 4, 1),
+            check_duplicates=False,
+        )
+        assert result["status"] == "created"
+        # The auto-fill source should be the real transaction, not
+        # the template. If it were the template, the created
+        # transaction's splits would point at template accounts
+        # (which would also throw balance-sheet reporting off).
+        # Verify by fetching the new transaction.
+        created = gc.get_transaction(result["guid"])
+        accounts = {s["account"] for s in created["splits"]}
+        # Template accounts have "Utility Bill Template" in their
+        # fullname; real transaction uses Expenses:Groceries /
+        # Assets:Checking.
+        assert not any("Template" in a for a in accounts), accounts
+        assert "Assets:Checking" in accounts
+        assert "Expenses:Groceries" in accounts
 
 
 class TestDuplicatesTsvShape:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1112,6 +1112,124 @@ class TestDuplicateDetection:
         assert "duplicates" not in result
 
 
+class TestDuplicateAmountPrimaryOnly:
+    """The amount signal compares the proposed transaction's primary
+    amount (max absolute split value) to each candidate's primary
+    amount — not any-to-any across every split pair.
+
+    Earlier iterations compared all proposed splits against all
+    candidate splits, which produced false-positive MEDIUM matches
+    on multi-split transactions whenever a tiny deduction happened
+    to land within ±$1 of some unrelated single-split transaction's
+    total. The bookkeeper's 2026-01-09 paycheck fired MEDIUM-AD
+    matches against two same-day coffee purchases ($5.67 Analog,
+    $5.29 Slate) because one of the paycheck's deduction lines was
+    in that ~$5 range — completely unrelated transactions,
+    meaninglessly flagged.
+
+    These tests pin the new behavior: multi-split transactions only
+    amount-match when their HEADLINE number (what a human reading
+    the register would call "the amount") lines up.
+    """
+
+    def test_paycheck_does_not_false_match_coffee(self, test_book: Path):
+        """Regression for the bookkeeper's -AD paycheck/coffee false
+        positive. A paycheck with a ~$5 deduction line and a
+        same-day coffee purchase near $5 must not surface as
+        duplicates of each other."""
+        gc = GnuCashBook(str(test_book))
+        # Seed Analog Coffee $5.67 on 2026-01-09.
+        gc.create_transaction(
+            description="Analog Coffee",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "5.67"},
+                {"account": "Assets:Checking", "amount": "-5.67"},
+            ],
+            trans_date=date(2026, 1, 9),
+            check_duplicates=False,
+        )
+        # Paycheck on the same day. Gross 3269.23, net 2141.84,
+        # deductions including a $5.65 line that's within $1 of the
+        # coffee's $5.67 total. The old any-to-any predicate would
+        # fire MEDIUM-AD; primary-max ignores deduction-tail
+        # coincidences.
+        result = gc.create_transaction(
+            description="Robin's Paycheck (UW Medical)",
+            splits=[
+                {"account": "Income:Salary", "amount": "-3269.23"},
+                {"account": "Assets:Checking", "amount": "2141.84"},
+                {"account": "Expenses:Groceries", "amount": "980.00"},
+                {"account": "Expenses:Groceries", "amount": "141.74"},
+                {"account": "Expenses:Groceries", "amount": "5.65"},
+            ],
+            trans_date=date(2026, 1, 9),
+            check_duplicates=True,
+        )
+        assert result["status"] == "created"
+        dups = _parse_duplicates(result.get("duplicates", ""))
+        # No coffee in the duplicate list — it would have shown up
+        # with signals "-AD" under the old predicate.
+        descriptions = [d["description"] for d in dups]
+        assert "Analog Coffee" not in descriptions
+
+    def test_paycheck_matches_paycheck(self, test_book: Path):
+        """The positive case: two paychecks with matching gross (the
+        primary amount on each side) still surface as duplicates.
+        Verifies primary-max didn't over-prune."""
+        gc = GnuCashBook(str(test_book))
+        # Seed an earlier paycheck with the same gross.
+        gc.create_transaction(
+            description="Robin's Paycheck (UW Medical)",
+            splits=[
+                {"account": "Income:Salary", "amount": "-3269.23"},
+                {"account": "Assets:Checking", "amount": "2141.84"},
+                {"account": "Expenses:Groceries", "amount": "1127.39"},
+            ],
+            trans_date=date(2025, 12, 26),
+            check_duplicates=False,
+        )
+        # Now create a same-gross paycheck two weeks later (same
+        # ±30d window, different date → D, A, not D → MEDIUM-DA-).
+        result = gc.create_transaction(
+            description="Robin's Paycheck (UW Medical)",
+            splits=[
+                {"account": "Income:Salary", "amount": "-3269.23"},
+                {"account": "Assets:Checking", "amount": "2141.84"},
+                {"account": "Expenses:Groceries", "amount": "1127.39"},
+            ],
+            trans_date=date(2026, 1, 9),
+            check_duplicates=True,
+        )
+        dups = _parse_duplicates(result.get("duplicates", ""))
+        assert any(
+            d["description"] == "Robin's Paycheck (UW Medical)"
+            and d["signals"] == "DA-"
+            for d in dups
+        )
+
+    def test_two_split_transactions_still_amount_match(
+        self, test_book: Path,
+    ):
+        """Two-split transactions (the common case) weren't touched by
+        this change — their primary amount IS their headline amount,
+        so near-match detection keeps working."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Weekly Groceries",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "150.99"},
+                {"account": "Assets:Checking", "amount": "-150.99"},
+            ],
+            # Existing fixture transaction is same-desc $150 on
+            # 2024-01-20; within ±$1 and ±2 days → HIGH.
+            trans_date=date(2024, 1, 20),
+        )
+        assert result["status"] == "rejected"
+        dups = _parse_duplicates(result["duplicates"])
+        assert dups[0]["confidence"] == "HIGH"
+        assert dups[0]["signals"] == "DAD"
+
+
 class TestDuplicatesTsvShape:
     """The ``duplicates`` response field is a newline-separated TSV
     string, not a list of dicts. Abe's bookkeeper thread parses it


### PR DESCRIPTION
## Summary

Three related fixes to the duplicate-detection and account-listing code, all stemming from bookkeeper observations on Alex's book. Wrapped together because they share a predicate (template-account filtering) and a test surface (the same fixtures and helpers).

### 1. Amount signal: primary-max vs primary-max (commit 4392d35)

Duplicate detection's amount signal was any-to-any across every split pair. On multi-split transactions (paychecks with 10+ deduction lines) this produced false-positive MEDIUM matches whenever a tiny deduction landed within ±$1 of an unrelated transaction's total. Bookkeeper's 2026-01-09 paycheck fired ``-AD`` matches against two same-day coffees because some ~$5 deduction line coincidentally matched each coffee's total. Now compares primary amounts only (max abs split value on each side). Displayed ``amount`` column is truthful again.

### 2. Hide scheduled-transaction template accounts from user-facing lookups (commit cf6f0b9)

GnuCash persists scheduled-transaction split templates as real Account rows under ``book.root_template``. ``list_accounts`` and ``get_account`` were leaking those GnuCash internals into the user's chart. New ``BaseGnuCashBook._template_account_guids`` helper walks the template subtree; ``_find_account`` and ``list_accounts`` filter it out. ``get_book_summary`` refactored to use the helper instead of its own inline version.

### 3. Exclude template-backed transactions from duplicate scan (commit 23b49e4)

Same class of leak, next layer down. GnuCash also persists each SX's split recipe as a real Transaction whose splits post to template accounts. Our duplicate scan was matching against them — bookkeeper's 2026-04-23 mortgage backfill returned ``D-D`` MEDIUM matches against a stale ``$2,485`` template row for every ``$2,850`` real payment. ``_collect_create_signals`` now skips transactions with any split in the template subtree, covering every bucket it fills: auto-fill, stability, duplicates, recent-matches.

## Test plan

- [x] ``uv run pytest`` — 770 passed (763 → 767 → 770 across the three commits, 10 new regressions total)
- [x] ``TestDuplicateAmountPrimaryOnly`` — 3 tests: paycheck/coffee no-false-match, paycheck/paycheck positive case, two-split common case
- [x] ``TestTemplateAccountsHidden`` — 4 tests: list_accounts hides templates (compact + verbose), get_account returns None, scheduled instantiation still works, root-filter doesn't leak templates
- [x] ``TestTemplateTransactionsExcluded`` — 3 tests: template never surfaces on fresh create (Abe's mortgage scenario), real transaction still matches when a template shares its description, auto-fill prefers real over template
- [ ] Abe live-verification on Alex's book: re-run the 2026-01-09 paycheck and the 2026-04-23 mortgage backfill; confirm only real matches surface, and list_accounts no longer shows template scaffolding