### PR TITLE
fix(scheduling): anchor _next_occurrence to start_date, no drift

### DIFF
--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -90,19 +90,28 @@ class SchedulingMixin:
         if last_occur is not None and last_occur > after:
             after = last_occur
 
-        delta_map = {
-            "weekly": relativedelta(weeks=1),
-            "biweekly": relativedelta(weeks=2),
-            "monthly": relativedelta(months=1),
-            "bimonthly": relativedelta(months=2),
-            "quarterly": relativedelta(months=3),
-            "yearly": relativedelta(years=1),
-        }
-        delta = delta_map[frequency]
+        # Anchor each occurrence to ``start_date + (n × period)`` rather
+        # than chaining ``occurrence += delta``. ``relativedelta`` clamps
+        # to month-end on day-of-month overflow, so a monthly schedule
+        # starting Jan 31 chained as Jan 31 → Feb 28 → Mar 28 → … (drift
+        # never recovers). Anchored from start_date: Feb 28 → Mar 31 →
+        # Apr 30 → May 31, preserving the bookkeeper's "31st of every
+        # month, falling back to month-end where needed" intent.
+        delta_for = {
+            "weekly": lambda n: relativedelta(weeks=n),
+            "biweekly": lambda n: relativedelta(weeks=2 * n),
+            "monthly": lambda n: relativedelta(months=n),
+            "bimonthly": lambda n: relativedelta(months=2 * n),
+            "quarterly": lambda n: relativedelta(months=3 * n),
+            "yearly": lambda n: relativedelta(years=n),
+        }[frequency]
 
-        occurrence = start_date
-        while occurrence <= after:
-            occurrence += delta
+        n = 0
+        while True:
+            occurrence = start_date + delta_for(n)
+            if occurrence > after:
+                break
+            n += 1
 
         if end_date and occurrence > end_date:
             return None

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -573,6 +573,55 @@ class TestNextOccurrence:
         )
         assert result == date(2026, 4, 1)
 
+    def test_monthly_31st_does_not_drift_after_february(self, scheduled_book):
+        """A monthly schedule starting Jan 31 must hit Mar 31, Apr 30,
+        May 31, ... — not drift to the 28th forever after Feb.
+
+        Pre-fix, ``occurrence += relativedelta(months=1)`` chained the
+        clamping: Jan 31 → Feb 28 (clamped) → Mar 28 → Apr 28 → ...
+        Anchoring to ``start_date + relativedelta(months=n)`` recovers
+        the original day-of-month intent.
+        """
+        gb = GnuCashBook(str(scheduled_book))
+        # After Feb 1: should be Feb 28 (clamped, no Feb 31).
+        assert gb._next_occurrence(
+            start_date=date(2026, 1, 31), frequency="monthly",
+            after=date(2026, 2, 1),
+        ) == date(2026, 2, 28)
+        # After Feb 28: should be MARCH 31, not March 28.
+        assert gb._next_occurrence(
+            start_date=date(2026, 1, 31), frequency="monthly",
+            after=date(2026, 2, 28),
+        ) == date(2026, 3, 31)
+        # After Mar 31: should be April 30 (April has 30 days).
+        assert gb._next_occurrence(
+            start_date=date(2026, 1, 31), frequency="monthly",
+            after=date(2026, 3, 31),
+        ) == date(2026, 4, 30)
+        # After Apr 30: should be MAY 31, not May 30.
+        assert gb._next_occurrence(
+            start_date=date(2026, 1, 31), frequency="monthly",
+            after=date(2026, 4, 30),
+        ) == date(2026, 5, 31)
+        # 12 months later: should be Jan 31 of the next year.
+        assert gb._next_occurrence(
+            start_date=date(2026, 1, 31), frequency="monthly",
+            after=date(2026, 12, 31),
+        ) == date(2027, 1, 31)
+
+    def test_yearly_leap_day_does_not_drift(self, scheduled_book):
+        """A yearly schedule starting Feb 29 (leap day) must stay on
+        Feb 29 in subsequent leap years, even though intervening
+        non-leap years clamp to Feb 28."""
+        gb = GnuCashBook(str(scheduled_book))
+        # 2024 is a leap year; next yearly from Feb 29, 2024 falls on
+        # Feb 28 in 2025/2026/2027 (clamped) but recovers to Feb 29
+        # in 2028 (next leap year).
+        assert gb._next_occurrence(
+            start_date=date(2024, 2, 29), frequency="yearly",
+            after=date(2027, 6, 1),
+        ) == date(2028, 2, 29)
+
 
 # ── Integration ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

\`_next_occurrence\` chained \`occurrence += relativedelta(months=1)\`. \`relativedelta\` clamps to month-end on day-of-month overflow, so a monthly schedule starting Jan 31 advanced as Jan 31 → Feb 28 (clamped) → Mar 28 (drift!) → Apr 28 → ... The schedule lost its 31st-of-month intent permanently after the first February.

Anchoring to \`start_date + (n × period)\` lets relativedelta clamp from the original anchor each time: Feb 28 → Mar 31 → Apr 30 → May 31 — preserving the bookkeeper's "31st of every month, falling back to month-end where needed" intent. Same fix handles yearly Feb 29 leap-day recovery.

Severity: high (silent semantic drift on a recurring date helper).

## Test plan

- [x] Regression: monthly schedule from Jan 31 → period 2 is Mar 31, period 3 Apr 30, period 4 May 31, period 12 Jan 31 of next year
- [x] Regression: yearly schedule from Feb 29 (leap day) → recovers to Feb 29 of next leap year (2028 from 2024)
- [x] Existing 8 \`TestNextOccurrence\` tests pass unchanged
- [x] Full \`test_scheduled.py\` (37 tests) passes