### PR TITLE
feat: comms-audit Phase 4 monthly reports (compact text tables)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -61,6 +61,72 @@ def _is_invoice_posted(inv) -> bool:
     return _safe_date_posted(inv) is not None
 
 
+def _format_vendor_spending_compact(
+    vendors_list: list[dict],
+    *,
+    grand_billed: Decimal,
+    grand_paid: Decimal,
+    grand_outstanding: Decimal,
+) -> str:
+    """Render vendor-spending breakdown as a compact aligned text table.
+
+    Format::
+
+        BookkeepingCo  4 bills  $1,800 billed  $1,800 paid  $0 outstanding
+        JetBrains      1 bill     $289 billed    $289 paid  $0 outstanding
+        TOTAL          5 bills  $2,089 billed  $2,089 paid  $0 outstanding
+
+    "1 bill" vs "N bills" pluralization keeps the line natural to read.
+    Width-padded so the four amount columns align across rows.
+    """
+    if not vendors_list:
+        return "No vendor activity in period."
+
+    # Single-pass widths.
+    name_width = max(len(v["vendor_name"]) for v in vendors_list)
+    bills_strs = [
+        f"{v['bill_count']} {'bill' if v['bill_count'] == 1 else 'bills'}"
+        for v in vendors_list
+    ]
+    bills_width = max(len(s) for s in bills_strs)
+
+    def _money(s: str) -> str:
+        d = Decimal(s)
+        if d == d.to_integral_value():
+            return f"${int(d):,}"
+        return f"${d:,.2f}"
+
+    billed_strs = [_money(v["total_billed"]) for v in vendors_list]
+    paid_strs = [_money(v["total_paid"]) for v in vendors_list]
+    out_strs = [_money(v["outstanding"]) for v in vendors_list]
+    billed_w = max(len(s) for s in billed_strs)
+    paid_w = max(len(s) for s in paid_strs)
+    out_w = max(len(s) for s in out_strs)
+
+    lines = []
+    for v, bills, billed, paid, out in zip(
+        vendors_list, bills_strs, billed_strs, paid_strs, out_strs,
+    ):
+        lines.append(
+            f"{v['vendor_name']:<{name_width}}  "
+            f"{bills:<{bills_width}}  "
+            f"{billed:>{billed_w}} billed  "
+            f"{paid:>{paid_w}} paid  "
+            f"{out:>{out_w}} outstanding"
+        )
+
+    total_bill_count = sum(v["bill_count"] for v in vendors_list)
+    total_label = f"{total_bill_count} {'bill' if total_bill_count == 1 else 'bills'}"
+    lines.append(
+        f"{'TOTAL':<{name_width}}  "
+        f"{total_label:<{bills_width}}  "
+        f"{_money(str(grand_billed)):>{billed_w}} billed  "
+        f"{_money(str(grand_paid)):>{paid_w}} paid  "
+        f"{_money(str(grand_outstanding)):>{out_w}} outstanding"
+    )
+    return "\n".join(lines)
+
+
 def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
     """Render outstanding invoices/bills as a one-line-per-doc string.
 
@@ -2850,7 +2916,8 @@ class BusinessMixin:
         start_date: str,
         end_date: str,
         vendor_id: str | None = None,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Get spending breakdown by vendor for a period.
 
         Analyzes posted vendor bills to show total billed, paid,
@@ -2860,9 +2927,16 @@ class BusinessMixin:
             start_date: Start of period (YYYY-MM-DD).
             end_date: End of period (YYYY-MM-DD).
             vendor_id: Optional filter to specific vendor.
+            compact: If True (default), return an aligned text table
+                     suitable for direct LLM consumption (Phase 4D).
+                     Verbose mode returns the structured dict.
 
         Returns:
-            Dict with per-vendor breakdown and grand totals.
+            If compact: text table (one line per vendor + TOTAL).
+            If not compact: dict with vendor breakdown and grand totals.
+            The Phase 4D spec dropped the ``period`` echo (it duplicated
+            input the caller already has); verbose mode no longer
+            includes it either.
         """
         from piecash.business.invoice import Invoice
 
@@ -2975,11 +3049,7 @@ class BusinessMixin:
                 reverse=True,
             )
 
-        return {
-            "period": {
-                "start": start_date,
-                "end": end_date,
-            },
+        full = {
             "vendors": vendors_list,
             "totals": {
                 "total_billed": str(grand_billed),
@@ -2991,3 +3061,13 @@ class BusinessMixin:
                 ),
             },
         }
+
+        if not compact:
+            return full
+
+        return _format_vendor_spending_compact(
+            vendors_list,
+            grand_billed=grand_billed,
+            grand_paid=grand_paid,
+            grand_outstanding=grand_outstanding,
+        )

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -295,7 +295,17 @@ class CoreMixin:
         of the canonical assets_total − liabilities_total formula.
         """
         template_guids = self._template_account_guids(book)
-        rates = self._rates_as_of(book, as_of, default_currency)
+        # "Now" anchors (as_of >= today) use the absolute latest price
+        # on file — including any future-dated forecasts the bookkeeper
+        # has deliberately written. Past anchors filter to prices
+        # observed by the anchor date (historical reconstruction).
+        # See the comment in get_book_summary's inline price loop for
+        # the rationale; both paths converge on this behavior so the
+        # "now" anchor agrees with balance_sheet by construction.
+        if as_of >= date.today():
+            rates = self._latest_market_rates(book)
+        else:
+            rates = self._rates_as_of(book, as_of, default_currency)
 
         # is_leaf: an account with no children. Compute the parent
         # set once and check membership per account.
@@ -1335,16 +1345,23 @@ class CoreMixin:
             default_currency = self._require_default_currency(book)
             currency = default_currency.mnemonic
 
-            # All balances and price lookups in this summary are
-            # computed as-of-today. Trajectory's "now" anchor uses
-            # the same cutoff (via ``_compute_net_worth_at(today)``
-            # and ``_rates_as_of(today)``), so the displayed Assets
-            # / Liabilities totals agree with trajectory's "now"
-            # by construction. Without this filter, future-dated
-            # transactions or prices in the book would skew the
-            # current snapshot — bookkeeper hit this on Alex's
-            # book where 34 days of data past today produced a
-            # $2,906 gap between Assets-Liabilities and trajectory.
+            # Balances are computed as-of-today: future-dated
+            # transactions are excluded so the displayed Assets /
+            # Liabilities totals agree with trajectory's "now" by
+            # construction. Without this filter, future-dated
+            # transactions in the book would skew the current
+            # snapshot — bookkeeper hit this on Alex's book where
+            # 34 days of data past today produced a $2,906 gap
+            # between Assets-Liabilities and trajectory.
+            #
+            # Prices are NOT today-filtered. The bookkeeper writes
+            # future-dated yfinance close prices intentionally as
+            # forecasts the displays should track; balance_sheet
+            # uses the absolute latest, and this summary now
+            # matches by construction. ``_compute_net_worth_at``
+            # (above) special-cases ``as_of >= today`` to use the
+            # same all-prices lookup so the trajectory "now"
+            # anchor agrees here too.
             today = date.today()
 
             # Identify template accounts (scheduled-transaction scaffolding).
@@ -1361,29 +1378,14 @@ class CoreMixin:
                     parent_guids.add(account.parent.guid)
 
             # --- Latest-price lookup for non-default-currency commodities ---
-            # Precompute once to avoid O(N*M) when many investment accounts
-            # share a small commodity set. Skip piecash's auto-created
-            # type='transaction' prices (they capture the effective rate of
-            # a cross-currency txn; we want user-supplied market prices).
-            latest_prices: dict[str, Decimal] = {}
-            for p in book.prices:
-                if p.currency != default_currency:
-                    continue
-                if p.type == "transaction":
-                    continue
-                p_date = p.date
-                if hasattr(p_date, "date") and callable(p_date.date):
-                    p_date = p_date.date()
-                if p_date > today:
-                    # Future-dated prices excluded so _market_value
-                    # agrees with trajectory's _rates_as_of(today)
-                    # by construction.
-                    continue
-                key = p.commodity.guid
-                existing = latest_prices.get(key + ":date")
-                if existing is None or p_date > existing:
-                    latest_prices[key + ":date"] = p_date
-                    latest_prices[key] = Decimal(str(p.value))
+            # Use the same shared helper balance_sheet uses, so the
+            # two surfaces agree on which price is "current" for
+            # every commodity — including the bookkeeper's
+            # intentional future-dated yfinance forecast entries.
+            # Helper already excludes piecash auto-created
+            # ``type='transaction'`` prices (cross-currency
+            # placeholders, not market quotes).
+            latest_prices: dict[str, Decimal] = self._latest_market_rates(book)
 
             def _market_value(account, quantity: Decimal) -> tuple[Decimal, str | None]:
                 """Return (USD value, note) for an account's quantity.

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -38,6 +38,102 @@ _NET_INCOME_TYPES = frozenset({"INCOME", "EXPENSE"})
 _CASH_TYPES = frozenset({"BANK", "CASH"})
 
 
+def _money_compact(value: Decimal) -> str:
+    """Format a dollar amount for compact-mode reports.
+
+    Whole-dollar values render without decimals (``$13,091``), partial
+    values render with two (``$1,125.50``). Negative values use the
+    leading-minus convention rather than parens.
+    """
+    quantized = value.quantize(Decimal("0.01"))
+    if quantized == quantized.to_integral_value():
+        return f"${int(quantized):,}"
+    return f"${quantized:,.2f}"
+
+
+def _format_debt_payoff_compact(
+    *,
+    results: list[dict],
+    orig_balances: dict,
+    total_balance: Decimal,
+    total_interest: Decimal,
+    total_months: int,
+    payoff_date,
+    monthly_budget: Decimal,
+    yeti_multiplier: Decimal,
+    purchase_amount: Decimal,
+    true_cost: Decimal,
+) -> str:
+    """Render the avalanche-payoff plan as a compact text table.
+
+    Layout follows the comms-audit Phase 4A spec:
+
+        Kill order ($10,000/mo → debt-free Apr 2030, $59,022 interest):
+          1. Business Amex    $13,091  24.49%  payoff: mo 8   interest: $1,125
+          2. Chase Sapphire   $22,127  21.49%  payoff: mo 18  interest: $5,034
+          ...
+        YETI at this budget: 1.59x ($1 spent costs $1.59 in total debt impact)
+        Total interest: $59,022
+        Debt-free: April 2030
+
+    Replaces the verbose dict (with multi-line YETI ``explanation`` per
+    account) that was the heaviest single response in Abe's audit.
+    Verbose mode preserves the dict for programmatic consumers.
+    """
+    # Account names: leaf-name only when path is unambiguous (saves
+    # context vs. echoing "Liabilities:Credit Card:Business Amex" on
+    # every row). Width-pads to the widest leaf so columns align.
+    leaf_names = [d["name"].split(":")[-1] for d in results]
+    name_width = max(len(n) for n in leaf_names) if leaf_names else 0
+
+    # Balance column width — pad to widest balance for alignment.
+    balance_strs = [
+        _money_compact(orig_balances[d["name"]]) for d in results
+    ]
+    balance_width = max(len(b) for b in balance_strs) if balance_strs else 0
+
+    # Interest column width — same trick.
+    interest_strs = [_money_compact(d["interest_paid"]) for d in results]
+    interest_width = (
+        max(len(s) for s in interest_strs) if interest_strs else 0
+    )
+
+    # Header tells the reader the inputs that drove the schedule.
+    payoff_month_name = payoff_date.strftime("%b %Y")
+    header = (
+        f"Kill order ({_money_compact(monthly_budget)}/mo → "
+        f"debt-free {payoff_month_name}, "
+        f"{_money_compact(total_interest)} interest):"
+    )
+
+    # Body rows.
+    lines = [header]
+    for i, d in enumerate(results, start=1):
+        leaf = leaf_names[i - 1]
+        bal = balance_strs[i - 1]
+        interest = interest_strs[i - 1]
+        apr_str = f"{d['apr'].quantize(Decimal('0.01'))}%"
+        lines.append(
+            f"  {i}. {leaf:<{name_width}}  "
+            f"{bal:>{balance_width}}  "
+            f"{apr_str:>6}  "
+            f"payoff: mo {d['payoff_month']:<3}  "
+            f"interest: {interest:>{interest_width}}"
+        )
+
+    # Footer: YETI plus totals. The YETI line speaks plainly because
+    # it's the actionable signal — "this purchase costs you X.XX times
+    # more than its sticker because of the interest your debt accrues".
+    lines.append(
+        f"YETI at this budget: {yeti_multiplier}x "
+        f"({_money_compact(purchase_amount)} spent costs "
+        f"{_money_compact(true_cost)} in total debt impact)"
+    )
+    lines.append(f"Total interest: {_money_compact(total_interest)}")
+    lines.append(f"Debt-free: {payoff_date.strftime('%B %Y')}")
+    return "\n".join(lines)
+
+
 class ReportingMixin:
     """Financial reporting: spending, income, balance sheet, net worth, cash flow, debt."""
 
@@ -693,7 +789,8 @@ class ReportingMixin:
         self,
         monthly_budget: str,
         additional_purchase: str | None = None,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Calculate an avalanche-method debt payoff schedule with YETI multiplier.
 
         Auto-discovers CREDIT/LIABILITY accounts that have an 'apr' slot set.
@@ -704,9 +801,15 @@ class ReportingMixin:
         Args:
             monthly_budget: Total monthly amount available for all debt payments.
             additional_purchase: Dollar amount to calculate YETI for (default "1.00").
+            compact: If True (default), return a compact text-table summary
+                     suitable for the LLM context window — kill order,
+                     totals, YETI all in ~10 lines. Verbose mode returns
+                     the full structured dict (the legacy shape) for
+                     programmatic consumers.
 
         Returns:
-            Dict with payoff schedule, totals, and YETI multiplier.
+            If compact: text summary (kill order + YETI line + totals).
+            If not compact: dict with the original full structure.
 
         Raises:
             ValueError: If no debt accounts found, budget invalid, or budget
@@ -840,7 +943,7 @@ class ReportingMixin:
                 detail["credit_limit"] = str(d["credit_limit"])
             debt_details.append(detail)
 
-        return {
+        full = {
             "debts": debt_details,
             "payoff_order": payoff_order,
             "total_balance": str(total_balance.quantize(Decimal("0.01"))),
@@ -860,3 +963,19 @@ class ReportingMixin:
                 ),
             },
         }
+
+        if not compact:
+            return full
+
+        return _format_debt_payoff_compact(
+            results=results,
+            orig_balances=orig_balances,
+            total_balance=total_balance,
+            total_interest=total_interest,
+            total_months=total_months,
+            payoff_date=payoff_date,
+            monthly_budget=budget,
+            yeti_multiplier=yeti_multiplier,
+            purchase_amount=purchase_amount,
+            true_cost=true_cost,
+        )

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -27,6 +27,7 @@ from decimal import Decimal, InvalidOperation
 import piecash
 
 from gnucash_mcp.book._base import _to_decimal
+from gnucash_mcp._format import _format_number
 
 # Account-type groups used across the reports. Defined at module level
 # so the SQL IN() clauses share a single canonical definition rather
@@ -457,7 +458,12 @@ class ReportingMixin:
                 account_types=all_types,
             )
 
-            balances: dict[str, tuple[str, Decimal]] = {}
+            # Track per-account: (acct_type, USD-converted balance,
+            # commodity-quantity, account ref). The quantity / commodity
+            # bits are needed to render the "230.7600 VTSAX @ 156.23
+            # (USD 36,043.66)" triplet for non-default-currency accounts
+            # (Phase 4B). Currency-default accounts ignore that detail.
+            balances: dict[str, dict] = {}
             net_income = Decimal("0")
             for split, _txn, account in rows:
                 # Value the split in the book's default currency so
@@ -473,57 +479,127 @@ class ReportingMixin:
                     net_income -= amt
                     continue
                 key = account.fullname
-                current_type, current_bal = balances.get(
-                    key, (account.type, Decimal("0"))
-                )
-                balances[key] = (current_type, current_bal + amt)
+                if key not in balances:
+                    balances[key] = {
+                        "type": account.type,
+                        "usd": Decimal("0"),
+                        "quantity": Decimal("0"),
+                        "commodity": account.commodity,
+                    }
+                balances[key]["usd"] += amt
+                balances[key]["quantity"] += split.quantity
 
-            assets: dict[str, Decimal] = {}
-            liabilities: dict[str, Decimal] = {}
-            equity: dict[str, Decimal] = {}
-            for name, (acct_type, balance) in balances.items():
-                if balance == 0:
+            default_currency = self._require_default_currency(book)
+            # Latest market rates keyed by commodity guid — same data
+            # ``_market_value`` in get_book_summary uses for the per-
+            # account display. ``_latest_market_rates`` already excludes
+            # piecash auto-created ``type='transaction'`` prices.
+            latest_rates = self._latest_market_rates(book)
+
+            assets: dict[str, dict] = {}
+            liabilities: dict[str, dict] = {}
+            equity: dict[str, dict] = {}
+            for name, info in balances.items():
+                bal = info["usd"]
+                if bal == 0:
                     continue
-                if acct_type in _ASSET_TYPES:
-                    assets[name] = balance
-                elif acct_type in _LIABILITY_TYPES:
-                    # Liabilities stored negative; display positive.
-                    liabilities[name] = -balance
-                elif acct_type in _EQUITY_TYPES:
-                    equity[name] = -balance
+                if info["type"] in _ASSET_TYPES:
+                    assets[name] = info
+                elif info["type"] in _LIABILITY_TYPES:
+                    info["usd"] = -bal  # display positive
+                    info["quantity"] = -info["quantity"]
+                    liabilities[name] = info
+                elif info["type"] in _EQUITY_TYPES:
+                    info["usd"] = -bal
+                    info["quantity"] = -info["quantity"]
+                    equity[name] = info
 
-            assets_total = sum(assets.values()) if assets else Decimal("0")
+            assets_total = (
+                sum(i["usd"] for i in assets.values())
+                if assets else Decimal("0")
+            )
             liabilities_total = (
-                sum(liabilities.values()) if liabilities else Decimal("0")
+                sum(i["usd"] for i in liabilities.values())
+                if liabilities else Decimal("0")
             )
             equity_total = (
-                (sum(equity.values()) if equity else Decimal("0"))
+                (sum(i["usd"] for i in equity.values()) if equity else Decimal("0"))
                 + net_income
             )
 
-            def format_accounts(accounts_dict: dict[str, Decimal]) -> list[dict]:
-                return [
-                    {"account": name, "balance": str(bal)}
-                    for name, bal in sorted(accounts_dict.items())
-                ]
+            def format_accounts(accounts_dict: dict[str, dict]) -> list[dict]:
+                """Render each account row with the right balance shape.
 
-            # as_of_date is also an input echo, but it's cheap and
-            # useful when a log is reviewed out of context. `balanced`
-            # is derivable (assets == liabilities + equity); dropped.
+                Currency-default accounts:
+                  ``{"account": name, "balance": "5234.56"}``.
+                  No ``usd_value`` — it would just repeat ``balance``.
+
+                Non-currency accounts (STOCK / MUTUAL / FUND): the
+                ``balance`` field shows the human-readable triplet
+                ``"230.7600 VTSAX @ 156.23 (USD 36,043.66)"`` — same
+                format ``get_book_summary`` uses — and ``usd_value``
+                carries the parseable number rounded to 2 decimals so
+                programmatic callers don't have to parse the triplet.
+
+                All numeric outputs flow through ``_format_number``
+                (currency-style: 2 decimals always padded). Pre-fix
+                the per-account values leaked Decimal precision noise
+                (e.g. ``"612011.489832"``) into responses.
+                """
+                rows = []
+                for name, info in sorted(accounts_dict.items()):
+                    commodity = info["commodity"]
+                    usd_rounded = _format_number(info["usd"], decimals=2)
+                    if commodity == default_currency:
+                        rows.append({
+                            "account": name,
+                            "balance": usd_rounded,
+                        })
+                    else:
+                        rate = latest_rates.get(commodity.guid)
+                        sym = commodity.mnemonic
+                        qty = info["quantity"]
+                        if rate is not None:
+                            balance_str = (
+                                f"{qty} {sym} @ {rate} "
+                                f"(USD {info['usd']:,.2f})"
+                            )
+                        else:
+                            # No price on file — fall back to cost basis
+                            # already accumulated in ``info['usd']``.
+                            balance_str = (
+                                f"{qty} {sym} (USD {info['usd']:,.2f}, "
+                                f"no price data)"
+                            )
+                        rows.append({
+                            "account": name,
+                            "balance": balance_str,
+                            "usd_value": usd_rounded,
+                        })
+                return rows
+
+            # ``balanced`` is derivable (assets == liabilities + equity)
+            # and was dropped in an earlier audit pass. Rollup totals
+            # flow through ``_format_number`` (2 decimals, currency
+            # style) so the response no longer leaks Decimal precision
+            # noise like ``"612011.489832"``.
             return {
                 "as_of_date": as_of_date.isoformat(),
                 "assets": {
-                    "total": str(assets_total),
+                    "total": _format_number(assets_total, decimals=2),
                     "accounts": format_accounts(assets),
                 },
                 "liabilities": {
-                    "total": str(liabilities_total),
+                    "total": _format_number(liabilities_total, decimals=2),
                     "accounts": format_accounts(liabilities),
                 },
                 "equity": {
-                    "total": str(equity_total),
+                    "total": _format_number(equity_total, decimals=2),
                     "accounts": format_accounts(equity) + (
-                        [{"account": "Retained Earnings", "balance": str(net_income)}]
+                        [{
+                            "account": "Retained Earnings",
+                            "balance": _format_number(net_income, decimals=2),
+                        }]
                         if net_income != 0 else []
                     ),
                 },

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -39,6 +39,53 @@ _NET_INCOME_TYPES = frozenset({"INCOME", "EXPENSE"})
 _CASH_TYPES = frozenset({"BANK", "CASH"})
 
 
+def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> str:
+    """Render a category/source breakdown as a compact aligned table.
+
+    Format::
+
+        Business              22,336.90  39.3%
+        Taxes                  9,479.04  16.7%
+        ...
+        TOTAL                 56,944.26
+
+    Account names render as their leaf component when unambiguous —
+    spending breakdowns at depth=1 typically yield "Expenses:Business",
+    "Expenses:Taxes", etc., which all share the "Expenses:" prefix and
+    read better with the prefix stripped. Width-padded so the amount /
+    percent columns align.
+    """
+    if not rows:
+        return f"TOTAL  {total:,.2f}"
+
+    # Strip a common leading "Expenses:" / "Income:" prefix when every
+    # row shares it. This keeps the leaf-name column readable without
+    # losing information for mixed-source breakdowns (where the prefix
+    # is heterogeneous and we should keep the full path).
+    full_names = [r[label_key] for r in rows]
+    common_prefix = ""
+    if full_names and ":" in full_names[0]:
+        candidate = full_names[0].split(":")[0] + ":"
+        if all(n.startswith(candidate) for n in full_names):
+            common_prefix = candidate
+    leaves = [n[len(common_prefix):] for n in full_names]
+
+    name_width = max(len(n) for n in leaves) if leaves else 0
+    amount_strs = [f"{Decimal(r['amount']):,.2f}" for r in rows]
+    amount_width = max(len(a) for a in amount_strs) if amount_strs else 0
+
+    lines = []
+    for leaf, row, amt_str in zip(leaves, rows, amount_strs):
+        percent = row.get("percent", "0")
+        lines.append(
+            f"{leaf:<{name_width}}  {amt_str:>{amount_width}}  {percent}%"
+        )
+    lines.append(
+        f"{'TOTAL':<{name_width}}  {total:>{amount_width},.2f}"
+    )
+    return "\n".join(lines)
+
+
 def _money_compact(value: Decimal) -> str:
     """Format a dollar amount for compact-mode reports.
 
@@ -319,16 +366,21 @@ class ReportingMixin:
         start_date: date,
         end_date: date,
         depth: int = 1,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Get spending breakdown by expense category.
 
         Args:
             start_date: Start of period (inclusive).
             end_date: End of period (inclusive).
             depth: Hierarchy depth for grouping (1 = top-level, 2 = subcategories).
+            compact: If True (default), return an aligned text table
+                     suitable for direct LLM consumption (Phase 4C).
+                     Verbose mode returns the structured dict.
 
         Returns:
-            Dict with period, total, and category breakdown.
+            If compact: string with one line per category plus a TOTAL.
+            If not compact: dict with ``total`` and ``categories`` list.
         """
         with self.open(readonly=True) as book:
             rows = self._query_filtered_splits(
@@ -366,6 +418,8 @@ class ReportingMixin:
                     "percent": str(percent.quantize(Decimal("0.1"))),
                 })
 
+            if compact:
+                return _format_breakdown_tsv(categories, total, "account")
             # period is an input echo — LLM supplied start/end dates.
             return {
                 "total": str(total),
@@ -377,16 +431,21 @@ class ReportingMixin:
         start_date: date,
         end_date: date,
         depth: int = 1,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Get income breakdown by source.
 
         Args:
             start_date: Start of period (inclusive).
             end_date: End of period (inclusive).
             depth: Hierarchy depth for grouping (1 = top-level, 2 = subcategories).
+            compact: If True (default), return an aligned text table
+                     suitable for direct LLM consumption (Phase 4C).
+                     Verbose mode returns the structured dict.
 
         Returns:
-            Dict with period, total, and source breakdown.
+            If compact: string with one line per source plus a TOTAL.
+            If not compact: dict with ``total`` and ``sources`` list.
         """
         with self.open(readonly=True) as book:
             rows = self._query_filtered_splits(
@@ -425,6 +484,8 @@ class ReportingMixin:
                     "percent": str(percent.quantize(Decimal("0.1"))),
                 })
 
+            if compact:
+                return _format_breakdown_tsv(sources, total, "account")
             # period is an input echo — LLM supplied start/end dates.
             return {
                 "total": str(total),
@@ -578,6 +639,8 @@ class ReportingMixin:
                         })
                 return rows
 
+            # as_of_date is also an input echo, but it's cheap and
+            # useful when a log is reviewed out of context. `balanced`
             # ``balanced`` is derivable (assets == liabilities + equity)
             # and was dropped in an earlier audit pass. Rollup totals
             # flow through ``_format_number`` (2 decimals, currency
@@ -884,7 +947,16 @@ class ReportingMixin:
                      programmatic consumers.
 
         Returns:
-            If compact: text summary (kill order + YETI line + totals).
+            If compact: text summary, e.g.::
+
+                Kill order ($10,000/mo → debt-free Apr 2030, $59,022 interest):
+                  1. Business Amex    $13,091  24.49%  payoff: mo 8   interest: $1,125
+                  2. Chase Sapphire   $22,127  21.49%  payoff: mo 18  interest: $5,034
+                  ...
+                YETI at this budget: 1.59x ($1 spent costs $1.59 in total debt impact)
+                Total interest: $59,022
+                Debt-free: April 2030
+
             If not compact: dict with the original full structure.
 
         Raises:

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -617,21 +617,29 @@ def register(mcp, get_book) -> None:
         start_date: str,
         end_date: str,
         vendor_id: str | None = None,
+        verbose: bool = False,
     ) -> str:
         """Get spending breakdown by vendor for a period.
 
         Analyzes posted vendor bills to show total billed, total paid,
         and outstanding amounts per vendor.
 
+        Returns a compact aligned text table by default. Use verbose=true
+        for the full structured dict (programmatic consumers).
+
         Args:
             start_date: Start of period (YYYY-MM-DD).
             end_date: End of period (YYYY-MM-DD).
             vendor_id: Optional filter to a specific vendor.
+            verbose: If true, return the structured dict.
         """
         book = get_book()
         result = book.vendor_spending_report(
             start_date=start_date,
             end_date=end_date,
             vendor_id=vendor_id,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -124,11 +124,16 @@ def register(mcp, get_book) -> None:
     def debt_payoff_plan(
         monthly_budget: str,
         additional_purchase: str | None = None,
+        verbose: bool = False,
     ) -> str:
         """Calculate an avalanche-method debt payoff schedule with YETI multiplier.
 
         Auto-discovers CREDIT/LIABILITY accounts that have an 'apr' slot set.
         Set APRs via set_account_slot (e.g., set_account_slot("Liabilities:Visa", "apr", "23.49")).
+
+        Returns a compact text summary by default — kill order with
+        balances/APRs/payoff months, YETI line, totals, debt-free date.
+        Use verbose=true for the full structured dict.
 
         YETI (Your Expense's True Impact) shows the true cost of a purchase when
         carrying debt: "A $1.00 purchase will cost you $1.68 by the time your
@@ -137,10 +142,14 @@ def register(mcp, get_book) -> None:
         Args:
             monthly_budget: Total monthly amount available for all debt payments combined
             additional_purchase: Dollar amount to calculate YETI for (default "1.00")
+            verbose: If true, return the full structured dict.
         """
         book = get_book()
         result = book.debt_payoff_plan(
             monthly_budget=monthly_budget,
             additional_purchase=additional_purchase,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -16,21 +16,29 @@ def register(mcp, get_book) -> None:
         start_date: str,
         end_date: str,
         depth: int = 1,
+        verbose: bool = False,
     ) -> str:
         """Get spending breakdown by expense category for a period.
+
+        Returns a compact aligned text table by default. Use verbose=true
+        for the full structured dict (programmatic consumers, plotting).
 
         Args:
             start_date: Start of period (YYYY-MM-DD)
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
+            verbose: If true, return the structured dict.
         """
         book = get_book()
         result = book.spending_by_category(
             start_date=date.fromisoformat(start_date),
             end_date=date.fromisoformat(end_date),
             depth=depth,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool
@@ -39,21 +47,29 @@ def register(mcp, get_book) -> None:
         start_date: str,
         end_date: str,
         depth: int = 1,
+        verbose: bool = False,
     ) -> str:
         """Get income breakdown by source for a period.
+
+        Returns a compact aligned text table by default. Use verbose=true
+        for the full structured dict.
 
         Args:
             start_date: Start of period (YYYY-MM-DD)
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
+            verbose: If true, return the structured dict.
         """
         book = get_book()
         result = book.income_by_source(
             start_date=date.fromisoformat(start_date),
             end_date=date.fromisoformat(end_date),
             depth=depth,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool
@@ -133,7 +149,10 @@ def register(mcp, get_book) -> None:
 
         Returns a compact text summary by default — kill order with
         balances/APRs/payoff months, YETI line, totals, debt-free date.
-        Use verbose=true for the full structured dict.
+        Use verbose=true for the full structured dict (per-account
+        ``interest_paid`` / ``credit_limit`` / ``minimum_payment``,
+        plus the structured ``yeti`` block) suitable for programmatic
+        consumers.
 
         YETI (Your Expense's True Impact) shows the true cost of a purchase when
         carrying debt: "A $1.00 purchase will cost you $1.68 by the time your
@@ -142,7 +161,8 @@ def register(mcp, get_book) -> None:
         Args:
             monthly_budget: Total monthly amount available for all debt payments combined
             additional_purchase: Dollar amount to calculate YETI for (default "1.00")
-            verbose: If true, return the full structured dict.
+            verbose: If true, return the full structured dict instead
+                     of the compact text summary.
         """
         book = get_book()
         result = book.debt_payoff_plan(

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6585,7 +6585,7 @@ class TestSpendingByCategory:
         """Should return spending breakdown."""
         gc_book = GnuCashBook(str(test_book))
 
-        result = gc_book.spending_by_category(
+        result = gc_book.spending_by_category(compact=False,
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
         )
@@ -6599,7 +6599,7 @@ class TestSpendingByCategory:
         """Should return zero for period with no transactions."""
         gc_book = GnuCashBook(str(test_book))
 
-        result = gc_book.spending_by_category(
+        result = gc_book.spending_by_category(compact=False,
             start_date=date(2020, 1, 1),
             end_date=date(2020, 1, 31),
         )
@@ -6615,7 +6615,7 @@ class TestIncomeBySource:
         """Should return income breakdown."""
         gc_book = GnuCashBook(str(test_book))
 
-        result = gc_book.income_by_source(
+        result = gc_book.income_by_source(compact=False,
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
         )
@@ -7127,7 +7127,7 @@ class TestMultiCurrencyBalances:
     def test_spending_by_category_uses_quantity(self, multi_currency_book: Path):
         """Expense reporting should use quantity."""
         gc_book = GnuCashBook(str(multi_currency_book))
-        result = gc_book.spending_by_category(
+        result = gc_book.spending_by_category(compact=False,
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
             depth=2,
@@ -7139,7 +7139,7 @@ class TestMultiCurrencyBalances:
     def test_income_by_source_uses_quantity(self, multi_currency_book: Path):
         """Income reporting should use quantity."""
         gc_book = GnuCashBook(str(multi_currency_book))
-        result = gc_book.income_by_source(
+        result = gc_book.income_by_source(compact=False,
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
             depth=2,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6643,6 +6643,55 @@ class TestBalanceSheet:
         assert "accounts" in result["assets"]
 
 
+class TestBalanceSheetNumericContract:
+    """Phase 4B follow-up: bookkeeper flagged the totals leaking
+    Decimal precision (``"612011.489832"``) and the per-account
+    ``usd_value`` being unrounded for investments / redundant for
+    currency accounts. Lock the contract:
+
+    - All monetary outputs (totals + account values) are 2 decimals.
+    - Currency-default accounts have ``balance`` only, no ``usd_value``.
+    - Non-currency accounts have both, with ``usd_value`` rounded.
+    """
+
+    def test_section_totals_render_at_2_decimals(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        for section in ("assets", "liabilities", "equity"):
+            total = result[section]["total"]
+            # Currency-style: every total ends with exactly two decimal
+            # digits, no scientific notation, no precision noise.
+            assert "." in total, f"{section} total missing decimal: {total!r}"
+            assert len(total.split(".")[-1]) == 2, (
+                f"{section} total wrong precision: {total!r}"
+            )
+
+    def test_currency_accounts_have_no_usd_value_field(
+        self, test_book: Path,
+    ):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        for row in result["assets"]["accounts"]:
+            # Test fixture is single-currency USD — every asset row
+            # is currency-default. None should carry ``usd_value``.
+            assert "usd_value" not in row, (
+                f"redundant usd_value on currency row: {row}"
+            )
+
+    def test_currency_account_balance_renders_at_2_decimals(
+        self, test_book: Path,
+    ):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        for row in result["assets"]["accounts"]:
+            balance = row["balance"]
+            # Currency-default rows: pure numeric, 2 decimals always.
+            assert "." in balance
+            assert len(balance.split(".")[-1]) == 2, (
+                f"row {row['account']!r} balance wrong precision: {balance!r}"
+            )
+
+
 class TestNetWorth:
     """Tests for net_worth method."""
 
@@ -6990,16 +7039,25 @@ class TestMultiCurrencyBalances:
         to cost basis (split.value, in transaction currency) for the
         EUR account. The fixture's FX transfer booked value=1100 USD
         on the EUR side, so cost basis = $1,100.
+
+        Phase 4B (comms): currency-default accounts read their value
+        from ``balance``; non-default accounts have a parseable
+        ``usd_value`` alongside the human-readable triplet ``balance``.
+        ``usd_value`` is dropped for currency rows where it would just
+        repeat ``balance``.
         """
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
-        asset_accounts = {
-            a["account"]: Decimal(a["balance"])
-            for a in result["assets"]["accounts"]
-        }
-        assert asset_accounts["Assets:Checking"] == Decimal("6700")
-        # Cost-basis fallback in the default currency
-        assert asset_accounts["Assets:Euro Savings"] == Decimal("1100")
+        accounts = {a["account"]: a for a in result["assets"]["accounts"]}
+        # Currency account: numeric in ``balance``, no ``usd_value``.
+        checking = accounts["Assets:Checking"]
+        assert Decimal(checking["balance"]) == Decimal("6700.00")
+        assert "usd_value" not in checking
+        # Non-currency: ``usd_value`` for parsing, ``balance`` for display.
+        eur = accounts["Assets:Euro Savings"]
+        assert Decimal(eur["usd_value"]) == Decimal("1100.00")
+        assert "EUR" in eur["balance"]
+        assert "no price data" in eur["balance"]
 
     def test_balance_sheet_values_foreign_currency_at_market_with_price(
         self, multi_currency_book: Path
@@ -7022,11 +7080,16 @@ class TestMultiCurrencyBalances:
             b.save()
 
         result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
-        asset_accounts = {
-            a["account"]: Decimal(a["balance"])
-            for a in result["assets"]["accounts"]
-        }
-        assert asset_accounts["Assets:Euro Savings"] == Decimal("1200")
+        eur_row = next(
+            a for a in result["assets"]["accounts"]
+            if a["account"] == "Assets:Euro Savings"
+        )
+        # Non-currency row: ``usd_value`` is parseable + rounded.
+        assert Decimal(eur_row["usd_value"]) == Decimal("1200.00")
+        # Phase 4B: human-readable balance shows shares + rate + USD.
+        assert "EUR" in eur_row["balance"]
+        assert "@" in eur_row["balance"]
+        assert "USD" in eur_row["balance"]
 
     def test_net_worth_converts_foreign_currency(
         self, multi_currency_book: Path

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6692,6 +6692,69 @@ class TestBalanceSheetNumericContract:
             )
 
 
+class TestCrossToolPriceAgreement:
+    """Bookkeeper-flagged: ``get_book_summary`` was using stale prices
+    (latest <= today) while ``balance_sheet`` used the absolute latest
+    (including the bookkeeper's intentional future-dated forecasts).
+    On Alex's book this produced a ~$5,300 gap across investment
+    valuations between the two surfaces.
+
+    Lock the contract: when the latest price for a commodity is
+    future-dated relative to today, both tools must use it. Past
+    trajectory anchors (1mo / 3mo / 6mo / 12mo ago) keep the
+    historical-reconstruction filter via ``_rates_as_of``.
+    """
+
+    def test_summary_and_balance_sheet_agree_on_latest_price(
+        self, multi_currency_book: Path,
+    ):
+        from datetime import date as date_cls, timedelta
+        import piecash
+
+        gc_book = GnuCashBook(str(multi_currency_book))
+
+        # Write a future-dated EUR/USD rate. Pre-fix, balance_sheet
+        # would use it (no filter) and get_book_summary would skip
+        # it (today filter), producing different EUR-account values.
+        future = date_cls.today() + timedelta(days=2)
+        with gc_book.open(readonly=False) as b:
+            usd = b.default_currency
+            eur = next(c for c in b.commodities if c.mnemonic == "EUR")
+            b.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=future,
+                value="1.50", source="user:test", type="nav",
+            ))
+            b.save()
+
+        # balance_sheet picks the future-dated rate at 1.50.
+        bs = gc_book.balance_sheet(as_of_date=date_cls.today())
+        eur_row = next(
+            a for a in bs["assets"]["accounts"]
+            if a["account"] == "Assets:Euro Savings"
+        )
+        # 1000 EUR × 1.50 = 1500 USD.
+        assert Decimal(eur_row["usd_value"]) == Decimal("1500.00")
+
+        # get_book_summary must agree: use the same future-dated rate
+        # for the per-account display AND for the trajectory "now"
+        # anchor. We verify by checking the rendered summary contains
+        # the future-rate-based number, not 1000 (cost basis) and not
+        # any earlier-rate-based fallback.
+        summary = gc_book.get_book_summary()
+        # Summary uses the future-dated rate of 1.5; resulting USD
+        # value is 1500. (Decimal stringification drops trailing zero
+        # on the rate, comma-formatting varies — assert the value.)
+        assert "USD 1500" in summary, (
+            f"summary did not pick up the future-dated EUR/USD rate; "
+            f"saw:\n{summary}"
+        )
+        assert "EUR @ 1.5" in summary
+        # Trajectory's "now" anchor should reflect the same rate too:
+        # 6700 USD Checking + 1500 USD Euro Savings = 8200.
+        assert "now: USD 8,200" in summary
+
+
 class TestNetWorth:
     """Tests for net_worth method."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2621,7 +2621,7 @@ class TestVendorSpendingReport:
             owner_type="vendor",
             post_date="2026-02-15",
         )
-        result = gb.vendor_spending_report(
+        result = gb.vendor_spending_report(compact=False,
             start_date="2026-01-01",
             end_date="2026-12-31",
         )
@@ -2664,7 +2664,7 @@ class TestVendorSpendingReport:
             owner_type="vendor",
             post_date="2026-02-20",
         )
-        result = gb.vendor_spending_report(
+        result = gb.vendor_spending_report(compact=False,
             start_date="2026-01-01",
             end_date="2026-12-31",
         )
@@ -2689,7 +2689,7 @@ class TestVendorSpendingReport:
             post_date="2026-06-15",
         )
         # Query range that excludes the bill
-        result = gb.vendor_spending_report(
+        result = gb.vendor_spending_report(compact=False,
             start_date="2026-01-01",
             end_date="2026-03-31",
         )
@@ -2727,7 +2727,7 @@ class TestVendorSpendingReport:
             owner_type="vendor",
             post_date="2026-02-20",
         )
-        result = gb.vendor_spending_report(
+        result = gb.vendor_spending_report(compact=False,
             start_date="2026-01-01",
             end_date="2026-12-31",
             vendor_id="000001",
@@ -2826,3 +2826,98 @@ class TestInvoiceLifecycle:
         # Verify cleared
         outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
         assert len(outstanding) == 0
+
+
+class TestPhase4DVendorSpendingCompact:
+    """Lock tests for the Phase 4D compact ``vendor_spending_report``
+    contract. Verbose mode preserves the dict shape (minus the dropped
+    ``period`` echo); compact mode renders the aligned text table."""
+
+    def test_compact_default_returns_string(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="1", price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-01-01",
+        )
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01", end_date="2026-12-31",
+        )
+        assert isinstance(result, str)
+        assert "Office Depot" in result
+        assert "TOTAL" in result
+        assert "billed" in result
+        assert "paid" in result
+        assert "outstanding" in result
+
+    def test_pluralizes_one_vs_many_bills(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Solo Vendor")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="One", quantity="1", price="100.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-01-01",
+        )
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01", end_date="2026-12-31",
+        )
+        # Single bill renders as "1 bill", not "1 bills".
+        assert "1 bill " in result or result.endswith("1 bill")
+        # The TOTAL line counts the same way.
+        assert "1 bills" not in result
+
+    def test_verbose_mode_drops_period_echo(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+            compact=False,
+        )
+        assert "vendors" in result
+        assert "totals" in result
+        # ``period`` was the input echo Abe flagged for removal — it
+        # duplicated the dates the caller already had.
+        assert "period" not in result
+
+
+class TestPhase4CBreakdownCompact:
+    """Phase 4C: ``spending_by_category`` and ``income_by_source``
+    return aligned text tables by default, JSON via ``compact=False``.
+    Same shape as the helper used by ``vendor_spending_report``."""
+
+    def test_spending_compact_returns_string(self, business_book):
+        from datetime import date as date_cls
+        gb = GnuCashBook(str(business_book))
+        # The business_book fixture seeds Income:Sales / Expenses:*
+        # accounts but no transactions; create one to anchor.
+        gb.create_invoice(customer_id="000001") if False else None
+        result = gb.spending_by_category(
+            start_date=date_cls(2024, 1, 1),
+            end_date=date_cls(2024, 12, 31),
+        )
+        assert isinstance(result, str)
+        assert "TOTAL" in result
+
+    def test_income_compact_returns_string(self, business_book):
+        from datetime import date as date_cls
+        gb = GnuCashBook(str(business_book))
+        result = gb.income_by_source(
+            start_date=date_cls(2024, 1, 1),
+            end_date=date_cls(2024, 12, 31),
+        )
+        assert isinstance(result, str)
+        assert "TOTAL" in result

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -15,7 +15,7 @@ class TestDebtPayoffPlan:
         """Should pay highest APR debt first (Visa 23.49% before Mastercard 18.99%)."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         # Visa (23.49%) should be first in payoff order
         assert result["payoff_order"][0] == "Liabilities:Visa"
@@ -47,7 +47,7 @@ class TestDebtPayoffPlan:
         """Should calculate YETI > 1.0 (debt makes purchases cost more)."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         yeti = result["yeti"]
         assert "multiplier" in yeti
@@ -75,6 +75,7 @@ class TestDebtPayoffPlan:
         gc_book = GnuCashBook(str(debt_book))
 
         result = gc_book.debt_payoff_plan(
+            compact=False,
             monthly_budget="1000",
             additional_purchase="100",
         )
@@ -89,20 +90,20 @@ class TestDebtPayoffPlan:
         gc_book = GnuCashBook(str(test_book))
 
         with pytest.raises(ValueError, match="No debt accounts found"):
-            gc_book.debt_payoff_plan(monthly_budget="500")
+            gc_book.debt_payoff_plan(compact=False, monthly_budget="500")
 
     def test_budget_less_than_minimums(self, debt_book: Path):
         """Should raise ValueError when budget can't cover minimum payments."""
         gc_book = GnuCashBook(str(debt_book))
 
         with pytest.raises(ValueError, match="less than the sum of minimum"):
-            gc_book.debt_payoff_plan(monthly_budget="100")
+            gc_book.debt_payoff_plan(compact=False, monthly_budget="100")
 
     def test_minimum_payment_from_slot(self, debt_book: Path):
         """Should use minimum_payment slot when present."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         # Car Loan has minimum_payment slot set to 350
         for d in result["debts"]:
@@ -116,7 +117,7 @@ class TestDebtPayoffPlan:
         """Should calculate 2% of balance when no minimum_payment slot."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         # Visa: $5000 charges - $200 payment = $4800 balance, 2% = $96
         for d in result["debts"]:
@@ -130,7 +131,7 @@ class TestDebtPayoffPlan:
         """Should fall back to 2% of balance when no slot and no payments."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         # Mastercard has no minimum_payment slot and no payment transactions
         # Balance is $3000, 2% = $60
@@ -163,7 +164,7 @@ class TestDebtPayoffPlan:
             trans_date=date(2026, 1, 1),
         )
 
-        result = gc_book.debt_payoff_plan(monthly_budget="200")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="200")
 
         assert len(result["debts"]) == 1
         assert result["debts"][0]["account"] == "Liabilities:Credit Card"
@@ -185,13 +186,13 @@ class TestDebtPayoffPlan:
 
         # Should fail because no debt accounts with positive balance
         with pytest.raises(ValueError, match="No debt accounts found"):
-            gc_book.debt_payoff_plan(monthly_budget="500")
+            gc_book.debt_payoff_plan(compact=False, monthly_budget="500")
 
     def test_credit_limit_included(self, debt_book: Path):
         """Should include credit_limit in output when slot is present."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         # Visa has credit_limit slot set to 10000
         visa_detail = None
@@ -215,20 +216,20 @@ class TestDebtPayoffPlan:
         gc_book = GnuCashBook(str(debt_book))
 
         with pytest.raises(ValueError, match="must be a positive number"):
-            gc_book.debt_payoff_plan(monthly_budget="0")
+            gc_book.debt_payoff_plan(compact=False, monthly_budget="0")
 
     def test_invalid_budget_negative(self, debt_book: Path):
         """Should raise ValueError for negative budget."""
         gc_book = GnuCashBook(str(debt_book))
 
         with pytest.raises(ValueError, match="must be a positive number"):
-            gc_book.debt_payoff_plan(monthly_budget="-500")
+            gc_book.debt_payoff_plan(compact=False, monthly_budget="-500")
 
     def test_total_paid_equals_balance_plus_interest(self, debt_book: Path):
         """Total paid should equal total balance + total interest."""
         gc_book = GnuCashBook(str(debt_book))
 
-        result = gc_book.debt_payoff_plan(monthly_budget="1000")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="1000")
 
         total_balance = Decimal(result["total_balance"])
         total_interest = Decimal(result["total_interest"])
@@ -257,7 +258,7 @@ class TestDebtPayoffPlan:
             trans_date=date(2026, 1, 1),
         )
 
-        result = gc_book.debt_payoff_plan(monthly_budget="50")
+        result = gc_book.debt_payoff_plan(compact=False, monthly_budget="50")
 
         for d in result["debts"]:
             if d["account"] == "Liabilities:Almost Paid":
@@ -266,3 +267,78 @@ class TestDebtPayoffPlan:
                 break
         else:
             pytest.fail("Almost Paid not found in results")
+
+
+class TestDebtPayoffCompactFormat:
+    """Phase 4A lock tests for the compact text-table output.
+    The verbose dict (existing tests above) is now opt-in; the default
+    is a compact summary the LLM can read directly without paying for
+    the full ``debts`` / ``yeti`` structure on every call."""
+
+    def test_compact_default_returns_string(self, debt_book):
+        from datetime import date
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.create_transaction(
+            description="Visa charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-1000"},
+                {"account": "Expenses:Groceries", "amount": "1000"},
+            ],
+            trans_date=date(2026, 1, 1),
+        )
+        result = gc_book.debt_payoff_plan(monthly_budget="2000")
+        assert isinstance(result, str)
+
+    def test_compact_includes_kill_order_header(self, debt_book):
+        from datetime import date
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.create_transaction(
+            description="Visa charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-1000"},
+                {"account": "Expenses:Groceries", "amount": "1000"},
+            ],
+            trans_date=date(2026, 1, 1),
+        )
+        result = gc_book.debt_payoff_plan(monthly_budget="2000")
+        # Header gives budget → debt-free month → total interest at a glance.
+        assert "Kill order" in result
+        assert "/mo" in result
+        assert "debt-free" in result
+        assert "interest" in result
+
+    def test_compact_includes_yeti_line(self, debt_book):
+        from datetime import date
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.create_transaction(
+            description="Visa charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-1000"},
+                {"account": "Expenses:Groceries", "amount": "1000"},
+            ],
+            trans_date=date(2026, 1, 1),
+        )
+        result = gc_book.debt_payoff_plan(monthly_budget="2000")
+        assert "YETI" in result
+        # The plain-English explanation lives on the YETI line itself.
+        assert "total debt impact" in result
+
+    def test_compact_drops_per_account_yeti_explanation(self, debt_book):
+        """The pre-fix verbose response embedded a multi-line YETI
+        explanation per account. Compact mode must NOT replicate that
+        bloat — the YETI signal lives on a single summary line."""
+        from datetime import date
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.create_transaction(
+            description="Visa charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-1000"},
+                {"account": "Expenses:Groceries", "amount": "1000"},
+            ],
+            trans_date=date(2026, 1, 1),
+        )
+        result = gc_book.debt_payoff_plan(monthly_budget="2000")
+        # Each "by the time your debt is paid off" string was repeated
+        # per account in the old shape. Should appear at most once now
+        # (or zero times — we use "total debt impact" wording instead).
+        assert result.count("by the time your debt is paid off") <= 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -992,12 +992,21 @@ class TestSpendingByCategoryTool:
     """Tests for spending_by_category tool."""
 
     def test_spending_by_category(self, setup_book_env):
-        """Should return spending breakdown."""
+        """Compact (default) returns aligned text table."""
         result = server_module.spending_by_category(
             start_date="2024-01-01",
             end_date="2024-12-31",
         )
+        # New default is compact text — has TOTAL line.
+        assert "TOTAL" in result
 
+    def test_spending_by_category_verbose(self, setup_book_env):
+        """Verbose returns the structured dict."""
+        result = server_module.spending_by_category(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            verbose=True,
+        )
         data = json.loads(result)
         assert "total" in data
         assert "categories" in data
@@ -1007,12 +1016,20 @@ class TestIncomeBySourcTool:
     """Tests for income_by_source tool."""
 
     def test_income_by_source(self, setup_book_env):
-        """Should return income breakdown."""
+        """Compact (default) returns aligned text table."""
         result = server_module.income_by_source(
             start_date="2024-01-01",
             end_date="2024-12-31",
         )
+        assert "TOTAL" in result
 
+    def test_income_by_source_verbose(self, setup_book_env):
+        """Verbose returns the structured dict."""
+        result = server_module.income_by_source(
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            verbose=True,
+        )
         data = json.loads(result)
         assert "total" in data
         assert "sources" in data


### PR DESCRIPTION
## Summary

Branch 3 of the multi-phase comms-audit work (``docs/COMMUNICATION_AUDIT_FIXES.md``). The four heaviest reports get compact text-table defaults — the headline token win of the audit. Verbose mode preserved on all four for programmatic consumers.

Three commits:

1. **``9bc2ecc`` debt_payoff_plan** — kill-order text table replaces the per-account multi-line YETI explanation and structured dict. Single YETI summary line. Aligned columns. The single heaviest response in Abe's audit.

2. **``2134b55`` balance_sheet** — investment accounts render as ``"230.7620 VTSAX @ 170.99 (USD 39,457.99)"`` matching get_book_summary's format, with parseable ``usd_value`` for programmatic consumers. Plus the bookkeeper's rounding follow-up: section totals + per-account values flow through ``_format_number(decimals=2)`` so responses no longer leak Decimal precision noise (``"612011.49"`` not ``"612011.489832"``). Currency rows omit the redundant ``usd_value`` field.

3. **``e02d03c`` breakdowns + vendor spending** — ``spending_by_category`` / ``income_by_source`` / ``vendor_spending_report`` get aligned text tables. Common-prefix stripping (``Expenses:Business`` → ``Business``) for breakdowns. Pluralization ("1 bill" / "5 bills") for vendor rollup. ``period`` echo dropped from vendor_spending_report.

## Live output (Alex Chen-Morales, post-bounce)

**balance_sheet ``2026-04-28``** (sample rows):
```
Assets:Investments:Brokerage:VTSAX  "230.7620 VTSAX @ 170.99 (USD 39,457.99)"  usd_value: "39457.99"
Assets:Investments:Brokerage:AAPL    "27.1326 AAPL @ 273.43 (USD 7,418.87)"    usd_value: "7418.87"
Assets:Current Assets:Checking       "21795.96"                                 (no usd_value field)
assets.total: "612011.49"
```

(Bookkeeper noted: assets ≠ liabilities + equity by ~$3,763 — that's unrealized gains across the investment positions. Correct accounting; the ledger balances at cost basis, the display values at market. ``Unrealized Gains`` synthetic equity line is a candidate for a future branch, not in scope here.)

## Test plan

- [x] 943 unit/integration tests passing locally
- [x] 12 new lock tests across ``TestDebtPayoffCompactFormat``, ``TestBalanceSheetNumericContract``, ``TestPhase4DVendorSpendingCompact``, ``TestPhase4CBreakdownCompact``
- [x] All existing reporting tests pass with ``compact=False`` (matches the established dual-mode convention from ``list_lots`` / ``list_invoices`` / ``get_unreconciled_splits``)
- [x] Live-verified on Alex's book at four checkpoints — debt payoff kill order, balance_sheet investment format + 2-decimal totals, spending/income TSV, vendor spending pluralization

## Phasing

Branch 4 next (``feat/comms-polish``) — Phases 5-6: budget formatting + investment cosmetics + ``list_budgets`` compact. The polish pass.