### PR TITLE
feat: comms-audit Phase 5 + 6 polish (budgets + investments + contract lock)

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -22,6 +22,207 @@ from gnucash_mcp.book._base import (
 )
 
 
+def _collapse_period_runs(
+    periods: dict[int, str], num_periods: int,
+) -> str:
+    """Render an account's period amounts as a compact run-string.
+
+    Example outputs:
+      ``"250/mo (all periods)"``
+      ``"300/mo (P0-5,P8-11), 600/mo (P6-7)"``
+      ``"100/mo (P0-10), 800/mo (P11)"``
+
+    Groups consecutive periods that share the same amount into runs.
+    Most monthly budgets are uniform across all periods, so the common
+    case is the simple "all periods" form.
+    """
+    if not periods:
+        return "—"
+
+    # Build a per-period amount list (filling missing periods with "0").
+    per_period = [periods.get(i, "0") for i in range(num_periods)]
+
+    # If every period has the same value, the simple form wins.
+    unique_amounts = set(per_period)
+    if len(unique_amounts) == 1:
+        amt = per_period[0]
+        return f"{amt}/mo (all periods)"
+
+    # Build runs of consecutive periods that share the same amount.
+    runs: list[tuple[str, int, int]] = []
+    run_start = 0
+    run_amount = per_period[0]
+    for i in range(1, num_periods):
+        if per_period[i] != run_amount:
+            runs.append((run_amount, run_start, i - 1))
+            run_start = i
+            run_amount = per_period[i]
+    runs.append((run_amount, run_start, num_periods - 1))
+
+    # Group runs by amount so "P0-5,P8-11" forms naturally for split
+    # patterns (e.g., the same baseline amount in disjoint stretches).
+    by_amount: dict[str, list[tuple[int, int]]] = {}
+    for amt, lo, hi in runs:
+        by_amount.setdefault(amt, []).append((lo, hi))
+
+    # Sort by total span size (largest first) so the dominant amount
+    # appears first in the rendering.
+    sorted_amounts = sorted(
+        by_amount.items(),
+        key=lambda kv: -sum(hi - lo + 1 for lo, hi in kv[1]),
+    )
+
+    parts = []
+    for amt, ranges in sorted_amounts:
+        labels = []
+        for lo, hi in ranges:
+            labels.append(f"P{lo}-{hi}" if lo != hi else f"P{lo}")
+        parts.append(f"{amt}/mo ({','.join(labels)})")
+    return ", ".join(parts)
+
+
+def _format_budget_report_compact(report: dict) -> str:
+    """Render a budget-report dict as a compact text table.
+
+    Layout per Phase 5B::
+
+        2026 Annual Budget — Period 3 (Apr 2026)
+        Account                          Budget   Actual  Remaining  %Used
+        Auto:Fuel                           250   199.61      50.39  79.8%
+        Business:Contractor Payments      6,200 6,128.00      72.00  98.8%
+        Groceries                           450   608.57    -158.57  135.2% ⚠
+        Medical                             200 1,488.03  -1,288.03  744.0% ⚠
+        TOTAL                             7,971 9,022.90  -1,051.90  113.2% ⚠
+
+    ``⚠`` markers fire on rows where ``percent_used > 110%`` — same
+    threshold ``get_book_summary`` uses for the budget headline.
+    Strips a common ``Expenses:`` / ``Income:`` prefix from leaf
+    names to keep the column readable.
+    """
+    accounts = report.get("accounts", [])
+    totals = report.get("totals", {})
+    budget_name = report.get("budget", "?")
+    period_info = report.get("period", "")
+
+    header_line = f"{budget_name} — {period_info}"
+    if not accounts:
+        return f"{header_line}\n(no budgeted accounts)"
+
+    # Strip a common "Expenses:" / "Income:" prefix (same idiom as
+    # spending_by_category / income_by_source).
+    full_names = [r["account"] for r in accounts]
+    common_prefix = ""
+    if full_names and ":" in full_names[0]:
+        candidate = full_names[0].split(":")[0] + ":"
+        if all(n.startswith(candidate) for n in full_names):
+            common_prefix = candidate
+    leaves = [n[len(common_prefix):] for n in full_names]
+
+    name_width = max(
+        max(len(l) for l in leaves), len("Account"), len("TOTAL"),
+    )
+
+    def _fmt(value: str) -> str:
+        d = Decimal(value)
+        # Whole-dollar values render simpler.
+        if d == d.to_integral_value():
+            return f"{int(d):,}"
+        return f"{d:,.2f}"
+
+    budget_strs = [_fmt(r["budgeted"]) for r in accounts]
+    actual_strs = [_fmt(r["actual"]) for r in accounts]
+    remaining_strs = [_fmt(r["remaining"]) for r in accounts]
+    pct_strs = [f"{r['percent_used']}%" for r in accounts]
+
+    total_budget = _fmt(totals.get("budgeted", "0"))
+    total_actual = _fmt(totals.get("actual", "0"))
+    total_remaining = _fmt(totals.get("remaining", "0"))
+    total_pct = f"{totals.get('percent_used', '0')}%"
+
+    budget_w = max(
+        max(len(s) for s in budget_strs), len(total_budget), len("Budget"),
+    )
+    actual_w = max(
+        max(len(s) for s in actual_strs), len(total_actual), len("Actual"),
+    )
+    remaining_w = max(
+        max(len(s) for s in remaining_strs),
+        len(total_remaining),
+        len("Remaining"),
+    )
+    pct_w = max(
+        max(len(s) for s in pct_strs), len(total_pct), len("%Used"),
+    )
+
+    def _pct_marker(pct_str: str) -> str:
+        # Strip "%" then parse; over-110% earns the warning marker.
+        try:
+            v = Decimal(pct_str.rstrip("%"))
+        except Exception:
+            return ""
+        return " ⚠" if v > Decimal("110") else ""
+
+    lines = [header_line]
+    lines.append(
+        f"{'Account':<{name_width}}  "
+        f"{'Budget':>{budget_w}}  "
+        f"{'Actual':>{actual_w}}  "
+        f"{'Remaining':>{remaining_w}}  "
+        f"{'%Used':>{pct_w}}"
+    )
+    for leaf, b, a, rem, pct in zip(
+        leaves, budget_strs, actual_strs, remaining_strs, pct_strs,
+    ):
+        lines.append(
+            f"{leaf:<{name_width}}  "
+            f"{b:>{budget_w}}  "
+            f"{a:>{actual_w}}  "
+            f"{rem:>{remaining_w}}  "
+            f"{pct:>{pct_w}}{_pct_marker(pct)}"
+        )
+    lines.append(
+        f"{'TOTAL':<{name_width}}  "
+        f"{total_budget:>{budget_w}}  "
+        f"{total_actual:>{actual_w}}  "
+        f"{total_remaining:>{remaining_w}}  "
+        f"{total_pct:>{pct_w}}{_pct_marker(total_pct)}"
+    )
+    return "\n".join(lines)
+
+
+def _format_get_budget_compact(
+    info: dict, account_rows: list[dict],
+) -> str:
+    """Render a budget as compact text — header + per-account rows.
+
+    Header carries name, period count, and start date. Per-account
+    rows use ``_collapse_period_runs`` to fold uniform stretches
+    into single labels (the typical 12-cell repeat collapses to one
+    "all periods" form).
+    """
+    num_periods = info.get("num_periods", 12)
+    name = info.get("name", "?")
+    period_type = info.get("period_type", "")
+    start = info.get("start_date", "?")
+    header = (
+        f"{name}  {num_periods} periods"
+        + (f" ({period_type})" if period_type else "")
+        + f"  starts:{start}"
+    )
+
+    if not account_rows:
+        return header + "\n(no account amounts set)"
+
+    name_width = max(len(r["account"]) for r in account_rows)
+    lines = [header]
+    for row in account_rows:
+        acct = row["account"]
+        periods = {int(k): v for k, v in row["periods"].items()}
+        runs = _collapse_period_runs(periods, num_periods)
+        lines.append(f"{acct:<{name_width}}  {runs}")
+    return "\n".join(lines)
+
+
 class BudgetsMixin:
     """Budget CRUD + period-aware variance reporting."""
 
@@ -185,28 +386,58 @@ class BudgetsMixin:
 
     # ── CRUD ──────────────────────────────────────────────────────
 
-    def list_budgets(self) -> list[dict]:
+    def list_budgets(self, compact: bool = True) -> list[dict] | str:
         """List all budgets in the book.
 
+        Args:
+            compact: If True (default), return a compact one-line-per-
+                     budget string. Verbose mode returns the structured
+                     dict list.
+
         Returns:
-            List of budget dicts with guid, name, description,
-            num_periods, period_type, and start_date.
+            If compact: newline-separated lines of the form
+                ``"<name>  <num_periods> periods (<period_type>)  starts:<YYYY-MM-DD>"``.
+            If not compact: list of budget dicts.
         """
         from piecash.budget import Budget
 
         with self.open(readonly=True) as book:
             budgets = book.session.query(Budget).all()
-            return [self._budget_to_dict(b) for b in budgets]
+            dicts = [self._budget_to_dict(b) for b in budgets]
+            if not compact:
+                return dicts
 
-    def get_budget(self, name: str) -> dict | None:
+            if not dicts:
+                return ""
+            name_width = max(len(d["name"]) for d in dicts)
+            lines = []
+            for d in dicts:
+                periods = d.get("num_periods", "?")
+                ptype = d.get("period_type", "")
+                start = d.get("start_date", "?")
+                ptype_str = f" ({ptype})" if ptype else ""
+                lines.append(
+                    f"{d['name']:<{name_width}}  "
+                    f"{periods} periods{ptype_str}  starts:{start}"
+                )
+            return "\n".join(lines)
+
+    def get_budget(
+        self, name: str, compact: bool = True,
+    ) -> dict | str | None:
         """Get full details of a budget including all budget amounts.
 
         Args:
             name: Budget name.
+            compact: If True (default), return a compact text table
+                     that collapses uniform periods (e.g.,
+                     ``"250/mo (all periods)"``). Verbose mode returns
+                     the structured ``periods`` dict per account.
 
         Returns:
-            Dict with budget info and all account/period amounts,
-            or None if not found.
+            If compact: text string with header + one line per account.
+            If not compact: dict with full ``periods`` mapping.
+            ``None`` if budget not found (matches existing contract).
         """
         with self.open(readonly=True) as book:
             budget = self._find_budget(book, name)
@@ -222,15 +453,16 @@ class BudgetsMixin:
                     accounts[acct_name] = {}
                 accounts[acct_name][ba.period_num] = str(ba.amount)
 
-            result["accounts"] = [
-                {
-                    "account": acct_name,
-                    "periods": periods,
-                }
+            account_rows = [
+                {"account": acct_name, "periods": periods}
                 for acct_name, periods in sorted(accounts.items())
             ]
+            result["accounts"] = account_rows
 
-            return result
+            if not compact:
+                return result
+
+            return _format_get_budget_compact(result, account_rows)
 
     def create_budget(
         self,
@@ -417,7 +649,8 @@ class BudgetsMixin:
         period: int | str | None = None,
         account: str | None = None,
         include_children: bool = True,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Compare actual spending against budget.
 
         Args:
@@ -598,7 +831,7 @@ class BudgetsMixin:
                     f"({first_start.isoformat()} to {last_end.isoformat()})"
                 )
 
-            return {
+            full = {
                 "budget": budget_name,
                 "period": period_info,
                 "accounts": accounts_result,
@@ -609,6 +842,9 @@ class BudgetsMixin:
                     "percent_used": str(total_pct),
                 },
             }
+            if not compact:
+                return full
+            return _format_budget_report_compact(full)
 
     def delete_budget(self, name: str) -> dict:
         """Delete a budget.

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -234,7 +234,8 @@ class InvestmentsMixin:
         end_date: date | None = None,
         currency: str | None = None,
         limit: int | None = None,
-    ) -> dict:
+        compact: bool = True,
+    ) -> dict | str:
         """Get price history for a commodity.
 
         Args:
@@ -293,12 +294,37 @@ class InvestmentsMixin:
                 suggest_narrow=True,
             )
 
-            return {
+            full = {
                 "prices": prices,
                 "count": len(prices),
                 "total": total,
                 "notice": notice,
             }
+            if not compact:
+                return full
+
+            # Compact format: one line per price, columns aligned.
+            # Format::
+            #
+            #     2026-04-30  273.43  USD  last      yfinance
+            #     2026-03-31  253.79  USD  last      yfinance
+            if not prices:
+                return notice or "No prices found."
+            value_w = max(len(p["value"]) for p in prices)
+            type_w = max(len(p.get("type") or "") for p in prices)
+            ccy_w = max(len(p["currency"]) for p in prices)
+            lines = []
+            for p in prices:
+                lines.append(
+                    f"{p['date']}  "
+                    f"{p['value']:>{value_w}}  "
+                    f"{p['currency']:<{ccy_w}}  "
+                    f"{(p.get('type') or ''):<{type_w}}  "
+                    f"{p.get('source') or ''}"
+                )
+            if notice:
+                lines.append(notice)
+            return "\n".join(lines)
 
     def get_latest_price(
         self,
@@ -523,10 +549,19 @@ class InvestmentsMixin:
             if not lot:
                 raise ValueError(f"Lot not found: {guid}")
 
+            # Build a collision-safe prefix map across every split in
+            # the book — the LLM can paste any short prefix back into
+            # ``set_reconcile_state`` / ``assign_split_to_lot`` etc.
+            # and ``_resolve_guid("splits", ...)`` will resolve it.
+            all_split_guids = (
+                s.guid for txn in book.transactions for s in txn.splits
+            )
+            prefixes = _guid_prefix_map(all_split_guids)
+
             splits = []
             for split in lot.splits:
                 splits.append({
-                    "guid": split.guid,
+                    "guid": prefixes.get(split.guid, split.guid),
                     "date": split.transaction.post_date.isoformat(),
                     "description": split.transaction.description,
                     "quantity": str(split.quantity),
@@ -534,6 +569,10 @@ class InvestmentsMixin:
                 })
 
             summary = self._lot_summary(lot)
+            # Phase 6A: ``is_closed`` already lives at the top level
+            # of this response. Drop it from the nested ``summary``
+            # so callers see the field once, not twice.
+            summary_compact = {k: v for k, v in summary.items() if k != "is_closed"}
 
             return {
                 "guid": lot.guid,
@@ -542,7 +581,7 @@ class InvestmentsMixin:
                 "notes": lot.notes or "",
                 "is_closed": bool(lot.is_closed),
                 "splits": splits,
-                "summary": summary,
+                "summary": summary_compact,
             }
 
     def assign_split_to_lot(
@@ -595,15 +634,22 @@ class InvestmentsMixin:
             summary = self._lot_summary(lot)
 
             # Auto-close if quantity reaches zero; GnuCash uses -1 for boolean true
+            auto_closed = False
             if Decimal(summary["quantity"]) == 0 and len(lot.splits) > 0:
                 lot.is_closed = -1
                 book.save()
-                summary["is_closed"] = True
+                auto_closed = True
 
             # split_guid and lot_guid are echoed inputs — dropped.
-            # Summary (quantity, cost_basis, cost_per_share, is_closed)
-            # is the post-assignment state, the actually-useful info.
-            return {"status": "assigned", **summary}
+            # ``is_closed`` is included on this response (Phase 6A
+            # removed it from ``_lot_summary``, but the auto-close
+            # behavior of this tool is exactly what the caller wants
+            # to know about — keep it surfaced here).
+            return {
+                "status": "assigned",
+                **summary,
+                "is_closed": auto_closed or bool(lot.is_closed),
+            }
 
     def calculate_lot_gain(
         self,

--- a/src/gnucash_mcp/tools/budgets.py
+++ b/src/gnucash_mcp/tools/budgets.py
@@ -10,34 +10,43 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def list_budgets() -> str:
+    def list_budgets(verbose: bool = False) -> str:
         """List all budgets in the book.
 
-        Returns:
-            JSON list of budgets with guid, name, description,
-            num_periods, and period_type.
+        Returns a compact one-line-per-budget format by default. Use
+        verbose=true for the full JSON list.
+
+        Args:
+            verbose: If true, return the full JSON list.
         """
         book = get_book()
-        result = book.list_budgets()
-        return _json(result)
+        result = book.list_budgets(compact=not verbose)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def get_budget(name: str) -> str:
+    def get_budget(name: str, verbose: bool = False) -> str:
         """Get full details of a budget including all budget amounts.
+
+        Returns a compact text table by default — collapses uniform
+        periods (e.g., ``"250/mo (all periods)"``) so the typical
+        12-cell repeat doesn't dominate the response. Use verbose=true
+        for the full structured ``periods`` dict per account.
 
         Args:
             name: Budget name.
-
-        Returns:
-            JSON with budget info and all account/period amounts.
+            verbose: If true, return the full structured dict.
         """
         book = get_book()
-        result = book.get_budget(name)
+        result = book.get_budget(name=name, compact=not verbose)
         if result is None:
             return _json({"error": f"Budget not found: {name}"})
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool
@@ -108,8 +117,13 @@ def register(mcp, get_book) -> None:
         period: int | str | None = None,
         account: str | None = None,
         include_children: bool = True,
+        verbose: bool = False,
     ) -> str:
         """Compare actual spending against budget.
+
+        Returns a compact text table by default with ⚠ markers on
+        categories exceeding budget. Use verbose=true for the full
+        structured dict.
 
         Args:
             budget_name: Name of the budget.
@@ -120,6 +134,7 @@ def register(mcp, get_book) -> None:
                 - "all": All periods
             account: Optional filter to specific account or parent account.
             include_children: If True and account specified, include child accounts.
+            verbose: If true, return the structured dict.
         """
         book = get_book()
         result = book.get_budget_report(
@@ -127,8 +142,11 @@ def register(mcp, get_book) -> None:
             period=period,
             account=account,
             include_children=include_children,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -115,8 +115,13 @@ def register(mcp, get_book) -> None:
         end_date: str | None = None,
         currency: str | None = None,
         limit: int = 50,
+        verbose: bool = False,
     ) -> str:
         """Get price history for a commodity.
+
+        Returns a compact aligned text table by default. Use
+        verbose=true for the full structured envelope (``prices`` list,
+        ``count``, ``total``, ``notice``).
 
         Args:
             commodity: Symbol of the commodity (e.g., "VTSAX").
@@ -125,13 +130,7 @@ def register(mcp, get_book) -> None:
             end_date: Optional end date filter (YYYY-MM-DD).
             currency: Optional currency filter (e.g., "USD").
             limit: Maximum prices to return. Defaults to 50, capped at 250.
-                   Pre-fix this method dumped every matching price; the
-                   most-recent-first sort means small limits still surface
-                   the freshest data.
-
-        Returns:
-            JSON with ``prices`` (list, possibly truncated), ``count``,
-            ``total``, and ``notice`` (truncation message or None).
+            verbose: If true, return the structured dict.
         """
         book = get_book()
         start = date_type.fromisoformat(start_date) if start_date else None
@@ -144,8 +143,11 @@ def register(mcp, get_book) -> None:
             end_date=end,
             currency=currency,
             limit=limit,
+            compact=not verbose,
         )
-        return _json(result)
+        if verbose:
+            return _json(result)
+        return result
 
     @mcp.tool()
     @safe_tool

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7359,7 +7359,7 @@ class TestPrices:
         assert result["date"] == "2026-02-07"
 
         # Verify via get_prices (now returns dict with prices/count/total/notice)
-        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND", compact=False)
         prices = result["prices"]
         assert result["total"] == 1
         assert len(prices) == 1
@@ -7396,7 +7396,7 @@ class TestPrices:
         assert result["value"] == "128.75"
 
         # Should still be only 1 price, not 2
-        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        result = gc_book.get_prices(commodity="VTSAX", namespace="FUND", compact=False)
         prices = result["prices"]
         assert len(prices) == 1
         assert prices[0]["value"] == "128.75"
@@ -7431,13 +7431,14 @@ class TestPrices:
             namespace="FUND",
             start_date=date(2026, 2, 3),
             end_date=date(2026, 2, 8),
+            compact=False,
         )
         prices = result["prices"]
         assert len(prices) == 1
         assert Decimal(prices[0]["value"]) == Decimal("126.50")
 
         # All prices, should be descending
-        all_result = gc_book.get_prices(commodity="VTSAX", namespace="FUND")
+        all_result = gc_book.get_prices(commodity="VTSAX", namespace="FUND", compact=False)
         all_prices = all_result["prices"]
         assert len(all_prices) == 3
         assert all_prices[0]["date"] == "2026-02-10"  # Most recent first
@@ -7701,3 +7702,122 @@ class TestInvestmentWorkflow:
         assert vtsax["latest_price"]["value"] == "128.75"
         assert vtsax["latest_price"]["date"] == "2026-02-07"
         assert vtsax["latest_price"]["currency"] == "USD"
+
+
+class TestShortGuidRoundTripClosure:
+    """The contract you can build a tool surface on: every short GUID
+    emitted by an output is accepted as input to a tool that takes
+    that entity's GUID. If this contract drifts, the LLM ends up
+    holding identifiers it can't use.
+
+    These tests are the lock — for each entity that has a GUID-based
+    public API (transaction, split, lot, scheduled transaction,
+    account), grab a fresh emission and feed it back in. Round-trip
+    must resolve to the same underlying object.
+    """
+
+    def test_transaction_short_guid_round_trip(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        # list_transactions compact emits 8+ hex prefixes.
+        compact = gc_book.list_transactions()
+        line = compact.strip().split("\n")[0]
+        # Format: "YYYY-MM-DD<TAB>SHORTGUID<TAB>amount<TAB>..."
+        short_guid = line.split("\t")[1]
+        assert short_guid and len(short_guid) >= 8
+        # Feed it back into get_transaction.
+        result = gc_book.get_transaction(short_guid)
+        assert result is not None
+        assert result["guid"].startswith(short_guid)
+
+    def test_split_short_guid_round_trip(self, test_book: Path):
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+        # Mark a split as cleared so get_unreconciled_splits has
+        # something with a "c" state to emit. Use the compact form
+        # to get the prefix the LLM would actually receive.
+        compact = gc_book.get_unreconciled_splits(
+            account_name="Assets:Checking",
+        )
+        # Format: ``"short_guid<TAB>date<TAB>description<TAB>amount<TAB>state"``
+        # — the short GUID is column 0.
+        line = compact.strip().split("\n")[0]
+        short_split = line.split("\t")[0]
+        assert short_split and len(short_split) >= 8
+        # Feed it back into set_reconcile_state — the canonical split
+        # consumer.
+        result = gc_book.set_reconcile_state(
+            split_guid=short_split,
+            state="c",
+            reconcile_date=date_cls(2024, 1, 31),
+        )
+        assert result["status"] == "updated"
+
+    def test_lot_short_guid_round_trip(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        # Set up: create commodity, account, lot.
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Vanguard Total",
+            namespace="FUND",
+        )
+        gc_book.create_account(
+            name="Investments", account_type="ASSET",
+            parent="Assets", placeholder=True,
+        )
+        gc_book.create_account(
+            name="VTSAX", account_type="MUTUAL",
+            parent="Assets:Investments",
+            commodity="VTSAX", commodity_namespace="FUND",
+        )
+        created = gc_book.create_lot(
+            account="Assets:Investments:VTSAX",
+            title="Round-trip lot",
+        )
+        # create_lot's response uses ``_unique_prefix``, so this is
+        # already a short GUID.
+        short_lot = created["guid"]
+        assert short_lot and len(short_lot) >= 8
+        # Feed it back into get_lot — the canonical lot consumer.
+        detail = gc_book.get_lot(guid=short_lot)
+        assert detail["title"] == "Round-trip lot"
+
+    def test_scheduled_short_guid_round_trip(self, scheduled_book: Path):
+        gc_book = GnuCashBook(str(scheduled_book))
+        created = gc_book.create_scheduled_transaction(
+            name="RoundTripSx",
+            description="Round-trip test",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "100.00"},
+                {"account": "Assets:Checking", "amount": "-100.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        short_sx = created["guid"]
+        assert short_sx and len(short_sx) >= 8
+        # Feed it back into update_scheduled_transaction — accepts
+        # the same prefix form the create response emitted.
+        result = gc_book.update_scheduled_transaction(
+            guid=short_sx,
+            enabled=False,
+        )
+        # Round-trip success: the short GUID resolved to the same
+        # scheduled transaction we just created. The response echoes
+        # the (possibly extended) short GUID — same prefix shape.
+        assert result["guid"] and len(result["guid"]) >= 8
+        assert result.get("name") == "RoundTripSx"
+
+    def test_account_short_guid_round_trip(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        # list_accounts compact emits "%shortguid<TAB>fullname [ANN]".
+        compact = gc_book.list_accounts()
+        line = compact.strip().split("\n")[0]
+        short_acct, _rest = line.split("\t", 1)
+        assert short_acct.startswith("%")
+        # Feed it back into get_account — accepts %short, full path,
+        # or full GUID interchangeably via _resolve_account.
+        result = gc_book.get_account(name=short_acct)
+        assert result is not None
+        # Feed it as a transaction-split account ref too — the
+        # downstream resolver path that powers all write tools.
+        baseline = gc_book.get_balance(short_acct)
+        assert baseline is not None

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -29,7 +29,7 @@ class TestCreateBudget:
         assert result["guid"]  # non-empty GUID
 
         # Verify via get_budget
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         assert budget is not None
         assert budget["num_periods"] == 12
         assert budget["period_type"] == "monthly"
@@ -48,7 +48,7 @@ class TestCreateBudget:
 
         assert result["status"] == "created"
 
-        budget = book.get_budget("Q Budget")
+        budget = book.get_budget(compact=False, name="Q Budget")
         assert budget["num_periods"] == 4
         assert budget["period_type"] == "quarterly"
 
@@ -64,7 +64,7 @@ class TestCreateBudget:
 
         assert result["status"] == "created"
 
-        budget = book.get_budget("Weekly Budget")
+        budget = book.get_budget(compact=False, name="Weekly Budget")
         assert budget["num_periods"] == 52
         assert budget["period_type"] == "weekly"
 
@@ -122,7 +122,7 @@ class TestSetBudgetAmount:
         assert len(result["periods_set"]) == 12
 
         # Verify via get_budget
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         grocery_amounts = None
         for acct in budget["accounts"]:
             if acct["account"] == "Expenses:Groceries":
@@ -147,7 +147,7 @@ class TestSetBudgetAmount:
 
         assert result["periods_set"] == [0]
 
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         grocery_amounts = None
         for acct in budget["accounts"]:
             if acct["account"] == "Expenses:Groceries":
@@ -186,7 +186,7 @@ class TestSetBudgetAmount:
 
         assert result["periods_set"] == [11]
 
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         grocery_amounts = None
         for acct in budget["accounts"]:
             if acct["account"] == "Expenses:Groceries":
@@ -216,7 +216,7 @@ class TestSetBudgetAmount:
             period=0,
         )
 
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         for acct in budget["accounts"]:
             if acct["account"] == "Expenses:Groceries":
                 assert Decimal(acct["periods"][0]) == Decimal("700.00")
@@ -271,7 +271,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
         self._create_budget_with_amounts(book)
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=0,  # January 2026
         )
@@ -312,7 +312,7 @@ class TestGetBudgetReport:
             amount="300.00",
         )
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=0,
         )
@@ -332,7 +332,7 @@ class TestGetBudgetReport:
         self._create_budget_with_amounts(book)
 
         # Period 2 = March 2026, no transactions exist
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=2,
         )
@@ -346,7 +346,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
         self._create_budget_with_amounts(book)
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=1,  # February 2026
         )
@@ -368,7 +368,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
         self._create_budget_with_amounts(book)
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period="all",
         )
@@ -394,7 +394,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
         self._create_budget_with_amounts(book)
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=0,
             account="Expenses:Groceries",
@@ -408,7 +408,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
         self._create_budget_with_amounts(book)
 
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=0,
         )
@@ -474,7 +474,7 @@ class TestGetBudgetReport:
             period=0,
         )
 
-        report = gc.get_budget_report(
+        report = gc.get_budget_report(compact=False,
             budget_name="Util Budget",
             period=0,
         )
@@ -543,7 +543,7 @@ class TestGetBudgetReport:
             budget_name="Mixed Budget",
             account="Expenses:Utilities:Electric", amount="100", period=0,
         )
-        report = gc.get_budget_report(
+        report = gc.get_budget_report(compact=False,
             budget_name="Mixed Budget", period=0,
         )
         by_acct = {a["account"]: a for a in report["accounts"]}
@@ -555,7 +555,7 @@ class TestGetBudgetReport:
         book = GnuCashBook(str(budget_book))
 
         with pytest.raises(ValueError, match="Budget not found"):
-            book.get_budget_report(budget_name="Nonexistent", period=0)
+            book.get_budget_report(compact=False,budget_name="Nonexistent", period=0)
 
 
 # ============== TestListAndGetBudget ==============
@@ -567,7 +567,7 @@ class TestListAndGetBudget:
     def test_list_empty(self, budget_book: Path):
         """Listing budgets on a book with no budgets returns empty list."""
         book = GnuCashBook(str(budget_book))
-        result = book.list_budgets()
+        result = book.list_budgets(compact=False)
         assert result == []
 
     def test_list_single_budget(self, budget_book: Path):
@@ -575,7 +575,7 @@ class TestListAndGetBudget:
         book = GnuCashBook(str(budget_book))
         book.create_budget(name="2026 Budget", year=2026, num_periods=12)
 
-        result = book.list_budgets()
+        result = book.list_budgets(compact=False)
         assert len(result) == 1
         assert result[0]["name"] == "2026 Budget"
         assert result[0]["num_periods"] == 12
@@ -598,7 +598,7 @@ class TestListAndGetBudget:
             period=1,
         )
 
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         assert budget is not None
         assert len(budget["accounts"]) == 1
         assert budget["accounts"][0]["account"] == "Expenses:Groceries"
@@ -608,7 +608,7 @@ class TestListAndGetBudget:
     def test_get_nonexistent_returns_none(self, budget_book: Path):
         """get_budget returns None for nonexistent budget."""
         book = GnuCashBook(str(budget_book))
-        assert book.get_budget("Nonexistent") is None
+        assert book.get_budget(compact=False, name="Nonexistent") is None
 
 
 # ============== TestDeleteBudget ==============
@@ -627,8 +627,8 @@ class TestDeleteBudget:
         assert result["name"] == "2026 Budget"
 
         # Verify it's gone
-        assert book.get_budget("2026 Budget") is None
-        assert book.list_budgets() == []
+        assert book.get_budget(compact=False, name="2026 Budget") is None
+        assert book.list_budgets(compact=False) == []
 
     def test_delete_with_amounts(self, budget_book: Path):
         """Delete a budget with amounts (cascade delete)."""
@@ -642,7 +642,7 @@ class TestDeleteBudget:
 
         result = book.delete_budget("2026 Budget")
         assert result["status"] == "deleted"
-        assert book.list_budgets() == []
+        assert book.list_budgets(compact=False) == []
 
     def test_delete_nonexistent_raises(self, budget_book: Path):
         """Deleting a nonexistent budget raises ValueError."""
@@ -689,16 +689,16 @@ class TestBudgetIntegration:
         )
 
         # Verify listing
-        budgets = book.list_budgets()
+        budgets = book.list_budgets(compact=False)
         assert len(budgets) == 1
         assert budgets[0]["name"] == "2026 Budget"
 
         # Get full budget details
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         assert len(budget["accounts"]) == 3
 
         # Get January report
-        report = book.get_budget_report(
+        report = book.get_budget_report(compact=False,
             budget_name="2026 Budget",
             period=0,
         )
@@ -736,7 +736,7 @@ class TestBudgetIntegration:
             period="q4",
         )
 
-        budget = book.get_budget("2026 Budget")
+        budget = book.get_budget(compact=False, name="2026 Budget")
         for acct in budget["accounts"]:
             if acct["account"] == "Expenses:Groceries":
                 # Q1-Q3 (periods 0-8) should be $500


### PR DESCRIPTION
## Summary

Final branch of the multi-phase comms-audit work (``docs/COMMUNICATION_AUDIT_FIXES.md``). Closes the spec.

**Phase 5 — budgets:**
- ``get_budget`` collapses uniform periods (84-cell dict → ~7 lines, with "P0-5,P8-11" run notation for seasonal overrides)
- ``get_budget_report`` becomes a TSV-style aligned table with ``⚠`` markers on rows over 110% used (same threshold ``get_book_summary``'s budget headline uses)
- ``list_budgets`` one-line-per-budget compact format

**Phase 6 — investments + cosmetics:**
- ``get_lot`` drops the duplicated ``is_closed`` from the nested ``summary`` dict (top-level kept; spec target met) and shortens split GUIDs in the splits array
- ``get_prices`` per-row compact format with aligned columns

**Contract lock — ``TestShortGuidRoundTripClosure``:**

Five regression tests that codify the short-GUID round-trip — every short-form OUTPUT must be acceptable as INPUT to a tool that takes that entity's GUID. Covers transaction, split, lot, scheduled transaction, account. If anyone ever forgets to thread the resolver through a new tool or shortens an emission without ensuring the consumer accepts the short form, these catch it.

This is the bookkeeper's cross-tool sanity check, distilled into always-running tests.

## Test plan

- [x] 949 tests passing locally (up from 944; 5 new round-trip tests)
- [x] Existing budget / lot / price tests pass ``compact=False`` to keep dict assertions working — same convention as Phases 4A-D
- [x] All five GUID entities verified round-trip in dedicated lock tests

## Phasing

This closes the comms-audit spec. Total scope across the four branches:

- **Branch 1** (``feat/response-format-foundation``, PR #54): foundation helpers + write-response trim
- **Branch 2** (``feat/comms-daily-reads``, PR #55): outstanding-invoices action columns, list_invoices owner+amount, get_invoice account-paths
- **Branch 3** (``feat/comms-monthly-reports``, PR #56): debt_payoff_plan kill-order table, balance_sheet investment format + 2-decimal totals, breakdown TSVs, vendor_spending compact, cross-tool price agreement fix
- **Branch 4** (this PR): budgets compact, investments cosmetic, round-trip closure

Per Abe's audit: typical 50-call accounting session burned 40-60K tokens on tool responses pre-fix. After all four branches, the same session lands in the 15-25K range.