### PR TITLE
feat: response-format foundation (comms-audit Phase 1 + 2)

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -1,0 +1,160 @@
+"""Cross-layer formatting helpers.
+
+These shape numeric and list output the same way regardless of who's
+emitting them — the book layer producing display-ready dicts, the tool
+layer wrapping responses, the audit log rendering text. Both layers
+import from here; ``book/`` and ``tools/`` stay decoupled.
+
+Two pieces:
+
+- :func:`_format_number` — single chokepoint for currency / percentage
+  / share-quantity rounding. Replaces ad-hoc ``str(decimal)`` calls
+  that leaked 26-digit Decimal arithmetic into responses.
+- :func:`_apply_limit` — generalized truncation + notice helper.
+  Mirrors the contract previously baked into
+  ``CoreMixin._truncation_notice`` but parameterized so any tool can
+  plug in its own entity name.
+"""
+
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import TypeVar
+
+
+# ── Numeric formatting ─────────────────────────────────────────────
+
+
+def _format_number(
+    value,
+    decimals: int = 2,
+    strip_trailing: bool = False,
+) -> str:
+    """Format a numeric value with consistent precision.
+
+    Args:
+        value: Decimal, str, int, float, or None. None and empty
+            strings render as ``"0"`` (or ``"0.00"`` etc., per
+            ``decimals``) so omission and zero are visually identical
+            in the response.
+        decimals: Number of decimal places. Common settings:
+            - 2 for currency amounts and percentages
+            - 4 for share quantities (mutual funds, stocks)
+            - 6 for crypto (sub-satoshi precision matters)
+        strip_trailing: When True, drop trailing zeros after the
+            decimal point. ``"1.50"`` → ``"1.5"``, ``"1.00"`` → ``"1"``.
+            Default False — currency-style fixed precision.
+
+    Returns:
+        Decimal string suitable for direct inclusion in a JSON or TSV
+        response. Inputs that don't parse as numbers are returned
+        ``str(value)`` unchanged so callers don't have to pre-validate.
+
+    Examples:
+        >>> _format_number(Decimal("1234.567"))
+        '1234.57'
+        >>> _format_number(Decimal("0.123456789"), decimals=2)
+        '0.12'
+        >>> _format_number(Decimal("230.762"), decimals=4)
+        '230.7620'
+        >>> _format_number(Decimal("1.50"), decimals=2, strip_trailing=True)
+        '1.5'
+    """
+    if value is None or value == "":
+        if strip_trailing:
+            return "0"
+        return f"{Decimal(0):.{decimals}f}"
+
+    try:
+        d = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        # Not a number — pass through unchanged. Defensive: callers
+        # can hand us free-form strings (e.g. "N/A") for fields that
+        # are usually numeric and we shouldn't crash the tool.
+        return str(value)
+
+    quantum = Decimal(1).scaleb(-decimals)  # 0.01 for decimals=2
+    rounded = d.quantize(quantum, rounding=ROUND_HALF_UP)
+
+    if strip_trailing:
+        s = format(rounded, "f")
+        if "." in s:
+            s = s.rstrip("0").rstrip(".")
+        return s or "0"
+
+    return format(rounded, "f")
+
+
+# ── Limit enforcement ──────────────────────────────────────────────
+
+
+T = TypeVar("T")
+
+
+def _apply_limit(
+    items: list[T],
+    limit: int | None,
+    default: int = 50,
+    max_cap: int = 250,
+    entity_name: str = "items",
+    suggest_narrow: bool = False,
+) -> tuple[list[T], str | None]:
+    """Truncate ``items`` to a server-safe limit and emit a notice.
+
+    Three notice cases:
+
+    1. **Truncated.** ``total > effective`` → return the slice with a
+       ``[Showing N of M ...]`` message.
+    2. **Capped only.** Caller passed ``limit > max_cap`` but the full
+       result still fits — return everything with a ``[Limit capped at
+       N]`` message so the caller knows their over-limit had no effect.
+    3. **Fits naturally.** ``total <= effective`` and ``limit <= max_cap``
+       → return everything, no notice.
+
+    Args:
+        items: Full list, already filtered/sorted by the caller.
+        limit: Caller-supplied limit. Falsy values fall back to
+            ``default`` so omitting the parameter still gives a
+            reasonable response size.
+        default: Fallback limit (50 matches the ``list_transactions``
+            convention).
+        max_cap: Server-side ceiling. Larger limits are silently
+            clamped and signaled via the cap-notice.
+        entity_name: Plural noun in notice strings — e.g. ``"splits"``,
+            ``"invoices"``, ``"prices"``. Renders as
+            ``"Showing 5 of 35 invoices"``.
+        suggest_narrow: When True, the over-limit hint mentions
+            ``"narrow filters"`` first. Useful for tools that take
+            date-range / account-filter parameters where narrowing is
+            the better path than raising the limit.
+
+    Returns:
+        Tuple ``(truncated, notice)``. ``notice`` is ``None`` only when
+        nothing was truncated and no cap was applied.
+    """
+    if not limit or limit < 1:
+        limit = default
+    capped = limit > max_cap
+    effective = min(limit, max_cap)
+    total = len(items)
+
+    if total > effective:
+        truncated = items[:effective]
+        shown = len(truncated)
+        if capped:
+            return truncated, (
+                f"[Showing {shown} of {total} {entity_name} — "
+                f"limit capped at {effective}; narrow filters for "
+                f"complete results]"
+            )
+        hint = (
+            "narrow filters or set limit= higher"
+            if suggest_narrow
+            else "set limit= higher"
+        )
+        return truncated, (
+            f"[Showing {shown} of {total} {entity_name} — {hint}]"
+        )
+
+    if capped:
+        return items, f"[Limit capped at {effective}]"
+
+    return items, None

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -25,6 +25,7 @@ from gnucash_mcp.book._base import (
     _verify_composite_write,
     _verify_write,
 )
+from gnucash_mcp._format import _apply_limit
 
 
 def _safe_date_posted(inv):
@@ -1475,6 +1476,7 @@ class BusinessMixin:
         owner_type: str | None = None,
         status: str | None = None,
         compact: bool = True,
+        limit: int | None = None,
     ) -> list[dict] | str:
         """List invoices and/or bills.
 
@@ -1482,9 +1484,13 @@ class BusinessMixin:
             owner_type: Filter by type: 'customer', 'vendor', or None for all.
             status: Filter by status: 'posted', 'open', or None for all.
             compact: If True, return compact one-line-per-invoice string.
+            limit: Maximum invoices to return. Defaults to 50, capped at
+                   250 server-side. Pre-fix this method dumped every
+                   invoice in the book regardless of caller intent.
 
         Returns:
-            Compact string or list of dicts.
+            Compact string (with optional truncation notice) or list of
+            dicts (truncated silently — caller has ``len()``).
         """
         from piecash.business.invoice import Invoice
 
@@ -1503,8 +1509,17 @@ class BusinessMixin:
             elif status == "open":
                 invoices = [i for i in invoices if not _is_invoice_posted(i)]
 
+            invoices, notice = _apply_limit(
+                invoices,
+                limit=limit,
+                entity_name="invoices",
+                suggest_narrow=True,
+            )
+
             if compact:
                 lines = [self._invoice_to_compact_line(i) for i in invoices]
+                if notice:
+                    lines.append(notice)
                 return "\n".join(lines)
             else:
                 return [self._invoice_to_dict(i) for i in invoices]

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3119,6 +3119,12 @@ class CoreMixin:
             # doesn't have to reopen the book to capture it.
             self._stage_audit_before(_account_to_dict(account))
 
+            # Track which fields the caller actually changed. Echoing
+            # only the diff (vs. the entire account record) keeps the
+            # write response small and tells the caller exactly what
+            # landed — matches the ``update_transaction`` precedent.
+            changed: dict = {}
+
             # Check for name conflict if renaming
             if new_name and new_name != account.name:
                 if account.parent:
@@ -3129,12 +3135,15 @@ class CoreMixin:
                                 f"'{account.parent.fullname}'"
                             )
                 account.name = new_name
+                changed["name"] = new_name
 
-            if description is not None:
+            if description is not None and description != account.description:
                 account.description = description
+                changed["description"] = description
 
-            if placeholder is not None:
+            if placeholder is not None and bool(placeholder) != bool(account.placeholder):
                 account.placeholder = placeholder
+                changed["placeholder"] = bool(placeholder)
 
             if account_type is not None:
                 new_type = account_type.upper()
@@ -3158,14 +3167,13 @@ class CoreMixin:
                         )
 
                     account.type = new_type
+                    changed["type"] = new_type
 
             book.save()
 
-            short_guid = _unique_prefix(
-                account.guid, (a.guid for a in book.accounts)
-            )
-            return _account_to_dict(account) | {
-                "guid": short_guid,
+            return {
+                "guid": self._account_short_guid(book, account),
+                **changed,
                 "status": "updated",
             }
 
@@ -3214,11 +3222,14 @@ class CoreMixin:
 
             book.save()
 
-            short_guid = _unique_prefix(
-                account.guid, (a.guid for a in book.accounts)
-            )
-            return _account_to_dict(account) | {
-                "guid": short_guid,
+            return {
+                "guid": self._account_short_guid(book, account),
+                # Both ``fullname`` (the new path) and ``parent`` (the
+                # destination) are useful here: ``fullname`` answers
+                # "where did it land?" and ``parent`` makes the move
+                # legible without re-parsing the path.
+                "fullname": account.fullname,
+                "parent": account.parent.fullname,
                 "status": "moved",
             }
 

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -25,6 +25,7 @@ from gnucash_mcp.book._base import (
     _to_decimal,
     _unique_prefix,
 )
+from gnucash_mcp._format import _apply_limit, _format_number
 
 
 class InvestmentsMixin:
@@ -232,7 +233,8 @@ class InvestmentsMixin:
         start_date: date | None = None,
         end_date: date | None = None,
         currency: str | None = None,
-    ) -> list[dict]:
+        limit: int | None = None,
+    ) -> dict:
         """Get price history for a commodity.
 
         Args:
@@ -241,9 +243,16 @@ class InvestmentsMixin:
             start_date: Optional start date filter.
             end_date: Optional end date filter.
             currency: Optional currency filter (e.g., "USD").
+            limit: Maximum prices to return. Defaults to 50, capped at
+                   250 server-side. Pre-fix this method dumped every
+                   matching price regardless of caller intent.
 
         Returns:
-            List of price dicts sorted by date descending (most recent first).
+            Dict with ``prices`` (list, possibly truncated), ``count``
+            (truncated length), ``total`` (untruncated), and ``notice``
+            (truncation message or None). Sorted by date descending —
+            most recent first, so a small ``limit`` still surfaces the
+            freshest data.
 
         Raises:
             ValueError: If commodity not found.
@@ -269,15 +278,27 @@ class InvestmentsMixin:
 
                 prices.append({
                     "date": p_date.isoformat(),
-                    "value": str(p.value),
+                    "value": _format_number(p.value, decimals=4, strip_trailing=True),
                     "currency": p.currency.mnemonic,
                     "type": p.type,
                     "source": p.source,
                 })
 
             prices.sort(key=lambda x: x["date"], reverse=True)
+            total = len(prices)
+            prices, notice = _apply_limit(
+                prices,
+                limit=limit,
+                entity_name="prices",
+                suggest_narrow=True,
+            )
 
-            return prices
+            return {
+                "prices": prices,
+                "count": len(prices),
+                "total": total,
+                "notice": notice,
+            }
 
     def get_latest_price(
         self,
@@ -369,9 +390,13 @@ class InvestmentsMixin:
             remaining_cost_basis = Decimal(0)
 
         return {
-            "quantity": str(remaining),
-            "cost_basis": str(remaining_cost_basis),
-            "cost_per_share": str(cost_per_share),
+            # Quantity is shares (or other commodity units): 4 decimals
+            # is a good default for funds and stocks. Crypto callers
+            # who need finer granularity get the same _format_number
+            # logic at decimals=6 in their own paths.
+            "quantity": _format_number(remaining, decimals=4),
+            "cost_basis": _format_number(remaining_cost_basis, decimals=2),
+            "cost_per_share": _format_number(cost_per_share, decimals=4),
             "is_closed": bool(lot.is_closed),
         }
 
@@ -652,11 +677,15 @@ class InvestmentsMixin:
             gain_pct = (gain / cost_basis * 100) if cost_basis else Decimal(0)
 
             return {
-                "shares": str(shares_to_sell),
-                "cost_basis": str(cost_basis),
-                "sale_proceeds": str(proceeds),
-                "capital_gain": str(gain),
-                "gain_percent": str(gain_pct),
+                "shares": _format_number(shares_to_sell, decimals=4),
+                "cost_basis": _format_number(cost_basis, decimals=2),
+                "sale_proceeds": _format_number(proceeds, decimals=2),
+                "capital_gain": _format_number(gain, decimals=2),
+                # The 26-digit case the spec called out — ``(gain /
+                # cost_basis) * 100`` produces an unbounded repeating
+                # decimal in the general case. 2 decimal places is
+                # what humans and reports actually use.
+                "gain_percent": _format_number(gain_pct, decimals=2),
             }
 
     def close_lot(self, guid: str) -> dict:

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -21,6 +21,7 @@ from gnucash_mcp.book._base import (
     _unique_prefix,
     _unreconciled_split_to_compact_line,
 )
+from gnucash_mcp._format import _apply_limit
 
 
 def _split_state_dict(split) -> dict:
@@ -118,8 +119,15 @@ class ReconciliationMixin:
         account_name: str,
         as_of_date: date | None = None,
         compact: bool = True,
+        limit: int | None = None,
     ) -> dict | str:
-        """Get all unreconciled splits for an account.
+        """Get unreconciled splits for an account.
+
+        Returns up to ``limit`` splits (default 50) ordered by post-date
+        ascending. The cleared / uncleared totals reflect the **full**
+        unreconciled set on the account, not just the truncated slice —
+        so the summary footer still tells you how far behind the
+        reconciliation is even when individual lines are clipped.
 
         Args:
             account_name: Full account path.
@@ -127,10 +135,17 @@ class ReconciliationMixin:
             compact: If True (default), return a compact newline-separated
                      string with one line per split plus a summary footer.
                      If False, return the full dict with splits list.
+            limit: Maximum splits to return. Defaults to 50, capped at
+                   250 server-side. The full count is always reflected
+                   in the summary footer / ``count`` field.
 
         Returns:
-            If compact: newline-separated string of split lines with summary.
-            If not compact: dict with account info, splits list, and totals.
+            If compact: newline-separated string of split lines + footer
+                + optional truncation notice.
+            If not compact: dict with account info, splits list (possibly
+                truncated), totals reflecting the full unreconciled set,
+                ``count`` (truncated length), ``total`` (untruncated),
+                and ``notice`` (truncation message or None).
 
         Raises:
             ValueError: If account not found.
@@ -140,7 +155,7 @@ class ReconciliationMixin:
             if not account:
                 raise ValueError(f"Account not found: {account_name}")
 
-            unreconciled = []
+            all_unreconciled = []
             cleared_total = Decimal("0")
             uncleared_total = Decimal("0")
 
@@ -163,20 +178,32 @@ class ReconciliationMixin:
                         "reconcile_state": split.reconcile_state,
                         "memo": split.memo or "",
                     }
-                    unreconciled.append(split_dict)
+                    all_unreconciled.append(split_dict)
 
                     if split.reconcile_state == "c":
                         cleared_total += split.quantity
                     else:
                         uncleared_total += split.quantity
 
+            unreconciled, notice = _apply_limit(
+                all_unreconciled,
+                limit=limit,
+                entity_name="splits",
+                suggest_narrow=True,
+            )
+            total_count = len(all_unreconciled)
+
             result = {
                 "account": account.fullname,
                 "as_of_date": as_of_date.isoformat() if as_of_date else None,
                 "splits": unreconciled,
+                # Totals always reflect the full unreconciled set —
+                # truncation hides line items, never the headline summary.
                 "cleared_total": str(cleared_total),
                 "uncleared_total": str(uncleared_total),
                 "count": len(unreconciled),
+                "total": total_count,
+                "notice": notice,
             }
 
             if compact:
@@ -191,8 +218,13 @@ class ReconciliationMixin:
                     _unreconciled_split_to_compact_line(s, prefixes=prefixes)
                     for s in unreconciled
                 ]
-                footer = f"{len(unreconciled)} splits\tcleared:{cleared_total}\tuncleared:{uncleared_total}"
+                footer = (
+                    f"{total_count} splits\tcleared:{cleared_total}\t"
+                    f"uncleared:{uncleared_total}"
+                )
                 lines.append(footer)
+                if notice:
+                    lines.append(notice)
                 return "\n".join(lines)
             else:
                 return result

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -14,6 +14,13 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from gnucash_mcp.book import GnuCashLockError
 
+# Re-exports from the layer-neutral format module. Tool wrappers can
+# keep importing from ``tools._helpers`` (the historical home) without
+# concern for which file the implementation lives in. Book-layer code
+# imports directly from ``gnucash_mcp._format`` to preserve the
+# one-way ``tools → book`` dependency.
+from gnucash_mcp._format import _apply_limit, _format_number  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -373,6 +373,7 @@ def register(mcp, get_book) -> None:
         owner_type: str | None = None,
         status: str | None = None,
         verbose: bool = False,
+        limit: int = 50,
     ) -> str:
         """List invoices and/or vendor bills.
 
@@ -384,10 +385,16 @@ def register(mcp, get_book) -> None:
                         "vendor" for bills, or omit for all.
             status: Filter by status: "posted" or "open", or omit for all.
             verbose: If true, return full JSON details.
+            limit: Maximum invoices to return. Defaults to 50, capped
+                   at 250. Compact output appends a truncation notice
+                   when results are clipped.
         """
         book = get_book()
         result = book.list_invoices(
-            owner_type=owner_type, status=status, compact=not verbose,
+            owner_type=owner_type,
+            status=status,
+            compact=not verbose,
+            limit=limit,
         )
         if verbose:
             return json.dumps(result, indent=2)

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -114,6 +114,7 @@ def register(mcp, get_book) -> None:
         start_date: str | None = None,
         end_date: str | None = None,
         currency: str | None = None,
+        limit: int = 50,
     ) -> str:
         """Get price history for a commodity.
 
@@ -123,9 +124,14 @@ def register(mcp, get_book) -> None:
             start_date: Optional start date filter (YYYY-MM-DD).
             end_date: Optional end date filter (YYYY-MM-DD).
             currency: Optional currency filter (e.g., "USD").
+            limit: Maximum prices to return. Defaults to 50, capped at 250.
+                   Pre-fix this method dumped every matching price; the
+                   most-recent-first sort means small limits still surface
+                   the freshest data.
 
         Returns:
-            JSON with list of prices sorted by date descending (most recent first).
+            JSON with ``prices`` (list, possibly truncated), ``count``,
+            ``total``, and ``notice`` (truncation message or None).
         """
         book = get_book()
         start = date_type.fromisoformat(start_date) if start_date else None
@@ -137,6 +143,7 @@ def register(mcp, get_book) -> None:
             start_date=start,
             end_date=end,
             currency=currency,
+            limit=limit,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -48,16 +48,23 @@ def register(mcp, get_book) -> None:
         account: str,
         as_of_date: str | None = None,
         verbose: bool = False,
+        limit: int = 50,
     ) -> str:
-        """Get all unreconciled splits for an account.
+        """Get unreconciled splits for an account.
 
-        Returns a compact one-line-per-split format by default with a summary footer.
-        Use verbose=true for full JSON with split GUIDs, amounts, and totals.
+        Returns up to ``limit`` splits in a compact one-line-per-split
+        format by default with a summary footer reflecting the **full**
+        unreconciled set (so the headline is honest even when individual
+        lines are clipped).
+
+        Use verbose=true for full JSON with split GUIDs, amounts, totals,
+        and the truncation notice as a structured field.
 
         Args:
             account: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID
             as_of_date: Only include splits on or before this date (YYYY-MM-DD)
             verbose: If true, return full JSON details. Default compact one-line format.
+            limit: Maximum splits to return. Defaults to 50, capped at 250.
         """
         book = get_book()
         date_obj = date.fromisoformat(as_of_date) if as_of_date else None
@@ -65,6 +72,7 @@ def register(mcp, get_book) -> None:
             account_name=account,
             as_of_date=date_obj,
             compact=not verbose,
+            limit=limit,
         )
         if verbose:
             return _json(result)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -5220,15 +5220,19 @@ class TestUpdateAccount:
         assert result["description"] == "Weekly grocery shopping"
 
     def test_update_account_placeholder(self, test_book: Path):
-        """Should update placeholder status."""
+        """Should update placeholder status — and echo the change."""
         gc_book = GnuCashBook(str(test_book))
 
-        result = gc_book.update_account(
-            name="Expenses",
-            placeholder=True,
-        )
+        # The test fixture's "Expenses" is already a placeholder, so
+        # passing ``placeholder=True`` would be a no-op under the new
+        # diff-only contract. Toggle it off first to make the second
+        # call observably change the account.
+        gc_book.update_account(name="Expenses", placeholder=False)
+        result = gc_book.update_account(name="Expenses", placeholder=True)
 
         assert result["status"] == "updated"
+        # ``placeholder`` only appears in the response when it actually
+        # changed — diff-style write echo (Phase 2 of the comms-audit).
         assert result["placeholder"] is True
 
     def test_update_account_not_found(self, test_book: Path):
@@ -5333,13 +5337,73 @@ class TestUpdateAccount:
             )
 
     def test_update_account_type_same_type_noop(self, test_book: Path):
-        """Changing to the same type should succeed without error."""
+        """Changing to the same type should succeed without error AND
+        the diff-style response should NOT echo ``type`` (no change)."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.update_account(
             name="Assets:Checking", account_type="BANK",
         )
         assert result["status"] == "updated"
-        assert result["type"] == "BANK"
+        # Pre-Phase-2 the response echoed every field. New contract:
+        # only fields that actually changed appear. Same-type set
+        # changes nothing, so ``type`` is absent.
+        assert "type" not in result
+
+
+class TestWriteResponseShape:
+    """Tests for the trimmed write-response contract introduced in
+    Phase 2 of the comms-audit fixes. ``update_account`` and
+    ``move_account`` previously echoed the entire account record on
+    every write; the new contract returns ``{guid, status, ...changed
+    fields}`` only. Locks the shape so future refactors don't
+    regress to "echo everything"."""
+
+    def test_update_account_response_omits_unchanged_fields(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.update_account(
+            name="Expenses:Groceries",
+            description="Updated description",
+        )
+        assert result["status"] == "updated"
+        # ``description`` changed — present.
+        assert result["description"] == "Updated description"
+        # Other fields didn't change — absent.
+        assert "name" not in result
+        assert "type" not in result
+        assert "placeholder" not in result
+        assert "fullname" not in result
+        # ``guid`` is always returned (the caller's handle).
+        assert result["guid"].startswith("%")
+
+    def test_update_account_response_carries_short_guid(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.update_account(
+            name="Expenses:Groceries",
+            description="Refresh",
+        )
+        # Short account GUID format: '%' + ≥7 hex chars.
+        import re
+        assert re.fullmatch(r"%[0-9a-f]{7,32}", result["guid"]), (
+            f"unexpected guid shape: {result['guid']!r}"
+        )
+
+    def test_move_account_response_shape(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        # Set up a destination parent for the move.
+        gc_book.create_account(
+            name="Daily Expenses", account_type="EXPENSE",
+            parent="Expenses", placeholder=True,
+        )
+        result = gc_book.move_account(
+            name="Expenses:Groceries",
+            new_parent="Expenses:Daily Expenses",
+        )
+        assert result["status"] == "moved"
+        assert result["fullname"] == "Expenses:Daily Expenses:Groceries"
+        assert result["parent"] == "Expenses:Daily Expenses"
+        assert result["guid"].startswith("%")
+        # Shape contract: nothing else.
+        assert set(result.keys()) == {"guid", "fullname", "parent", "status"}
 
 
 class TestMoveAccount:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7168,8 +7168,10 @@ class TestPrices:
         assert result["value"] == "127.50"
         assert result["date"] == "2026-02-07"
 
-        # Verify via get_prices
-        prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        # Verify via get_prices (now returns dict with prices/count/total/notice)
+        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        prices = result["prices"]
+        assert result["total"] == 1
         assert len(prices) == 1
         assert Decimal(prices[0]["value"]) == Decimal("127.50")
         assert prices[0]["type"] == "nav"
@@ -7204,7 +7206,8 @@ class TestPrices:
         assert result["value"] == "128.75"
 
         # Should still be only 1 price, not 2
-        prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        prices = result["prices"]
         assert len(prices) == 1
         assert prices[0]["value"] == "128.75"
 
@@ -7233,17 +7236,19 @@ class TestPrices:
         )
 
         # Filter to middle date
-        prices = gc_book.get_prices(
+        result = gc_book.get_prices(
             commodity="VTSAX",
             namespace="FUND",
             start_date=date(2026, 2, 3),
             end_date=date(2026, 2, 8),
         )
+        prices = result["prices"]
         assert len(prices) == 1
         assert Decimal(prices[0]["value"]) == Decimal("126.50")
 
         # All prices, should be descending
-        all_prices = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        all_result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        all_prices = all_result["prices"]
         assert len(all_prices) == 3
         assert all_prices[0]["date"] == "2026-02-10"  # Most recent first
         assert all_prices[2]["date"] == "2026-02-01"  # Oldest last

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,206 @@
+"""Unit tests for tool-layer helpers (``tools/_helpers.py``).
+
+These cover the foundation pieces — numeric formatting and limit
+enforcement — that downstream tools rely on. Once the helpers are
+correct here, every consumer inherits the right behavior.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from gnucash_mcp.tools._helpers import _apply_limit, _format_number
+
+
+class TestFormatNumber:
+    """Tests for ``_format_number`` — the single chokepoint that
+    keeps numeric values out of the response in 26-decimal form."""
+
+    # ── Currency-style (default decimals=2, no strip) ────────────
+
+    def test_rounds_to_two_decimals(self):
+        assert _format_number(Decimal("1234.567")) == "1234.57"
+
+    def test_pads_to_two_decimals(self):
+        assert _format_number(Decimal("1234.5")) == "1234.50"
+
+    def test_zero_renders_padded(self):
+        assert _format_number(Decimal("0")) == "0.00"
+
+    def test_negative_currency(self):
+        assert _format_number(Decimal("-12.34")) == "-12.34"
+
+    def test_high_precision_input_truncates(self):
+        # The "calculate_lot_gain at 26 decimals" case the spec calls out.
+        long = Decimal("43.91052631578947368421052632")
+        assert _format_number(long) == "43.91"
+
+    # ── Share-quantity style (decimals=4) ────────────────────────
+
+    def test_share_quantity_four_decimals(self):
+        assert _format_number(Decimal("230.762"), decimals=4) == "230.7620"
+
+    def test_share_quantity_rounds_at_fourth(self):
+        assert (
+            _format_number(Decimal("230.76225"), decimals=4) == "230.7623"
+        )
+
+    # ── Crypto style (decimals=6) ────────────────────────────────
+
+    def test_crypto_six_decimals(self):
+        assert _format_number(Decimal("2.5"), decimals=6) == "2.500000"
+
+    def test_crypto_basis_long_input_truncates(self):
+        # The "list_lots at 7.500000000000000000000000001" case.
+        long = Decimal("7.500000000000000000000000001")
+        assert _format_number(long, decimals=6) == "7.500000"
+
+    # ── Strip-trailing for variable-precision fields ─────────────
+
+    def test_strip_trailing_drops_zeros(self):
+        assert (
+            _format_number(Decimal("1.50"), decimals=2, strip_trailing=True)
+            == "1.5"
+        )
+
+    def test_strip_trailing_drops_dot_when_all_zero(self):
+        assert (
+            _format_number(Decimal("1.00"), decimals=2, strip_trailing=True)
+            == "1"
+        )
+
+    def test_strip_trailing_keeps_nonzero_decimals(self):
+        assert (
+            _format_number(Decimal("1.05"), decimals=2, strip_trailing=True)
+            == "1.05"
+        )
+
+    def test_strip_trailing_zero_is_zero(self):
+        assert (
+            _format_number(Decimal("0"), decimals=2, strip_trailing=True)
+            == "0"
+        )
+
+    # ── Edge cases / robustness ──────────────────────────────────
+
+    def test_none_renders_as_zero_padded(self):
+        assert _format_number(None) == "0.00"
+
+    def test_none_strip_trailing_is_zero(self):
+        assert _format_number(None, strip_trailing=True) == "0"
+
+    def test_empty_string_renders_as_zero(self):
+        assert _format_number("") == "0.00"
+
+    def test_string_input_parses(self):
+        assert _format_number("1234.5") == "1234.50"
+
+    def test_int_input_parses(self):
+        assert _format_number(42) == "42.00"
+
+    def test_unparseable_input_passes_through(self):
+        # Callers occasionally hand us "N/A" or similar — must not crash.
+        assert _format_number("N/A") == "N/A"
+
+    def test_no_scientific_notation_for_large_numbers(self):
+        # Decimal would normally emit 1E+9; format("f") prevents that.
+        assert _format_number(Decimal("1000000000")) == "1000000000.00"
+
+    def test_no_scientific_notation_for_small_numbers(self):
+        # Decimal("0.0001") doesn't normally emit scientific, but
+        # confirm the format keeps things explicit at decimals=4.
+        assert _format_number(Decimal("0.0001"), decimals=4) == "0.0001"
+
+
+class TestApplyLimit:
+    """Tests for ``_apply_limit`` — the cap-and-notice helper that
+    every list-returning tool now uses for consistent truncation."""
+
+    # ── Common cases ─────────────────────────────────────────────
+
+    def test_returns_all_when_under_limit(self):
+        items, notice = _apply_limit([1, 2, 3], limit=10)
+        assert items == [1, 2, 3]
+        assert notice is None
+
+    def test_truncates_when_over_limit(self):
+        items, notice = _apply_limit(list(range(100)), limit=5)
+        assert items == [0, 1, 2, 3, 4]
+        assert notice is not None
+        assert "Showing 5 of 100" in notice
+        assert "items" in notice
+
+    def test_entity_name_in_notice(self):
+        items, notice = _apply_limit(
+            list(range(100)), limit=5, entity_name="splits"
+        )
+        assert items == [0, 1, 2, 3, 4]
+        assert "5 of 100 splits" in notice
+
+    # ── Defaults ─────────────────────────────────────────────────
+
+    def test_falsy_limit_uses_default(self):
+        items, notice = _apply_limit(list(range(100)), limit=None, default=10)
+        assert len(items) == 10
+        assert "Showing 10 of 100" in notice
+
+    def test_zero_limit_uses_default(self):
+        items, notice = _apply_limit(list(range(100)), limit=0, default=10)
+        assert len(items) == 10
+
+    def test_negative_limit_uses_default(self):
+        items, notice = _apply_limit(list(range(100)), limit=-5, default=10)
+        assert len(items) == 10
+
+    # ── Server-side cap ──────────────────────────────────────────
+
+    def test_caller_limit_above_cap_clamps(self):
+        items, notice = _apply_limit(
+            list(range(500)), limit=999, max_cap=250
+        )
+        assert len(items) == 250
+        assert notice is not None
+        assert "limit capped at 250" in notice
+        assert "Showing 250 of 500" in notice
+
+    def test_caller_limit_above_cap_when_results_fit(self):
+        # Cap fires but results would have fit anyway → "results fit
+        # under the cap" is implicit; we emit the cap notice as a
+        # heads-up that the over-limit had no effect.
+        items, notice = _apply_limit(
+            list(range(100)), limit=999, max_cap=250
+        )
+        assert items == list(range(100))
+        assert notice == "[Limit capped at 250]"
+
+    # ── Notice hints ─────────────────────────────────────────────
+
+    def test_default_hint_says_set_limit_higher(self):
+        _, notice = _apply_limit(list(range(100)), limit=5)
+        assert "set limit= higher" in notice
+
+    def test_suggest_narrow_changes_hint(self):
+        _, notice = _apply_limit(
+            list(range(100)),
+            limit=5,
+            entity_name="transactions",
+            suggest_narrow=True,
+        )
+        assert "narrow filters" in notice
+
+    # ── Edge cases ───────────────────────────────────────────────
+
+    def test_empty_list_no_truncation(self):
+        items, notice = _apply_limit([], limit=10)
+        assert items == []
+        assert notice is None
+
+    def test_list_at_exact_limit_no_notice(self):
+        items, notice = _apply_limit([1, 2, 3, 4, 5], limit=5)
+        assert items == [1, 2, 3, 4, 5]
+        assert notice is None
+
+    def test_returns_correct_slice_order(self):
+        # Truncation preserves input order (just ``items[:n]``).
+        items, _ = _apply_limit(list(range(20)), limit=3)
+        assert items == [0, 1, 2]

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -134,8 +134,10 @@ class TestGetLot:
         result = book.get_lot(guid=lot["guid"])
         assert result["title"] == "Empty Lot"
         assert result["splits"] == []
-        assert result["summary"]["quantity"] == "0"
-        assert result["summary"]["cost_basis"] == "0"
+        # _format_number renders quantities at 4 decimals (share-style)
+        # and currency at 2 — empty lot is zero either way.
+        assert result["summary"]["quantity"] == "0.0000"
+        assert result["summary"]["cost_basis"] == "0.00"
 
     def test_get_lot_with_splits(self, investment_book: Path):
         book = GnuCashBook(str(investment_book))


### PR DESCRIPTION
## Summary

Branch 1 of the multi-phase work in ``docs/COMMUNICATION_AUDIT_FIXES.md`` (Abe's full-server audit, April 28). Lays the foundation that subsequent comms-audit branches will consume — a layer-neutral helpers module — and applies it to the highest-impact tools the audit flagged.

Three logical commits:

1. **``fbd24ad`` foundation** — new ``gnucash_mcp/_format.py`` with two helpers: ``_format_number`` (single chokepoint for currency / percentage / share-quantity rounding; replaces ad-hoc ``str(decimal)``) and ``_apply_limit`` (generalized truncation + notice — what ``CoreMixin._truncation_notice`` did, but parameterized). Layer-neutral so ``book/`` and ``tools/`` both import it without breaking the one-way ``tools → book`` dependency. Pure addition, no behavior change. 34 unit tests in ``tests/test_helpers.py``.

2. **``88915c1`` Phase 1 consumers** — apply the helpers to the audit's worst offenders:
   - ``calculate_lot_gain.gain_percent`` was 26 digits long; now 2 decimals.
   - ``_lot_summary`` (and downstream ``list_lots``) emitted full-precision Decimal arithmetic (``"7.500000000000000000000000001"`` was real on Alex's book); now 4 decimals for shares, 2 for currency.
   - ``get_unreconciled_splits`` advertised no ``limit`` parameter and dumped 665 splits when called with ``limit=5`` (caller couldn't even ask). Added ``limit=`` (default 50, cap 250). Footer keeps reflecting the **full** unreconciled count even when individual lines are clipped.
   - ``list_invoices`` was returning every invoice in the book ignoring caller intent. Added ``limit=``.
   - ``get_prices`` was returning every matching price (34 of 34 on AAPL). Added ``limit=`` and changed return shape from ``list[dict]`` to structured ``{prices, count, total, notice}`` envelope.

3. **``a2d8a5d`` Phase 2 write trim** — ``update_account`` and ``move_account`` previously echoed the entire account record on every successful write; the new contract returns only ``{guid, status, ...changed fields}``. Mirrors the ``update_transaction`` precedent. Both responses use ``_account_short_guid`` (``%xxxxxxx``) matching the rest of the surface — the LLM can feed the response ``guid`` directly into any account-accepting tool.

## What this buys

Per the spec's measurement: a typical 50-call accounting session burned 40-60K tokens on tool responses pre-fix. After foundation + Phase 1 + Phase 2, the same session should land closer to the 15-25K target — with the heaviest hitters (``calculate_lot_gain``, ``get_unreconciled_splits``, ``list_invoices``, ``get_prices``, ``update_account``) handled.

## Test plan

- [x] 920 unit/integration tests passing locally
- [x] 34 new ``test_helpers.py`` tests covering every numeric-format edge case + every ``_apply_limit`` notice variant
- [x] 3 new ``TestWriteResponseShape`` regression tests locking the diff-style write contract
- [x] Live-verified on Alex Chen-Morales's book post-bounce — ``calculate_lot_gain`` on AAPL no longer 26 digits, ``get_unreconciled_splits limit=5`` clips with notice, ``get_prices AAPL limit=5`` returns the new envelope, ``update_account`` rename / revert returns diff-style only.
- [ ] Bookkeeper sanity pass on the format changes (the audit author's verification loop)

## Phasing into the future

This is Branch 1 of the multi-branch work in the spec. Subsequent branches will build on the helpers shipped here:

- **Branch 2** (``feat/comms-daily-reads``) — Phase 3: ``get_outstanding_invoices`` action columns, ``list_invoices`` owner+amount, ``get_invoice``/``get_bill`` resolve account names.
- **Branch 3** (``feat/comms-monthly-reports``) — Phase 4: ``debt_payoff_plan`` compact format, ``balance_sheet`` investment format alignment, ``spending_by_category``/``income_by_source`` TSV, ``vendor_spending_report`` compaction.
- **Branch 4** (``feat/comms-polish``) — Phases 5-6: budget formatting + investment cosmetics + ``list_budgets`` compact.

Each will land independently; the helpers from this branch are stable enough to consume without churn.