### PR TITLE
fix(business): _find_invoice raises on ID collision

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -389,7 +389,23 @@ class BusinessMixin:
             book: piecash Book instance.
             invoice_id: Human-readable ID (e.g., '000001').
             owner_type: Filter by owner type (2=customer, 4=vendor).
-                        None returns first match of either type.
+                        None requires the ID to be unambiguous across
+                        types — see Raises.
+
+        Raises:
+            ValueError: When ``owner_type=None`` and the ID matches
+                both a customer invoice *and* a vendor bill. GnuCash
+                runs the two as separate ID sequences sharing one
+                ``invoices`` table, so collisions are normal — both
+                can legitimately be id ``"000003"``. Pre-fix this
+                returned whichever row the query happened to surface
+                first, silently routing reads/writes to the wrong
+                document. The bookkeeper hit this on a CNY book
+                where ``get_invoice("000003")`` returned a customer
+                invoice's CNY currency for what was actually a USD
+                vendor bill. The error lists candidates with their
+                type and currency so the caller can pass
+                ``owner_type`` to disambiguate.
         """
         from piecash.business.invoice import Invoice
         from sqlalchemy import text
@@ -410,8 +426,27 @@ class BusinessMixin:
 
         query = book.session.query(Invoice).filter(Invoice.id == invoice_id)
         if owner_type is not None:
-            query = query.filter(Invoice.owner_type == owner_type)
-        return query.first()
+            return query.filter(Invoice.owner_type == owner_type).first()
+
+        # owner_type=None: caller didn't disambiguate. Pull all
+        # matches and fail loud on collision rather than silently
+        # picking the first one (which depends on row order /
+        # piecash internals — non-deterministic from the caller's
+        # perspective).
+        matches = query.all()
+        if len(matches) <= 1:
+            return matches[0] if matches else None
+
+        candidates = []
+        for m in matches:
+            label = "vendor bill" if m.owner_type == 4 else "customer invoice"
+            currency = m.currency.mnemonic if m.currency else "?"
+            candidates.append(f"{label} (currency={currency})")
+        raise ValueError(
+            f"Found {len(matches)} documents with ID {invoice_id!r}: "
+            f"{', '.join(candidates)}. Pass owner_type='customer' "
+            f"or 'vendor' to disambiguate."
+        )
 
     @staticmethod
     def _address_to_dict(entity) -> dict:

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1218,13 +1218,18 @@ class TestInvoiceBillIdCollision:
         gb.create_vendor(name="Office Depot")
         gb.create_invoice(customer_id="000001")  # ID 000001
         gb.create_bill(vendor_id="000001")        # ID 000001
-        # Should target the customer invoice, not the vendor bill
+        # Should target the customer invoice, not the vendor bill —
+        # add_invoice_entry passes owner_type=2 explicitly.
         result = gb.add_invoice_entry(
             invoice_id="000001", account="Income:Sales",
             description="Consulting", quantity="1", price="100",
         )
         assert result["status"] == "created"
-        inv = gb.get_invoice("000001")
+        # get_invoice without owner_type now raises on the same
+        # collision (see TestInvoiceBillIdCollision::test_get_invoice
+        # _on_collision_raises_disambiguation_error). Pass owner_type
+        # to retrieve the customer invoice.
+        inv = gb.get_invoice("000001", owner_type="customer")
         assert inv["type"] == "invoice"
         assert len(inv["entries"]) == 1
 
@@ -1242,16 +1247,32 @@ class TestInvoiceBillIdCollision:
         )
         assert result["status"] == "created"
 
-    def test_get_invoice_with_collision_defaults_to_first(self, business_book):
-        """get_invoice without owner_type returns first match."""
+    def test_get_invoice_on_collision_raises_disambiguation_error(
+        self, business_book,
+    ):
+        """When a customer invoice and vendor bill share the same
+        numeric ID, ``get_invoice`` (called without ``owner_type``)
+        must raise rather than silently return whichever the SQL
+        query happened to surface first. The bookkeeper hit this on
+        a CNY book where ``get_invoice("000003")`` returned a CNY
+        customer invoice instead of the USD vendor bill they were
+        verifying — silent wrong-document reads are worse than a
+        clear error."""
         gb = GnuCashBook(str(business_book))
         gb.create_customer(name="Acme Corp")
         gb.create_vendor(name="Office Depot")
         gb.create_invoice(customer_id="000001")
         gb.create_bill(vendor_id="000001")
-        result = gb.get_invoice("000001")
-        # Returns whichever was created first (invoice)
-        assert result["type"] in ("invoice", "bill")
+
+        with pytest.raises(ValueError) as exc_info:
+            gb.get_invoice("000001")
+        msg = str(exc_info.value)
+        # Error tells the caller exactly what's ambiguous and how to fix.
+        assert "2 documents" in msg
+        assert "'000001'" in msg
+        assert "customer invoice" in msg
+        assert "vendor bill" in msg
+        assert "owner_type" in msg
 
     def test_get_invoice_with_owner_type_filter(self, business_book):
         """get_invoice with owner_type disambiguates colliding IDs."""
@@ -1264,6 +1285,22 @@ class TestInvoiceBillIdCollision:
         assert inv["type"] == "invoice"
         bill = gb.get_invoice("000001", owner_type="vendor")
         assert bill["type"] == "bill"
+
+    def test_get_invoice_unambiguous_id_no_owner_type_works(
+        self, business_book,
+    ):
+        """When an ID is unique (only one document with it), the
+        ambiguity check doesn't fire and ``get_invoice`` returns
+        the matching document without requiring ``owner_type``.
+        This is the common case — the disambiguation is paid for
+        only when actually ambiguous."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        # No vendor bill 000001, so the invoice ID is unambiguous.
+        inv = gb.get_invoice("000001")
+        assert inv["type"] == "invoice"
 
 
 # ============== Post Invoice Tests ==============


### PR DESCRIPTION
## Summary

When a customer invoice and a vendor bill share the same numeric ID (which is normal — GnuCash auto-numbers them from independent counter sequences but stores both in the same ``invoices`` table), ``_find_invoice`` with ``owner_type=None`` silently returned whichever row the SQL query surfaced first. The bookkeeper hit this on a CNY-default book where ``get_invoice(\"000003\")`` returned a CNY customer invoice instead of the USD vendor bill they were verifying — and didn't notice the type/currency mismatch in time.

Fix: when ``owner_type=None``, pull all matches and fail loud on >1.

```
ValueError: Found 2 documents with ID '000001':
customer invoice (currency=CNY), vendor bill (currency=USD).
Pass owner_type='customer' or 'vendor' to disambiguate.
```

The fix lives in ``_find_invoice`` so every caller benefits atomically — ``get_invoice``, ``pay_invoice``, and ``post_invoice``'s fallback path (when ``post_account`` type-inference can't disambiguate). Callers that pass ``owner_type`` explicitly (e.g. ``add_invoice_entry`` with hardcoded ``owner_type=2``) keep their existing deterministic semantics.

## Test plan

- [x] 949 passing (was 948 — net +1: two tests updated to reflect new contract, one new test added)
- [x] Updated tests:
  - ``test_get_invoice_with_collision_defaults_to_first`` → ``test_get_invoice_on_collision_raises_disambiguation_error`` (asserts error mentions both candidates and the ``owner_type`` hint)
  - ``test_add_invoice_entry_with_collision`` updated to pass ``owner_type='customer'`` on the post-write verification call
- [x] New test: ``test_get_invoice_unambiguous_id_no_owner_type_works`` — disambiguation fires only when actually ambiguous
- [x] Live-verified against the CNY test book where customer invoice and vendor bill both have id 000001: error correctly identifies both candidates by type and currency