### PR TITLE
fix(investments): prorate cost basis to recover precision

### DIFF
--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -506,11 +506,20 @@ class InvestmentsMixin:
             raise
         return book.session.query(Lot).filter_by(guid=full_guid).first()
 
-    def _lot_summary(self, lot) -> dict:
-        """Compute current state of a lot from its splits.
+    def _lot_decimals(self, lot) -> dict:
+        """Raw-Decimal source of truth for a lot's current state.
+
+        Keeps full precision; ``_lot_summary`` formats the egress.
+        Math (cost basis, gain) consumes this directly so we never
+        round-trip a number through a formatted string for further
+        computation. The classic precision-loss path: $100 / 3 shares
+        formatted to 4 decimals as 33.3333, multiplied back by 3
+        shares becomes $99.99 — but the actual cost was $100.
 
         Returns:
-            Dict with quantity, cost_basis, cost_per_share as strings.
+            Dict of Decimals: purchase_quantity, purchase_value,
+            sale_quantity, remaining, cost_per_share,
+            remaining_cost_basis.
         """
         purchase_quantity = Decimal(0)
         purchase_value = Decimal(0)
@@ -527,19 +536,42 @@ class InvestmentsMixin:
 
         if purchase_quantity > 0:
             cost_per_share = purchase_value / purchase_quantity
-            remaining_cost_basis = cost_per_share * remaining
+            # Prorate cost basis on shares remaining, not
+            # ``cost_per_share * remaining`` — for a lot bought at
+            # $100/3 shares, the latter gives $99.999... while the
+            # prorated form gives exactly $100 when ``remaining ==
+            # purchase_quantity``.
+            remaining_cost_basis = (
+                purchase_value * remaining / purchase_quantity
+            )
         else:
             cost_per_share = Decimal(0)
             remaining_cost_basis = Decimal(0)
 
         return {
+            "purchase_quantity": purchase_quantity,
+            "purchase_value": purchase_value,
+            "sale_quantity": sale_quantity,
+            "remaining": remaining,
+            "cost_per_share": cost_per_share,
+            "remaining_cost_basis": remaining_cost_basis,
+        }
+
+    def _lot_summary(self, lot) -> dict:
+        """Compute current state of a lot from its splits.
+
+        Returns:
+            Dict with quantity, cost_basis, cost_per_share as strings.
+        """
+        raw = self._lot_decimals(lot)
+        return {
             # Quantity is shares (or other commodity units): 4 decimals
             # is a good default for funds and stocks. Crypto callers
             # who need finer granularity get the same _format_number
             # logic at decimals=6 in their own paths.
-            "quantity": _format_number(remaining, decimals=4),
-            "cost_basis": _format_number(remaining_cost_basis, decimals=2),
-            "cost_per_share": _format_number(cost_per_share, decimals=4),
+            "quantity": _format_number(raw["remaining"], decimals=4),
+            "cost_basis": _format_number(raw["remaining_cost_basis"], decimals=2),
+            "cost_per_share": _format_number(raw["cost_per_share"], decimals=4),
             "is_closed": bool(lot.is_closed),
         }
 
@@ -812,8 +844,8 @@ class InvestmentsMixin:
             if not lot:
                 raise ValueError(f"Lot not found: {lot_guid}")
 
-            summary = self._lot_summary(lot)
-            remaining = Decimal(summary["quantity"])
+            raw = self._lot_decimals(lot)
+            remaining = raw["remaining"]
 
             if remaining <= 0:
                 # Distinguish "lot ran to zero through sales" (normal,
@@ -864,8 +896,15 @@ class InvestmentsMixin:
                     )
                 price = Decimal(str(latest_price.value))
 
-            cost_per_share = Decimal(summary["cost_per_share"])
-            cost_basis = cost_per_share * shares_to_sell
+            # Prorate cost basis on shares-to-sell. Avoids the precision
+            # loss of ``cost_per_share * shares`` for non-round
+            # per-share costs (e.g., $100 / 3 shares: prorate gives
+            # exactly $100 for selling all 3, while the divide-then-
+            # multiply path gives $99.99...). Tax-relevant.
+            cost_basis = (
+                raw["purchase_value"] * shares_to_sell
+                / raw["purchase_quantity"]
+            )
             proceeds = price * shares_to_sell
             gain = proceeds - cost_basis
             gain_pct = (gain / cost_basis * 100) if cost_basis else Decimal(0)

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -323,6 +323,57 @@ class TestCalculateLotGain:
         assert Decimal(result["sale_proceeds"]) == Decimal("520")
         assert Decimal(result["capital_gain"]) == Decimal("20")
 
+    def test_cost_basis_recovers_exactness_for_indivisible_per_share_cost(
+        self, investment_book: Path,
+    ):
+        """A lot bought at a non-round per-share cost should recover
+        the exact total cost basis when all shares are sold.
+
+        Pre-fix, ``cost_per_share`` was formatted to 4 decimals via
+        ``_lot_summary``, then re-parsed in ``calculate_lot_gain``
+        and multiplied by shares — losing precision. A $100 / 3 share
+        lot showed cost_basis $99.99 on a 3-share sale instead of
+        $100.
+
+        The prorate formula
+        ``cost_basis = purchase_value * shares / purchase_quantity``
+        recovers exactness for the all-shares case. Tax-relevant.
+        """
+        book = GnuCashBook(str(investment_book))
+        lot = book.create_lot(
+            account="Assets:Investments:VTSAX", title="Indivisible cost",
+        )
+        # Buy 3 shares at $33.3333.../share (total $100)
+        result = book.create_transaction(
+            description="Buy 3 VTSAX with non-round per-share cost",
+            splits=[
+                {
+                    "account": "Assets:Investments:VTSAX",
+                    "amount": "100",
+                    "quantity": "3",
+                },
+                {"account": "Assets:Checking", "amount": "-100"},
+            ],
+            trans_date=date(2026, 1, 15),
+        )
+        txn = book.get_transaction(result["guid"])
+        buy_guid = next(
+            s["guid"] for s in txn["splits"]
+            if s["account"] == "Assets:Investments:VTSAX"
+        )
+        book.assign_split_to_lot(
+            split_guid=buy_guid, lot_guid=lot["guid"],
+        )
+
+        # Sell all 3 shares at $50/share. Cost basis MUST be exactly
+        # $100, gain MUST be exactly $50 — not $99.99 / $50.01.
+        gain = book.calculate_lot_gain(
+            lot_guid=lot["guid"], sale_price="50",
+        )
+        assert Decimal(gain["cost_basis"]) == Decimal("100.00")
+        assert Decimal(gain["sale_proceeds"]) == Decimal("150.00")
+        assert Decimal(gain["capital_gain"]) == Decimal("50.00")
+
     def test_gain_no_remaining_shares(self, investment_book: Path):
         """Empty lot raises error."""
         book = GnuCashBook(str(investment_book))


### PR DESCRIPTION
## Summary

\`calculate_lot_gain\` re-parsed \`cost_per_share\` back through the formatted-to-4-decimals string from \`_lot_summary\`, then multiplied by shares — losing precision for non-round per-share costs. A lot bought at \$100 / 3 shares (\$33.3333.../share) showed cost_basis \$99.99 on a 3-share sale instead of exactly \$100. Tax-relevant.

Two changes:

- Extract \`_lot_decimals\` as the raw-Decimal source of truth. \`_lot_summary\` becomes a thin formatter wrapper. Math consumes the raw helper directly — never round-trip through a formatted string for further computation.
- Prorate cost basis as \`purchase_value × shares / purchase_quantity\` rather than \`cost_per_share × shares\`. Recovers exactness for the all-shares case (\$100 × 3 / 3 = \$100 exactly).

Severity: high (silent precision loss in capital-gain math; tax-relevant).

## Test plan

- [x] Regression test: buy 3 shares for \$100 (\$33.3333.../share), sell all 3 at \$50, assert cost_basis is exactly \$100.00 and capital_gain exactly \$50.00
- [x] Existing 25 lot tests pass unchanged
- [x] Full suite passes (652 + 396 = 1048 + 3 new = 1051; same two pre-existing TestDeletePrice failures)