### PR TITLE
fix: debt_payoff_plan handles amortizing loans (mortgages, auto loans)

### DIFF
--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1035,7 +1035,8 @@ class ReportingMixin:
 
                 min_payment = None
 
-                # 1. Check minimum_payment slot (user override)
+                # 1. Check minimum_payment slot (user override; wins
+                #    for either account type).
                 try:
                     mp_val = account["minimum_payment"]
                     mp_str = str(mp_val.value) if hasattr(mp_val, "value") else str(mp_val)
@@ -1043,13 +1044,63 @@ class ReportingMixin:
                 except (KeyError, InvalidOperation):
                     pass
 
-                # 2. Calculate from balance: greater of $25 or 2% of balance
+                # 2. Type-specific defaults when no slot.
+                #    CREDIT (revolving cards) use the 2%-of-balance
+                #    heuristic — that's the standard card-issuer
+                #    minimum. LIABILITY (amortizing loans like
+                #    mortgages, auto loans) need the actual recurring
+                #    payment, which the 2% rule wildly overstates
+                #    on large balances. Infer from the most recent
+                #    payment transaction; require an explicit slot
+                #    when there's no history to read from.
                 if min_payment is None:
-                    two_percent = (balance * Decimal("0.02")).quantize(Decimal("0.01"))
-                    min_payment = max(two_percent, Decimal("25"))
-                    # If balance is below $25, minimum is the full balance
-                    if balance < Decimal("25"):
-                        min_payment = balance
+                    if account.type == "CREDIT":
+                        # Revolving-card minimum: greater of 2% of
+                        # balance or 25 (in default currency units).
+                        # Capped at the balance itself for tiny debts.
+                        two_percent = (
+                            balance * Decimal("0.02")
+                        ).quantize(Decimal("0.01"))
+                        min_payment = max(two_percent, Decimal("25"))
+                        if balance < Decimal("25"):
+                            min_payment = balance
+                    else:
+                        # LIABILITY (amortizing loan). Infer the
+                        # recurring payment from the most recent
+                        # payment-side split — that's the user's
+                        # actual fixed payment for a mortgage / auto
+                        # loan / etc. Liabilities are stored with
+                        # negative balances (the canonical accounting
+                        # sign); positive ``split.quantity`` reduces
+                        # the balance toward zero, i.e. is a payment.
+                        payment_splits = [
+                            s for s in account.splits
+                            if s.quantity > 0
+                            and s.transaction.post_date is not None
+                        ]
+                        if payment_splits:
+                            latest = max(
+                                payment_splits,
+                                key=lambda s: s.transaction.post_date,
+                            )
+                            min_payment = abs(
+                                Decimal(str(latest.quantity))
+                            )
+                        else:
+                            # No payment history to infer from. The
+                            # 2% rule is wrong for amortizing loans
+                            # (would overstate the mortgage payment
+                            # by 4-5×). Better to fail loud and tell
+                            # the user how to fix it.
+                            raise ValueError(
+                                f"LIABILITY account "
+                                f"{account.fullname!r} has no "
+                                f"payment history to infer a minimum "
+                                f"payment from. Set the "
+                                f"'minimum_payment' slot explicitly "
+                                f"via set_account_slot, or record at "
+                                f"least one payment transaction first."
+                            )
 
                 credit_limit = None
                 try:

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -344,3 +344,206 @@ class TestDebtPayoffCompactFormat:
         # per account in the old shape. Should appear at most once now
         # (or zero times — we use "total debt impact" wording instead).
         assert result.count("by the time your debt is paid off") <= 1
+
+
+class TestAmortizingLoanMinimums:
+    """Bug 3 from the CNY cousin verification: ``debt_payoff_plan``
+    treated every CREDIT/LIABILITY account as a revolving card,
+    computing minimum payment as 2% of balance. That formula
+    over-states the minimum for amortizing loans (mortgages, auto
+    loans) by 4-5×, so a CNY-default book with a real mortgage
+    raised "budget less than minimums" even at ¥30K/mo when
+    actual obligations were ¥17,705.
+
+    New rule: ``CREDIT`` keeps the 2% heuristic; ``LIABILITY``
+    infers from the most recent payment-side split. Slot still
+    wins for either type. Liability with no payment history and
+    no slot raises a clear error.
+    """
+
+    def test_liability_minimum_inferred_from_recent_payment(
+        self, test_book: Path,
+    ):
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+
+        # Mortgage-shaped LIABILITY: 100,000 balance, 3.85% APR, real
+        # monthly payment of 600. Pre-fix the 2% formula would have
+        # said minimum = 2,000 — wrong by 3.3×.
+        gc_book.create_account(
+            name="Mortgage", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc_book.set_account_slot("Liabilities:Mortgage", "apr", "3.85")
+        # Origination: charge balance to the liability.
+        gc_book.create_transaction(
+            description="Mortgage origination",
+            splits=[
+                {"account": "Liabilities:Mortgage", "amount": "-100000"},
+                {"account": "Expenses:Groceries", "amount": "100000"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+            check_duplicates=False,
+        )
+        # Recurring payment: reduces balance by 600/month.
+        gc_book.create_transaction(
+            description="Mortgage payment",
+            splits=[
+                {"account": "Liabilities:Mortgage", "amount": "600"},
+                {"account": "Assets:Checking", "amount": "-600"},
+            ],
+            trans_date=date_cls(2026, 2, 1),
+            check_duplicates=False,
+        )
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="700",
+        )
+        mortgage = next(
+            d for d in result["debts"]
+            if d["account"] == "Liabilities:Mortgage"
+        )
+        # Inferred from the most recent payment of 600, not the
+        # 2% formula's 2,000. (Pre-fix, the budget=700 call would
+        # have raised "less than minimums".)
+        assert Decimal(mortgage["minimum_payment"]) == Decimal("600")
+
+    def test_liability_minimum_uses_slot_when_set(
+        self, test_book: Path,
+    ):
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_account(
+            name="Auto Loan", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc_book.set_account_slot("Liabilities:Auto Loan", "apr", "4.90")
+        gc_book.set_account_slot(
+            "Liabilities:Auto Loan", "minimum_payment", "350",
+        )
+        gc_book.create_transaction(
+            description="Auto loan origination",
+            splits=[
+                {"account": "Liabilities:Auto Loan", "amount": "-20000"},
+                {"account": "Expenses:Groceries", "amount": "20000"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+            check_duplicates=False,
+        )
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="500",
+        )
+        auto = next(
+            d for d in result["debts"]
+            if d["account"] == "Liabilities:Auto Loan"
+        )
+        # Slot wins over inference; no payment history needed.
+        assert Decimal(auto["minimum_payment"]) == Decimal("350")
+
+    def test_liability_without_history_or_slot_raises(
+        self, test_book: Path,
+    ):
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_account(
+            name="HELOC", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc_book.set_account_slot("Liabilities:HELOC", "apr", "6.50")
+        # Balance but no payment history yet.
+        gc_book.create_transaction(
+            description="HELOC draw",
+            splits=[
+                {"account": "Liabilities:HELOC", "amount": "-50000"},
+                {"account": "Expenses:Groceries", "amount": "50000"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+            check_duplicates=False,
+        )
+        with pytest.raises(ValueError, match="no payment history"):
+            gc_book.debt_payoff_plan(
+                compact=False, monthly_budget="2000",
+            )
+
+    def test_credit_keeps_two_percent_heuristic(
+        self, test_book: Path,
+    ):
+        """CREDIT accounts retain the 2% rule — that's the standard
+        revolving-card minimum and it's correct for that account type.
+        """
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_account(
+            name="Visa", account_type="CREDIT",
+            parent="Liabilities",
+        )
+        gc_book.set_account_slot("Liabilities:Visa", "apr", "20")
+        gc_book.create_transaction(
+            description="Visa charge",
+            splits=[
+                {"account": "Liabilities:Visa", "amount": "-5000"},
+                {"account": "Expenses:Groceries", "amount": "5000"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+            check_duplicates=False,
+        )
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="500",
+        )
+        visa = next(
+            d for d in result["debts"]
+            if d["account"] == "Liabilities:Visa"
+        )
+        # 2% of 5000 = 100. Min floor 25 doesn't bind.
+        assert Decimal(visa["minimum_payment"]) == Decimal("100.00")
+
+    def test_mortgage_with_realistic_numbers_does_not_blow_minimums(
+        self, test_book: Path,
+    ):
+        """The bug-report scenario, scaled: a real mortgage in the
+        millions with a real fixed payment. Pre-fix the 2% rule would
+        compute ~57K/mo as the minimum on a 2.7M balance. Post-fix
+        the inference reads the actual ~14.8K payment. The whole
+        plan must run without raising 'budget less than minimums'.
+        """
+        from datetime import date as date_cls
+        gc_book = GnuCashBook(str(test_book))
+
+        gc_book.create_account(
+            name="Mortgage", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc_book.set_account_slot("Liabilities:Mortgage", "apr", "3.85")
+        gc_book.create_transaction(
+            description="Mortgage origination",
+            splits=[
+                {"account": "Liabilities:Mortgage", "amount": "-2729518"},
+                {"account": "Expenses:Groceries", "amount": "2729518"},
+            ],
+            trans_date=date_cls(2026, 1, 1),
+            check_duplicates=False,
+        )
+        gc_book.create_transaction(
+            description="Mortgage payment",
+            splits=[
+                {"account": "Liabilities:Mortgage", "amount": "14800"},
+                {"account": "Assets:Checking", "amount": "-14800"},
+            ],
+            trans_date=date_cls(2026, 2, 1),
+            check_duplicates=False,
+        )
+        # 30K/mo budget — the bug-report value. Plenty above the
+        # actual 14.8K mortgage payment, but pre-fix the 2% rule
+        # would have computed minimum=54,590 and raised.
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+        mortgage = next(
+            d for d in result["debts"]
+            if d["account"] == "Liabilities:Mortgage"
+        )
+        assert Decimal(mortgage["minimum_payment"]) == Decimal("14800")
+        # And the plan as a whole runs cleanly.
+        assert result["payoff_months"] > 0


### PR DESCRIPTION
## Summary

Bug 3 from the CNY bug report. ``debt_payoff_plan`` was computing the minimum payment as 2% of balance for every CREDIT/LIABILITY account, blocking the report on books with a mortgage. On Lin Wei's CNY book a 2.7M mortgage produced a 54,590 "minimum" — wrong by 4× — which raised "budget less than minimums" even at the spec's ¥30,000/mo budget.

## The fix

Differentiate by ``account.type``:

- **``CREDIT``** — 2%-of-balance heuristic preserved (correct for revolving cards)
- **``LIABILITY``** — infer from most recent payment-side split on the account (the actual amortizing payment the user is obligated to)
- **Both** — explicit ``minimum_payment`` slot wins, as before
- **``LIABILITY`` with no slot AND no payment history** — clear error pointing to ``set_account_slot`` (rather than silently using a wildly-wrong heuristic)

## Test plan

- [x] 953 tests passing (up from 948 — 5 new ``TestAmortizingLoanMinimums``)
- [x] All 19 existing ``TestDebtPayoffPlan`` tests pass — the existing LIABILITY accounts in fixtures have payment history, so the inference path handles them correctly
- [x] Bug-report scenario locked: 2.7M mortgage + 14.8K real payment + 30K budget → minimum reads 14,800 (not 54,590), plan runs cleanly
- [ ] Cousin re-verifies on Lin Wei's book at ¥30,000/mo

## What the cousin should look for next round

Same call from the bug report:

```
debt_payoff_plan(monthly_budget="30000")
```

Should now produce a kill-order plan ordered by APR (CMB Card 18.25% first, ICBC Card 18.25% next, Auto Loan 4.90%, Mortgage 3.85% last). Total interest reasonable. Payoff date some years out. No "budget less than minimums" error.