### PR TITLE
fix(backup): microsecond filenames + lock the auto-backup gate

### DIFF
--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -27,6 +27,7 @@ import json
 import logging
 import re
 import sqlite3
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -72,12 +73,15 @@ _AUTO_STAGE_NAMES: frozenset[str] = frozenset(s.name for s in _AUTO_STAGES)
 _ALL_STAGE_NAMES: frozenset[str] = _AUTO_STAGE_NAMES | {_MANUAL_STAGE_NAME}
 
 # Filename schema:
-#   {book_stem}-{YYYYmmddTHHMMSS}-{stage}[-{label}].gnucash
-# Timestamp is UTC, colons stripped for filesystem safety. Label is
-# sanitized to [A-Za-z0-9_-].
+#   {book_stem}-{YYYYmmddTHHMMSSffffff}-{stage}[-{label}].gnucash
+# Timestamp is UTC, colons stripped for filesystem safety. The
+# microsecond suffix (``ffffff``) is optional in the regex so legacy
+# second-resolution backups continue to parse — files written by
+# v1.2.1 and earlier had no microseconds. New writes always emit the
+# 20-digit form. Label is sanitized to [A-Za-z0-9_-].
 _FILENAME_RE = re.compile(
     r"^(?P<stem>.+)"
-    r"-(?P<ts>\d{8}T\d{6})"
+    r"-(?P<ts>\d{8}T\d{6}(?:\d{6})?)"
     r"-(?P<stage>[a-z]+)"
     r"(?:-(?P<label>[A-Za-z0-9_-]+))?"
     r"\.gnucash$"
@@ -102,15 +106,26 @@ def _now_utc() -> datetime:
 
 
 def _format_ts(ts: datetime) -> str:
-    """Format a UTC timestamp for filenames (colons stripped)."""
-    return ts.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    """Format a UTC timestamp for filenames (colons stripped).
+
+    Includes microseconds. Pre-fix, second-resolution timestamps meant
+    two ``create_backup`` calls within the same second produced the
+    same filename — and SQLite's ``connection.backup(dest_conn)``
+    truncates an existing dest, so the second snapshot silently
+    overwrote the first. Microsecond resolution makes collisions
+    practically impossible; the explicit ``Path.exists()`` check in
+    ``create_backup`` is the second line of defense.
+    """
+    return ts.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
 
 
 def _parse_ts(ts_str: str) -> datetime:
-    """Inverse of ``_format_ts``. Returns tz-aware UTC datetime."""
-    return datetime.strptime(ts_str, "%Y%m%dT%H%M%S").replace(
-        tzinfo=timezone.utc
-    )
+    """Inverse of ``_format_ts``. Accepts both new (microsecond) and
+    legacy (second) resolution so v1.2.1-and-earlier backup files
+    continue to parse. Returns tz-aware UTC datetime.
+    """
+    fmt = "%Y%m%dT%H%M%S%f" if len(ts_str) > 15 else "%Y%m%dT%H%M%S"
+    return datetime.strptime(ts_str, fmt).replace(tzinfo=timezone.utc)
 
 
 def _describe_age(ts: datetime, reference: datetime | None = None) -> str:
@@ -224,6 +239,15 @@ class BackupMixin:
     # decided this process is up-to-date.
     _backup_checked_in_process: bool = False
 
+    # Serialize the read+write of ``_backup_checked_in_process`` across
+    # threads. Without this, two simultaneous "first writes" of the
+    # session both pass the gate and both call ``create_backup`` —
+    # second-resolution filenames could collide, and the second backup
+    # would silently overwrite the first. The standard MCP deployment
+    # is single-threaded, so this is defense-in-depth for any future
+    # multi-worker deployment.
+    _backup_check_lock: threading.Lock = threading.Lock()
+
     # ── Paths ────────────────────────────────────────────────────
 
     def _backups_dir(self) -> Path:
@@ -287,6 +311,18 @@ class BackupMixin:
             filename += f"-{safe_label}"
         filename += ".gnucash"
         backup_path = backups_dir / filename
+
+        # Defense in depth against filename collisions. The microsecond
+        # resolution in ``_format_ts`` makes this practically
+        # impossible, but ``sqlite3.connect(path)`` would happily
+        # truncate an existing file — so refuse to overwrite explicitly
+        # rather than silently destroy a prior snapshot.
+        if backup_path.exists():
+            raise RuntimeError(
+                f"Backup path already exists, refusing to overwrite: "
+                f"{backup_path}. This indicates a clock-resolution "
+                f"collision; retry."
+            )
 
         # Perform the SQLite online backup. We open the source via
         # piecash's readonly context (no write lock on the live book)
@@ -474,11 +510,18 @@ class BackupMixin:
         ``_backup_checked_in_process`` gates it — but the audit
         decorator already enforces that contract at its layer.
         """
-        if self._backup_checked_in_process:
-            return
-        # Flag BEFORE running so a raise here won't cause the audit
-        # hook to retry on every subsequent write of the process.
-        self._backup_checked_in_process = True
+        # Serialize the gate so concurrent first-writes can't both
+        # pass the check before either flips the flag. Without the
+        # lock, two threads racing on the very first write would each
+        # call ``create_backup`` — and with file-level naming they'd
+        # collide on the same path.
+        with self._backup_check_lock:
+            if self._backup_checked_in_process:
+                return
+            # Flag BEFORE running so a raise here won't cause the
+            # audit hook to retry on every subsequent write of the
+            # process.
+            self._backup_checked_in_process = True
 
         try:
             backups_dir = self._backups_dir()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -124,6 +124,67 @@ class TestCreateBackup:
         assert "review" in label
         assert "2026" in label
 
+    def test_two_backups_in_same_second_do_not_collide(
+        self, test_book: Path,
+    ):
+        """Pre-fix, ``_format_ts`` had second resolution. Two
+        ``create_backup`` calls within the same second produced the
+        same filename and ``sqlite3.connect(path).backup(...)``
+        truncated the existing file — second snapshot silently
+        overwrote the first.
+
+        Microsecond resolution makes collisions practically
+        impossible. The ``Path.exists()`` precheck is the second line
+        of defense if a clock-resolution collision somehow occurs.
+        """
+        book = GnuCashBook(str(test_book))
+        r1 = book.create_backup(stage="manual", label="rapid-1")
+        r2 = book.create_backup(stage="manual", label="rapid-2")
+        # Different filenames even though wall-clock seconds match
+        assert r1["path"] != r2["path"]
+        # Both files exist on disk
+        assert Path(r1["path"]).exists()
+        assert Path(r2["path"]).exists()
+
+    def test_create_backup_refuses_to_overwrite(self, test_book: Path):
+        """If a backup file with the target name already exists (e.g.,
+        clock-resolution collision or pathological monkeypatched
+        time), ``create_backup`` raises rather than silently
+        truncating the prior snapshot."""
+        book = GnuCashBook(str(test_book))
+        fixed_ts = datetime(2026, 5, 1, 12, 0, 0, 123456, tzinfo=timezone.utc)
+        with patch(
+            "gnucash_mcp.book.backup._now_utc", return_value=fixed_ts,
+        ):
+            r1 = book.create_backup(stage="manual", label="first")
+            assert Path(r1["path"]).exists()
+            # Same wall-clock = same filename = refusal.
+            with pytest.raises(RuntimeError, match="refusing to overwrite"):
+                book.create_backup(stage="manual", label="first")
+
+    def test_legacy_second_resolution_filenames_still_parse(
+        self, test_book: Path,
+    ):
+        """Pre-fix backup files (14-digit second-resolution timestamp)
+        must still be readable by ``list_backups`` after the upgrade
+        to microsecond filenames. Otherwise users would lose
+        visibility on their pre-upgrade backups."""
+        backups_dir = test_book.parent / f"{test_book.name}.mcp" / "backups"
+        backups_dir.mkdir(parents=True, exist_ok=True)
+        # Write a fake legacy-format file. Content doesn't matter for
+        # this listing test (list_backups only stats the file).
+        legacy = backups_dir / f"{test_book.stem}-20260101T120000-manual.gnucash"
+        legacy.write_bytes(b"fake")
+
+        book = GnuCashBook(str(test_book))
+        listed = book.list_backups()
+        legacy_entry = next(
+            (e for e in listed if Path(e["path"]).name == legacy.name),
+            None,
+        )
+        assert legacy_entry is not None, "Legacy filename failed to parse"
+        assert legacy_entry["stage"] == "manual"
+
     def test_label_sanitize_helper_edge_cases(self):
         """Low-level helper: empty / all-unsafe inputs become None."""
         assert _sanitize_label(None) is None


### PR DESCRIPTION
## Summary

Two compounding silent-failure modes in the backup module:

1. **Filename collision (high).** \`_format_ts\` produced second-resolution timestamps. Two backups in the same wall-clock second produced the same filename, and \`sqlite3.connect(path).backup(dest)\` truncates the dest — so the second snapshot silently overwrote the first.

2. **Auto-backup gate race (critical-by-design).** \`_backup_checked_in_process\` was read+set without a lock. Two simultaneous "first writes" both passed the gate and both called \`create_backup\` — then collided on filename per (1).

## Fixes

- Microsecond-resolution filenames (\`YYYYmmddTHHMMSSffffff\`)
- \`_FILENAME_RE\` + \`_parse_ts\` accept both new (20-digit) and legacy (14-digit) formats — pre-upgrade backups still list correctly
- \`Path.exists()\` precheck in \`create_backup\` — refuse to overwrite explicitly
- \`threading.Lock\` around the auto-backup gate

## Test plan

- [x] Regression: two rapid backups in same second land as distinct files
- [x] Regression: monkeypatched same-microsecond timestamp raises \`refusing to overwrite\` rather than silently truncating
- [x] Regression: legacy 14-digit timestamp filenames parse via \`list_backups\`
- [x] Existing 19 backup tests pass unchanged
- [x] Live: three back-to-back \`create_backup\` calls on copy of lin.wei book produce three distinct files