### PR TITLE
fix: small fixes from CNY test book (JSON UTF-8, FX routing, debt amortization, typo)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -229,48 +229,77 @@ class BusinessMixin:
     # simplicity.
     FX_GAIN_LOSS_PATH = "Income:Foreign Exchange Gain/Loss"
 
-    # Keywords that identify an existing user-named FX gain/loss
-    # account during the fuzzy fallback below. Bookkeepers commonly
-    # name this account "FX Gain Loss", "Forex Gains", "Currency
-    # Adjustment", etc. — the canonical
-    # "Foreign Exchange Gain/Loss" path the auto-create uses is one
-    # convention among many.
-    _FX_NAME_KEYWORDS = ("fx", "forex", "exchange", "currency")
+    # Substrings that identify a user-named FX gain/loss account on
+    # the leaf-name match below. Books in the wild use a wide range
+    # of names — "FX Gain Loss", "Currency Translation", "Foreign
+    # Exchange Gain/Loss", etc. — and the canonical name above is
+    # only one convention among many. Bare ``currency`` is excluded
+    # deliberately: too many books have accounts like "Foreign
+    # Currency Cash" that aren't gain/loss accounts.
+    _FX_NAME_KEYWORDS = (
+        "fx",
+        "forex",
+        "foreign exchange",
+        "currency gain",
+        "currency loss",
+        "exchange gain",
+        "exchange loss",
+        "currency translation",
+    )
 
-    def _get_or_create_fx_account(self, book):
+    def _get_or_create_fx_account(self, book, fx_account: str | None = None):
         """Find or lazily create the FX-gain/loss account.
+
+        Returns ``(account, notice)`` where ``notice`` is ``None`` in
+        the unambiguous cases and a dict describing the ambiguity
+        when the fuzzy match found multiple candidates and we fell
+        back to the canonical default.
 
         Resolution order:
 
-        1. Exact canonical path ``Income:Foreign Exchange Gain/Loss``
-           (the path this method auto-creates when nothing matches).
-        2. Fuzzy match — any INCOME or EXPENSE account whose name
-           contains "fx" / "forex" / "exchange" / "currency"
-           (case-insensitive). Bookkeepers commonly create accounts
-           like "Income:FX Gain Loss" before any cross-currency
-           activity; matching them prevents us from silently
-           creating a parallel canonical account, leaving the user
-           with two FX accounts where one carries the activity and
-           the other is orphaned.
-        3. Auto-create the canonical path under ``Income``.
+        1. **Explicit ``fx_account``** (path, ``%short``, or full
+           GUID) — caller wants a specific account. Validated for
+           existence and INCOME/EXPENSE type, then used.
+        2. **Fuzzy match**, leaf-name substring against
+           ``_FX_NAME_KEYWORDS`` over INCOME/EXPENSE accounts:
+           - Exactly one match → use it.
+           - Zero matches → fall through to the canonical default
+             (existing path lookup, then auto-create if absent).
+           - More than one match → fall through to the canonical
+             default *and* return a notice asking the caller to
+             pass ``fx_account`` next time. Don't guess between
+             user-created accounts.
+        3. **Canonical default**: existing ``Income:Foreign Exchange
+           Gain/Loss`` if present, else auto-create it under
+           ``Income``.
 
         Created on first cross-currency pay whose post-date rate
         differs from its pay-date rate, so books without foreign-
         currency activity never accumulate an unused account.
 
         Raises:
-            ValueError: If the parent ``Income`` account doesn't exist.
-                Caller must create it first — we won't auto-create a
-                top-level account.
+            ValueError: If ``fx_account`` is supplied but doesn't
+                exist or isn't INCOME/EXPENSE; or if no fuzzy match
+                exists and the parent ``Income`` account is missing.
         """
-        # Step 1: exact canonical path.
-        fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
-        if fx_acct is not None:
-            return fx_acct
+        # Layer 1: caller-supplied account wins.
+        if fx_account is not None:
+            acct = self._resolve_account(book, fx_account)
+            if acct is None:
+                raise ValueError(
+                    f"fx_account not found: {fx_account!r}. Pass a "
+                    f"full path, %short GUID, or full 32-char GUID "
+                    f"of an INCOME or EXPENSE account."
+                )
+            if acct.type not in {"INCOME", "EXPENSE"}:
+                raise ValueError(
+                    f"fx_account {acct.fullname!r} is type "
+                    f"{acct.type}; must be INCOME or EXPENSE to "
+                    f"receive realized FX gain/loss."
+                )
+            return acct, None
 
-        # Step 2: fuzzy match against existing income/expense accounts.
-        # Sort by fullname for deterministic selection if multiple
-        # match (rare but possible).
+        # Layer 2: fuzzy match by leaf-name substring.
         candidates = []
         for account in book.accounts:
             if account.type not in {"INCOME", "EXPENSE"}:
@@ -278,9 +307,29 @@ class BusinessMixin:
             name_lower = account.name.lower()
             if any(kw in name_lower for kw in self._FX_NAME_KEYWORDS):
                 candidates.append(account)
-        if candidates:
-            candidates.sort(key=lambda a: a.fullname)
-            return candidates[0]
+
+        notice = None
+        if len(candidates) == 1:
+            return candidates[0], None
+        if len(candidates) > 1:
+            sorted_paths = sorted(c.fullname for c in candidates)
+            notice = {
+                "type": "ambiguous_fx_account",
+                "candidates": sorted_paths,
+                "message": (
+                    f"Found {len(candidates)} candidate FX accounts "
+                    f"({', '.join(sorted_paths)}). Routed to "
+                    f"{self.FX_GAIN_LOSS_PATH} as the canonical "
+                    f"default; pass fx_account explicitly to "
+                    f"disambiguate."
+                ),
+            }
+            # Fall through to canonical default below.
+
+        # Layer 3: canonical default (existing or auto-create).
+        fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
+        if fx_acct is not None:
+            return fx_acct, notice
 
         income = self._find_account(book, "Income")
         if income is None:
@@ -308,7 +357,7 @@ class BusinessMixin:
                 "and pay-date). Auto-created on first use."
             ),
         )
-        return fx_acct
+        return fx_acct, notice
 
     @staticmethod
     def _rate_from_post_transaction(post_txn, invoice_currency):
@@ -1386,7 +1435,10 @@ class BusinessMixin:
             owner_id: Customer ID or vendor ID (human-readable '000001').
             date_opened: ISO date; defaults to now.
             notes: Free-text notes.
-            currency: ISO currency code; defaults to book default.
+            currency: ISO currency code; defaults to the owner's
+                currency (set when the customer/vendor was created),
+                falling back to the book's default if the owner has
+                no currency set.
             term: Billterm name; optional.
             doc_id: Custom invoice/bill number; auto-generated from the
                 relevant counter when omitted.
@@ -1425,7 +1477,31 @@ class BusinessMixin:
                     raise ValueError(f"Currency not found: {currency}")
                 currency_guid = currency_obj.guid
             else:
-                currency_guid = self._require_default_currency(book).guid
+                # Resolution order when currency isn't passed explicitly:
+                #   1. Owner's currency (customer/vendor) — every
+                #      business document inherits the trading
+                #      relationship's currency by default. A USD
+                #      vendor's bill should be USD, not the book's
+                #      default. This matches GnuCash desktop UI
+                #      behavior and the bookkeeper's mental model.
+                #   2. Book default — fallback for owners that have
+                #      no currency set (shouldn't happen with piecash
+                #      owners, but defensive).
+                #
+                # Pre-fix this fallback used book default unconditionally,
+                # which broke cross-currency posting for any book with
+                # foreign customers/vendors: bills against a USD vendor
+                # on a CNY book got created in CNY, then ``post_invoice``
+                # saw inv.currency == account.commodity and skipped the
+                # rate-conversion path entirely. $500 was then booked
+                # as ¥500.
+                owner_currency = getattr(owner, "currency", None)
+                if owner_currency is not None:
+                    currency_guid = owner_currency.guid
+                else:
+                    currency_guid = self._require_default_currency(
+                        book,
+                    ).guid
 
             term_guid = None
             if term:
@@ -1539,7 +1615,10 @@ class BusinessMixin:
             customer_id: Customer ID (e.g., '000001').
             date_opened: Date in ISO format. Defaults to today.
             notes: Optional notes.
-            currency: ISO currency code. Defaults to book's default currency.
+            currency: ISO currency code. Defaults to the customer's
+                currency, falling back to the book's default. Pass
+                explicitly to override (rare — most invoices are in
+                the customer's currency).
             term: Billterm name (e.g., 'Net 30'). Optional.
             invoice_id: Custom invoice number. If omitted, auto-generates
                 from the book's invoice counter.
@@ -1572,7 +1651,10 @@ class BusinessMixin:
             vendor_id: Vendor ID (e.g., '000001').
             date_opened: Date in ISO format. Defaults to today.
             notes: Optional notes.
-            currency: ISO currency code. Defaults to book's default currency.
+            currency: ISO currency code. Defaults to the vendor's
+                currency, falling back to the book's default. Pass
+                explicitly to override (rare — most bills are in the
+                vendor's currency).
             term: Billterm name (e.g., 'Net 30'). Optional.
             bill_id: Custom bill number. If omitted, auto-generates
                 from the book's bill counter.
@@ -2225,6 +2307,7 @@ class BusinessMixin:
         payment_date: str | None = None,
         description: str | None = None,
         owner_type: str | None = None,
+        fx_account: str | None = None,
     ) -> dict:
         """Record a payment against a posted invoice or bill.
 
@@ -2240,6 +2323,24 @@ class BusinessMixin:
         recent price on or before the date, falling back to closest
         after). A clear error is raised if no matching price exists.
 
+        For cross-currency payments where the rate moved between
+        post-date and pay-date, a realized FX gain/loss split is
+        booked to an income/expense account. Routing rules (highest
+        priority first):
+
+        1. ``fx_account`` if supplied — must exist, must be
+           INCOME or EXPENSE.
+        2. Otherwise, the unique INCOME/EXPENSE account whose leaf
+           name matches one of "fx", "forex", "foreign exchange",
+           "currency gain/loss", "exchange gain/loss", "currency
+           translation".
+        3. Otherwise (zero matches OR multiple matches) the canonical
+           ``Income:Foreign Exchange Gain/Loss`` account, auto-
+           created if not present. If there were multiple
+           candidates, the result includes an ``fx_notice`` field
+           listing them so the caller can pass ``fx_account``
+           explicitly next time.
+
         Args:
             invoice_id: Human-readable ID (e.g., '000001').
             payment_account: Bank or cash account path.
@@ -2247,6 +2348,10 @@ class BusinessMixin:
             payment_date: ISO date (YYYY-MM-DD). Defaults to today.
             description: Description for the payment transaction.
             owner_type: 'customer' or 'vendor' for disambiguation.
+            fx_account: Optional account to receive any realized FX
+                gain/loss (cross-currency payments only). Accepts a
+                full path, ``%short`` GUID, or full 32-char GUID.
+                Must be an INCOME or EXPENSE account.
 
         Returns:
             Dict with payment details and remaining balance. For cross-
@@ -2255,7 +2360,8 @@ class BusinessMixin:
 
         Raises:
             ValueError: If invoice not found, not posted, invalid account,
-                or cross-currency payment with no exchange rate available.
+                cross-currency payment with no exchange rate available,
+                or ``fx_account`` is supplied but invalid.
         """
         ot = None
         if owner_type == "customer":
@@ -2403,6 +2509,7 @@ class BusinessMixin:
             fx_gain_loss = None
             fx_diff = Decimal("0")
             fx_acct = None
+            fx_notice = None
             if exchange_rate is not None:
                 rate_at_post = self._rate_from_post_transaction(
                     inv.post_txn, inv.currency
@@ -2413,7 +2520,9 @@ class BusinessMixin:
                     ).quantize(Decimal("0.01"))
                     fx_diff = pay_quantity - expected_at_post
                     if abs(fx_diff) >= Decimal("0.01"):
-                        fx_acct = self._get_or_create_fx_account(book)
+                        fx_acct, fx_notice = self._get_or_create_fx_account(
+                            book, fx_account=fx_account,
+                        )
                         # Customer (is_bill=False): we received MORE
                         # USD than income recorded → gain → credit
                         # income account (quantity = -fx_diff for a
@@ -2485,6 +2594,8 @@ class BusinessMixin:
                         "direction": direction,
                         "account": fx_acct.fullname,
                     }
+                    if fx_notice is not None:
+                        result["fx_notice"] = fx_notice
 
         return result
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -164,10 +164,16 @@ def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
         if days is None:
             days_str = ""
         elif days > 0:
-            anchor = (
-                "30-day default" if r.get("no_terms") else "past due"
-            )
-            days_str = f"  {days} days past {anchor}"
+            # Two phrasings — "X days past due" reads as contractual
+            # (the user agreed to a date and missed it), "X days past
+            # 30-day default" anchors the duration to the assumption
+            # we made when no term was set. Pre-fix the templating
+            # concatenated "days past " with another "past due" so
+            # the contractual case rendered as "days past past due".
+            if r.get("no_terms"):
+                days_str = f"  {days} days past 30-day default"
+            else:
+                days_str = f"  {days} days past due"
         elif days == 0:
             days_str = "  due today"
         else:
@@ -223,8 +229,30 @@ class BusinessMixin:
     # simplicity.
     FX_GAIN_LOSS_PATH = "Income:Foreign Exchange Gain/Loss"
 
+    # Keywords that identify an existing user-named FX gain/loss
+    # account during the fuzzy fallback below. Bookkeepers commonly
+    # name this account "FX Gain Loss", "Forex Gains", "Currency
+    # Adjustment", etc. — the canonical
+    # "Foreign Exchange Gain/Loss" path the auto-create uses is one
+    # convention among many.
+    _FX_NAME_KEYWORDS = ("fx", "forex", "exchange", "currency")
+
     def _get_or_create_fx_account(self, book):
-        """Find or lazily create ``Income:Foreign Exchange Gain/Loss``.
+        """Find or lazily create the FX-gain/loss account.
+
+        Resolution order:
+
+        1. Exact canonical path ``Income:Foreign Exchange Gain/Loss``
+           (the path this method auto-creates when nothing matches).
+        2. Fuzzy match — any INCOME or EXPENSE account whose name
+           contains "fx" / "forex" / "exchange" / "currency"
+           (case-insensitive). Bookkeepers commonly create accounts
+           like "Income:FX Gain Loss" before any cross-currency
+           activity; matching them prevents us from silently
+           creating a parallel canonical account, leaving the user
+           with two FX accounts where one carries the activity and
+           the other is orphaned.
+        3. Auto-create the canonical path under ``Income``.
 
         Created on first cross-currency pay whose post-date rate
         differs from its pay-date rate, so books without foreign-
@@ -235,9 +263,24 @@ class BusinessMixin:
                 Caller must create it first — we won't auto-create a
                 top-level account.
         """
+        # Step 1: exact canonical path.
         fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
         if fx_acct is not None:
             return fx_acct
+
+        # Step 2: fuzzy match against existing income/expense accounts.
+        # Sort by fullname for deterministic selection if multiple
+        # match (rare but possible).
+        candidates = []
+        for account in book.accounts:
+            if account.type not in {"INCOME", "EXPENSE"}:
+                continue
+            name_lower = account.name.lower()
+            if any(kw in name_lower for kw in self._FX_NAME_KEYWORDS):
+                candidates.append(account)
+        if candidates:
+            candidates.sort(key=lambda a: a.fullname)
+            return candidates[0]
 
         income = self._find_account(book, "Income")
         if income is None:

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -151,7 +151,7 @@ class InvestmentsMixin:
         commodity: str,
         namespace: str,
         value: str,
-        currency: str = "USD",
+        currency: str | None = None,
         price_date: date | None = None,
         price_type: str = "nav",
         source: str = "user:price",
@@ -162,14 +162,21 @@ class InvestmentsMixin:
             commodity: Symbol of the commodity (e.g., "VTSAX", "AAPL").
             namespace: Namespace of the commodity (e.g., "FUND", "NASDAQ").
             value: Price per unit as decimal string (e.g., "250.45").
-            currency: Currency the price is denominated in. Default "USD".
+            currency: Currency the price is denominated in. Defaults to
+                the book's default currency. For non-USD-default books
+                (e.g. CNY) the default makes ``create_price(commodity=
+                "USD", value="7.30")`` mean "1 USD = 7.30 CNY", which
+                matches the bookkeeper's mental model. Pass explicitly
+                to store cross-currency pairs that don't involve the
+                book default.
             price_date: Price date. Defaults to today.
             price_type: Type of price: "nav", "last", "bid", "ask", "unknown".
                         Default "nav".
             source: Source identifier. Default "user:price".
 
         Returns:
-            Dict with commodity, date, value, type, and status.
+            Dict with commodity, date, value, type, currency (the
+            resolved currency mnemonic, not the input), and status.
 
         Raises:
             ValueError: If commodity not found or invalid currency.
@@ -184,14 +191,25 @@ class InvestmentsMixin:
                     f"Commodity not found: {namespace}:{commodity}"
                 )
 
-            curr = self._get_or_create_currency(book, currency)
+            # Resolve currency: explicit input wins; otherwise default
+            # to the book's currency. Pre-fix, an unspecified currency
+            # silently became "USD" — which on a non-USD-default book
+            # stored prices like ``commodity=USD currency=USD`` (1 USD
+            # = X USD, nonsense), invisible to ``_find_exchange_rate``
+            # and silently shadowed by older valid prices on lookup.
+            if currency is None:
+                resolved_currency = self._require_default_currency(book)
+            else:
+                resolved_currency = self._get_or_create_currency(
+                    book, currency,
+                )
 
             # Check for existing price (same commodity/currency/date/source)
             existing = None
             for p in book.prices:
                 if (
                     p.commodity == comm
-                    and p.currency == curr
+                    and p.currency == resolved_currency
                     and _to_date(p.date) == price_date
                     and p.source == source
                 ):
@@ -205,7 +223,7 @@ class InvestmentsMixin:
                 # piecash expects datetime.date, not datetime.datetime
                 piecash.Price(
                     commodity=comm,
-                    currency=curr,
+                    currency=resolved_currency,
                     date=price_date,
                     value=_to_decimal(value),
                     type=price_type,
@@ -217,7 +235,10 @@ class InvestmentsMixin:
             result = {
                 "commodity": commodity,
                 "namespace": namespace,
-                "currency": currency,
+                # Echo the resolved mnemonic, not the input — the input
+                # might have been None (book default). This way the
+                # caller sees what was actually stored.
+                "currency": resolved_currency.mnemonic,
                 "date": price_date.isoformat(),
                 "value": value,
                 "type": price_type,

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1035,7 +1035,9 @@ class ReportingMixin:
 
                 min_payment = None
 
-                # 1. Check minimum_payment slot (user override)
+                # 1. Check minimum_payment slot (user override).
+                #    Wins for both CREDIT and LIABILITY — the user has
+                #    declared the contractual amount.
                 try:
                     mp_val = account["minimum_payment"]
                     mp_str = str(mp_val.value) if hasattr(mp_val, "value") else str(mp_val)
@@ -1043,13 +1045,46 @@ class ReportingMixin:
                 except (KeyError, InvalidOperation):
                     pass
 
-                # 2. Calculate from balance: greater of $25 or 2% of balance
+                # 2. Type-aware fallback. Credit cards and amortizing
+                #    loans have very different minimum-payment shapes:
+                #    CREDIT cards charge ~2% of balance (revolving,
+                #    no fixed term), while LIABILITY loans are
+                #    contractually fixed payments derived from
+                #    principal × rate × term (mortgage, auto, student).
+                #    Applying the 2% rule to a mortgage produces a
+                #    minimum that's ~3-4× the actual payment, which
+                #    makes the budget-vs-minimums gate trip on any
+                #    realistic household budget.
                 if min_payment is None:
-                    two_percent = (balance * Decimal("0.02")).quantize(Decimal("0.01"))
-                    min_payment = max(two_percent, Decimal("25"))
-                    # If balance is below $25, minimum is the full balance
-                    if balance < Decimal("25"):
-                        min_payment = balance
+                    if account.type == "CREDIT":
+                        two_percent = (
+                            balance * Decimal("0.02")
+                        ).quantize(Decimal("0.01"))
+                        min_payment = max(two_percent, Decimal("25"))
+                        if balance < Decimal("25"):
+                            min_payment = balance
+                    else:
+                        # LIABILITY: standard amortization formula.
+                        # PMT = P × r(1+r)^n / ((1+r)^n − 1)
+                        # Term defaults: 30 years if "mortgage" appears
+                        # anywhere in the account path (Liabilities:
+                        # Mortgage, Loans:Mortgage:Principal, etc.),
+                        # else 5 years (auto, personal, etc.). Users
+                        # with non-standard terms should set the
+                        # minimum_payment slot explicitly.
+                        is_mortgage = "mortgage" in account.fullname.lower()
+                        term_months = 360 if is_mortgage else 60
+                        monthly_rate = (
+                            apr / Decimal("100") / Decimal("12")
+                        )
+                        factor = (Decimal("1") + monthly_rate) ** term_months
+                        min_payment = (
+                            balance * monthly_rate * factor / (factor - Decimal("1"))
+                        ).quantize(Decimal("0.01"))
+                        # Cap at balance for tiny remainders where the
+                        # formula could over-shoot a near-paid-off loan.
+                        if min_payment > balance:
+                            min_payment = balance
 
                 credit_limit = None
                 try:

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -157,8 +157,20 @@ def _strip_noise(obj):
 
 
 def _json(obj) -> str:
-    """Serialize to minified JSON, stripping noise values."""
-    return json.dumps(_strip_noise(obj), separators=(",", ":"))
+    """Serialize to minified JSON, stripping noise values.
+
+    ``ensure_ascii=False`` so non-ASCII strings (Chinese commodity
+    names like "贵州茅台", customer names with accented characters,
+    etc.) round-trip as raw UTF-8 instead of being escaped to
+    ``\\uXXXX`` form. The escape behavior is technically valid JSON
+    but makes the wire format unreadable for human reviewers and
+    breaks any downstream substring match on the original text.
+    Bookkeeper-flagged on a CNY-default test book where every
+    SSE/SZSE commodity name came back as escape sequences.
+    """
+    return json.dumps(
+        _strip_noise(obj), separators=(",", ":"), ensure_ascii=False,
+    )
 
 
 def safe_tool(func: Callable) -> Callable:

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -265,7 +265,9 @@ def register(mcp, get_book) -> None:
             customer_id: Customer ID (e.g., "000001").
             date_opened: Date in ISO format (YYYY-MM-DD). Defaults to today.
             notes: Optional notes.
-            currency: ISO currency code. Defaults to book's default currency.
+            currency: ISO currency code. Defaults to the customer's
+                currency, falling back to the book's default. Pass
+                explicitly to override.
             term: Billterm name (e.g., "Net 30"). Optional.
             invoice_id: Custom invoice number (e.g., "INV-2026-001"). If omitted,
                 auto-generates from the book's invoice counter.
@@ -295,7 +297,9 @@ def register(mcp, get_book) -> None:
             vendor_id: Vendor ID (e.g., "000001").
             date_opened: Date in ISO format (YYYY-MM-DD). Defaults to today.
             notes: Optional notes.
-            currency: ISO currency code. Defaults to book's default currency.
+            currency: ISO currency code. Defaults to the vendor's
+                currency, falling back to the book's default. Pass
+                explicitly to override.
             term: Billterm name (e.g., "Net 30"). Optional.
             bill_id: Custom bill number (e.g., "BILL-2026-001"). If omitted,
                 auto-generates from the book's bill counter.
@@ -468,11 +472,24 @@ def register(mcp, get_book) -> None:
         payment_date: str | None = None,
         description: str | None = None,
         owner_type: str | None = None,
+        fx_account: str | None = None,
     ) -> str:
         """Record a payment against a posted invoice or bill.
 
         Creates a payment transaction from the specified bank/cash account
         to the invoice's A/R or A/P account. Partial payments are supported.
+
+        For cross-currency payments where the rate moved between
+        post-date and pay-date, a realized FX gain/loss split is
+        booked. Pass ``fx_account`` to control routing; otherwise
+        the server picks the unique INCOME/EXPENSE account whose
+        leaf name matches "fx", "forex", "foreign exchange",
+        "currency gain/loss", "exchange gain/loss", or "currency
+        translation". When zero or multiple match, the canonical
+        ``Income:Foreign Exchange Gain/Loss`` is used (auto-created
+        if absent), and an ``fx_notice`` is returned listing
+        ambiguous candidates so you can pass ``fx_account``
+        explicitly next time.
 
         Args:
             id: Invoice or bill ID (e.g., "000001").
@@ -481,6 +498,9 @@ def register(mcp, get_book) -> None:
             payment_date: Payment date (YYYY-MM-DD). Defaults to today.
             description: Description for the payment transaction. Optional.
             owner_type: "customer" or "vendor" for disambiguation.
+            fx_account: Optional INCOME or EXPENSE account to receive
+                realized FX gain/loss (cross-currency payments only).
+                Accepts a full path, %short GUID, or full 32-char GUID.
         """
         book = get_book()
         result = book.pay_invoice(
@@ -490,6 +510,7 @@ def register(mcp, get_book) -> None:
             payment_date=payment_date,
             description=description,
             owner_type=owner_type,
+            fx_account=fx_account,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -71,7 +71,7 @@ def register(mcp, get_book) -> None:
         commodity: str,
         namespace: str,
         value: str,
-        currency: str = "USD",
+        currency: str | None = None,
         date: str | None = None,
         price_type: str = "nav",
         source: str = "user:price",
@@ -85,7 +85,11 @@ def register(mcp, get_book) -> None:
             commodity: Symbol (e.g., "VTSAX").
             namespace: Commodity namespace (e.g., "FUND", "NASDAQ").
             value: Price per unit as decimal string (e.g., "250.45").
-            currency: ISO currency code. Default "USD".
+            currency: ISO currency code. Defaults to the book's default
+                currency — so ``create_price(commodity="USD", value="7.30")``
+                on a CNY-default book stores "1 USD = 7.30 CNY" (the
+                natural reading). Pass explicitly for cross-currency
+                pairs that don't involve the book default.
             date: ISO date (YYYY-MM-DD). Defaults to today.
             price_type: "nav" (default, mutual funds), "last", "bid",
                 "ask", or "unknown".

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7750,6 +7750,102 @@ class TestPrices:
                 value="100.00",
             )
 
+    def test_create_price_currency_defaults_to_book_default_usd(
+        self, test_book: Path,
+    ):
+        """When currency isn't supplied on a USD-default book, the
+        price is stored as USD-denominated. Backwards-compatible
+        with pre-fix behavior on USD books — the only change is that
+        the default is now derived from the book, not hardcoded."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Total Stock", namespace="FUND",
+        )
+
+        result = gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.50",
+            price_date=date(2026, 2, 7),
+        )
+
+        # Echoed currency is the resolved mnemonic (USD on this book).
+        assert result["currency"] == "USD"
+
+    def test_create_price_currency_defaults_to_book_default_cny(
+        self, tmp_path: Path,
+    ):
+        """The user's reported bug: on a CNY-default book,
+        ``create_price(commodity="USD", value="7.30")`` (no currency
+        arg) was storing ``commodity=USD currency=USD`` (nonsense) and
+        being silently skipped by ``_find_exchange_rate``. With the
+        fix, the default resolves to CNY so the price stores as
+        ``commodity=USD currency=CNY`` (1 USD = 7.30 CNY)."""
+        book_path = tmp_path / "cny_default.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="CNY", overwrite=True,
+        )
+        # Pre-load USD as a known currency so create_price can resolve it.
+        from piecash import factories
+        usd = factories.create_currency_from_ISO("USD")
+        book.session.add(usd)
+        book.save()
+        book.close()
+
+        gc_book = GnuCashBook(str(book_path))
+        result = gc_book.create_price(
+            commodity="USD", namespace="CURRENCY",
+            value="7.30", price_date=date(2026, 4, 1),
+        )
+
+        # Result echoes the resolved mnemonic, not the input.
+        assert result["currency"] == "CNY"
+
+        # Verify storage: the price's currency is CNY (the book
+        # default), not USD (the old hardcoded default).
+        with gc_book.open(readonly=True) as book:
+            stored = [
+                p for p in book.prices
+                if p.type != "transaction"
+                and p.commodity.mnemonic == "USD"
+            ]
+            assert len(stored) == 1
+            assert stored[0].currency.mnemonic == "CNY"
+            assert Decimal(str(stored[0].value)) == Decimal("7.30")
+
+    def test_create_price_explicit_currency_overrides_default(
+        self, tmp_path: Path,
+    ):
+        """An explicit ``currency`` parameter wins over the book
+        default — for callers who want to store a non-default-
+        currency price (e.g. EUR/USD on a CNY-default book)."""
+        book_path = tmp_path / "cny_default.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="CNY", overwrite=True,
+        )
+        from piecash import factories
+        usd = factories.create_currency_from_ISO("USD")
+        eur = factories.create_currency_from_ISO("EUR")
+        book.session.add(usd)
+        book.session.add(eur)
+        book.save()
+        book.close()
+
+        gc_book = GnuCashBook(str(book_path))
+        result = gc_book.create_price(
+            commodity="EUR", namespace="CURRENCY",
+            value="1.08", currency="USD",
+            price_date=date(2026, 4, 1),
+        )
+
+        assert result["currency"] == "USD"
+        with gc_book.open(readonly=True) as book:
+            stored = [
+                p for p in book.prices
+                if p.type != "transaction"
+                and p.commodity.mnemonic == "EUR"
+            ]
+            assert len(stored) == 1
+            assert stored[0].currency.mnemonic == "USD"
+
 
 class TestInvestmentWorkflow:
     """Integration tests for the full investment workflow."""

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -616,6 +616,42 @@ class TestCreateInvoice:
         with pytest.raises(ValueError, match="Billterm not found"):
             gb.create_invoice(customer_id="000001", term="Nonexistent")
 
+    def test_currency_defaults_to_customer_currency(self, business_book):
+        """When ``currency`` is not passed, the invoice inherits the
+        customer's currency — not the book default. A USD customer
+        on a USD-default book happens to look the same either way,
+        so we set the customer's currency to EUR explicitly to
+        prove the inheritance: the resulting invoice should be EUR
+        regardless of book default."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            book.session.add(piecash.factories.create_currency_from_ISO("EUR"))
+            book.save()
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        result = gb.create_invoice(customer_id="000001")
+        # Read back via get_invoice to verify the stored currency.
+        inv = gb.get_invoice(result["id"])
+        assert inv["currency"] == "EUR"
+
+    def test_explicit_currency_overrides_customer_currency(
+        self, business_book,
+    ):
+        """An explicit ``currency`` parameter wins over the
+        customer's currency. Edge case but supported — callers
+        sometimes record cross-currency invoices intentionally."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            book.session.add(piecash.factories.create_currency_from_ISO("EUR"))
+            book.save()
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        result = gb.create_invoice(
+            customer_id="000001", currency="USD",
+        )
+        inv = gb.get_invoice(result["id"])
+        assert inv["currency"] == "USD"
+
 
 class TestCreateBill:
     """Tests for create_bill."""
@@ -869,6 +905,37 @@ class TestCreateBill:
             book.save()
         result = gb.create_invoice(customer_id="000002")
         assert result["id"] == "000006"
+
+    def test_currency_defaults_to_vendor_currency(self, business_book):
+        """The bill bug from the bookkeeper: vendors with foreign
+        currency had their bills created in the book's default
+        currency instead of inheriting the vendor's. ``post_invoice``
+        then saw inv.currency == account.commodity and skipped
+        cross-currency conversion entirely — $500 was booked as
+        ¥500. The fix: bills inherit the vendor's currency when
+        ``currency`` isn't passed, matching customer-invoice
+        behavior and GnuCash desktop UI."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="JetBrains", currency="USD")
+        result = gb.create_bill(vendor_id="000001")
+        bill = gb.get_invoice(result["id"])
+        assert bill["currency"] == "USD"
+
+    def test_explicit_currency_overrides_vendor_currency(
+        self, business_book,
+    ):
+        """Explicit ``currency`` wins over the vendor's currency."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            book.session.add(piecash.factories.create_currency_from_ISO("EUR"))
+            book.save()
+        gb.create_vendor(name="JetBrains", currency="USD")
+        result = gb.create_bill(
+            vendor_id="000001", currency="EUR",
+        )
+        bill = gb.get_invoice(result["id"])
+        assert bill["currency"] == "EUR"
 
 
 class TestDeleteInvoice:
@@ -1740,6 +1807,99 @@ class TestPostInvoice:
             assert Decimal(str(income_split.value)) == Decimal("-1000")
             assert Decimal(str(income_split.quantity)) == Decimal("-1100.00")
 
+    def test_cross_currency_bill_post_uses_vendor_currency(
+        self, business_book,
+    ):
+        """Regression for the vendor-bill FX bug: a EUR vendor on a
+        USD-default book had bills created in USD (book default)
+        instead of EUR (vendor's currency). Posted transactions
+        then skipped cross-currency conversion entirely — €500 was
+        booked as $500. With the fix, ``create_bill`` inherits the
+        vendor's currency and ``post_invoice`` runs the same
+        cross-currency conversion path that customer invoices use.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gb = GnuCashBook(str(business_book))
+
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = piecash.factories.create_currency_from_ISO("EUR")
+            book.session.add(eur)
+
+            assets = next(a for a in book.accounts if a.fullname == "Assets")
+            ap_eur = piecash.Account(
+                name="Accounts Payable EUR",
+                type="PAYABLE",
+                parent=assets,
+                commodity=eur,
+            )
+            book.session.add(ap_eur)
+
+            # USD/EUR rate: 1 EUR = 1.10 USD (i.e. EUR is the more
+            # valuable currency). Stored as commodity=EUR, currency=USD.
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2026, 3, 10), value="1.10",
+                source="user:test", type="nav",
+            ))
+            book.save()
+
+        # No explicit currency on create_bill — should inherit EUR
+        # from the vendor.
+        gb.create_vendor(name="München GmbH", currency="EUR")
+        result = gb.create_bill(
+            vendor_id="000001", date_opened="2026-03-10",
+        )
+        # Confirm inheritance worked at create time.
+        bill = gb.get_invoice(result["id"])
+        assert bill["currency"] == "EUR"
+
+        # add_bill_entry on a USD expense account; post to EUR A/P.
+        gb.add_bill_entry(
+            bill_id=result["id"],
+            account="Expenses:Office Supplies",  # USD account
+            description="Software license",
+            quantity="1", price="1000.00",
+        )
+        gb.post_invoice(
+            invoice_id=result["id"],
+            post_account="Assets:Accounts Payable EUR",
+            post_date="2026-03-10",
+        )
+
+        # Inspect splits: expense quantity should be the USD-equivalent
+        # at 1.10 (€1000 × 1.10 = $1100), while value stays at €1000.
+        # A/P EUR matches transaction currency → quantity == value.
+        with gb.open(readonly=True) as book:
+            inv = None
+            for i in book.session.query(piecash.business.Invoice).all():
+                if i.id == result["id"]:
+                    inv = i
+                    break
+            assert inv is not None
+            txn = inv.post_txn
+            assert txn is not None
+            # Bill posted in EUR, not USD.
+            assert txn.currency.mnemonic == "EUR"
+
+            expense_split = next(
+                s for s in txn.splits
+                if s.account.fullname == "Expenses:Office Supplies"
+            )
+            ap_split = next(
+                s for s in txn.splits
+                if s.account.fullname == "Assets:Accounts Payable EUR"
+            )
+
+            # Bill (vendor): A/P credit (negative), expense debit (positive).
+            assert Decimal(str(ap_split.value)) == Decimal("-1000")
+            assert Decimal(str(ap_split.quantity)) == Decimal("-1000")
+            assert Decimal(str(expense_split.value)) == Decimal("1000")
+            # Expense split is USD; quantity converted at rate 1.10.
+            assert Decimal(str(expense_split.quantity)) == Decimal("1100.00")
+
 
 # ============== Pay Invoice Tests ==============
 
@@ -2281,6 +2441,143 @@ class TestPayInvoice:
         assert Decimal(result["remaining_balance"]) == Decimal("0")
         # Same-currency payment: no exchange_rate field in result.
         assert "exchange_rate" not in result
+
+    def test_pay_invoice_fx_account_parameter_routes_explicit(
+        self, business_book,
+    ):
+        """End-to-end: ``pay_invoice(fx_account=...)`` routes the
+        realized FX gain/loss to the user-specified account, not
+        the canonical default. This is the primary fix for the FX
+        account-routing bug — bookkeepers can pin a specific
+        account without depending on naming heuristics."""
+        gb = GnuCashBook(str(business_book))
+        # Pre-create a user-named FX account; route to it explicitly.
+        gb.create_account(
+            name="FX Gain Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.12")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="EUR services", quantity="1", price="4500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable EUR",
+            post_date="2026-03-10",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+            fx_account="Income:FX Gain Loss",
+        )
+
+        # FX gain routed to the user's account, not the canonical one.
+        assert result["fx_realized"]["account"] == "Income:FX Gain Loss"
+        assert "fx_notice" not in result
+        # Canonical account was never auto-created.
+        assert gb.get_account(
+            name="Income:Foreign Exchange Gain/Loss"
+        ) is None
+        # User's account holds the gain.
+        assert gb.get_balance(account_name="Income:FX Gain Loss") == Decimal("-90")
+
+    def test_pay_invoice_ambiguous_fx_emits_notice(
+        self, business_book,
+    ):
+        """When two candidate FX accounts exist (Lin Wei's situation:
+        ``Income:FX Gain Loss`` user-created, ``Income:Foreign
+        Exchange Gain/Loss`` auto-created by a prior pay_invoice
+        call), routing falls through to canonical with a notice."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_account(
+            name="FX Gain Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        gb.create_account(
+            name="Foreign Exchange Gain/Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.12")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="EUR services", quantity="1", price="4500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable EUR",
+            post_date="2026-03-10",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+
+        # Routed to canonical (the deterministic choice when ambiguous).
+        assert result["fx_realized"]["account"] == "Income:Foreign Exchange Gain/Loss"
+        # Notice surfaces both candidates so the caller can fix it.
+        notice = result["fx_notice"]
+        assert notice["type"] == "ambiguous_fx_account"
+        assert "Income:FX Gain Loss" in notice["candidates"]
+        assert "Income:Foreign Exchange Gain/Loss" in notice["candidates"]
+        # User's untouched account stays at zero.
+        assert gb.get_balance(account_name="Income:FX Gain Loss") == Decimal("0")
+
+    def test_pay_invoice_fx_account_invalid_path_raises(
+        self, business_book,
+    ):
+        """A typo in ``fx_account`` should fail loud, not silently
+        fall back to the canonical default — that masks the typo
+        and routes income to a different account than the caller
+        asked for."""
+        gb = GnuCashBook(str(business_book))
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.12")
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="EUR services", quantity="1", price="4500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable EUR",
+            post_date="2026-03-10",
+        )
+
+        with pytest.raises(ValueError, match="fx_account not found"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="4500.00",
+                payment_date="2026-03-20",
+                fx_account="Income:Typo Account That Does Not Exist",
+            )
 
 
 # ============== Outstanding Invoices Tests ==============
@@ -2987,27 +3284,26 @@ class TestCnyBugReportFollowups:
         self, business_book,
     ):
         """When the user has pre-created a fuzzy-named FX account
-        (``Income:FX Gain Loss``), ``_get_or_create_fx_account``
-        should match it instead of silently creating a parallel
+        (``Income:FX Gain Loss``) and *no* canonical account exists,
+        ``_get_or_create_fx_account`` should match it (single
+        candidate) instead of silently creating a parallel
         ``Income:Foreign Exchange Gain/Loss``."""
         gb = GnuCashBook(str(business_book))
-        # User pre-creates with a different but recognizable name.
         gb.create_account(
             name="FX Gain Loss",
             account_type="INCOME",
             parent="Income",
         )
         with gb.open(readonly=True) as book:
-            fx_acct = gb._get_or_create_fx_account(book)
-            # Must reuse the user's account rather than create the
-            # canonical-named one.
+            fx_acct, notice = gb._get_or_create_fx_account(book)
             assert fx_acct.fullname == "Income:FX Gain Loss"
+            assert notice is None
 
     def test_fx_account_reuse_matches_alternate_keywords(
         self, business_book,
     ):
-        """Match any of fx / forex / exchange / currency in the
-        account name (case-insensitive)."""
+        """Match any of the FX-name substrings in the leaf account
+        name (case-insensitive). 'Forex Adjustments' contains 'forex'."""
         gb = GnuCashBook(str(business_book))
         gb.create_account(
             name="Forex Adjustments",
@@ -3015,16 +3311,18 @@ class TestCnyBugReportFollowups:
             parent="Income",
         )
         with gb.open(readonly=True) as book:
-            fx_acct = gb._get_or_create_fx_account(book)
+            fx_acct, notice = gb._get_or_create_fx_account(book)
             assert fx_acct.fullname == "Income:Forex Adjustments"
+            assert notice is None
 
-    def test_fx_account_canonical_path_still_wins(
+    def test_fx_account_ambiguous_falls_through_with_notice(
         self, business_book,
     ):
-        """If both canonical and fuzzy-matchable accounts exist, the
-        canonical exact-path lookup wins (it's the path we'd auto-
-        create — preserving deterministic behavior on books with
-        existing FX activity)."""
+        """If multiple candidate FX accounts exist (e.g., the user
+        pre-created one *and* a previous pay_invoice call auto-
+        created the canonical), don't guess between them. Route to
+        canonical and surface a notice listing the candidates so the
+        caller can pass ``fx_account`` explicitly next time."""
         gb = GnuCashBook(str(business_book))
         gb.create_account(
             name="FX Gain Loss",
@@ -3037,16 +3335,85 @@ class TestCnyBugReportFollowups:
             parent="Income",
         )
         with gb.open(readonly=True) as book:
-            fx_acct = gb._get_or_create_fx_account(book)
+            fx_acct, notice = gb._get_or_create_fx_account(book)
             assert fx_acct.fullname == "Income:Foreign Exchange Gain/Loss"
+            assert notice is not None
+            assert notice["type"] == "ambiguous_fx_account"
+            assert "Income:FX Gain Loss" in notice["candidates"]
+            assert "Income:Foreign Exchange Gain/Loss" in notice["candidates"]
+            assert "fx_account" in notice["message"]
 
     def test_fx_account_falls_through_to_canonical_create(
         self, business_book,
     ):
         """No fuzzy match available → canonical account auto-created
-        under Income."""
+        under Income, no notice."""
         gb = GnuCashBook(str(business_book))
         with gb.open(readonly=False) as book:
-            fx_acct = gb._get_or_create_fx_account(book)
+            fx_acct, notice = gb._get_or_create_fx_account(book)
             book.save()
             assert fx_acct.fullname == "Income:Foreign Exchange Gain/Loss"
+            assert notice is None
+
+    def test_fx_account_explicit_parameter_overrides_heuristic(
+        self, business_book,
+    ):
+        """When the caller passes ``fx_account``, that account is
+        used regardless of what fuzzy matches exist. This is the
+        explicit-control path for callers who want determinism."""
+        gb = GnuCashBook(str(business_book))
+        # Create two candidates that would normally be ambiguous AND
+        # a third unrelated account the caller will pin to.
+        gb.create_account(
+            name="FX Gain Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        gb.create_account(
+            name="Foreign Exchange Gain/Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        gb.create_account(
+            name="Currency Translation Gain/Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        with gb.open(readonly=True) as book:
+            fx_acct, notice = gb._get_or_create_fx_account(
+                book,
+                fx_account="Income:Currency Translation Gain/Loss",
+            )
+            # Caller's explicit choice wins; no notice (no ambiguity
+            # to flag when the caller has already disambiguated).
+            assert fx_acct.fullname == "Income:Currency Translation Gain/Loss"
+            assert notice is None
+
+    def test_fx_account_explicit_invalid_path_raises(
+        self, business_book,
+    ):
+        """Passing a non-existent ``fx_account`` is a hard error —
+        the caller asked for a specific account, so silently
+        falling back would mask a typo."""
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=True) as book:
+            with pytest.raises(ValueError, match="fx_account not found"):
+                gb._get_or_create_fx_account(
+                    book, fx_account="Income:Does Not Exist",
+                )
+
+    def test_fx_account_explicit_wrong_type_raises(
+        self, business_book,
+    ):
+        """``fx_account`` must be INCOME or EXPENSE — booking a
+        gain/loss to an asset/liability/equity account would corrupt
+        the financial statements."""
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=True) as book:
+            with pytest.raises(
+                ValueError, match="must be INCOME or EXPENSE"
+            ):
+                # business_book has Assets:Checking (BANK type).
+                gb._get_or_create_fx_account(
+                    book, fx_account="Assets:Checking",
+                )

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2921,3 +2921,132 @@ class TestPhase4CBreakdownCompact:
         )
         assert isinstance(result, str)
         assert "TOTAL" in result
+
+
+class TestCnyBugReportFollowups:
+    """Regression tests for the small-bug findings in the CNY
+    cousin-verification report (separate PR from the substantive
+    Bug 3 work that lives on its own branch)."""
+
+    # ── Bug 4: "days past past due" typo ─────────────────────────
+
+    def test_outstanding_invoices_overdue_no_double_word(
+        self, business_book,
+    ):
+        """The compact-format ``get_outstanding_invoices`` template
+        was concatenating "days past " with " past due" and producing
+        "X days past past due". Should read either "X days past due"
+        (contractual) or "X days past 30-day default" (no terms)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        # Post with explicit due date in the past — exercises the
+        # contractual branch where the typo lived.
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-01",
+            due_date="2026-02-01",
+        )
+        compact = gb.get_outstanding_invoices()
+        assert "past past due" not in compact, (
+            f"typo regression — found duplicated word in:\n{compact}"
+        )
+        # And the correct form is present.
+        assert "past due" in compact
+
+    def test_outstanding_invoices_no_terms_renders_30_day_default(
+        self, business_book,
+    ):
+        """No-terms branch should annotate as ``"X days past 30-day
+        default"`` — also doesn't have the duplicated word."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="Consulting", quantity="1", price="500.00",
+        )
+        # No due_date and no billterm — falls to 30-day default.
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-01-01",
+        )
+        compact = gb.get_outstanding_invoices()
+        assert "past past" not in compact
+        assert "30-day default" in compact
+
+    # ── Bug 2: pay_invoice should reuse existing FX accounts ─────
+
+    def test_fx_account_reuse_picks_up_user_named_account(
+        self, business_book,
+    ):
+        """When the user has pre-created a fuzzy-named FX account
+        (``Income:FX Gain Loss``), ``_get_or_create_fx_account``
+        should match it instead of silently creating a parallel
+        ``Income:Foreign Exchange Gain/Loss``."""
+        gb = GnuCashBook(str(business_book))
+        # User pre-creates with a different but recognizable name.
+        gb.create_account(
+            name="FX Gain Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        with gb.open(readonly=True) as book:
+            fx_acct = gb._get_or_create_fx_account(book)
+            # Must reuse the user's account rather than create the
+            # canonical-named one.
+            assert fx_acct.fullname == "Income:FX Gain Loss"
+
+    def test_fx_account_reuse_matches_alternate_keywords(
+        self, business_book,
+    ):
+        """Match any of fx / forex / exchange / currency in the
+        account name (case-insensitive)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_account(
+            name="Forex Adjustments",
+            account_type="INCOME",
+            parent="Income",
+        )
+        with gb.open(readonly=True) as book:
+            fx_acct = gb._get_or_create_fx_account(book)
+            assert fx_acct.fullname == "Income:Forex Adjustments"
+
+    def test_fx_account_canonical_path_still_wins(
+        self, business_book,
+    ):
+        """If both canonical and fuzzy-matchable accounts exist, the
+        canonical exact-path lookup wins (it's the path we'd auto-
+        create — preserving deterministic behavior on books with
+        existing FX activity)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_account(
+            name="FX Gain Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        gb.create_account(
+            name="Foreign Exchange Gain/Loss",
+            account_type="INCOME",
+            parent="Income",
+        )
+        with gb.open(readonly=True) as book:
+            fx_acct = gb._get_or_create_fx_account(book)
+            assert fx_acct.fullname == "Income:Foreign Exchange Gain/Loss"
+
+    def test_fx_account_falls_through_to_canonical_create(
+        self, business_book,
+    ):
+        """No fuzzy match available → canonical account auto-created
+        under Income."""
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            fx_acct = gb._get_or_create_fx_account(book)
+            book.save()
+            assert fx_acct.fullname == "Income:Foreign Exchange Gain/Loss"

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -271,6 +271,202 @@ class TestDebtPayoffPlan:
             pytest.fail("Almost Paid not found in results")
 
 
+class TestDebtPayoffAmortizingLoans:
+    """Regression: LIABILITY accounts (mortgage, auto loan) must use
+    the amortization formula, not the credit-card 2%-of-balance rule.
+
+    Pre-fix, a ¥2.7M mortgage at 3.85% APR was assigned a minimum of
+    ¥54,590/month (2% of balance), tripping the budget gate on any
+    realistic household budget. Post-fix, amortization gives
+    ~¥12,800/month, leaving plenty of room for a ¥30K budget.
+    """
+
+    def _liability_book(self, tmp_path: Path) -> Path:
+        """A book with a mortgage + auto loan + credit card, no min slot."""
+        import piecash
+
+        book_path = tmp_path / "amort_test.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="CNY", overwrite=True,
+        )
+        cny = book.default_currency
+        root = book.root_account
+
+        liabilities = piecash.Account(
+            name="Liabilities", type="LIABILITY", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        loans = piecash.Account(
+            name="Loans", type="LIABILITY", parent=liabilities,
+            commodity=cny, placeholder=True,
+        )
+        mortgage = piecash.Account(
+            name="Mortgage", type="LIABILITY", parent=loans,
+            commodity=cny,
+        )
+        auto = piecash.Account(
+            name="Auto Loan", type="LIABILITY", parent=loans,
+            commodity=cny,
+        )
+        cc = piecash.Account(
+            name="Credit Card", type="CREDIT", parent=liabilities,
+            commodity=cny,
+        )
+        equity = piecash.Account(
+            name="Equity", type="EQUITY", parent=root,
+            commodity=cny, placeholder=True,
+        )
+        opening = piecash.Account(
+            name="Opening Balance", type="EQUITY", parent=equity,
+            commodity=cny,
+        )
+        book.save()
+
+        mortgage["apr"] = "3.85"
+        auto["apr"] = "4.90"
+        cc["apr"] = "18.25"
+        book.save()
+
+        # Set opening balances. Liabilities are credit-normal (negative
+        # quantity = positive amount owed).
+        for acct, amount in (
+            (mortgage, "-2729518"),
+            (auto, "-96798"),
+            (cc, "-19385"),
+        ):
+            tx = piecash.Transaction(
+                currency=cny,
+                description=f"Opening: {acct.name}",
+                post_date=date(2026, 1, 1),
+                splits=[
+                    piecash.Split(account=acct, value=Decimal(amount)),
+                    piecash.Split(account=opening, value=-Decimal(amount)),
+                ],
+            )
+            book.session.add(tx)
+        book.save()
+        return book_path
+
+    def test_mortgage_uses_amortization_not_two_percent(self, tmp_path: Path):
+        """The mortgage minimum should be ~¥12-13K (amortization on a
+        30-year term), not ¥54K (2% of balance)."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+
+        for d in result["debts"]:
+            if d["account"] == "Liabilities:Loans:Mortgage":
+                mp = Decimal(d["minimum_payment"])
+                # 30-year amortization on ¥2,729,518 at 3.85% =
+                # ~¥12,789. Allow a generous ±¥500 band — the formula
+                # is exact; the band protects against future
+                # refactors choosing nearby term defaults.
+                assert Decimal("12200") < mp < Decimal("13400"), (
+                    f"Mortgage minimum {mp} outside expected range"
+                )
+                # And nowhere near the broken 2% answer (¥54,590).
+                assert mp < Decimal("20000")
+                break
+        else:
+            pytest.fail("Mortgage not found in results")
+
+    def test_auto_loan_uses_amortization_not_two_percent(self, tmp_path: Path):
+        """Auto loan should use 5-year amortization default."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+
+        for d in result["debts"]:
+            if d["account"] == "Liabilities:Loans:Auto Loan":
+                mp = Decimal(d["minimum_payment"])
+                # 5-year amortization on ¥96,798 at 4.9% = ~¥1,824.
+                # Generous ±¥150 band.
+                assert Decimal("1700") < mp < Decimal("2000"), (
+                    f"Auto loan minimum {mp} outside expected range"
+                )
+                # Nowhere near the broken 2% answer (¥1,936) — actually
+                # those are close here, so use the term as the
+                # discriminator instead. Auto with 5y term: ~¥1,824.
+                # Auto with 30y term (mortgage default): ~¥514.
+                assert mp > Decimal("1500"), (
+                    "Auto loan got mortgage's 30-year term — name "
+                    "heuristic should require 'mortgage' in path"
+                )
+                break
+        else:
+            pytest.fail("Auto Loan not found in results")
+
+    def test_credit_card_keeps_two_percent(self, tmp_path: Path):
+        """Credit cards still use the 2% formula post-fix — only
+        LIABILITY accounts switched to amortization."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+
+        for d in result["debts"]:
+            if d["account"] == "Liabilities:Credit Card":
+                # 2% of ¥19,385 = ¥387.70 (above the ¥25 floor).
+                assert d["minimum_payment"] == "387.70"
+                break
+        else:
+            pytest.fail("Credit Card not found in results")
+
+    def test_realistic_budget_no_longer_trips_gate(self, tmp_path: Path):
+        """The original bug: ¥30K budget on a ¥2.85M debt stack
+        rejected as 'less than sum of minimum payments' because the
+        2% rule was demanding ¥57K/month. Post-fix it should clear."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+
+        # No exception → fix works.
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+        assert "debts" in result
+        # Sum of minimums should land in the ~¥15-17K range
+        # (mortgage + auto + 2% of CC), well under ¥30K.
+        total_min = sum(
+            Decimal(d["minimum_payment"]) for d in result["debts"]
+        )
+        assert total_min < Decimal("18000"), (
+            f"Sum of minimums {total_min} too high; "
+            "amortization fix may have regressed"
+        )
+
+    def test_minimum_payment_slot_still_wins_for_liability(
+        self, tmp_path: Path,
+    ):
+        """The user-set minimum_payment slot must still override the
+        amortization formula — explicit user input always wins."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+        # Pin mortgage minimum to a specific value via slot.
+        gc_book.set_account_slot(
+            "Liabilities:Loans:Mortgage", "minimum_payment", "14800",
+        )
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+
+        for d in result["debts"]:
+            if d["account"] == "Liabilities:Loans:Mortgage":
+                # Slot value (14800) wins over amortization estimate (~12789).
+                assert d["minimum_payment"] == "14800"
+                break
+        else:
+            pytest.fail("Mortgage not found in results")
+
+
 class TestDebtPayoffCompactFormat:
     """Phase 4A lock tests for the compact text-table output.
     The verbose dict (existing tests above) is now opt-in; the default

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1234,3 +1234,47 @@ class TestCreateTransactionMultiCurrencyTool:
 
         data = json.loads(result)
         assert data["status"] == "created"
+
+
+class TestNonAsciiJsonEncoding:
+    """Bug 1 from the CNY cousin verification: ``_json`` (the
+    serializer every tool wrapper uses) was hitting Python's default
+    ``json.dumps(ensure_ascii=True)``, escaping non-ASCII characters
+    like 贵州茅台 as ``\\uXXXX`` in tool responses. Storage was correct
+    (the audit log renders Chinese natively); only the wire format
+    was wrong, breaking human readability and downstream substring
+    matching.
+    """
+
+    def test_chinese_commodity_name_returns_raw_utf8(
+        self, setup_book_env,
+    ):
+        result = server_module.create_commodity(
+            mnemonic="600519",
+            fullname="贵州茅台 (Kweichow Moutai)",
+            namespace="SSE",
+            fraction=100,
+        )
+        # Raw Chinese characters, not \uXXXX escape sequences.
+        assert "贵州茅台" in result, (
+            f"non-ASCII characters were escaped:\n{result}"
+        )
+        # Still valid JSON.
+        data = json.loads(result)
+        assert data["fullname"] == "贵州茅台 (Kweichow Moutai)"
+
+    def test_accented_european_characters_round_trip(
+        self, setup_book_env,
+    ):
+        # Same bug, different alphabet — accented Latin (German
+        # umlauts, French accents) gets escaped without ensure_ascii=False.
+        result = server_module.create_commodity(
+            mnemonic="MÜNCH",
+            fullname="Münchener Rückversicherungs-Gesellschaft",
+            namespace="XETRA",
+            fraction=100,
+        )
+        assert "Münchener" in result
+        assert "Rückversicherungs" in result
+        data = json.loads(result)
+        assert data["fullname"] == "Münchener Rückversicherungs-Gesellschaft"


### PR DESCRIPTION
## Summary

Six fixes surfaced by testing on a CNY-default book (~314 transactions, mortgage + auto loan + USD/EUR FX activity + Chinese commodity names). Each is a discrete defect; bundled because each is small.

**Bug 1 — JSON UTF-8 encoding.** ``_json`` was hitting Python's default ``ensure_ascii=True``, escaping every Chinese commodity name (贵州茅台 → ``\uXXXX``) on the wire. Storage was always correct (the audit log renders Chinese natively); only the wire format was wrong. One-line fix: ``ensure_ascii=False``.

**Bug 2 — FX gain/loss correctness on non-USD-default books.** Three coupled defects that together broke end-to-end FX accounting on any book whose default currency isn't USD:

1. ``create_price`` defaulted ``currency="USD"``. On a CNY-default book, ``create_price(commodity="USD", value="7.30")`` (no currency arg) stored the price as ``commodity=USD currency=USD value=7.30`` (nonsense). ``_find_exchange_rate`` filters for prices matching the requested direction (USD→CNY), so the malformed price was invisible and the lookup silently fell back to whatever older valid rate happened to exist. Posting and payment then both resolved to the same stale rate, the FX delta came out zero, and no FX split was generated regardless of how ``pay_invoice`` was called. Fix: ``currency`` defaults to the book's default currency; the result dict echoes the resolved mnemonic.

2. ``create_invoice`` / ``create_bill`` ignored owner currency. The currency fallback in ``_create_business_document`` used the book's default currency unconditionally when no explicit currency was passed, regardless of the customer's or vendor's currency. A bill against a USD vendor on a CNY book got created in CNY, ``post_invoice`` then saw ``inv.currency == account.commodity`` and skipped the rate-conversion path entirely — \$500 was booked as ¥500. Fix: prefer ``owner.currency`` over the book default; matches GnuCash desktop UI behavior. Pass ``currency`` explicitly to override.

3. ``pay_invoice`` FX-account routing was hardcoded to ``Income:Foreign Exchange Gain/Loss``, auto-creating it if absent — even on books where the bookkeeper had pre-created an account like ``Income:FX Gain Loss``. Fix: two layers. (a) Explicit ``fx_account`` parameter on ``pay_invoice`` accepting a path / ``%short`` / full GUID, validated for INCOME/EXPENSE type. (b) Refined fuzzy heuristic on the leaf name (``fx``, ``forex``, ``foreign exchange``, ``currency gain/loss``, ``exchange gain/loss``, ``currency translation``): exactly one match wins; zero matches fall through to the canonical default; multiple matches fall through to canonical *plus* an ``fx_notice`` field listing candidates.

Both customer-invoice and vendor-bill flows now produce identical FX accounting on cross-currency posts and pays. Employee expense vouchers (``owner_type=5``) aren't implemented yet — when added they'll route through the same ``_create_business_document`` helper and inherit the fix.

**Bug 3 — ``debt_payoff_plan`` LIABILITY minimum payments.** Pre-fix the minimum-payment fallback applied the credit-card 2%-of-balance heuristic to all debt accounts (CREDIT and LIABILITY). For amortizing loans this gives ~3-4× the actual contractual minimum: a ¥2.7M mortgage at 3.85% APR was demanding ¥54,590/month vs. the actual ~¥14,800. Total minimums summed to ¥57,154 — tripping the budget-vs-minimums gate on any realistic household budget.

Now branches on ``account.type``:

- **CREDIT** keeps the 2%-of-balance + \$25 floor formula (revolving cards, no fixed term).
- **LIABILITY** uses the standard amortization formula ``PMT = P × r(1+r)^n / ((1+r)^n − 1)``. Term defaults: 360 months if "mortgage" appears in the account fullname, else 60 months. Capped at balance for tiny remainders. Users with non-standard terms set the ``minimum_payment`` slot explicitly.

Test stack post-fix totals ¥15,123/month (mortgage ¥12,796 + auto ¥1,822 + 2% on the cards) — a ¥30K budget now clears the gate cleanly.

**Bug 4 — "days past past due" typo.** ``_format_outstanding_invoices_compact`` concatenated "X days past " + "past due" on the contractual branch. Fixed the template; no-terms branch ("past 30-day default") was unaffected.

## Test plan

- [x] 975 tests passing (up from 948 baseline — 27 new regression tests):
  - ``TestNonAsciiJsonEncoding`` — UTF-8 round-trips for Chinese and accented Latin
  - ``TestPrices`` — ``create_price`` currency default resolves to book default on USD and CNY books, explicit currency overrides
  - ``TestCnyBugReportFollowups`` — typo gone, FX routing under all candidate cardinalities, explicit-parameter validation
  - ``TestPayInvoice`` — end-to-end ``pay_invoice(fx_account=...)`` routes correctly with no canonical auto-creation, ambiguous case emits ``fx_notice``, invalid ``fx_account`` raises
  - ``TestCreateInvoice`` / ``TestCreateBill`` — owner currency inherits to document default; explicit override still works
  - ``TestDebtPayoffAmortizingLoans`` — mortgage uses 30y amortization, auto loan uses 5y, CC keeps 2%, ¥30K budget clears on a ¥2.85M debt stack, slot still overrides
- [x] All existing tests pass unchanged
- [x] End-to-end verified on the CNY test book: invoice posts at the right rate, pays at the right rate, correct FX delta booked. Vendor bill verified identically — USD transaction currency, CNY quantities on the checking split, FX split with correct loss amount and memo.