### PR TITLE
feat: 1.2.1 patch — unpost_invoice, delete_price, data-range regression test

### DIFF
--- a/docs/PATCH_1_2_1_TESTING.md
+++ b/docs/PATCH_1_2_1_TESTING.md
@@ -1,0 +1,244 @@
+# 1.2.1 Patch Testing Spec
+
+**Companion to:** `docs/PATCH_1_2_1_SPEC.md`
+**Verifies:** PR #62 — `feat/patch-1-2-1`
+**Test against:** Alex's book for Fix 1, Lin Wei's book for Fix 2 and Fix 3
+**Cleanup:** Required at end (see Cleanup section)
+
+The bookkeeper runs this against the running MCP server to verify
+all three patch fixes from the spec landed correctly. Each fix has
+a happy path and one or more rejection branches; the rejection
+branches are the actual point of the fix and should be exercised
+explicitly.
+
+---
+
+## Fix 1: `unpost_invoice` + `delete_transaction` guard
+
+### Setup (Alex's book)
+
+```
+create_customer(name="Test Co - DELETE ME")
+# Note the returned id, e.g. "000023"
+create_invoice(customer_id="<that id>", currency="USD", date_opened="2026-04-15")
+# Note the invoice id, e.g. "000019"
+add_invoice_entry(invoice_id="<inv id>", account="Income:Consulting",
+                  description="Test", quantity="1", price="500.00")
+post_invoice(id="<inv id>", post_account="Assets:Receivables:Accounts Receivable",
+             post_date="2026-04-15")
+# Capture the transaction_guid from the response.
+```
+
+### Verifications
+
+**A. `delete_transaction` rejects posting records**
+
+```
+delete_transaction(guid="<the captured transaction_guid>")
+```
+
+Expect `validation_error`:
+*"Transaction is the posting record for invoice ⟨inv id⟩. Use unpost_invoice first."*
+
+**B. `unpost_invoice` reverses cleanly**
+
+```
+unpost_invoice(id="<inv id>")
+```
+
+Expect `{"id": "<inv id>", "type": "invoice", "status": "unposted"}`.
+Then:
+
+```
+get_invoice(id="<inv id>", owner_type="customer")
+```
+
+Expect `date_posted: null` and the entry still present.
+
+**C. Re-post works after unpost**
+
+```
+post_invoice(id="<inv id>", post_account="Assets:Receivables:Accounts Receivable",
+             post_date="2026-05-01")
+```
+
+Expect `status: "posted"`, `post_date: "2026-05-01"`. Lifecycle verified end-to-end.
+
+**D. `unpost_invoice` rejects payments-applied invoice**
+
+Create a second test invoice, post it, then apply a partial payment:
+
+```
+pay_invoice(id="<second inv id>", payment_account="Assets:Current Assets:Checking Account",
+            amount="50.00", payment_date="2026-04-15")
+```
+
+Then:
+
+```
+unpost_invoice(id="<second inv id>")
+```
+
+Expect `validation_error`:
+*"Invoice ⟨id⟩ has payments applied. Void payments first, then unpost."*
+
+**E. `unpost_invoice` rejects unposted invoice**
+
+On any open (not-yet-posted) invoice:
+
+```
+unpost_invoice(id="<some open invoice id>")
+```
+
+Expect `validation_error`: *"Invoice ⟨id⟩ is not posted"*.
+
+**F. `unpost_invoice` rejects unknown id**
+
+```
+unpost_invoice(id="999999")
+```
+
+Expect `validation_error`: *"Invoice/bill not found: 999999"*.
+
+**Pass criteria for Fix 1:** A through F all return their expected
+outcomes. B and C verify the happy path; A, D, E, F verify each
+rejection branch.
+
+---
+
+## Fix 2: `delete_price`
+
+### Setup (Lin Wei's book)
+
+Pick any commodity with prices already in the book (e.g., `USD` in
+`CURRENCY` namespace). `get_book_summary` lists the available
+commodities.
+
+### Verifications
+
+**A. Single-price delete echoes value**
+
+```
+create_price(commodity="USD", namespace="CURRENCY", date="2099-01-01", value="99.99")
+get_prices(commodity="USD", namespace="CURRENCY", limit=3)
+```
+
+Confirm `2099-01-01` appears.
+
+```
+delete_price(commodity="USD", namespace="CURRENCY", date="2099-01-01")
+```
+
+Expect `{"status": "deleted", "value": "99.99", "date": "2099-01-01", ...}`.
+Then `get_prices` again — `2099-01-01` should be gone.
+
+**B. No-match raises clearly**
+
+```
+delete_price(commodity="USD", namespace="CURRENCY", date="2099-01-01")
+```
+
+(After A, this date has no price.) Expect `validation_error`:
+*"No price found for CURRENCY:USD on 2099-01-01"*.
+
+**C. Ambiguous-without-source lists candidates**
+
+```
+create_price(commodity="USD", namespace="CURRENCY", date="2099-02-01",
+             value="7.10", source="user:price")
+create_price(commodity="USD", namespace="CURRENCY", date="2099-02-01",
+             value="7.15", source="user:yfinance")
+delete_price(commodity="USD", namespace="CURRENCY", date="2099-02-01")
+```
+
+Expect `validation_error` mentioning *both* `user:price (7.1)` and
+`user:yfinance (7.15)` and the phrase
+*"Specify source= to disambiguate"*.
+
+**D. Source disambiguates**
+
+```
+delete_price(commodity="USD", namespace="CURRENCY", date="2099-02-01", source="user:yfinance")
+```
+
+Expect `status: "deleted"` with `value: "7.15"`. Then:
+
+```
+get_prices(commodity="USD", namespace="CURRENCY", limit=3)
+```
+
+Confirm the `user:price` entry for 2099-02-01 (value 7.10) is
+still there. Then clean up:
+
+```
+delete_price(commodity="USD", namespace="CURRENCY", date="2099-02-01", source="user:price")
+```
+
+**Pass criteria for Fix 2:** All four branches behave as expected.
+Note any case where the value echo strips trailing zeros (`7.1`
+vs `7.10`) — that's piecash's storage behavior, not a fix bug.
+
+---
+
+## Fix 3: `get_book_summary` data range
+
+### Verification (Lin Wei's book)
+
+Optionally inject a far-future test price first to exercise the
+case the spec described:
+
+```
+create_price(commodity="USD", namespace="CURRENCY", date="2099-01-01", value="99.99")
+```
+
+Then:
+
+```
+get_book_summary()
+```
+
+Look at the **Data range** line near the top:
+
+```
+Data range: 2025-01-01 to 2025-12-31
+```
+
+**Pass criteria for Fix 3:** The displayed range matches Lin Wei's
+actual transaction range and does *not* reach into 2099 (or
+whatever far-future price you injected). Clean up the test price
+afterward via `delete_price`.
+
+> Note: this fix is "regression test only" — the underlying code
+> already iterated transactions only. The patch locks the contract
+> so a future refactor can't accidentally union price dates back in.
+> If the displayed range surprises you, that's worth flagging.
+
+---
+
+## Cleanup
+
+After the test run, on whichever books you used:
+
+1. `delete_transaction(guid=...)` for any test transactions you
+   created. (The regular-deposit ones; posting records will
+   refuse — use `unpost_invoice` first, then delete the unposted
+   invoice via `delete_invoice`.)
+2. `delete_invoice(invoice_id=...)` for unposted test invoices.
+3. `delete_customer(customer_id=...)` for the "Test Co - DELETE ME"
+   customer.
+4. `delete_price(...)` for any test prices that survived.
+
+If anything resists cleanup, that's interesting — flag it.
+
+---
+
+## Signoff
+
+Three lines back:
+
+- **Fix 1** (`unpost_invoice` + `delete_transaction` guard): ✅ / ❌ + notes
+- **Fix 2** (`delete_price`): ✅ / ❌ + notes
+- **Fix 3** (`get_book_summary` data range): ✅ / ❌ + notes
+
+If all three are green, PR #62 is ready to merge to `develop`,
+and that closes the 1.2.1 patch scope per the spec.

--- a/docs/PATCH_1_2_1_TESTING.md
+++ b/docs/PATCH_1_2_1_TESTING.md
@@ -82,6 +82,22 @@ unpost_invoice(id="<second inv id>")
 Expect `validation_error`:
 *"Invoice ⟨id⟩ has payments applied. Void payments first, then unpost."*
 
+**D2. `unpost_invoice` succeeds when payments are voided**
+
+Continuing from D — void the partial payment, then retry the unpost.
+Capture the payment's transaction guid from D's `pay_invoice` response,
+then:
+
+```
+void_transaction(guid="<payment transaction_guid>", reason="Test cleanup")
+unpost_invoice(id="<second inv id>")
+```
+
+Expect `{"status": "unposted"}`. The "has payments applied" guard
+asks an *economic* question; voided payments have zero economic
+effect (they're zombie splits preserved for audit trail), so they
+shouldn't block unpost.
+
 **E. `unpost_invoice` rejects unposted invoice**
 
 On any open (not-yet-posted) invoice:
@@ -100,9 +116,9 @@ unpost_invoice(id="999999")
 
 Expect `validation_error`: *"Invoice/bill not found: 999999"*.
 
-**Pass criteria for Fix 1:** A through F all return their expected
-outcomes. B and C verify the happy path; A, D, E, F verify each
-rejection branch.
+**Pass criteria for Fix 1:** A, B, C, D, D2, E, F all return their
+expected outcomes. B, C, D2 verify happy paths; A, D, E, F verify
+each rejection branch.
 
 ---
 

--- a/docs/PATCH_1_2_1_TESTING.md
+++ b/docs/PATCH_1_2_1_TESTING.md
@@ -231,6 +231,147 @@ afterward via `delete_price`.
 
 ---
 
+## Fix 4: void-aware behavior in lot listing and gain calculation
+
+Voided splits are zombie splits — preserved for audit but zeroed.
+Two downstream display surfaces had to learn the same lesson the
+``unpost_invoice`` guard learned in Fix 1: zero-value splits are
+not real positions.
+
+### Setup (Alex's book)
+
+Pick any USD-denominated investment account that has at least one
+buy transaction. Alex's ``Assets:Investments:VTSAX`` works if it
+exists; otherwise ``Assets:Investments:S&P 500 ETF`` or any
+similar.
+
+```
+list_lots(account="<the investment account>", verbose=True)
+```
+
+Note any existing lots and their states. We'll add and void one
+without disturbing the rest.
+
+### Verifications
+
+**A. ``list_lots`` skips empty lots in the default view**
+
+Create a brand-new lot, then list. With nothing assigned, the
+new lot has zero remaining quantity:
+
+```
+create_lot(account="<the investment account>", title="DELETE ME — empty test")
+list_lots(account="<the investment account>")
+```
+
+Expect the new lot to be **absent** from the output. The default
+view is "open positions"; a zero-quantity lot doesn't qualify.
+
+Then:
+
+```
+list_lots(account="<the investment account>", include_closed=true, verbose=true)
+```
+
+Expect the new lot to **appear** with `quantity: 0.0000` and
+`cost_basis: 0.00`. ``include_closed=true`` is the audit-trail
+view that surfaces empty lots.
+
+**B. ``calculate_lot_gain`` calls out voided buys explicitly**
+
+This requires a slightly more involved setup — a lot whose buy
+transaction was voided. Skip if the live test would risk
+disturbing real lots; the unit-test coverage locks the message
+shape.
+
+Optional: against a scratch invoice/lot, post → assign → void
+the buy → call ``calculate_lot_gain``. Expect a
+`validation_error` containing the phrases *"no remaining
+shares"* and *"voided"* — not the generic message.
+
+**Cleanup:** delete the test lot via `close_lot` (close-then-skip
+is fine; lots can't be deleted directly).
+
+**Pass criteria for Fix 4:**
+- A: empty lot absent from default view, present with
+  ``include_closed=true``
+- B: voided-buy error mentions "voided" explicitly (or skip if
+  not exercised live)
+
+---
+
+## Fix 5: ``void_transaction`` warns on reconciled splits
+
+Voiding a transaction whose splits are reconciled breaks the
+reconciled balance for the affected accounts. The void should
+proceed (audit trail trumps bookkeeping cleanliness) but the
+result must include a ``warning`` naming the affected accounts
+so the bookkeeper knows what just got broken.
+
+### Setup (Lin Wei's book)
+
+Find an existing reconciled transaction:
+
+```
+get_unreconciled_splits(account="<some account>")
+```
+
+… or pick any transaction you know contains a reconciled split.
+A transaction Lin Wei voided previously was on her checking
+account; the test book ships with at least a few reconciled
+transactions tied to opening balances.
+
+If you'd rather create a fresh test, post a small transaction,
+mark its checking-side split reconciled via
+``set_reconcile_state(split_guid="...", state="y")``, then void
+that transaction.
+
+### Verifications
+
+**A. Void with reconciled splits → warning surfaced**
+
+```
+void_transaction(guid="<txn guid>", reason="Test cleanup")
+```
+
+Expect:
+- `status: "voided"` (the void went through)
+- `warning` field present, containing:
+  - the word "reconciled"
+  - the account name(s) of the reconciled splits
+  - language about the reconciled balance no longer matching the
+    cleared statement
+
+Example:
+```json
+{
+  "status": "voided",
+  "warning": "Voided transaction contained 1 reconciled account(s): Assets:Current Assets:Checking Account. The reconciled balance for these accounts no longer matches the cleared statement."
+}
+```
+
+**B. Void without reconciled splits → no warning**
+
+Sanity: pick any non-reconciled transaction, void it.
+
+```
+void_transaction(guid="<non-reconciled txn guid>", reason="Test")
+```
+
+Expect `status: "voided"` and **no** `warning` field. (A clean
+void must not invent a warning.)
+
+**Cleanup:** ``unvoid_transaction(guid="...")`` to restore both
+test voids if they affected real data. The reconciliation state
+restores along with the values.
+
+**Pass criteria for Fix 5:**
+- A: warning surfaces with the affected account name(s) and
+  reconciliation language
+- B: clean voids carry no warning
+
+---
+
 ## Cleanup
 
 After the test run, on whichever books you used:
@@ -250,11 +391,13 @@ If anything resists cleanup, that's interesting — flag it.
 
 ## Signoff
 
-Three lines back:
+Five lines back:
 
 - **Fix 1** (`unpost_invoice` + `delete_transaction` guard): ✅ / ❌ + notes
 - **Fix 2** (`delete_price`): ✅ / ❌ + notes
 - **Fix 3** (`get_book_summary` data range): ✅ / ❌ + notes
+- **Fix 4** (`list_lots` / `calculate_lot_gain` void-awareness): ✅ / ❌ + notes
+- **Fix 5** (`void_transaction` reconciled-splits warning): ✅ / ❌ + notes
 
-If all three are green, PR #62 is ready to merge to `develop`,
+If all five are green, PR #62 is ready to merge to `develop`,
 and that closes the 1.2.1 patch scope per the spec.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2409,13 +2409,31 @@ class BusinessMixin:
             txn = inv.post_txn
             lot = inv.post_lot
 
-            # Reject when there are splits in the lot beyond the
-            # original A/R posting. Each pay_invoice call adds one
-            # split to the lot (the A/R credit reducing the
-            # outstanding balance). The posting transaction itself
-            # contributes exactly one split (the A/R debit). So
-            # ``len(lot.splits) > 1`` ⇔ payments applied.
-            if lot is not None and len(lot.splits) > 1:
+            # Reject when there are *live* (non-voided) payment splits
+            # in the lot. The lot starts with one split — the A/R
+            # debit/credit from the posting transaction. Each
+            # ``pay_invoice`` call adds one more split. A voided
+            # transaction in GnuCash preserves its splits with zeroed
+            # values for audit-trail purposes, so a naive
+            # ``len(lot.splits) > 1`` check counts voided payments as
+            # still-applied — which contradicts GnuCash's void
+            # semantics ("voided" means "neutralize the economic
+            # effect, preserve the record"). Filter to splits that
+            # are (a) not part of the posting transaction itself and
+            # (b) carry non-zero value.
+            posting_txn_guid = txn.guid if txn else None
+            real_payment_splits = []
+            if lot is not None:
+                for s in lot.splits:
+                    if (
+                        posting_txn_guid is not None
+                        and s.transaction_guid == posting_txn_guid
+                    ):
+                        continue
+                    if Decimal(str(s.value)) == 0:
+                        continue
+                    real_payment_splits.append(s)
+            if real_payment_splits:
                 raise ValueError(
                     f"{doc_label} {invoice_id} has payments applied. "
                     f"Void payments first, then unpost."

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2334,6 +2334,119 @@ class BusinessMixin:
 
         return result
 
+    def unpost_invoice(
+        self,
+        invoice_id: str,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Unpost a previously-posted invoice or bill.
+
+        Reverses ``post_invoice`` cleanly: deletes the posting
+        transaction and its splits, removes the posting lot, and
+        clears the invoice's posted-state metadata
+        (``date_posted``, ``post_txn``, ``post_lot``,
+        ``post_account``). The invoice returns to "open" state and
+        is editable again — entries can be added/changed and the
+        invoice can be re-posted.
+
+        Refuses if the invoice has any payments applied (the lot
+        contains splits beyond the original A/R posting). Unposting
+        a partially-paid invoice would orphan the payment splits
+        and corrupt the lot's balance accounting; the caller must
+        void payments first.
+
+        Args:
+            invoice_id: Human-readable ID (e.g., '000001').
+            owner_type: 'customer' or 'vendor' for cross-sequence
+                ID disambiguation. Required when the same numeric
+                ID exists for both an invoice and a bill.
+
+        Returns:
+            ``{"id": "000015", "type": "invoice", "status": "unposted"}``.
+
+        Raises:
+            ValueError: If the invoice/bill isn't found, isn't posted,
+                or has payments applied.
+        """
+        ot = None
+        if owner_type == "customer":
+            ot = 2
+        elif owner_type == "vendor":
+            ot = 4
+
+        with self.open(readonly=False) as book:
+            inv = self._find_invoice(book, invoice_id, owner_type=ot)
+            if not inv:
+                raise ValueError(
+                    f"Invoice/bill not found: {invoice_id}"
+                )
+
+            if not _is_invoice_posted(inv):
+                raise ValueError(
+                    f"Invoice {invoice_id} is not posted"
+                )
+
+            is_bill = inv.owner_type == 4
+            doc_label = "Bill" if is_bill else "Invoice"
+
+            # Capture before-state for the audit log: the user wants
+            # to see what they unposted ("was posted: 2026-04-01,
+            # post_account: Assets:Receivables:..."). Read pre-clear
+            # so the values are still set on the ORM object.
+            prev_post_date = _safe_date_posted(inv)
+            prev_post_account = (
+                inv.post_account.fullname if inv.post_account else None
+            )
+            self._stage_audit_before({
+                "id": inv.id,
+                "type": "bill" if is_bill else "invoice",
+                "date_posted": (
+                    str(prev_post_date.date()) if prev_post_date else None
+                ),
+                "post_account": prev_post_account,
+            })
+
+            txn = inv.post_txn
+            lot = inv.post_lot
+
+            # Reject when there are splits in the lot beyond the
+            # original A/R posting. Each pay_invoice call adds one
+            # split to the lot (the A/R credit reducing the
+            # outstanding balance). The posting transaction itself
+            # contributes exactly one split (the A/R debit). So
+            # ``len(lot.splits) > 1`` ⇔ payments applied.
+            if lot is not None and len(lot.splits) > 1:
+                raise ValueError(
+                    f"{doc_label} {invoice_id} has payments applied. "
+                    f"Void payments first, then unpost."
+                )
+
+            # Clear the invoice's posted-state pointers BEFORE
+            # deleting the underlying transaction/lot. Otherwise the
+            # ORM cascade may resurrect the references via the
+            # relationships and trip on dangling FKs at flush.
+            inv.date_posted = None
+            inv.post_txn = None
+            inv.post_lot = None
+            inv.post_account = None
+            book.flush()
+
+            # Delete the posting transaction (which cascades its
+            # splits) and the lot (now empty after the inv.post_lot
+            # = None nullified the only split-lot link).
+            if txn is not None:
+                book.session.delete(txn)
+            if lot is not None:
+                book.session.delete(lot)
+
+            book.save()
+
+            return {
+                "id": inv.id,
+                "type": "bill" if is_bill else "invoice",
+                "status": "unposted",
+            }
+
     def pay_invoice(
         self,
         invoice_id: str,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3214,6 +3214,26 @@ class CoreMixin:
             if not transaction:
                 raise ValueError(f"Transaction not found: {guid}")
 
+            # Reject if this transaction is the posting record for
+            # an invoice or bill. Deleting it directly orphans the
+            # invoice's posted-state metadata (date_posted, post_txn,
+            # post_lot, post_acc fields all reference objects that
+            # no longer exist) — the invoice then refuses both
+            # delete ("posted") and re-post ("already posted") and
+            # the only escape is SQL surgery. Force the caller
+            # through unpost_invoice, which clears the metadata as
+            # part of removing the transaction.
+            from sqlalchemy import text
+            posting_for = book.session.execute(
+                text("SELECT id FROM invoices WHERE post_txn = :guid"),
+                {"guid": transaction.guid},
+            ).fetchone()
+            if posting_for:
+                raise ValueError(
+                    f"Transaction is the posting record for invoice "
+                    f"{posting_for[0]}. Use unpost_invoice first."
+                )
+
             # Check for reconciled splits
             reconciled = [
                 s for s in transaction.splits if s.reconcile_state == "y"

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -247,6 +247,102 @@ class InvestmentsMixin:
 
             return result
 
+    def delete_price(
+        self,
+        commodity: str,
+        namespace: str,
+        price_date: date,
+        source: str | None = None,
+    ) -> dict:
+        """Delete a single price entry.
+
+        Identifies the price by ``(commodity, namespace, date)``.
+        When the same date has multiple prices for one commodity
+        (different sources, e.g. one user-entered and one fetched
+        from a feed), ``source`` disambiguates. If ``source`` is
+        omitted and multiple matches exist, raises with a list of
+        the matches so the caller can retry with the right source.
+
+        Args:
+            commodity: Symbol (e.g., "VTSAX", "USD", "EUR").
+            namespace: Namespace (e.g., "FUND", "CURRENCY").
+            price_date: Date of the price to delete.
+            source: Optional source tag (e.g., "user:price",
+                "user:yfinance"). Required to disambiguate when
+                multiple prices exist on the same commodity+date.
+
+        Returns:
+            Dict with the deleted price's commodity, date, value,
+            and ``status: "deleted"``. Echoing the value lets the
+            caller confirm they removed the right one.
+
+        Raises:
+            ValueError: If commodity not found, no matching price,
+                or multiple prices match without a ``source``
+                disambiguator.
+        """
+        with self.open(readonly=False) as book:
+            comm = self._find_commodity(book, commodity, namespace)
+            if not comm:
+                raise ValueError(
+                    f"Commodity not found: {namespace}:{commodity}"
+                )
+
+            matches = []
+            for p in book.prices:
+                if p.commodity != comm:
+                    continue
+                if _to_date(p.date) != price_date:
+                    continue
+                if source is not None and p.source != source:
+                    continue
+                matches.append(p)
+
+            if len(matches) == 0:
+                raise ValueError(
+                    f"No price found for {namespace}:{commodity} on "
+                    f"{price_date.isoformat()}"
+                    + (f" (source={source!r})" if source else "")
+                )
+
+            if len(matches) > 1:
+                # source omitted but multiple sources match — the
+                # caller's call would have been destructive without
+                # disambiguation. List what's there so they can retry.
+                summary = ", ".join(
+                    f"{p.source} ({p.value})" for p in matches
+                )
+                raise ValueError(
+                    f"Multiple prices found for {namespace}:{commodity} "
+                    f"on {price_date.isoformat()}: {summary}. "
+                    f"Specify source= to disambiguate."
+                )
+
+            target = matches[0]
+            # Capture before-state for audit log: source + value
+            # tell the human reader exactly what was deleted.
+            result = {
+                "commodity": commodity,
+                "namespace": namespace,
+                "currency": target.currency.mnemonic,
+                "date": price_date.isoformat(),
+                "value": str(target.value),
+                "source": target.source,
+                "status": "deleted",
+            }
+            self._stage_audit_before({
+                "commodity": commodity,
+                "namespace": namespace,
+                "date": price_date.isoformat(),
+                "value": str(target.value),
+                "source": target.source,
+            })
+
+            book.session.delete(target)
+            book.save()
+
+            return result
+
     def get_prices(
         self,
         commodity: str,

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -598,6 +598,21 @@ class InvestmentsMixin:
                 if not include_closed and lot.is_closed:
                     continue
                 summary = self._lot_summary(lot)
+                # Skip lots with no remaining position in the default
+                # (open-positions) view. This catches three cases that
+                # all read the same to a portfolio manager: voided
+                # buys (GnuCash zeros the splits but preserves them
+                # in the lot), never-assigned lots, and lots that
+                # round-tripped to zero without being closed. All
+                # three appear as "0 shares, 0 cost basis" rows that
+                # add noise to a holdings listing. Available via
+                # ``include_closed=True`` for callers who need the
+                # full audit trail.
+                if (
+                    not include_closed
+                    and Decimal(summary["quantity"]) == 0
+                ):
+                    continue
                 results.append({
                     "guid": lot.guid,
                     "title": lot.title,
@@ -755,6 +770,22 @@ class InvestmentsMixin:
             remaining = Decimal(summary["quantity"])
 
             if remaining <= 0:
+                # Distinguish "lot ran to zero through sales" (normal,
+                # closed lot) from "lot has voided splits zeroing its
+                # purchase quantity" (likely an accounting mistake the
+                # caller should know about). GnuCash marks voided
+                # splits with reconcile_state='v'.
+                voided_split_count = sum(
+                    1 for s in lot.splits if s.reconcile_state == "v"
+                )
+                if voided_split_count:
+                    raise ValueError(
+                        f"Lot has no remaining shares — "
+                        f"{voided_split_count} split(s) in this lot "
+                        f"are voided, zeroing the lot's quantity. "
+                        f"Unvoid the underlying transaction(s) or "
+                        f"calculate gain on a different lot."
+                    )
                 raise ValueError("Lot has no remaining shares")
 
             if shares is not None:

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -320,12 +320,25 @@ class ReconciliationMixin:
         all split values. Original values are stored in slots for potential
         unvoiding.
 
+        When the transaction contains reconciled splits, voiding them
+        breaks the reconciliation balance for the affected accounts —
+        the bank statement that originally reconciled is no longer
+        accurate. The void proceeds (audit trail trumps bookkeeping
+        cleanliness), but the result includes a ``warning`` field
+        listing the affected accounts so the caller can re-reconcile
+        or investigate as needed. Unlike ``delete_transaction`` (which
+        blocks on reconciled splits absent ``force=True``), voiding is
+        an audit operation that should never be silently rejected —
+        the warning is informational, not gating.
+
         Args:
             guid: Transaction GUID to void.
             reason: Reason for voiding (required for audit trail).
 
         Returns:
-            Dict with transaction details and status.
+            Dict with transaction details and status. When reconciled
+            splits were affected, also includes ``warning`` describing
+            the reconciliation impact.
 
         Raises:
             ValueError: If transaction not found or already voided.
@@ -340,6 +353,14 @@ class ReconciliationMixin:
 
             if any(s.reconcile_state == "v" for s in transaction.splits):
                 raise ValueError(f"Transaction {guid} is already voided")
+
+            # Detect reconciled splits BEFORE zeroing — capture the
+            # account names we'll cite in the warning.
+            reconciled_accounts = sorted({
+                s.account.fullname
+                for s in transaction.splits
+                if s.reconcile_state == "y"
+            })
 
             # Stage pre-void state — the VOID formatter renders "Was:
             # description (date)" plus the original splits from it.
@@ -363,12 +384,21 @@ class ReconciliationMixin:
             short_guid = _unique_prefix(
                 transaction.guid, (t.guid for t in book.transactions)
             )
-            return {
+            result = {
                 "guid": short_guid,
                 "description": transaction.description,
                 "void_reason": reason,
                 "status": "voided",
             }
+            if reconciled_accounts:
+                result["warning"] = (
+                    f"Voided transaction contained "
+                    f"{len(reconciled_accounts)} reconciled "
+                    f"account(s): {', '.join(reconciled_accounts)}. "
+                    f"The reconciled balance for these accounts no "
+                    f"longer matches the cleared statement."
+                )
+            return result
 
     def unvoid_transaction(self, guid: str) -> dict:
         """Restore a voided transaction.

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -702,6 +702,25 @@ def _fmt_invoice_post(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_price_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+
+    namespace = params.get("namespace", "")
+    commodity = params.get("commodity", "")
+    head = f"{time_part}  DELETE PRICE  {namespace}:{commodity}"
+    if before:
+        date_str = before.get("date", "")
+        value = before.get("value", "")
+        source = before.get("source", "")
+        return [
+            head,
+            f"{_INDENT}date: {date_str}  value: {value}  source: {source}",
+        ]
+    return [head]
+
+
 def _fmt_invoice_unpost(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -809,6 +828,7 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("bill", "CREATE"): _fmt_bill_create,
     ("bill", "DELETE"): _fmt_bill_delete,
     ("entry", "CREATE"): _fmt_entry_create,
+    ("price", "DELETE"): _fmt_price_delete,
 }
 
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -702,6 +702,22 @@ def _fmt_invoice_post(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_invoice_unpost(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+
+    lines = [f"{time_part}  UNPOST INVOICE  id:{params.get('id', '')}"]
+    if before:
+        was_posted = before.get("date_posted", "") or ""
+        was_account = before.get("post_account", "") or ""
+        lines.append(
+            f"{_INDENT}was posted:{was_posted}  "
+            f"post_account:{was_account}"
+        )
+    return lines
+
+
 def _fmt_invoice_pay(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -788,6 +804,7 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("invoice", "CREATE"): _fmt_invoice_create,
     ("invoice", "DELETE"): _fmt_invoice_delete,
     ("invoice", "POST"): _fmt_invoice_post,
+    ("invoice", "UNPOST"): _fmt_invoice_unpost,
     ("invoice", "PAY"): _fmt_invoice_pay,
     ("bill", "CREATE"): _fmt_bill_create,
     ("bill", "DELETE"): _fmt_bill_delete,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -141,6 +141,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "assign_split_to_lot",
         "calculate_lot_gain",
         "close_lot",
+        "delete_price",
     ],
     "admin": [
         "get_account_slots",
@@ -179,6 +180,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "delete_vendor",
         "delete_employee",
         "get_outstanding_invoices",
+        "unpost_invoice",
         "vendor_spending_report",
     ],
 }

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -464,6 +464,33 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="unpost", entity_type="invoice")
+    def unpost_invoice(
+        id: str,
+        owner_type: str | None = None,
+    ) -> str:
+        """Reverse a posted invoice or bill.
+
+        Deletes the posting transaction and lot, and clears the
+        invoice's posted-state metadata. The invoice returns to
+        "open" state and can be edited or re-posted. Refuses if
+        the invoice has any payments applied — void payments first,
+        then unpost.
+
+        Args:
+            id: Invoice or bill ID (e.g., "000001").
+            owner_type: "customer" or "vendor" for disambiguation
+                when IDs collide.
+        """
+        book = get_book()
+        result = book.unpost_invoice(
+            invoice_id=id,
+            owner_type=owner_type,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="write", operation="pay", entity_type="invoice")
     def pay_invoice(
         id: str,

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -111,6 +111,39 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="delete", entity_type="price")
+    def delete_price(
+        commodity: str,
+        namespace: str,
+        date: str,
+        source: str | None = None,
+    ) -> str:
+        """Delete a single price entry.
+
+        Identifies the price by ``(commodity, namespace, date)``.
+        Pass ``source`` to disambiguate when multiple prices exist
+        on the same commodity+date (e.g. one user-entered and one
+        fetched from a feed).
+
+        Args:
+            commodity: Symbol (e.g., "VTSAX", "USD", "EUR").
+            namespace: Namespace (e.g., "FUND", "CURRENCY").
+            date: ISO date (YYYY-MM-DD) of the price to delete.
+            source: Optional source tag (e.g., "user:price",
+                "user:yfinance"). Required when multiple prices
+                exist on the same commodity+date.
+        """
+        book = get_book()
+        result = book.delete_price(
+            commodity=commodity,
+            namespace=namespace,
+            price_date=date_type.fromisoformat(date),
+            source=source,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="read")
     def get_prices(
         commodity: str,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6541,12 +6541,62 @@ class TestVoidTransaction:
 
         assert result["status"] == "voided"
         assert result["void_reason"] == "Entered in error"
+        # Non-reconciled void: no warning surfaced.
+        assert "warning" not in result
 
         # Verify the transaction is voided (splits have 0 value and 'v' state)
         voided = gc_book.get_transaction(guid)
         for split in voided["splits"]:
             assert split["value"] == "0"
             assert split["reconcile_state"] == "v"
+
+    def test_void_transaction_warns_on_reconciled_splits(
+        self, test_book: Path,
+    ):
+        """Voiding a transaction that contains reconciled splits
+        breaks the reconciled balance for the affected accounts —
+        the bank statement that originally reconciled is no longer
+        accurate. Unlike ``delete_transaction`` (which blocks on
+        reconciled splits), voiding is an audit operation that
+        should never be silently rejected; the result includes a
+        ``warning`` field naming the affected account(s) so the
+        caller knows what they just broke."""
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.list_transactions(compact=False)
+        guid = transactions[0]["guid"]
+
+        # Mark one split as reconciled before voiding.
+        txn = gc_book.get_transaction(guid)
+        target_split = txn["splits"][0]
+        target_account = target_split["account"]
+        gc_book.set_reconcile_state(
+            split_guid=target_split["guid"],
+            state="y",
+        )
+
+        result = gc_book.void_transaction(
+            guid, reason="Wrong amount entered",
+        )
+
+        # Void still succeeded.
+        assert result["status"] == "voided"
+        # And surfaced a warning naming the affected account.
+        assert "warning" in result
+        assert "reconciled" in result["warning"].lower()
+        assert target_account in result["warning"]
+
+    def test_void_transaction_no_warning_when_no_reconciled_splits(
+        self, test_book: Path,
+    ):
+        """Belt-and-suspenders: a clean (no reconciled splits)
+        void must not invent a warning."""
+        gc_book = GnuCashBook(str(test_book))
+        transactions = gc_book.list_transactions(compact=False)
+        result = gc_book.void_transaction(
+            transactions[0]["guid"], reason="Test",
+        )
+        assert "warning" not in result
 
     def test_void_transaction_no_reason(self, test_book: Path):
         """Should raise ValueError if no reason provided."""

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -158,6 +158,59 @@ class TestGetBookSummary:
         result = gc_book.get_book_summary()
         assert f"Book: {test_book}" in result
 
+    def test_data_range_uses_transaction_dates_not_prices(
+        self, test_book: Path,
+    ):
+        """The "Data range" line reflects transactions only, never
+        prices. Prices on dates outside the transaction range are
+        valid signals (forecast rates, NAVs the user pulls in
+        ahead of recording related transactions) and should NOT
+        stretch the displayed range — that misleads the LLM into
+        thinking there's transaction activity in periods where
+        none exists.
+
+        Lin Wei's CNY book hit a misread of this: transactions
+        ended 2025-12-31, test prices extended to 2026-04-30,
+        and the spec author thought the range was being polluted.
+        Locking the correct behavior here so a future refactor
+        can't accidentally union price dates back into the range.
+        """
+        import piecash
+        gc_book = GnuCashBook(str(test_book))
+
+        # Add a transaction in 2025 so the range has a known boundary.
+        # The test_book fixture provides Assets:Checking and
+        # Income:Salary out of the box.
+        gc_book.create_transaction(
+            description="Range anchor",
+            splits=[
+                {"account": "Assets:Checking", "amount": "100"},
+                {"account": "Income:Salary", "amount": "-100"},
+            ],
+            trans_date=date(2025, 6, 15),
+        )
+
+        # Add a price WAY in the future. If the range loop ever
+        # starts scanning prices, this will stretch the upper bound.
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Total Stock", namespace="FUND",
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="200.00",
+            currency="USD", price_date=date(2099, 1, 1),
+        )
+
+        summary = gc_book.get_book_summary()
+
+        # Data range should show 2025 only — not 2099.
+        data_range_lines = [
+            line for line in summary.splitlines()
+            if line.startswith("Data range:")
+        ]
+        assert len(data_range_lines) == 1
+        assert "2025" in data_range_lines[0]
+        assert "2099" not in data_range_lines[0]
+
     def test_investment_valued_at_latest_price(
         self, multi_currency_book: Path
     ):

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7847,6 +7847,130 @@ class TestPrices:
             assert stored[0].currency.mnemonic == "USD"
 
 
+class TestDeletePrice:
+    """Tests for delete_price — single-price removal with source
+    disambiguation. Closes a CRUD gap: pre-fix, callers had to use
+    raw SQL to remove a stale or test-injected price."""
+
+    def _setup_commodity(self, gc_book):
+        gc_book.create_commodity(
+            mnemonic="VTSAX", fullname="Total Stock", namespace="FUND",
+        )
+
+    def test_delete_existing_price_returns_value_echo(
+        self, test_book: Path,
+    ):
+        """Echoing the deleted value lets the caller confirm they
+        removed the right one."""
+        gc_book = GnuCashBook(str(test_book))
+        self._setup_commodity(gc_book)
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.50",
+            currency="USD", price_date=date(2026, 2, 7),
+        )
+
+        result = gc_book.delete_price(
+            commodity="VTSAX", namespace="FUND",
+            price_date=date(2026, 2, 7),
+        )
+
+        assert result["status"] == "deleted"
+        # piecash strips trailing zeros on Decimal storage, so the
+        # echoed value can be "127.5" even when stored as "127.50".
+        # Compare as Decimal.
+        assert Decimal(result["value"]) == Decimal("127.50")
+        assert result["date"] == "2026-02-07"
+
+        # Verify it's actually gone.
+        prices = gc_book.get_prices(
+            commodity="VTSAX", namespace="FUND",
+        )
+        assert prices["total"] == 0
+
+    def test_delete_unknown_commodity_raises(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Commodity not found"):
+            gc_book.delete_price(
+                commodity="NOPE", namespace="FUND",
+                price_date=date(2026, 2, 7),
+            )
+
+    def test_delete_no_match_raises(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        self._setup_commodity(gc_book)
+        # Commodity exists, but no price on this date.
+        with pytest.raises(ValueError, match="No price found"):
+            gc_book.delete_price(
+                commodity="VTSAX", namespace="FUND",
+                price_date=date(2026, 2, 7),
+            )
+
+    def test_delete_ambiguous_without_source_raises(
+        self, test_book: Path,
+    ):
+        """When two prices on the same date come from different
+        sources, deleting without ``source`` would be destructive
+        in a non-deterministic way. Force the caller to choose."""
+        gc_book = GnuCashBook(str(test_book))
+        self._setup_commodity(gc_book)
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.50",
+            currency="USD", price_date=date(2026, 2, 7),
+            source="user:price",
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.99",
+            currency="USD", price_date=date(2026, 2, 7),
+            source="user:yfinance",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            gc_book.delete_price(
+                commodity="VTSAX", namespace="FUND",
+                price_date=date(2026, 2, 7),
+            )
+        msg = str(exc_info.value)
+        # Error lists both sources and their values so the caller
+        # can target the right one on retry. piecash may strip
+        # trailing zeros from stored values; check the integer
+        # part to stay implementation-agnostic.
+        assert "user:price" in msg
+        assert "user:yfinance" in msg
+        assert "127.5" in msg
+        assert "127.99" in msg
+        assert "source=" in msg
+
+    def test_delete_with_source_disambiguates(self, test_book: Path):
+        """Specifying ``source`` selects exactly one of the
+        same-date entries, leaving the other intact."""
+        gc_book = GnuCashBook(str(test_book))
+        self._setup_commodity(gc_book)
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.50",
+            currency="USD", price_date=date(2026, 2, 7),
+            source="user:price",
+        )
+        gc_book.create_price(
+            commodity="VTSAX", namespace="FUND", value="127.99",
+            currency="USD", price_date=date(2026, 2, 7),
+            source="user:yfinance",
+        )
+
+        result = gc_book.delete_price(
+            commodity="VTSAX", namespace="FUND",
+            price_date=date(2026, 2, 7), source="user:yfinance",
+        )
+
+        assert Decimal(result["value"]) == Decimal("127.99")
+        # The other price stays put.
+        remaining = gc_book.get_prices(
+            commodity="VTSAX", namespace="FUND",
+        )
+        assert remaining["total"] == 1
+        assert Decimal(remaining["prices"][0]["value"]) == Decimal("127.50")
+        assert remaining["prices"][0]["source"] == "user:price"
+
+
 class TestInvestmentWorkflow:
     """Integration tests for the full investment workflow."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1938,6 +1938,218 @@ class TestPostInvoice:
             assert Decimal(str(expense_split.quantity)) == Decimal("1100.00")
 
 
+# ============== Unpost Invoice Tests ==============
+
+
+class TestUnpostInvoice:
+    """Tests for unpost_invoice — the reverse of post_invoice.
+
+    The bookkeeper hit the orphaned-invoice problem on both Alex's
+    and Lin Wei's books: a posting transaction got deleted via
+    ``delete_transaction``, but the invoice retained its
+    ``date_posted`` / ``post_txn`` / ``post_lot`` / ``post_acc``
+    pointers. The invoice then refused both delete ("already
+    posted") and re-post ("posted"); only SQL surgery escaped.
+    Two-prong fix: ``unpost_invoice`` for clean reversal +
+    ``delete_transaction`` rejection of posting records.
+    """
+
+    def _post_invoice(self, gb, amount="500.00"):
+        """Returns the post_invoice result dict (includes
+        ``transaction_guid`` and ``lot_guid``, which ``get_invoice``
+        doesn't surface)."""
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        return gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+
+    def test_unpost_returns_invoice_to_open_state(self, business_book):
+        """Unposting clears date_posted, post_txn, post_lot,
+        post_account; the invoice is editable again."""
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+
+        result = gb.unpost_invoice(invoice_id=posted["id"])
+
+        assert result["id"] == posted["id"]
+        assert result["type"] == "invoice"
+        assert result["status"] == "unposted"
+
+        # Invoice is open again.
+        inv = gb.get_invoice(posted["id"], owner_type="customer")
+        assert inv["date_posted"] is None
+
+    def test_unpost_deletes_posting_transaction(self, business_book):
+        """The transaction that posting created is removed from
+        the book — not just unlinked from the invoice."""
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+        txn_guid = posted["transaction_guid"]
+
+        gb.unpost_invoice(invoice_id=posted["id"])
+
+        # Transaction is gone.
+        with gb.open(readonly=True) as book:
+            from piecash.core.transaction import Transaction
+            tx = (
+                book.session.query(Transaction)
+                .filter_by(guid=txn_guid)
+                .first()
+            )
+            assert tx is None
+
+    def test_unpost_allows_re_posting(self, business_book):
+        """After unpost, the invoice can be posted again — the
+        canonical lifecycle is post → unpost → edit → post."""
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+        gb.unpost_invoice(invoice_id=posted["id"])
+
+        # Re-post on a different date with a different account.
+        result = gb.post_invoice(
+            invoice_id=posted["id"],
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-05-15",
+        )
+        assert result["status"] == "posted"
+        assert result["post_date"] == "2026-05-15"
+
+    def test_unpost_rejects_invoice_with_payment_applied(
+        self, business_book,
+    ):
+        """Unposting an invoice that has any payment applied would
+        orphan the payment splits. Force the user to void payments
+        first."""
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+        gb.pay_invoice(
+            invoice_id=posted["id"],
+            payment_account="Assets:Checking",
+            amount="100.00",
+        )
+
+        with pytest.raises(ValueError, match="has payments applied"):
+            gb.unpost_invoice(invoice_id=posted["id"])
+
+    def test_unpost_rejects_unposted_invoice(self, business_book):
+        """Open invoices have nothing to unpost."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+
+        with pytest.raises(ValueError, match="is not posted"):
+            gb.unpost_invoice(invoice_id="000001")
+
+    def test_unpost_rejects_unknown_invoice(self, business_book):
+        """Clear error when the ID doesn't match anything."""
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.unpost_invoice(invoice_id="999999")
+
+    def test_unpost_works_for_vendor_bill(self, business_book):
+        """Symmetry — the bill side reverses cleanly too."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="Paper", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+        )
+
+        result = gb.unpost_invoice(
+            invoice_id="000001", owner_type="vendor",
+        )
+        assert result["type"] == "bill"
+        assert result["status"] == "unposted"
+
+    def test_unpost_disambiguates_via_owner_type(self, business_book):
+        """When customer invoice and vendor bill share an ID,
+        ``owner_type`` selects which side to unpost."""
+        gb = GnuCashBook(str(business_book))
+        # Post both on the same id 000001.
+        gb.create_customer(name="Acme Corp")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")
+        gb.create_bill(vendor_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="x", quantity="1", price="100",
+        )
+        gb.add_bill_entry(
+            bill_id="000001", account="Expenses:Office Supplies",
+            description="y", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+
+        # Unpost the customer side; the vendor bill stays posted.
+        gb.unpost_invoice(invoice_id="000001", owner_type="customer")
+
+        inv = gb.get_invoice("000001", owner_type="customer")
+        bill = gb.get_invoice("000001", owner_type="vendor")
+        assert inv["date_posted"] is None
+        assert bill["date_posted"] is not None
+
+    def test_delete_transaction_rejects_posting_record(
+        self, business_book,
+    ):
+        """Direct deletion of a posting transaction is the original
+        defect this whole fix exists to prevent. The check rejects
+        the call with a message pointing at unpost_invoice."""
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+
+        with pytest.raises(ValueError) as exc_info:
+            gb.delete_transaction(guid=posted["transaction_guid"])
+        msg = str(exc_info.value)
+        assert "posting record" in msg
+        assert posted["id"] in msg
+        assert "unpost_invoice" in msg
+
+    def test_delete_transaction_works_for_non_posting_records(
+        self, business_book,
+    ):
+        """Regression: only posting transactions are protected.
+        Plain transactions (e.g., regular bank deposits) still
+        delete cleanly."""
+        gb = GnuCashBook(str(business_book))
+        from datetime import date as _date
+        result = gb.create_transaction(
+            description="Regular deposit",
+            splits=[
+                {"account": "Assets:Checking", "amount": "100"},
+                {"account": "Income:Sales", "amount": "-100"},
+            ],
+            trans_date=_date(2026, 1, 1),
+        )
+        gb.delete_transaction(guid=result["guid"])  # no error
+
+
 # ============== Pay Invoice Tests ==============
 
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2040,6 +2040,38 @@ class TestUnpostInvoice:
         with pytest.raises(ValueError, match="has payments applied"):
             gb.unpost_invoice(invoice_id=posted["id"])
 
+    def test_unpost_succeeds_when_payment_was_voided(
+        self, business_book,
+    ):
+        """A voided payment has zero economic effect — GnuCash's
+        void operation preserves the split for audit purposes but
+        zeroes the values. The "has payments applied" guard asks
+        an *economic* question ("would unposting orphan real
+        money?"); voided splits answer no.
+
+        The bookkeeper hit this on Alex's book: posted invoice →
+        partial payment → voided the payment → ``unpost_invoice``
+        rejected with "has payments applied" even though zero
+        dollars would have been orphaned. Treating voided
+        payments as still-applied contradicted GnuCash's own
+        void semantics. Regression locks the fix.
+        """
+        gb = GnuCashBook(str(business_book))
+        posted = self._post_invoice(gb)
+        pay = gb.pay_invoice(
+            invoice_id=posted["id"],
+            payment_account="Assets:Checking",
+            amount="100.00",
+        )
+        gb.void_transaction(
+            guid=pay["transaction_guid"],
+            reason="Test cleanup — voiding partial payment",
+        )
+
+        # Voided payment has zero economic effect → unpost allowed.
+        result = gb.unpost_invoice(invoice_id=posted["id"])
+        assert result["status"] == "unposted"
+
     def test_unpost_rejects_unposted_invoice(self, business_book):
         """Open invoices have nothing to unpost."""
         gb = GnuCashBook(str(business_book))

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -95,27 +95,81 @@ class TestListLots:
         assert result == []
 
     def test_list_lots_with_lots(self, investment_book: Path):
+        """The default view shows lots with active positions. Empty
+        lots (no splits assigned, or all splits voided) are filtered
+        out — see ``test_list_lots_skips_empty_lots_in_default_view``."""
         book = GnuCashBook(str(investment_book))
         book.create_lot(account="Assets:Investments:VTSAX", title="Lot A")
         book.create_lot(account="Assets:Investments:VTSAX", title="Lot B")
-        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
+        # Empty lots have zero remaining position, so the default
+        # (open-positions) view skips them. ``include_closed=True``
+        # surfaces them for callers who need the audit-trail view.
+        result = book.list_lots(
+            account="Assets:Investments:VTSAX",
+            include_closed=True, compact=False,
+        )
         assert len(result) == 2
         titles = {r["title"] for r in result}
         assert titles == {"Lot A", "Lot B"}
 
-    def test_list_lots_exclude_closed(self, investment_book: Path):
+    def test_list_lots_skips_empty_lots_in_default_view(
+        self, investment_book: Path,
+    ):
+        """Empty lots (no splits, or all splits zeroed by void) appear
+        as "0 shares, 0 cost basis" rows that add noise to a
+        portfolio listing. The bookkeeper flagged this as confusing
+        when managing a real portfolio. The default ``include_closed
+        =False`` view skips them; ``include_closed=True`` surfaces
+        them."""
         book = GnuCashBook(str(investment_book))
-        lot_a = book.create_lot(account="Assets:Investments:VTSAX", title="Open Lot")
-        lot_b = book.create_lot(account="Assets:Investments:VTSAX", title="Closed Lot")
+        book.create_lot(account="Assets:Investments:VTSAX", title="Empty A")
+        book.create_lot(account="Assets:Investments:VTSAX", title="Empty B")
+
+        # Default view: zero empty lots show up.
+        result = book.list_lots(
+            account="Assets:Investments:VTSAX", compact=False,
+        )
+        assert result == []
+
+        # Audit view: both surface.
+        result = book.list_lots(
+            account="Assets:Investments:VTSAX",
+            include_closed=True, compact=False,
+        )
+        assert len(result) == 2
+
+    def test_list_lots_exclude_closed(self, investment_book: Path):
+        """Closed lots are filtered out by default; ``include_closed
+        =True`` surfaces them. With the empty-lot filter, an "Open"
+        lot needs an actual position to appear in the default view —
+        so assign a non-zero buy split to it."""
+        book = GnuCashBook(str(investment_book))
+        lot_a = book.create_lot(
+            account="Assets:Investments:VTSAX", title="Open Lot",
+        )
+        lot_b = book.create_lot(
+            account="Assets:Investments:VTSAX", title="Closed Lot",
+        )
+        # Give Open Lot a real position so it survives the empty
+        # filter — buy 10 shares and assign the buy split to lot_a.
+        buy_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(
+            split_guid=buy_guid, lot_guid=lot_a["guid"],
+        )
         book.close_lot(guid=lot_b["guid"])
 
-        # Default: exclude closed
-        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
+        # Default: exclude closed AND empty.
+        result = book.list_lots(
+            account="Assets:Investments:VTSAX", compact=False,
+        )
         assert len(result) == 1
         assert result[0]["title"] == "Open Lot"
 
-        # Include closed
-        result = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True, compact=False)
+        # Include closed → all lots surface, even empty/closed ones.
+        result = book.list_lots(
+            account="Assets:Investments:VTSAX",
+            include_closed=True, compact=False,
+        )
         assert len(result) == 2
 
 
@@ -275,6 +329,40 @@ class TestCalculateLotGain:
         lot = book.create_lot(account="Assets:Investments:VTSAX", title="Empty")
         with pytest.raises(ValueError, match="no remaining shares"):
             book.calculate_lot_gain(lot_guid=lot["guid"], sale_price="130")
+
+    def test_gain_no_remaining_shares_due_to_voided_buy(
+        self, investment_book: Path,
+    ):
+        """When the lot's purchase was voided, the generic "no
+        remaining shares" message hides the *cause*. The error
+        should call out the voided splits explicitly so the caller
+        knows to unvoid the underlying transaction (or pick a
+        different lot) instead of staring at a vague error."""
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(
+            account="Assets:Investments:VTSAX", title="Voided Buy Lot",
+        )
+        buy_guid = _buy_shares(book, 10, Decimal("125"), date(2026, 1, 15))
+        book.assign_split_to_lot(
+            split_guid=buy_guid, lot_guid=lot["guid"],
+        )
+        # Find and void the buy transaction.
+        with book.open(readonly=True) as b:
+            from piecash.core.transaction import Split
+            split = b.session.query(Split).filter_by(guid=buy_guid).first()
+            buy_txn_guid = split.transaction.guid
+        book.void_transaction(
+            guid=buy_txn_guid, reason="Mistaken purchase",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            book.calculate_lot_gain(
+                lot_guid=lot["guid"], sale_price="130",
+            )
+        msg = str(exc_info.value)
+        assert "no remaining shares" in msg
+        # The improved error explicitly points at voided splits.
+        assert "voided" in msg.lower()
 
 
 # ── TestCloseLot ─────────────────────────────────────────────

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -52,14 +52,13 @@ class TestToolModulesMapping:
         assert len(TOOL_MODULES["core"]) == 15
 
     def test_total_tool_count(self):
-        """Total tools across all modules should be 82.
+        """Total tools across all modules should be 84.
 
-        82 = 78 pre-Employee + 4 Employee CRUD tools (create_employee,
-        list_employees, get_employee, delete_employee) added in the
-        feat/employees branch.
+        84 = 78 pre-Employee + 4 Employee CRUD (1.2.0) +
+        2 from the 1.2.1 patch (``unpost_invoice``, ``delete_price``).
         """
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 82
+        assert total == 84
 
     def test_expected_modules_exist(self):
         """All expected module names should be present."""
@@ -90,9 +89,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 82 tools."""
+        """--modules=all should keep all 84 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 82
+        assert len(self._tool_names()) == 84
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to core + backup.
@@ -128,12 +127,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 82
+        assert len(self._tool_names()) == 84
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 82 tools."""
+        """'all' mixed with other modules should keep all 84 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 82
+        assert len(self._tool_names()) == 84
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -74,6 +74,85 @@ class TestToolModulesMapping:
         _validate_tool_modules()  # Should not raise
 
 
+class TestToolFileVsModulesMapping:
+    """Each ``tools/<module>.py`` file's ``@mcp.tool()`` decorations
+    must match the corresponding entry in ``TOOL_MODULES`` exactly.
+
+    Bug class this prevents: a tool added with ``@mcp.tool()`` in
+    ``tools/<module>.py`` but missing from ``TOOL_MODULES`` gets
+    *registered* during lazy-load, then immediately *removed* by
+    ``_apply_module_filter``'s "drop anything not in the keep set"
+    step. The tool is invisible at runtime even though the
+    decorator fired and the function exists. Symptom is "I bounced
+    the server, the new tool still doesn't show up" — and the
+    earlier ``test_registered_tools_are_a_subset_of_mapped`` check
+    silently passes because the unmapped tool was already removed
+    by the filter.
+
+    The reverse — a name in ``TOOL_MODULES`` that no file actually
+    defines — is just as bad: ``_apply_module_filter`` will
+    silently keep the missing tool in its ``keep`` set without
+    error, but ``mcp.remove_tool`` won't be called on a non-
+    existent tool, so the symptom is just "this tool is in the
+    docs but doesn't work."
+
+    Both omissions slipped through PR #62 (``unpost_invoice`` and
+    ``delete_price`` defined but not in ``TOOL_MODULES``) before
+    Claude Chat caught them mid-test. This class locks the
+    contract.
+    """
+
+    @pytest.fixture(autouse=True)
+    def save_and_restore_tools(self):
+        original = dict(mcp._tool_manager._tools)
+        yield
+        mcp._tool_manager._tools.clear()
+        mcp._tool_manager._tools.update(original)
+
+    @pytest.mark.parametrize("module_name", sorted(TOOL_MODULES.keys()))
+    def test_module_file_decorations_match_mapping(
+        self, module_name: str,
+    ):
+        """For each module: load it, capture the tool names that
+        actually got registered, compare to ``TOOL_MODULES[name]``."""
+        from gnucash_mcp.book import extracted_modules
+        from gnucash_mcp.server import _lazy_load_tool_module
+
+        # Skip non-extracted modules (their tools register at server
+        # import time, not via the lazy-load path). Extracted modules
+        # are the ones with a tools/<name>.py file.
+        if module_name not in extracted_modules():
+            pytest.skip(f"{module_name!r} is not an extracted module")
+
+        # Reset to a clean slate so we can attribute new registrations
+        # to this specific module's load.
+        mcp._tool_manager._tools.clear()
+        before = set(mcp._tool_manager._tools.keys())
+        _lazy_load_tool_module(module_name)
+        after = set(mcp._tool_manager._tools.keys())
+        actually_registered = after - before
+
+        mapped = set(TOOL_MODULES[module_name])
+
+        unmapped = actually_registered - mapped
+        assert not unmapped, (
+            f"Module {module_name!r}: tools have @mcp.tool() in "
+            f"tools/{module_name}.py but are missing from "
+            f"TOOL_MODULES[{module_name!r}]: {sorted(unmapped)}. "
+            f"Add them to the mapping or _apply_module_filter will "
+            f"silently remove them after registration."
+        )
+
+        phantom = mapped - actually_registered
+        assert not phantom, (
+            f"Module {module_name!r}: TOOL_MODULES[{module_name!r}] "
+            f"lists tools that aren't defined in "
+            f"tools/{module_name}.py: {sorted(phantom)}. "
+            f"Either add the @mcp.tool() in the file or remove the "
+            f"name from the mapping."
+        )
+
+
 class TestApplyModuleFilter:
     """Tests for _apply_module_filter."""
 


### PR DESCRIPTION
## Summary

The three fixes from ``docs/PATCH_1_2_1_SPEC.md``. Required before 1.2.1 ships.

**Fix 1 — ``unpost_invoice`` tool + ``delete_transaction`` posting-record guard.**

Closes a correctness hole: a posted invoice/bill could become orphaned when its posting transaction was deleted directly via ``delete_transaction``. The invoice retained ``date_posted``, ``post_txn``, ``post_lot``, and ``post_acc`` metadata pointing at objects that no longer existed; the server then refused both ``delete_invoice`` ("Cannot delete posted invoice") and ``post_invoice`` ("already posted"), and the only escape was direct SQL surgery. Hit during both Alex's and Lin Wei's testing rounds.

Two-prong fix:
1. ``unpost_invoice(id, owner_type=None)`` — reverses ``post_invoice`` cleanly: deletes the posting transaction and lot, clears the invoice's posted-state pointers. Refuses if the invoice has any payments applied (would orphan payment splits — void payments first). Same ``owner_type`` cross-sequence disambiguation pattern as ``post_invoice`` / ``pay_invoice``.
2. ``delete_transaction`` rejects with a clear error pointing at ``unpost_invoice`` when the target is referenced by an invoice's ``post_txn``. Prevents the orphaning at the source.

**Fix 2 — ``delete_price`` tool with source disambiguation.**

Closes a CRUD gap. ``create_price`` / ``get_prices`` / ``get_latest_price`` existed; there was no way to delete a price short of raw SQL. Test prices, mistaken imports, and stale data accumulate over time. Both synthetic-book builds had to clear test prices via ``DELETE FROM prices``.

Identifies the price by ``(commodity, namespace, date)``. When multiple prices exist on the same commodity+date (e.g. one from ``user:price`` and one from ``user:yfinance``), ``source`` disambiguates. Omitted ``source`` with multiple matches raises a clear error listing both sources and values — same fail-loud-on-ambiguity philosophy as ``_resolve_account`` and ``_find_invoice``. Bulk ``delete_prices(before_date=…)`` extension is **not** implemented; out of scope for 1.2.1.

**Fix 3 — ``get_book_summary`` data range, locked by regression test.**

Spec'd a defect where the "Data range" line could include price dates that lay outside the transaction range. On investigation, the current code is already correct: the data-range loop has only ever iterated ``book.transactions`` (``git log -L`` confirms the loop hasn't changed since ``b487952`` introduced the tool). The spec author was likely reading an older snapshot. Live-verified on Lin Wei's CNY book — range correctly shows 2025-01-01 to 2025-12-31 even with my injected test prices reaching 2026-04-30. Added a regression test that injects a 2099-dated price and asserts the displayed range stays in 2025, locking the contract against future refactors.

## Test plan

- [x] **992 tests passing** (was 975 — +17 across the three fixes)
- [x] ``TestUnpostInvoice`` (10 tests): unpost returns invoice to open state, deletes posting transaction, allows re-posting, rejects payments-applied / unposted / unknown-id, works for vendor bills, disambiguates owner_type, ``delete_transaction`` guard fires on posting records and stays out of the way for non-posting transactions
- [x] ``TestDeletePrice`` (5 tests): single-price delete with value echo, unknown commodity, no-match-on-date, ambiguous-without-source raises with both sources listed, ``source=`` disambiguates and leaves the other intact
- [x] ``test_data_range_uses_transaction_dates_not_prices`` regression
- [x] Live-verified on Lin Wei's CNY book:
  - Fix 1: post → reject ``delete_transaction`` → ``unpost_invoice`` → re-post on a new date
  - Fix 2: inject test price for 2099-01-01, confirm visible, delete, confirm gone
  - Fix 3: data range shows 2025 only despite 2026 test prices

## Scope

This is the complete 1.2.1 patch scope per the spec. Tax tables, jobs, credit notes, aging reports, and bulk-write extensions are 1.3.