### PR TITLE
feat(backup): surface auto-backup status in get_book_summary

### DIFF
--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -185,6 +185,72 @@ def _write_state(backups_dir: Path, state: dict[str, datetime]) -> None:
     tmp.replace(path)
 
 
+# ── Auto-backup attempt status (separate file) ───────────────────────
+#
+# Decoupled from .state.json on purpose: the per-stage timestamp file
+# advances only on successful backup, so it can't tell us "we tried
+# 6 hours ago and it failed." A separate ``.last_attempt.json``
+# captures every attempt — success or failure — so get_book_summary
+# can surface backup-chain breaks the bookkeeper would otherwise
+# discover only by reading debug logs.
+
+
+def _attempt_path(backups_dir: Path) -> Path:
+    return backups_dir / ".last_attempt.json"
+
+
+def _read_attempt_status(backups_dir: Path) -> dict | None:
+    """Return ``{status, reason, at}`` for the most recent auto-backup
+    attempt, or None if no attempt has ever been recorded.
+
+    ``status`` is ``"ok"`` or ``"failed"``. ``reason`` is the
+    exception string for failures (None on success). ``at`` is a
+    tz-aware UTC datetime.
+    """
+    path = _attempt_path(backups_dir)
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    try:
+        at = datetime.fromisoformat(data["at"])
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=timezone.utc)
+    except (KeyError, TypeError, ValueError):
+        return None
+    status = data.get("status")
+    if status not in ("ok", "failed"):
+        return None
+    return {
+        "status": status,
+        "reason": data.get("reason"),
+        "at": at,
+    }
+
+
+def _write_attempt_status(
+    backups_dir: Path,
+    status: str,
+    reason: str | None,
+    at: datetime,
+) -> None:
+    """Persist the most recent auto-backup attempt result. Atomic
+    temp+rename, same pattern as ``_write_state``.
+    """
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "status": status,
+        "reason": reason,
+        "at": at.astimezone(timezone.utc).isoformat(),
+    }
+    path = _attempt_path(backups_dir)
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+    tmp.replace(path)
+
+
 # ── Filename inspection ──────────────────────────────────────────────
 
 
@@ -480,10 +546,10 @@ class BackupMixin:
         # hook to retry on every subsequent write of the process.
         self._backup_checked_in_process = True
 
+        backups_dir = self._backups_dir()
+        now = _now_utc()
         try:
-            backups_dir = self._backups_dir()
             state = _read_state(backups_dir)
-            now = _now_utc()
 
             # Identify due stages. Process in priority order (monthly
             # > weekly > session) so the first "due" stage becomes the
@@ -495,6 +561,9 @@ class BackupMixin:
                     due_stages.append(s)
 
             if not due_stages:
+                # Nothing was due, so this isn't an "attempt" we need
+                # to record — skipping is the expected outcome when
+                # the chain is healthy and recent.
                 return
 
             # Take ONE backup tagged with the highest-priority due
@@ -509,8 +578,68 @@ class BackupMixin:
 
             # Prune each auto stage to its keep_last_n.
             self._prune_auto_stages()
+
+            # Record success so get_book_summary can surface a green
+            # "auto-backup ran N minutes ago" signal — and so a later
+            # failure becomes visible against the prior baseline.
+            try:
+                _write_attempt_status(backups_dir, "ok", None, now)
+            except Exception as e:
+                debug_logger.warning(
+                    f"Could not record auto-backup success status: {e}"
+                )
         except Exception as e:
+            # Failure path: the user's write is still allowed to
+            # proceed, but the bookkeeper needs to find out — pre-fix,
+            # OSError-on-disk-full was silently swallowed for weeks.
+            # We persist the failure so get_book_summary's Warnings
+            # section can surface it on the next read.
             debug_logger.warning(f"Auto-backup skipped: {e}")
+            try:
+                _write_attempt_status(
+                    backups_dir, "failed", str(e), now,
+                )
+            except Exception as write_err:
+                debug_logger.warning(
+                    f"Could not record auto-backup failure status: "
+                    f"{write_err}"
+                )
+
+    def get_backup_health(self) -> dict:
+        """Return a small dict describing the auto-backup chain's
+        recent state. Read from disk on demand — does not require an
+        open book session.
+
+        Returns:
+            ``{
+                "last_attempt": {"status", "reason", "at"} | None,
+                "newest_backup_at": datetime | None,
+                "newest_backup_age_days": int | None,
+            }``
+        """
+        backups_dir = self._backups_dir()
+        attempt = _read_attempt_status(backups_dir)
+        try:
+            entries = self.list_backups()
+        except Exception:
+            entries = []
+        newest_at: datetime | None = None
+        newest_age_days: int | None = None
+        if entries:
+            # ``list_backups`` returns newest-first.
+            try:
+                ts_iso = entries[0]["timestamp"]
+                newest_at = datetime.fromisoformat(ts_iso)
+                if newest_at.tzinfo is None:
+                    newest_at = newest_at.replace(tzinfo=timezone.utc)
+                newest_age_days = (_now_utc() - newest_at).days
+            except (KeyError, TypeError, ValueError):
+                pass
+        return {
+            "last_attempt": attempt,
+            "newest_backup_at": newest_at,
+            "newest_backup_age_days": newest_age_days,
+        }
 
     def _prune_auto_stages(self) -> None:
         """Internal: prune every auto stage to its configured

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -909,11 +909,51 @@ class CoreMixin:
             except Exception:
                 pass
 
+        # ── 6. Backup health ──
+        # Surface auto-backup chain breaks. The single failure mode
+        # this server most fears is data loss; an auto-backup that has
+        # been silently failing for weeks turns into "you have no
+        # recovery option" the day the book corrupts. Pre-fix, the
+        # debug log was the only place this surfaced — and the
+        # bookkeeper doesn't read debug logs. We render the warning
+        # right next to integrity issues because backup health is
+        # itself a data-safety concern.
+        backup_health: list[str] = []
+        get_health = getattr(self, "get_backup_health", None)
+        if get_health is not None:
+            try:
+                health = get_health()
+                attempt = health.get("last_attempt")
+                if attempt and attempt.get("status") == "failed":
+                    age = today - attempt["at"].date()
+                    age_str = (
+                        f"{age.days} day{'s' if age.days != 1 else ''} ago"
+                        if age.days >= 1 else "today"
+                    )
+                    reason = attempt.get("reason") or "unknown"
+                    backup_health.append(
+                        f"Auto-backup failing: {reason} "
+                        f"(last attempt {age_str})"
+                    )
+                # No backup file in 30+ days: chain is stale even if
+                # the attempt status is fine. Could be that nothing
+                # has been due (well-spaced backups + recent prune)
+                # or the directory was emptied externally.
+                newest_age = health.get("newest_backup_age_days")
+                if newest_age is not None and newest_age >= 30:
+                    backup_health.append(
+                        f"No backup in {newest_age} days (most recent "
+                        f"snapshot is older than 1 month)"
+                    )
+            except Exception:
+                pass
+
         # Integrity tier (imbalance/orphan) leads — actual data
         # corruption that calls every other number into question.
         # The remaining categories follow in operational urgency.
         return (
             integrity
+            + backup_health
             + low_cash
             + overdue_invoices
             + overdue_scheduled

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -18,8 +18,10 @@ from gnucash_mcp.book import GnuCashBook
 from gnucash_mcp.book.backup import (
     _AUTO_STAGES,
     _FILENAME_RE,
+    _read_attempt_status,
     _read_state,
     _sanitize_label,
+    _write_attempt_status,
     _write_state,
 )
 
@@ -341,6 +343,66 @@ class TestMaybeAutoBackup:
         # All three timestamps equal (same moment)
         timestamps = list(state.values())
         assert timestamps[0] == timestamps[1] == timestamps[2]
+
+    def test_records_success_status(self, test_book: Path):
+        """A successful auto-backup writes ``status=ok`` to
+        ``.last_attempt.json`` so get_book_summary can surface it."""
+        book = GnuCashBook(str(test_book))
+        book._maybe_auto_backup()
+
+        attempt = _read_attempt_status(book._backups_dir())
+        assert attempt is not None
+        assert attempt["status"] == "ok"
+        assert attempt["reason"] is None
+
+    def test_records_failure_status_when_swallowed(
+        self, test_book: Path,
+    ):
+        """A failed auto-backup must not raise (the user's write
+        proceeds) BUT the failure must be persisted so the
+        bookkeeper finds out via get_book_summary's warnings —
+        not via reading debug logs weeks later. Pre-fix, OSError
+        was logged-and-forgotten, leaving the bookkeeper blind."""
+        book = GnuCashBook(str(test_book))
+
+        with patch.object(
+            book, "create_backup",
+            side_effect=OSError("disk full"),
+        ):
+            book._maybe_auto_backup()  # swallows
+
+        attempt = _read_attempt_status(book._backups_dir())
+        assert attempt is not None
+        assert attempt["status"] == "failed"
+        assert "disk full" in (attempt["reason"] or "")
+
+    def test_get_backup_health_reports_failure(self, test_book: Path):
+        """``get_backup_health`` exposes the persisted attempt
+        status, the structure get_book_summary reads."""
+        book = GnuCashBook(str(test_book))
+        with patch.object(
+            book, "create_backup", side_effect=OSError("readonly fs"),
+        ):
+            book._maybe_auto_backup()
+
+        health = book.get_backup_health()
+        assert health["last_attempt"]["status"] == "failed"
+        assert "readonly fs" in health["last_attempt"]["reason"]
+        # No backup file → newest is None.
+        assert health["newest_backup_at"] is None
+        assert health["newest_backup_age_days"] is None
+
+    def test_get_backup_health_reports_success_and_freshness(
+        self, test_book: Path,
+    ):
+        """Healthy state: success status + recent newest-backup age."""
+        book = GnuCashBook(str(test_book))
+        book._maybe_auto_backup()
+        health = book.get_backup_health()
+        assert health["last_attempt"]["status"] == "ok"
+        assert health["newest_backup_at"] is not None
+        # Created in this test run → 0 or close.
+        assert health["newest_backup_age_days"] in (0, 1)
 
     def test_promotes_to_highest_due_stage(self, test_book: Path):
         """Session done recently, weekly and monthly overdue → the

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -284,6 +284,28 @@ class TestGetBookSummary:
         result = gc_book.get_book_summary()
         assert "Budgets: 1" in result
 
+    def test_warns_on_failed_auto_backup(self, test_book: Path):
+        """When auto-backup is failing, get_book_summary surfaces it
+        in the Warnings section. Pre-fix, OSError was swallowed and
+        the bookkeeper had no visibility into chain breaks.
+        """
+        from unittest.mock import patch
+
+        gc_book = GnuCashBook(str(test_book))
+
+        # Force the auto-backup attempt to fail and persist that
+        # status to disk.
+        with patch.object(
+            gc_book, "create_backup",
+            side_effect=OSError("disk quota exceeded"),
+        ):
+            gc_book._maybe_auto_backup()
+
+        result = gc_book.get_book_summary()
+        assert "Warnings" in result
+        assert "Auto-backup failing" in result
+        assert "disk quota exceeded" in result
+
 
 class TestGetBookSummaryReconciliation:
     """Reconciliation section in get_book_summary.


### PR DESCRIPTION
## Summary

Pre-fix, \`_maybe_auto_backup\` swallowed every exception and only logged to the debug log. The bookkeeper's worst day is the day they discover the backup chain has been silently broken for two weeks — exactly the failure mode this module exists to prevent.

Now every auto-backup attempt is persisted to \`.last_attempt.json\`, and \`get_book_summary\` reads it via a new \`BackupMixin.get_backup_health()\` accessor. Two warnings render in the Warnings section right after data integrity issues:

- \`Auto-backup failing: <reason> (last attempt N days ago)\` — fires when the persisted attempt status is \`failed\`
- \`No backup in N days (most recent snapshot is older than 1 month)\` — fires when no backup file is younger than 30 days

Severity: critical (closes the silent-failure window on the project's most-trusted seatbelt).

## Test plan

- [x] Regression: \`_maybe_auto_backup\` records \`status=ok\` on success
- [x] Regression: \`_maybe_auto_backup\` records \`status=failed\` + reason on swallowed OSError
- [x] Regression: \`get_backup_health\` exposes both attempt status and newest-backup freshness
- [x] Integration: \`test_warns_on_failed_auto_backup\` — \`get_book_summary\` includes the failure warning
- [x] Live: forced backup failure on copy of lin.wei book renders as first warning in \`get_book_summary\` output
- [x] Existing 19 backup tests pass unchanged