### PR TITLE
fix(budgets): quantize set_budget_amount to commodity precision

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -10,7 +10,7 @@ SQLAlchemy Core API paired with _verify_* round-trip checks.
 """
 
 from datetime import date, datetime, timedelta
-from decimal import Decimal
+from decimal import ROUND_HALF_EVEN, Decimal
 
 import piecash
 
@@ -602,16 +602,27 @@ class BudgetsMixin:
 
             periods = self._resolve_periods(budget, period)
 
-            # Convert Decimal to num/denom for direct inserts
-            amount_denom = 100
-            amount_num = int(amount_decimal * amount_denom)
+            # Quantize to the account commodity's smallest fraction:
+            # USD (fraction=100) → 2 decimals, JPY (fraction=1) → 0,
+            # BHD (fraction=1000) → 3. Banker's rounding avoids
+            # systematic bias on ties. We must apply the same
+            # quantization on both the insert AND update branches —
+            # piecash's hybrid ``existing.amount`` setter doesn't
+            # quantize, so without this the two paths would store
+            # different values for the same input.
+            amount_denom = acct.commodity.fraction
+            quantum = Decimal(1) / Decimal(amount_denom)
+            quantized = amount_decimal.quantize(
+                quantum, rounding=ROUND_HALF_EVEN,
+            )
+            amount_num = int(quantized * amount_denom)
 
             for p in periods:
                 try:
                     existing = budget.amounts(
                         account=acct, period_num=p
                     )
-                    existing.amount = amount_decimal
+                    existing.amount = quantized
                 except KeyError:
                     # No existing amount — insert via table (BudgetAmount constructor blocked)
                     book.session.execute(

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -222,6 +222,82 @@ class TestSetBudgetAmount:
                 assert Decimal(acct["periods"][0]) == Decimal("700.00")
                 break
 
+    def test_subcent_amount_quantizes_consistently_on_insert_and_update(
+        self, budget_book: Path,
+    ):
+        """Sub-cent input quantizes to commodity precision and produces
+        identical stored values via the insert and update paths.
+
+        Pre-fix, the insert path did ``int(amount * 100)`` which
+        truncated; the update path used piecash's hybrid setter which
+        did not. Same input produced different stored values depending
+        on whether a row already existed.
+        """
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        # Insert path (no existing row) — period 0
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="499.995",
+            period=0,
+        )
+
+        # Update path — set period 0 again with same input
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="499.995",
+            period=0,
+        )
+
+        # And on a fresh period — also insert path
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="499.995",
+            period=1,
+        )
+
+        budget = book.get_budget(compact=False, name="2026 Budget")
+        groceries = next(
+            a for a in budget["accounts"]
+            if a["account"] == "Expenses:Groceries"
+        )
+        # Banker's rounding: 499.995 → 500.00 (round half to even,
+        # 9 is odd → up to 10 → carry → 500.00).
+        expected = Decimal("500.00")
+        assert Decimal(groceries["periods"][0]) == expected
+        assert Decimal(groceries["periods"][1]) == expected
+        # Insert and update paths produce the same stored value.
+        assert groceries["periods"][0] == groceries["periods"][1]
+
+    def test_subcent_amount_truncation_does_not_silently_drop_digits(
+        self, budget_book: Path,
+    ):
+        """Larger sub-cent input rounds, doesn't truncate.
+
+        Pre-fix, ``int(Decimal('1234.567') * 100)`` truncated to
+        123456 → stored 1234.56 instead of rounding to 1234.57.
+        """
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 Budget", year=2026, num_periods=12)
+
+        book.set_budget_amount(
+            budget_name="2026 Budget",
+            account="Expenses:Groceries",
+            amount="1234.567",
+            period=0,
+        )
+
+        budget = book.get_budget(compact=False, name="2026 Budget")
+        groceries = next(
+            a for a in budget["accounts"]
+            if a["account"] == "Expenses:Groceries"
+        )
+        assert Decimal(groceries["periods"][0]) == Decimal("1234.57")
+
     def test_set_nonexistent_budget_raises(self, budget_book: Path):
         """Setting amount on nonexistent budget raises ValueError."""
         book = GnuCashBook(str(budget_book))


### PR DESCRIPTION
## Summary

Pre-fix, `set_budget_amount` used `int(amount * 100)` on the insert path (truncates) while the update path used piecash's hybrid setter (preserves decimals). Same input could produce different stored values depending on whether the row already existed.

Now both paths quantize to `acct.commodity.fraction` with `ROUND_HALF_EVEN`, then store the same value. JPY (fraction=1), BHD (fraction=1000), and other non-2-decimal currencies are handled correctly.

Severity: critical (silent precision loss on a write tool, with insert/update divergence).

## Test plan

- [x] Unit: \`test_subcent_amount_quantizes_consistently_on_insert_and_update\` — same input via insert and update paths, identical stored values
- [x] Unit: \`test_subcent_amount_truncation_does_not_silently_drop_digits\` — \`1234.567\` → \`1234.57\` (round, not truncate)
- [x] Live: copy of CNY-default lin-wei book — \`499.995\` → \`500\` (banker's), \`1234.567\` → \`1234.57\`, insert/update parity holds
- [x] Full test suite passes (1049 prior + 2 new = 1051; two pre-existing TestDeletePrice failures unrelated)