### PR TITLE
fix: currency-aware compact formatters (non-USD-default books)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -67,17 +67,19 @@ def _format_vendor_spending_compact(
     grand_billed: Decimal,
     grand_paid: Decimal,
     grand_outstanding: Decimal,
+    currency: str = "USD",
 ) -> str:
     """Render vendor-spending breakdown as a compact aligned text table.
 
     Format::
 
-        BookkeepingCo  4 bills  $1,800 billed  $1,800 paid  $0 outstanding
-        JetBrains      1 bill     $289 billed    $289 paid  $0 outstanding
-        TOTAL          5 bills  $2,089 billed  $2,089 paid  $0 outstanding
+        BookkeepingCo  4 bills  USD 1,800 billed  USD 1,800 paid  USD 0 outstanding
+        JetBrains      1 bill     USD 289 billed    USD 289 paid  USD 0 outstanding
+        TOTAL          5 bills  USD 2,089 billed  USD 2,089 paid  USD 0 outstanding
 
-    "1 bill" vs "N bills" pluralization keeps the line natural to read.
-    Width-padded so the four amount columns align across rows.
+    Currency prefix flows from the book's default currency. "1 bill" vs
+    "N bills" pluralization keeps the line natural to read. Width-padded
+    so the four amount columns align across rows.
     """
     if not vendors_list:
         return "No vendor activity in period."
@@ -93,8 +95,8 @@ def _format_vendor_spending_compact(
     def _money(s: str) -> str:
         d = Decimal(s)
         if d == d.to_integral_value():
-            return f"${int(d):,}"
-        return f"${d:,.2f}"
+            return f"{currency} {int(d):,}"
+        return f"{currency} {d:,.2f}"
 
     billed_strs = [_money(v["total_billed"]) for v in vendors_list]
     paid_strs = [_money(v["total_paid"]) for v in vendors_list]
@@ -2944,6 +2946,13 @@ class BusinessMixin:
         parsed_end = date.fromisoformat(end_date)
 
         with self.open() as book:
+            # Capture default currency for the compact formatter —
+            # pre-fix the table emitted ``$`` regardless of book
+            # setting.
+            default_currency_mnemonic = (
+                self._require_default_currency(book).mnemonic
+            )
+
             query = book.session.query(Invoice).filter(
                 Invoice.owner_type == 4,
                 Invoice.date_posted.isnot(None),
@@ -3070,4 +3079,5 @@ class BusinessMixin:
             grand_billed=grand_billed,
             grand_paid=grand_paid,
             grand_outstanding=grand_outstanding,
+            currency=default_currency_mnemonic,
         )

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -86,17 +86,25 @@ def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> s
     return "\n".join(lines)
 
 
-def _money_compact(value: Decimal) -> str:
-    """Format a dollar amount for compact-mode reports.
+def _money_compact(value: Decimal, currency: str = "USD") -> str:
+    """Format a monetary amount for compact-mode reports.
 
-    Whole-dollar values render without decimals (``$13,091``), partial
-    values render with two (``$1,125.50``). Negative values use the
-    leading-minus convention rather than parens.
+    Whole-currency-unit values render without decimals
+    (``"USD 13,091"``), partial values render with two
+    (``"USD 1,125.50"``). Negative values use leading-minus rather
+    than parens.
+
+    The ``currency`` argument carries the book's default currency
+    mnemonic (``"USD"``, ``"CNY"``, ``"EUR"``, etc.) — matches
+    ``get_book_summary``'s ``"USD 6700.00"`` rendering style and
+    works for non-USD books out of the box. Pre-fix this helper
+    hardcoded ``$`` and broke as soon as the bookkeeper pointed it
+    at a CNY-default book.
     """
     quantized = value.quantize(Decimal("0.01"))
     if quantized == quantized.to_integral_value():
-        return f"${int(quantized):,}"
-    return f"${quantized:,.2f}"
+        return f"{currency} {int(quantized):,}"
+    return f"{currency} {quantized:,.2f}"
 
 
 def _format_debt_payoff_compact(
@@ -111,17 +119,19 @@ def _format_debt_payoff_compact(
     yeti_multiplier: Decimal,
     purchase_amount: Decimal,
     true_cost: Decimal,
+    currency: str = "USD",
 ) -> str:
     """Render the avalanche-payoff plan as a compact text table.
 
-    Layout follows the comms-audit Phase 4A spec:
+    Currency prefix flows from the book's default currency — works
+    for USD, CNY, EUR, anything piecash represents. Layout::
 
-        Kill order ($10,000/mo → debt-free Apr 2030, $59,022 interest):
-          1. Business Amex    $13,091  24.49%  payoff: mo 8   interest: $1,125
-          2. Chase Sapphire   $22,127  21.49%  payoff: mo 18  interest: $5,034
+        Kill order (USD 10,000/mo → debt-free Apr 2030, USD 59,022 interest):
+          1. Business Amex    USD 13,091  24.49%  payoff: mo 8   interest: USD 1,125
+          2. Chase Sapphire   USD 22,127  21.49%  payoff: mo 18  interest: USD 5,034
           ...
-        YETI at this budget: 1.59x ($1 spent costs $1.59 in total debt impact)
-        Total interest: $59,022
+        YETI at this budget: 1.59x (USD 1 spent costs USD 1.59 in total debt impact)
+        Total interest: USD 59,022
         Debt-free: April 2030
 
     Replaces the verbose dict (with multi-line YETI ``explanation`` per
@@ -136,12 +146,14 @@ def _format_debt_payoff_compact(
 
     # Balance column width — pad to widest balance for alignment.
     balance_strs = [
-        _money_compact(orig_balances[d["name"]]) for d in results
+        _money_compact(orig_balances[d["name"]], currency) for d in results
     ]
     balance_width = max(len(b) for b in balance_strs) if balance_strs else 0
 
     # Interest column width — same trick.
-    interest_strs = [_money_compact(d["interest_paid"]) for d in results]
+    interest_strs = [
+        _money_compact(d["interest_paid"], currency) for d in results
+    ]
     interest_width = (
         max(len(s) for s in interest_strs) if interest_strs else 0
     )
@@ -149,9 +161,9 @@ def _format_debt_payoff_compact(
     # Header tells the reader the inputs that drove the schedule.
     payoff_month_name = payoff_date.strftime("%b %Y")
     header = (
-        f"Kill order ({_money_compact(monthly_budget)}/mo → "
+        f"Kill order ({_money_compact(monthly_budget, currency)}/mo → "
         f"debt-free {payoff_month_name}, "
-        f"{_money_compact(total_interest)} interest):"
+        f"{_money_compact(total_interest, currency)} interest):"
     )
 
     # Body rows.
@@ -174,10 +186,12 @@ def _format_debt_payoff_compact(
     # more than its sticker because of the interest your debt accrues".
     lines.append(
         f"YETI at this budget: {yeti_multiplier}x "
-        f"({_money_compact(purchase_amount)} spent costs "
-        f"{_money_compact(true_cost)} in total debt impact)"
+        f"({_money_compact(purchase_amount, currency)} spent costs "
+        f"{_money_compact(true_cost, currency)} in total debt impact)"
     )
-    lines.append(f"Total interest: {_money_compact(total_interest)}")
+    lines.append(
+        f"Total interest: {_money_compact(total_interest, currency)}"
+    )
     lines.append(f"Debt-free: {payoff_date.strftime('%B %Y')}")
     return "\n".join(lines)
 
@@ -607,14 +621,20 @@ class ReportingMixin:
                 the per-account values leaked Decimal precision noise
                 (e.g. ``"612011.489832"``) into responses.
                 """
+                # Default-currency mnemonic for the triplet rendering.
+                # Pre-fix this hardcoded "USD"; on a CNY-default book
+                # that lied about the currency on every investment row.
+                ccy_mnemonic = default_currency.mnemonic
                 rows = []
                 for name, info in sorted(accounts_dict.items()):
                     commodity = info["commodity"]
-                    usd_rounded = _format_number(info["usd"], decimals=2)
+                    default_value_rounded = _format_number(
+                        info["usd"], decimals=2
+                    )
                     if commodity == default_currency:
                         rows.append({
                             "account": name,
-                            "balance": usd_rounded,
+                            "balance": default_value_rounded,
                         })
                     else:
                         rate = latest_rates.get(commodity.guid)
@@ -623,19 +643,24 @@ class ReportingMixin:
                         if rate is not None:
                             balance_str = (
                                 f"{qty} {sym} @ {rate} "
-                                f"(USD {info['usd']:,.2f})"
+                                f"({ccy_mnemonic} {info['usd']:,.2f})"
                             )
                         else:
                             # No price on file — fall back to cost basis
                             # already accumulated in ``info['usd']``.
                             balance_str = (
-                                f"{qty} {sym} (USD {info['usd']:,.2f}, "
-                                f"no price data)"
+                                f"{qty} {sym} ({ccy_mnemonic} "
+                                f"{info['usd']:,.2f}, no price data)"
                             )
+                        # ``default_currency_value`` carries the
+                        # parseable amount in the book's default
+                        # currency. Pre-fix this field was named
+                        # ``usd_value`` — a lie on non-USD books.
+                        # Renamed to reflect the actual semantics.
                         rows.append({
                             "account": name,
                             "balance": balance_str,
-                            "usd_value": usd_rounded,
+                            "default_currency_value": default_value_rounded,
                         })
                 return rows
 
@@ -976,6 +1001,12 @@ class ReportingMixin:
             raise ValueError("additional_purchase must be a positive number")
 
         with self.open(readonly=True) as book:
+            # Capture the book's default currency for the compact
+            # formatter — pre-fix this method emitted ``$`` regardless
+            # of book setting, breaking on non-USD books.
+            default_currency_mnemonic = (
+                self._require_default_currency(book).mnemonic
+            )
             debt_types = {"CREDIT", "LIABILITY"}
             debts = []
 
@@ -1105,8 +1136,9 @@ class ReportingMixin:
                 "purchase_amount": str(purchase_amount),
                 "true_cost": str(true_cost.quantize(Decimal("0.01"))),
                 "explanation": (
-                    f"A ${purchase_amount} purchase will cost you "
-                    f"${true_cost.quantize(Decimal('0.01'))} by the time your "
+                    f"A {default_currency_mnemonic} {purchase_amount} purchase "
+                    f"will cost you {default_currency_mnemonic} "
+                    f"{true_cost.quantize(Decimal('0.01'))} by the time your "
                     f"debt is paid off"
                 ),
             },
@@ -1126,4 +1158,5 @@ class ReportingMixin:
             yeti_multiplier=yeti_multiplier,
             purchase_amount=purchase_amount,
             true_cost=true_cost,
+            currency=default_currency_mnemonic,
         )

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6666,16 +6666,18 @@ class TestBalanceSheetNumericContract:
                 f"{section} total wrong precision: {total!r}"
             )
 
-    def test_currency_accounts_have_no_usd_value_field(
+    def test_currency_accounts_have_no_default_currency_value_field(
         self, test_book: Path,
     ):
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
         for row in result["assets"]["accounts"]:
             # Test fixture is single-currency USD — every asset row
-            # is currency-default. None should carry ``usd_value``.
-            assert "usd_value" not in row, (
-                f"redundant usd_value on currency row: {row}"
+            # is currency-default. None should carry the
+            # ``default_currency_value`` field (it would just repeat
+            # ``balance``).
+            assert "default_currency_value" not in row, (
+                f"redundant value field on currency row: {row}"
             )
 
     def test_currency_account_balance_renders_at_2_decimals(
@@ -6734,7 +6736,7 @@ class TestCrossToolPriceAgreement:
             if a["account"] == "Assets:Euro Savings"
         )
         # 1000 EUR × 1.50 = 1500 USD.
-        assert Decimal(eur_row["usd_value"]) == Decimal("1500.00")
+        assert Decimal(eur_row["default_currency_value"]) == Decimal("1500.00")
 
         # get_book_summary must agree: use the same future-dated rate
         # for the per-account display AND for the trajectory "now"
@@ -6753,6 +6755,253 @@ class TestCrossToolPriceAgreement:
         # Trajectory's "now" anchor should reflect the same rate too:
         # 6700 USD Checking + 1500 USD Euro Savings = 8200.
         assert "now: USD 8,200" in summary
+
+
+class TestNonUsdDefaultCurrency:
+    """Bookkeeper-flagged: every compact-mode formatter that emits
+    money-prefixed strings was hardcoding ``$`` / ``USD``. On a
+    non-USD-default book that's a lie at every reporting surface
+    — debt_payoff_plan would render kill-order rows as
+    ``$13,091`` when the book is in CNY (¥), vendor_spending as
+    ``$1,800 billed`` when the book is in EUR, and balance_sheet
+    investment rows would carry ``(USD 39,457.99)`` when they
+    should carry the actual default currency.
+
+    Set up a CNY-default book with the minimum data each affected
+    tool needs, then exercise each one. None of the responses
+    should contain ``$`` or ``USD``; all should reflect ``CNY``.
+    """
+
+    @staticmethod
+    def _cny_book(tmp_path: Path) -> Path:
+        """Build a fresh CNY-default book with enough seed data to
+        exercise every currency-sensitive compact formatter."""
+        import piecash
+        from piecash._common import GnucashException
+
+        book_path = tmp_path / "cny_book.gnucash"
+        book = piecash.create_book(
+            str(book_path),
+            currency="CNY",
+            overwrite=True,
+        )
+
+        cny = book.default_currency
+        root = book.root_account
+
+        assets = piecash.Account(
+            name="Assets", type="ASSET", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        piecash.Account(
+            name="Checking", type="BANK", parent=assets, commodity=cny,
+        )
+        liab = piecash.Account(
+            name="Liabilities", type="LIABILITY", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        piecash.Account(
+            name="Visa", type="CREDIT", parent=liab, commodity=cny,
+        )
+        income = piecash.Account(
+            name="Income", type="INCOME", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        piecash.Account(
+            name="Salary", type="INCOME", parent=income, commodity=cny,
+        )
+        expenses = piecash.Account(
+            name="Expenses", type="EXPENSE", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        piecash.Account(
+            name="Office Supplies", type="EXPENSE",
+            parent=expenses, commodity=cny,
+        )
+        ap = piecash.Account(
+            name="Accounts Payable", type="PAYABLE",
+            parent=liab, commodity=cny,
+        )
+        book.save()
+
+        return book_path
+
+    def test_debt_payoff_plan_emits_default_currency_mnemonic(
+        self, tmp_path: Path,
+    ):
+        from datetime import date as date_cls
+        book_path = self._cny_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        # Set APR on Visa, add a balance, run the plan.
+        gc_book.set_account_slot(
+            account_name="Liabilities:Visa",
+            key="apr",
+            value="18.99",
+        )
+        gc_book.create_transaction(
+            description="Charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-2000.00"},
+                {"account": "Expenses:Office Supplies", "amount": "2000.00"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+        )
+        result = gc_book.debt_payoff_plan(monthly_budget="500")
+        # Compact text must use CNY mnemonic, never $ or USD.
+        assert "$" not in result, (
+            f"hardcoded $ found in debt_payoff_plan output:\n{result}"
+        )
+        assert "USD" not in result, (
+            f"hardcoded USD found in debt_payoff_plan output:\n{result}"
+        )
+        assert "CNY" in result, (
+            f"CNY mnemonic missing from output:\n{result}"
+        )
+
+    def test_debt_payoff_plan_yeti_explanation_uses_default_currency(
+        self, tmp_path: Path,
+    ):
+        from datetime import date as date_cls
+        book_path = self._cny_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        gc_book.set_account_slot(
+            account_name="Liabilities:Visa",
+            key="apr",
+            value="18.99",
+        )
+        gc_book.create_transaction(
+            description="Charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-2000.00"},
+                {"account": "Expenses:Office Supplies", "amount": "2000.00"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+        )
+        # Verbose mode renders the yeti.explanation field directly.
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="500",
+        )
+        explanation = result["yeti"]["explanation"]
+        assert "$" not in explanation, (
+            f"hardcoded $ in yeti explanation: {explanation!r}"
+        )
+        assert "CNY" in explanation, (
+            f"CNY mnemonic missing from yeti explanation: {explanation!r}"
+        )
+
+    def test_vendor_spending_report_emits_default_currency_mnemonic(
+        self, tmp_path: Path,
+    ):
+        book_path = self._cny_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        gc_book.create_vendor(name="Office Depot")
+        gc_book.create_bill(vendor_id="000001")
+        gc_book.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="500.00",
+        )
+        gc_book.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2026-01-01",
+        )
+        result = gc_book.vendor_spending_report(
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+        )
+        assert "$" not in result, (
+            f"hardcoded $ found in vendor_spending output:\n{result}"
+        )
+        assert "USD" not in result, (
+            f"hardcoded USD found in vendor_spending output:\n{result}"
+        )
+        assert "CNY" in result, (
+            f"CNY missing from vendor_spending output:\n{result}"
+        )
+
+    def test_balance_sheet_investment_uses_default_currency_mnemonic(
+        self, tmp_path: Path,
+    ):
+        """Investment accounts (non-default-currency commodity) should
+        render the triplet ``"230.00 STOCK @ 50.00 (CNY 11,500.00)"``
+        on a CNY-default book — not "(USD ...)" as the pre-fix code
+        emitted regardless of book setting.
+        """
+        from datetime import date as date_cls
+        import piecash
+
+        book_path = self._cny_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        # Add a STOCK commodity and account so we hit the
+        # non-default-currency branch of balance_sheet's
+        # format_accounts (where the bug lived).
+        with gc_book.open(readonly=False) as b:
+            cny = b.default_currency
+            mock = piecash.Commodity(
+                namespace="NASDAQ", mnemonic="MOCK",
+                fullname="Mock Stock", fraction=10000,
+                book=b,
+            )
+            inv_parent = next(
+                a for a in b.accounts if a.fullname == "Assets"
+            )
+            # Keep direct references — book.accounts fullname lookups
+            # don't reflect newly-created accounts until flush.
+            stock_acct = piecash.Account(
+                name="Mock Stock", type="STOCK", parent=inv_parent,
+                commodity=mock,
+            )
+            # Buy 100 shares @ 50 CNY → quantity=100, value=5000.
+            checking = next(
+                a for a in b.accounts
+                if a.fullname == "Assets:Checking"
+            )
+            txn = piecash.Transaction(
+                currency=cny,
+                description="Buy MOCK",
+                post_date=date_cls(2026, 1, 1),
+                splits=[
+                    piecash.Split(
+                        account=checking, value=Decimal("-5000"),
+                        quantity=Decimal("-5000"),
+                    ),
+                    piecash.Split(
+                        account=stock_acct, value=Decimal("5000"),
+                        quantity=Decimal("100"),
+                    ),
+                ],
+            )
+            b.session.add(txn)
+            # Mark a price.
+            b.session.add(piecash.Price(
+                commodity=mock, currency=cny,
+                date=date_cls(2026, 1, 5),
+                value="60", source="user:test", type="last",
+            ))
+            b.save()
+
+        result = gc_book.balance_sheet(as_of_date=date_cls(2026, 1, 31))
+        stock_row = next(
+            a for a in result["assets"]["accounts"]
+            if a["account"] == "Assets:Mock Stock"
+        )
+        # The triplet's parenthetical must use CNY, not USD.
+        assert "USD" not in stock_row["balance"], (
+            f"hardcoded USD in balance_sheet investment row: "
+            f"{stock_row['balance']!r}"
+        )
+        assert "CNY" in stock_row["balance"], (
+            f"CNY missing from balance_sheet investment row: "
+            f"{stock_row['balance']!r}"
+        )
 
 
 class TestNetWorth:
@@ -7112,13 +7361,13 @@ class TestMultiCurrencyBalances:
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
         accounts = {a["account"]: a for a in result["assets"]["accounts"]}
-        # Currency account: numeric in ``balance``, no ``usd_value``.
+        # Currency account: numeric in ``balance``, no ``default_currency_value``.
         checking = accounts["Assets:Checking"]
         assert Decimal(checking["balance"]) == Decimal("6700.00")
-        assert "usd_value" not in checking
-        # Non-currency: ``usd_value`` for parsing, ``balance`` for display.
+        assert "default_currency_value" not in checking
+        # Non-currency: ``default_currency_value`` for parsing, ``balance`` for display.
         eur = accounts["Assets:Euro Savings"]
-        assert Decimal(eur["usd_value"]) == Decimal("1100.00")
+        assert Decimal(eur["default_currency_value"]) == Decimal("1100.00")
         assert "EUR" in eur["balance"]
         assert "no price data" in eur["balance"]
 
@@ -7147,9 +7396,11 @@ class TestMultiCurrencyBalances:
             a for a in result["assets"]["accounts"]
             if a["account"] == "Assets:Euro Savings"
         )
-        # Non-currency row: ``usd_value`` is parseable + rounded.
-        assert Decimal(eur_row["usd_value"]) == Decimal("1200.00")
-        # Phase 4B: human-readable balance shows shares + rate + USD.
+        # Non-currency row: ``default_currency_value`` parseable + rounded.
+        assert Decimal(eur_row["default_currency_value"]) == Decimal("1200.00")
+        # Phase 4B: human-readable balance shows shares + rate +
+        # default-currency mnemonic ("USD" on this single-currency
+        # book; would be "CNY" / "EUR" on a non-USD book).
         assert "EUR" in eur_row["balance"]
         assert "@" in eur_row["balance"]
         assert "USD" in eur_row["balance"]

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -66,8 +66,10 @@ class TestDebtPayoffPlan:
         true_cost = Decimal(yeti["true_cost"])
         assert true_cost > Decimal("1.00")
 
-        # Explanation should be human-readable
-        assert "$1.00 purchase" in yeti["explanation"]
+        # Explanation should be human-readable. Currency mnemonic
+        # flows from the book's default currency (USD on the test
+        # fixture; would be CNY/EUR/etc. on non-USD books).
+        assert "USD 1.00 purchase" in yeti["explanation"]
         assert "debt is paid off" in yeti["explanation"]
 
     def test_yeti_custom_purchase_amount(self, debt_book: Path):


### PR DESCRIPTION
## Summary

Bookkeeper-anticipated bug found ahead of the next-window verification on a CNY-default test book. Every compact-mode formatter that emits money-prefixed strings was hardcoding ``$`` / ``USD`` regardless of the book's default currency.

Three call sites fixed:

1. **``_money_compact``** in ``book/reporting.py`` — now takes a ``currency`` arg, emits ``"USD 13,091"`` / ``"CNY 13,091"`` matching ``get_book_summary``'s established mnemonic-prefix convention.

2. **``_format_debt_payoff_compact``** + verbose ``yeti.explanation`` — both now thread the book's default currency mnemonic through.

3. **``_format_vendor_spending_compact``** in ``book/business.py`` — same pattern.

Plus the ``balance_sheet`` investment-format hardcode at lines 626/632 that read ``"(USD ...)"`` literally — now uses ``default_currency.mnemonic``.

**Field rename:** ``usd_value`` → ``default_currency_value`` on balance_sheet investment rows. The old name was a lie on non-USD books (the field always carried the value in the *book's* default currency, not specifically USD). Self-documenting now.

## Why this PR exists ahead of the cousin's verification

Stephen flagged the suspicion before the next usage window opened. The plan was to verify next window against a fresh CNY book. Fixing it ahead of the verification turns that pass into a *measurement* — same accounting workload should fit within his usage window now that the comms-audit shipped, AND the CNY book exercises this fix. Two birds.

## Test plan

- [x] 948 tests passing locally (up from 944 — 4 new lock tests covering the four fixed surfaces)
- [x] New ``TestNonUsdDefaultCurrency`` class builds a CNY book inline and asserts no ``$`` / ``USD`` literal in any compact output, asserts ``CNY`` present where currency context applies
- [x] Existing single-currency-USD tests unchanged in behavior (mnemonic defaults to USD; output reads ``"USD 1,000"`` instead of ``"$1,000"``; two literal-``$`` assertions updated)
- [ ] Cousin verification on a real CNY-default book (next window — Stephen will run the test plan)

## What the bookkeeper should look for

Same Yuan-test plan from earlier. Any remaining ``$`` or hardcoded ``USD`` in compact mode is a missed call site.