### PR TITLE
feat: comms-audit Phase 3 daily reads (action columns + readable refs)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -14,7 +14,7 @@ in the ORM). All raw inserts are paired with `_verify_write` /
 `_verify_composite_write` from _base.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 import piecash
@@ -572,6 +572,98 @@ class BusinessMixin:
         for split in lot.splits:
             total += Decimal(str(split.value))
         return total
+
+    @staticmethod
+    def _resolve_invoice_due_date(
+        book, inv,
+    ) -> tuple[date | None, bool]:
+        """Resolve an invoice/bill due date through three sources.
+
+        Returns ``(due_date, no_terms_flag)``. ``due_date`` is ``None``
+        when the invoice isn't posted yet. ``no_terms_flag`` is True
+        when the 30-day default was used (so callers can annotate the
+        rendering as approximated).
+
+        Resolution order — first source that resolves wins:
+
+        1. ``trans-date-due`` slot on the posting transaction. Present
+           only when the user explicitly passed ``due_date`` to
+           ``post_invoice``.
+        2. ``Invoice.terms`` reference. Present when the user posted
+           with a billterm (e.g., "Net 30"). Read raw via SQL because
+           ``inv.terms`` exposes a relationship that's reliable only
+           through specific paths; raw SQL matches the pattern used
+           elsewhere in this codebase for slot-style reads. The
+           billterm's ``duedays`` is added to ``date_posted``.
+        3. 30-day default. Anchors the days count to the assumption.
+           Callers should annotate any "overdue" rendering as
+           approximated when this branch fires.
+
+        This helper exists so the warnings collector and
+        ``get_outstanding_invoices`` produce identical due-date math.
+        Without it the two were diverging — warnings used the full
+        three-step chain, ``get_outstanding_invoices`` had nothing.
+        """
+        from sqlalchemy import text
+
+        if not _is_invoice_posted(inv):
+            return None, False
+
+        txn = inv.post_txn
+        if txn is None:
+            return None, False
+
+        # Step 1: explicit due-date slot.
+        row = book.session.execute(
+            text(
+                "SELECT gdate_val FROM slots "
+                "WHERE obj_guid = :guid "
+                "AND name = 'trans-date-due'"
+            ),
+            {"guid": txn.guid},
+        ).first()
+        if row and row[0]:
+            gdate_val = row[0]
+            if isinstance(gdate_val, str):
+                return date.fromisoformat(gdate_val[:10]), False
+            if isinstance(gdate_val, datetime):
+                return gdate_val.date(), False
+            return gdate_val, False
+
+        # Step 2: billterm via the raw ``terms`` column.
+        try:
+            terms_row = book.session.execute(
+                text(
+                    "SELECT terms FROM invoices "
+                    "WHERE guid = :guid"
+                ),
+                {"guid": inv.guid},
+            ).first()
+            term_guid = terms_row[0] if terms_row else None
+            if term_guid:
+                from piecash.business.invoice import Billterm
+
+                bt = (
+                    book.session.query(Billterm)
+                    .filter_by(guid=term_guid)
+                    .first()
+                )
+                if bt and bt.duedays:
+                    posted = inv.date_posted
+                    if isinstance(posted, datetime):
+                        posted = posted.date()
+                    return (
+                        posted + timedelta(days=int(bt.duedays)),
+                        False,
+                    )
+        except Exception:
+            pass
+
+        # Step 3: 30-day default. Annotate.
+        posted = inv.date_posted
+        if isinstance(posted, datetime):
+            posted = posted.date()
+        return posted + timedelta(days=30), True
 
     def _get_invoice_entries_and_total(self, book, inv):
         """Query entries for an invoice/bill and compute total.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1721,6 +1721,7 @@ class BusinessMixin:
             elif status == "open":
                 invoices = [i for i in invoices if not _is_invoice_posted(i)]
 
+            total = len(invoices)
             invoices, notice = _apply_limit(
                 invoices,
                 limit=limit,
@@ -1748,7 +1749,20 @@ class BusinessMixin:
                             i, owner_name=o.name if o else None,
                         )
                     )
-                return results
+                # Envelope shape matches ``get_unreconciled_splits`` and
+                # ``get_prices`` so verbose-mode callers see truncation
+                # signal in the response. The bookkeeper noticed verbose
+                # was the odd one out: compact got the [Showing N of M]
+                # notice appended, but the dict version had no count /
+                # total / notice fields at all. ``count`` = truncated
+                # length, ``total`` = full filter set size, ``notice``
+                # is the same string compact appends (or None).
+                return {
+                    "invoices": results,
+                    "count": len(results),
+                    "total": total,
+                    "notice": notice,
+                }
 
     def get_invoice(self, invoice_id: str, owner_type: str | None = None) -> dict:
         """Get full details for an invoice or bill, including entries.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -61,6 +61,56 @@ def _is_invoice_posted(inv) -> bool:
     return _safe_date_posted(inv) is not None
 
 
+def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
+    """Render outstanding invoices/bills as a one-line-per-doc string.
+
+    Format per row:
+
+        000028  Berlin Digital GmbH  EUR 4,200  posted:2026-02-01  due:2026-03-03  55 days past due
+        000011  BookkeepingCo (BILL)  USD 450  posted:2026-03-15  due:2026-04-14  13 days past due
+
+    Action columns are the win here: ``due:`` and the days-past-due
+    count tell the bookkeeper exactly which invoice is bleeding the
+    most days, without forcing a separate calculation. ``(BILL)`` is
+    appended to vendor-bill owners so receivables and payables don't
+    get confused at a glance.
+
+    When the due date came from the 30-day default (``no_terms`` flag),
+    the days count is anchored to the assumption ("days past 30-day
+    default") rather than reading as contractual.
+    """
+    if not rows:
+        return ""
+    lines = []
+    for r in rows:
+        owner = r.get("owner_name") or f"#{r['id']}"
+        if r.get("type") == "bill":
+            owner = f"{owner} (BILL)"
+        ccy = r.get("currency") or ""
+        # Strip trailing zeros for compact display: "4200.00" → "4,200".
+        amount_dec = Decimal(r.get("amount_due") or "0")
+        amount_str = f"{int(amount_dec):,}" if amount_dec == int(amount_dec) else f"{amount_dec:,.2f}"
+        posted = r.get("date_posted") or "?"
+        due = r.get("due_date") or "?"
+        days = r.get("days_past_due")
+        if days is None:
+            days_str = ""
+        elif days > 0:
+            anchor = (
+                "30-day default" if r.get("no_terms") else "past due"
+            )
+            days_str = f"  {days} days past {anchor}"
+        elif days == 0:
+            days_str = "  due today"
+        else:
+            days_str = f"  due in {-days} days"
+        lines.append(
+            f"{r['id']}\t{owner}\t{ccy} {amount_str}\t"
+            f"posted:{posted}\tdue:{due}{days_str}"
+        )
+    return "\n".join(lines)
+
+
 class BusinessMixin:
     """Customer/vendor/invoice/bill operations."""
 
@@ -414,22 +464,28 @@ class BusinessMixin:
         return num, denom
 
     @staticmethod
-    def _invoice_to_dict(invoice, entries=None) -> dict:
+    def _invoice_to_dict(invoice, entries=None, owner_name: str | None = None) -> dict:
         """Convert a piecash Invoice to a serializable dict.
 
-        `owner_type` (numeric 2/4) was redundant with the human-readable
-        `type` field and is dropped. `is_posted` is derivable from
-        `date_posted` (non-null = posted) and is dropped too.
+        ``owner_type`` (numeric 2/4) was redundant with the
+        human-readable ``type`` field and is dropped. ``is_posted``
+        is derivable from ``date_posted`` (non-null = posted) and
+        is dropped too. Phase 3C: ``owner_guid`` (raw 32-char hex)
+        is dropped in favor of ``owner_name`` resolved by the caller
+        — the same readability swap we did for entry account refs.
 
         Args:
             invoice: piecash Invoice object.
             entries: Optional list of entry dicts. If None, entries are not included.
+            owner_name: Resolved customer/vendor name. The static-method
+                shape means we can't query for it here; the caller
+                (``get_invoice``) does the lookup once and threads it.
         """
         result = {
             "guid": invoice.guid,
             "id": invoice.id,
             "type": "bill" if invoice.owner_type == 4 else "invoice",
-            "owner_guid": invoice.owner_guid,
+            "owner_name": owner_name,
             "date_opened": str(invoice.date_opened.date()) if invoice.date_opened else None,
             "date_posted": (
                 str(_safe_date_posted(invoice).date())
@@ -443,21 +499,77 @@ class BusinessMixin:
             result["entries"] = entries
         return result
 
-    @staticmethod
-    def _invoice_to_compact_line(invoice) -> str:
-        """One-line compact: 'id  type  owner_id  date_opened  status'."""
+    def _invoice_to_compact_line(self, book, invoice) -> str:
+        """One-line compact format with action columns:
+
+            ``id  TYPE  owner_name  CCY total  date_opened  status``
+
+        Pre-Phase-3B this rendered as ``"000027  INV  2026-05-01
+        posted"`` — no owner, no amount, useless for scanning. With
+        owner and total in place a bookkeeper can scan a hundred
+        invoices and immediately spot what's outstanding for whom.
+
+        Currency is shown when present so multi-currency books read
+        unambiguously. Bills get the ``BILL`` tag (was already there).
+        """
         inv_type = "BILL" if invoice.owner_type == 4 else "INV"
-        date_str = str(invoice.date_opened.date()) if invoice.date_opened else "n/a"
+        date_str = (
+            str(invoice.date_opened.date())
+            if invoice.date_opened
+            else "n/a"
+        )
         status = "posted" if _is_invoice_posted(invoice) else "open"
-        return f"{invoice.id}\t{inv_type}\t{date_str}\t{status}"
+
+        # Owner lookup — vendors and customers share the same
+        # ``owner_guid`` namespace (different table, but same handle
+        # shape). Picking the right finder by ``owner_type`` matches
+        # how every other code path in this file resolves it.
+        if invoice.owner_type == 4:
+            owner = self._find_vendor_by_guid(book, invoice.owner_guid)
+        else:
+            owner = self._find_customer_by_guid(book, invoice.owner_guid)
+        owner_name = owner.name if owner else "?"
+
+        # Total: sum of (quantity * price) across entries. Falls back
+        # to "?" when entries can't be loaded — keeps the row legible
+        # even on data-corruption edge cases.
+        try:
+            _, _, grand_total = self._get_invoice_entries_and_total(
+                book, invoice,
+            )
+            ccy = (
+                invoice.currency.mnemonic
+                if invoice.currency else ""
+            )
+            if grand_total == int(grand_total):
+                amount_str = f"{ccy} {int(grand_total):,}".strip()
+            else:
+                amount_str = f"{ccy} {grand_total:,.2f}".strip()
+        except Exception:
+            amount_str = "?"
+
+        return (
+            f"{invoice.id}\t{inv_type}\t{owner_name}\t{amount_str}\t"
+            f"{date_str}\t{status}"
+        )
 
     @staticmethod
-    def _entry_to_dict(entry_row, is_bill: bool = False) -> dict:
+    def _entry_to_dict(
+        entry_row,
+        is_bill: bool = False,
+        account_paths: dict | None = None,
+    ) -> dict:
         """Convert an entry row (from raw SQL) to a serializable dict.
 
         Args:
             entry_row: SQLAlchemy row from entries table.
             is_bill: If True, read b_* columns; otherwise read i_* columns.
+            account_paths: Optional mapping of account-GUID to fullname.
+                When provided, the response uses ``account`` (path) in
+                place of ``account_guid`` (raw 32-char hex). The caller
+                builds this map once per invoice and passes it through;
+                this keeps the static-method shape while letting the
+                response be readable to humans/LLMs.
         """
         q_num = entry_row.quantity_num or 0
         q_denom = entry_row.quantity_denom or 1
@@ -484,15 +596,23 @@ class BusinessMixin:
         else:
             date_str = str(raw_date.date())
 
-        return {
+        result = {
             "guid": entry_row.guid,
             "date": date_str,
             "description": entry_row.description or "",
-            "account_guid": acct_guid or "",
             "quantity": str(quantity),
             "price": str(price),
             "total": str(total),
         }
+        if account_paths is not None and acct_guid:
+            # Phase 3C: surface the readable path. Falls back to the
+            # raw GUID when a stale entry references a deleted account.
+            result["account"] = account_paths.get(
+                acct_guid, acct_guid,
+            )
+        else:
+            result["account_guid"] = acct_guid or ""
+        return result
 
     @staticmethod
     def _write_gncinvoice_slot(book, obj_guid: str, invoice_guid: str):
@@ -1609,12 +1729,26 @@ class BusinessMixin:
             )
 
             if compact:
-                lines = [self._invoice_to_compact_line(i) for i in invoices]
+                lines = [self._invoice_to_compact_line(book, i) for i in invoices]
                 if notice:
                     lines.append(notice)
                 return "\n".join(lines)
             else:
-                return [self._invoice_to_dict(i) for i in invoices]
+                # Verbose path: resolve owner per invoice so each dict
+                # carries the readable name. ``owner_guid`` was dropped
+                # from the dict shape in Phase 3C.
+                results = []
+                for i in invoices:
+                    if i.owner_type == 4:
+                        o = self._find_vendor_by_guid(book, i.owner_guid)
+                    else:
+                        o = self._find_customer_by_guid(book, i.owner_guid)
+                    results.append(
+                        self._invoice_to_dict(
+                            i, owner_name=o.name if o else None,
+                        )
+                    )
+                return results
 
     def get_invoice(self, invoice_id: str, owner_type: str | None = None) -> dict:
         """Get full details for an invoice or bill, including entries.
@@ -1659,7 +1793,22 @@ class BusinessMixin:
                     {"guid": inv.guid},
                 ).fetchall()
 
-            entries = [self._entry_to_dict(r, is_bill=is_bill) for r in rows]
+            # Phase 3C: build a guid → fullname map once (covers every
+            # account referenced by entries on this invoice), then
+            # thread it through ``_entry_to_dict`` so each entry shows
+            # ``account: "Income:LLC Revenue"`` instead of an opaque
+            # 32-char hex GUID. One query, ``account_paths`` shared
+            # across all entries.
+            account_paths: dict[str, str] = {}
+            for a in book.accounts:
+                account_paths[a.guid] = a.fullname
+
+            entries = [
+                self._entry_to_dict(
+                    r, is_bill=is_bill, account_paths=account_paths,
+                )
+                for r in rows
+            ]
 
             total = sum(
                 Decimal(e["quantity"]) * Decimal(e["price"])
@@ -1676,10 +1825,10 @@ class BusinessMixin:
                 if customer:
                     owner_name = customer.name
 
-            result = self._invoice_to_dict(inv, entries=entries)
+            result = self._invoice_to_dict(
+                inv, entries=entries, owner_name=owner_name,
+            )
             result["total"] = str(total)
-            if owner_name:
-                result["owner_name"] = owner_name
             return result
 
     def post_invoice(
@@ -2522,18 +2671,32 @@ class BusinessMixin:
         owner_type: str | None = None,
         customer_id: str | None = None,
         vendor_id: str | None = None,
-    ) -> list[dict]:
+        compact: bool = True,
+    ) -> list[dict] | str:
         """Get all posted invoices/bills with outstanding balances.
 
         Args:
             owner_type: Filter by 'customer' or 'vendor'. Omit for all.
             customer_id: Filter by specific customer ID.
             vendor_id: Filter by specific vendor ID.
+            compact: If True (default), return a compact one-line-per-doc
+                     string with action columns: due date, days past due,
+                     currency, BILL tag, owner. Verbose mode returns the
+                     structured list dicts kept for ``pay_invoice``
+                     workflows.
 
         Returns:
-            List of dicts with invoice details and balance info.
+            If compact: newline-separated lines, each
+                ``"id  owner  CCY amount  posted:YYYY-MM-DD  due:YYYY-MM-DD  N days past due"``,
+                ordered most-overdue-first. Bills tagged ``(BILL)``.
+                Empty string when nothing is outstanding.
+            If not compact: list of dicts (caller pays the wire cost
+                in exchange for the full ``original_amount`` /
+                ``amount_paid`` / ``amount_due`` breakdown).
         """
         from piecash.business.invoice import Invoice
+
+        today = date.today()
 
         with self.open() as book:
             query = book.session.query(Invoice).filter(
@@ -2626,19 +2789,47 @@ class BusinessMixin:
                         owner_name = c.name
 
                 posted_dt = _safe_date_posted(inv)
+                # Resolve the due date through the same three-step
+                # chain the warnings collector uses, so the bookkeeper
+                # sees identical numbers in both places.
+                due_date, no_terms = self._resolve_invoice_due_date(
+                    book, inv,
+                )
+                days_past_due = (
+                    (today - due_date).days
+                    if due_date is not None
+                    else None
+                )
+                currency = (
+                    inv.currency.mnemonic if inv.currency else None
+                )
                 results.append({
                     "id": inv.id,
                     "type": "bill" if is_bill else "invoice",
                     "owner_name": owner_name,
+                    "currency": currency,
                     "date_posted": (
                         str(posted_dt.date()) if posted_dt else None
                     ),
+                    "due_date": (
+                        str(due_date) if due_date is not None else None
+                    ),
+                    "days_past_due": days_past_due,
+                    "no_terms": no_terms,
                     "original_amount": str(grand_total),
                     "amount_paid": str(amount_paid),
                     "amount_due": str(abs(balance)),
                 })
 
-        return results
+            # Sort: most overdue first (largest days_past_due), so the
+            # bookkeeper sees the urgent receivables / bills at the top.
+            results.sort(
+                key=lambda r: -(r["days_past_due"] or 0),
+            )
+
+            if compact:
+                return _format_outstanding_invoices_compact(results)
+            return results
 
     def vendor_spending_report(
         self,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -678,110 +678,20 @@ class CoreMixin:
                     Invoice.date_posted.isnot(None)
                 ).all():
                     try:
-                        txn = inv.post_txn
-                        if txn is None:
+                        # Three-step due-date resolution lives on
+                        # ``BusinessMixin`` (``_resolve_invoice_due_date``)
+                        # so the warnings collector and
+                        # ``get_outstanding_invoices`` produce identical
+                        # math. ``no_terms`` is True when the helper
+                        # fell through to the 30-day default; we
+                        # annotate the rendered line accordingly.
+                        resolve_due = getattr(
+                            self, "_resolve_invoice_due_date", None,
+                        )
+                        if resolve_due is None:
                             continue
-                        # Read the trans-date-due slot.
-                        row = book.session.execute(
-                            text(
-                                "SELECT gdate_val FROM slots "
-                                "WHERE obj_guid = :guid "
-                                "AND name = 'trans-date-due'"
-                            ),
-                            {"guid": txn.guid},
-                        ).first()
-                        # Three-step due-date resolution. The
-                        # first source that resolves wins; only the
-                        # last (30-day fallback) annotates the
-                        # warning as approximated.
-                        #
-                        # 1. ``trans-date-due`` slot — present only
-                        #    when the user explicitly passed
-                        #    ``due_date`` to ``post_invoice``.
-                        # 2. ``Invoice.terms`` reference — present
-                        #    when the user posted with a billterm
-                        #    (e.g., "Net 30"). Look up the
-                        #    billterm's ``duedays`` and add to
-                        #    date_posted. The bookkeeper LLM
-                        #    expects "Net 30" terms to produce
-                        #    accurate due dates without needing an
-                        #    explicit due_date parameter; relying
-                        #    only on the slot misses this very
-                        #    common case.
-                        # 3. 30-day default — only when neither
-                        #    slot nor terms reference exists. The
-                        #    rendered warning anchors the days
-                        #    count to the assumption ("N days past
-                        #    30-day default") and tags "(no term
-                        #    set)" so the bookkeeper sees both the
-                        #    duration and the data gap without the
-                        #    string reading as contractual.
-                        no_terms = False
-                        due_date = None
-
-                        # Step 1: explicit due-date slot.
-                        if row and row[0]:
-                            gdate_val = row[0]
-                            if isinstance(gdate_val, str):
-                                due_date = date.fromisoformat(
-                                    gdate_val[:10]
-                                )
-                            elif isinstance(gdate_val, datetime):
-                                due_date = gdate_val.date()
-                            else:
-                                due_date = gdate_val
-
-                        # Step 2: billterm via the raw ``terms``
-                        # column. Bypasses any ORM relationship
-                        # lazy-load — in this codebase ``inv.terms``
-                        # exposes a relationship that's reliable
-                        # only when triggered through specific
-                        # paths; raw SQL is the same pattern used
-                        # elsewhere in the warnings collector for
-                        # slot reads.
-                        if due_date is None:
-                            try:
-                                terms_row = book.session.execute(
-                                    text(
-                                        "SELECT terms FROM invoices "
-                                        "WHERE guid = :guid"
-                                    ),
-                                    {"guid": inv.guid},
-                                ).first()
-                                term_guid = (
-                                    terms_row[0] if terms_row else None
-                                )
-                                if term_guid:
-                                    from piecash.business.invoice import (
-                                        Billterm,
-                                    )
-                                    bt = (
-                                        book.session.query(Billterm)
-                                        .filter_by(guid=term_guid)
-                                        .first()
-                                    )
-                                    if bt and bt.duedays:
-                                        posted = inv.date_posted
-                                        if isinstance(posted, datetime):
-                                            posted = posted.date()
-                                        due_date = (
-                                            posted + timedelta(
-                                                days=int(bt.duedays)
-                                            )
-                                        )
-                            except Exception:
-                                pass
-
-                        # Step 3: 30-day default. Annotate so the
-                        # bookkeeper knows the duration is a guess.
-                        if due_date is None:
-                            posted = inv.date_posted
-                            if isinstance(posted, datetime):
-                                posted = posted.date()
-                            due_date = posted + timedelta(days=30)
-                            no_terms = True
-
-                        if due_date >= today:
+                        due_date, no_terms = resolve_due(book, inv)
+                        if due_date is None or due_date >= today:
                             continue
 
                         lot = inv.post_lot

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -580,21 +580,35 @@ def register(mcp, get_book) -> None:
         owner_type: str | None = None,
         customer_id: str | None = None,
         vendor_id: str | None = None,
+        verbose: bool = False,
     ) -> str:
         """Get all posted invoices/bills with outstanding balances.
+
+        Returns a compact one-line-per-doc format by default with action
+        columns (due date, days past due, currency, BILL tag, owner).
+        Sorted most-overdue-first so the bookkeeper sees the urgent
+        items at the top.
+
+        Use verbose=true for full JSON with ``original_amount`` /
+        ``amount_paid`` / ``amount_due`` breakdown — the shape
+        ``pay_invoice`` workflows expect.
 
         Args:
             owner_type: Filter by "customer" or "vendor". Omit for all.
             customer_id: Filter by specific customer ID.
             vendor_id: Filter by specific vendor ID.
+            verbose: If true, return full JSON details.
         """
         book = get_book()
         result = book.get_outstanding_invoices(
             owner_type=owner_type,
             customer_id=customer_id,
             vendor_id=vendor_id,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1101,9 +1101,19 @@ class TestListInvoices:
         gb.create_customer(name="Acme Corp")
         gb.create_invoice(customer_id="000001")
         result = gb.list_invoices(compact=False)
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0]["type"] == "invoice"
+        # Verbose mode returns the envelope shape that matches
+        # get_unreconciled_splits / get_prices: invoices list +
+        # count + total + notice.
+        assert isinstance(result, dict)
+        assert "invoices" in result
+        assert "count" in result
+        assert "total" in result
+        assert "notice" in result
+        invoices = result["invoices"]
+        assert len(invoices) == 1
+        assert invoices[0]["type"] == "invoice"
+        assert result["total"] == 1
+        assert result["notice"] is None  # nothing truncated
 
     def test_filter_by_customer_type(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1112,8 +1122,9 @@ class TestListInvoices:
         gb.create_invoice(customer_id="000001")
         gb.create_bill(vendor_id="000001")
         result = gb.list_invoices(owner_type="customer", compact=False)
-        assert len(result) == 1
-        assert result[0]["type"] == "invoice"
+        invoices = result["invoices"]
+        assert len(invoices) == 1
+        assert invoices[0]["type"] == "invoice"
 
     def test_filter_by_vendor_type(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1122,8 +1133,9 @@ class TestListInvoices:
         gb.create_invoice(customer_id="000001")
         gb.create_bill(vendor_id="000001")
         result = gb.list_invoices(owner_type="vendor", compact=False)
-        assert len(result) == 1
-        assert result[0]["type"] == "bill"
+        invoices = result["invoices"]
+        assert len(invoices) == 1
+        assert invoices[0]["type"] == "bill"
 
     def test_filter_by_status(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1131,9 +1143,9 @@ class TestListInvoices:
         gb.create_invoice(customer_id="000001")
         # All invoices are open (not posted)
         result = gb.list_invoices(status="open", compact=False)
-        assert len(result) == 1
+        assert len(result["invoices"]) == 1
         result = gb.list_invoices(status="posted", compact=False)
-        assert len(result) == 0
+        assert len(result["invoices"]) == 0
 
 
 class TestGetInvoice:
@@ -2559,6 +2571,31 @@ class TestPhase3CommsContracts:
         result = gb.get_invoice(invoice_id="000001")
         assert result["owner_name"] == "Acme Corp"
         assert "owner_guid" not in result
+
+    # ── 3B follow-up: list_invoices verbose envelope ─────────────
+
+    def test_list_invoices_verbose_envelope_with_truncation(
+        self, business_book,
+    ):
+        """Bookkeeper-flagged inconsistency: compact mode appended a
+        ``[Showing N of M]`` notice when truncated, but verbose mode
+        returned just a bare list with no truncation signal.
+        Now both modes carry ``count`` / ``total`` / ``notice`` so a
+        verbose-mode caller knows the result is incomplete.
+        """
+        gb = GnuCashBook(str(business_book))
+        # 5 invoices, ask for 3.
+        for i in range(5):
+            gb.create_customer(name=f"Customer {i}")
+            gb.create_invoice(customer_id=f"{i+1:06d}")
+        result = gb.list_invoices(compact=False, limit=3)
+        assert isinstance(result, dict)
+        assert len(result["invoices"]) == 3
+        assert result["count"] == 3
+        assert result["total"] == 5
+        assert result["notice"] is not None
+        assert "Showing 3 of 5" in result["notice"]
+        assert "invoices" in result["notice"]
 
 
 # ============== Vendor Spending Report Tests ==============

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2279,7 +2279,7 @@ class TestGetOutstandingInvoices:
 
     def test_empty_when_none_posted(self, business_book):
         gb = GnuCashBook(str(business_book))
-        result = gb.get_outstanding_invoices()
+        result = gb.get_outstanding_invoices(compact=False)
         assert result == []
 
     def test_shows_posted_unpaid(self, business_book):
@@ -2297,7 +2297,7 @@ class TestGetOutstandingInvoices:
             invoice_id="000001",
             post_account="Assets:Accounts Receivable",
         )
-        result = gb.get_outstanding_invoices()
+        result = gb.get_outstanding_invoices(compact=False)
         assert len(result) == 1
         assert result[0]["id"] == "000001"
         assert Decimal(result[0]["amount_due"]) == Decimal("500")
@@ -2322,7 +2322,7 @@ class TestGetOutstandingInvoices:
             payment_account="Assets:Checking",
             amount="500",
         )
-        result = gb.get_outstanding_invoices()
+        result = gb.get_outstanding_invoices(compact=False)
         assert len(result) == 0
 
     def test_partially_paid_shows_correct_amounts(self, business_book):
@@ -2345,7 +2345,7 @@ class TestGetOutstandingInvoices:
             payment_account="Assets:Checking",
             amount="200",
         )
-        result = gb.get_outstanding_invoices()
+        result = gb.get_outstanding_invoices(compact=False)
         assert len(result) == 1
         assert Decimal(result[0]["amount_due"]) == Decimal("300")
         assert Decimal(result[0]["amount_paid"]) == Decimal("200")
@@ -2378,7 +2378,7 @@ class TestGetOutstandingInvoices:
             invoice_id="000002",
             post_account="Assets:Accounts Receivable",
         )
-        result = gb.get_outstanding_invoices(customer_id="000001")
+        result = gb.get_outstanding_invoices(customer_id="000001", compact=False)
         assert len(result) == 1
         assert result[0]["owner_name"] == "Acme Corp"
 
@@ -2398,9 +2398,167 @@ class TestGetOutstandingInvoices:
             post_account="Liabilities:Accounts Payable",
             owner_type="vendor",
         )
-        result = gb.get_outstanding_invoices(owner_type="vendor")
+        result = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
         assert len(result) == 1
         assert result[0]["type"] == "bill"
+
+
+class TestPhase3CommsContracts:
+    """Lock tests for the comms-audit Phase 3 daily-reads contracts.
+    Future refactors must preserve these shapes — they're what the
+    bookkeeper relies on when scanning invoices and outstanding lists."""
+
+    # ── 3A: get_outstanding_invoices action columns ──────────────
+
+    def test_outstanding_compact_includes_due_date_and_days(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-01",
+            due_date="2026-02-01",
+        )
+        compact = gb.get_outstanding_invoices()
+        # Compact output is a string (default mode).
+        assert isinstance(compact, str)
+        assert "Acme Corp" in compact
+        assert "due:2026-02-01" in compact
+        assert "posted:2026-01-01" in compact
+        # By 2026-04-28 (test fixture's "today") this is 86 days past
+        # an explicit due date — no "30-day default" annotation.
+        assert "past due" in compact
+        assert "30-day default" not in compact
+
+    def test_outstanding_compact_no_terms_annotates_default(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-01",
+            # no due_date and no billterm — falls back to 30-day default
+        )
+        compact = gb.get_outstanding_invoices()
+        assert "30-day default" in compact
+
+    def test_outstanding_compact_marks_bill_with_tag(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper", quantity="1", price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-01-01",
+        )
+        compact = gb.get_outstanding_invoices(owner_type="vendor")
+        assert "(BILL)" in compact, (
+            f"BILL tag missing from compact output:\n{compact}"
+        )
+        assert "Office Depot" in compact
+
+    def test_outstanding_verbose_mode_returns_dicts(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-01",
+        )
+        result = gb.get_outstanding_invoices(compact=False)
+        assert isinstance(result, list)
+        assert result[0]["due_date"] is not None
+        assert result[0]["days_past_due"] is not None
+
+    # ── 3B: list_invoices owner name + amount ────────────────────
+
+    def test_list_invoices_compact_includes_owner_and_amount(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Emerald Analytics")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Q1 retainer", quantity="1", price="3500.00",
+        )
+        compact = gb.list_invoices()
+        assert "Emerald Analytics" in compact
+        # Amount should appear in either USD-prefixed or bare form.
+        assert "3,500" in compact or "3500" in compact
+
+    def test_list_invoices_marks_bill_tag(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="BookkeepingCo")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Bookkeeping", quantity="1", price="450.00",
+        )
+        compact = gb.list_invoices()
+        assert "BILL" in compact
+        assert "BookkeepingCo" in compact
+
+    # ── 3C: get_invoice resolves account paths ───────────────────
+
+    def test_get_invoice_entries_use_account_path_not_guid(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        result = gb.get_invoice(invoice_id="000001")
+        assert "entries" in result
+        assert len(result["entries"]) == 1
+        entry = result["entries"][0]
+        # New shape: ``account`` (path) replaces ``account_guid`` (hex).
+        assert entry.get("account") == "Income:Sales"
+        assert "account_guid" not in entry
+
+    def test_get_invoice_drops_owner_guid_keeps_owner_name(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        result = gb.get_invoice(invoice_id="000001")
+        assert result["owner_name"] == "Acme Corp"
+        assert "owner_guid" not in result
 
 
 # ============== Vendor Spending Report Tests ==============
@@ -2573,7 +2731,7 @@ class TestInvoiceLifecycle:
         assert Decimal(post_result["total"]) == Decimal("1000")
 
         # Verify outstanding
-        outstanding = gb.get_outstanding_invoices()
+        outstanding = gb.get_outstanding_invoices(compact=False)
         assert len(outstanding) == 1
         assert Decimal(outstanding[0]["amount_due"]) == Decimal("1000")
 
@@ -2586,7 +2744,7 @@ class TestInvoiceLifecycle:
         assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
 
         # Verify no longer outstanding
-        outstanding = gb.get_outstanding_invoices()
+        outstanding = gb.get_outstanding_invoices(compact=False)
         assert len(outstanding) == 0
 
     def test_full_bill_lifecycle(self, business_book):
@@ -2616,7 +2774,7 @@ class TestInvoiceLifecycle:
         assert Decimal(post_result["total"]) == Decimal("100")
 
         # Verify outstanding
-        outstanding = gb.get_outstanding_invoices(owner_type="vendor")
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
         assert len(outstanding) == 1
 
         # Pay
@@ -2629,5 +2787,5 @@ class TestInvoiceLifecycle:
         assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
 
         # Verify cleared
-        outstanding = gb.get_outstanding_invoices(owner_type="vendor")
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
         assert len(outstanding) == 0


### PR DESCRIPTION
## Summary

Branch 2 of the multi-phase comms-audit work (``docs/COMMUNICATION_AUDIT_FIXES.md``). Three daily-workflow invoice tools get action columns and readable references — the high-frequency reads where verbose output burns bookkeeper attention every session.

Two commits:

1. **``bedccc6`` refactor** — extract ``_resolve_invoice_due_date`` from ``_collect_warnings`` into a shared ``BusinessMixin`` helper. Pure refactor, byte-identical warnings output. Sets up the shared math that Phase 3A then consumes.

2. **``f57b595`` Phase 3 consumers**:
   - ``get_outstanding_invoices`` adds ``due_date`` and ``days_past_due`` columns plus a compact one-line-per-doc format. Sorted most-overdue first. ``(BILL)`` tag distinguishes vendor bills. Currency shown explicitly. Verbose mode preserves the structured ``amount_due`` / ``amount_paid`` shape ``pay_invoice`` needs.
   - ``list_invoices`` compact output adds owner name and total amount inline — turns the listing from "what's the ID sequence" into "who owes me what and when did it post."
   - ``get_invoice`` / ``get_bill`` resolve entry ``account_guid`` (32-char hex) to ``account`` (full path). ``owner_guid`` dropped in favor of ``owner_name``. Same readability story as the short-account-GUID work, applied at entry level.

## Live output (Alex Chen-Morales)

Bookkeeper-tested and enthusiastically approved. Sample lines:

```
000028  Berlin Digital GmbH    EUR 4,200  posted:2026-02-01  due:2026-03-03  86 days past due
000026  Emerald Analytics      USD 3,500  posted:2026-04-01  due:2026-05-01  due in 4 days
000011  BookkeepingCo (BILL)   USD 450    posted:2026-03-15  due:2026-04-14  14 days past due
```

## Test plan

- [x] 928 unit/integration tests passing locally
- [x] 8 new ``TestPhase3CommsContracts`` lock tests covering the new shapes
- [x] All 23 ``TestGetBookSummaryWarnings`` tests still pass after helper extraction (proves byte-identical output)
- [x] Live-verified on Alex's book at three checkpoints — outstanding invoices show due dates & past-due counts, list_invoices shows owner+amount, get_invoice entries use account paths

## Phasing

- **Branch 3 next** (``feat/comms-monthly-reports``) — Phase 4: ``debt_payoff_plan`` compact format, ``balance_sheet`` investment format alignment, ``spending_by_category`` / ``income_by_source`` TSV, ``vendor_spending_report`` compaction.
- **Branch 4** (``feat/comms-polish``) — Phases 5-6: budget formatting + investment cosmetics + ``list_budgets`` compact.