### PR TITLE
fix(audit): stage before-state for budget + scheduled mutations

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -602,6 +602,25 @@ class BudgetsMixin:
 
             periods = self._resolve_periods(budget, period)
 
+            # Stage prior amounts (per period) so the audit log can
+            # render before/after diffs. Without this, the bookkeeper
+            # sees only the new amount and has no way to verify what
+            # changed.
+            prior_amounts: dict = {}
+            for p in periods:
+                try:
+                    existing = budget.amounts(
+                        account=acct, period_num=p
+                    )
+                    prior_amounts[p] = str(existing.amount)
+                except KeyError:
+                    prior_amounts[p] = None
+            self._stage_audit_before({
+                "budget_name": budget_name,
+                "account": acct.fullname,
+                "prior_amounts": prior_amounts,
+            })
+
             # Convert Decimal to num/denom for direct inserts
             amount_denom = 100
             amount_num = int(amount_decimal * amount_denom)
@@ -864,6 +883,18 @@ class BudgetsMixin:
                 raise ValueError(f"Budget not found: {name}")
 
             from piecash.budget import Budget
+
+            # Stage budget snapshot for the audit log BEFORE delete.
+            # Without this, the audit log shows only "deleted budget X"
+            # — the bookkeeper can't tell what amounts/periods were
+            # lost. Capture the small set of facts that can't be
+            # recovered after the delete: name, num_periods, and how
+            # many account-amount rows existed.
+            self._stage_audit_before({
+                "name": budget.name,
+                "num_periods": budget.num_periods,
+                "amount_count": len(list(budget.amounts)),
+            })
 
             all_budget_guids = [
                 row[0]

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -705,6 +705,17 @@ class SchedulingMixin:
                     f"Scheduled transaction not found: {guid}"
                 )
 
+            # Stage prior state for the audit log so the bookkeeper
+            # can see what changed (enable/disable; end-date set/clear).
+            # Without this, the log only knows the new state.
+            self._stage_audit_before({
+                "name": sx.name,
+                "enabled": bool(sx.enabled),
+                "end_date": (
+                    sx.end_date.isoformat() if sx.end_date else None
+                ),
+            })
+
             if enabled is not None:
                 sx.enabled = 1 if enabled else 0
 
@@ -738,6 +749,16 @@ class SchedulingMixin:
                 raise ValueError(
                     f"Scheduled transaction not found: {guid}"
                 )
+
+            # Stage SX snapshot for the audit log BEFORE delete so the
+            # bookkeeper can recover the schedule's identity from the
+            # log if the delete was a mistake. _sx_to_dict captures
+            # frequency / start_date / end_date / instance_count.
+            try:
+                self._stage_audit_before(self._sx_to_dict(sx))
+            except Exception:
+                # Audit staging must never block the delete.
+                self._stage_audit_before({"name": sx.name})
 
             from piecash.core.transaction import ScheduledTransaction
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -849,6 +849,100 @@ def _fmt_entry_create(entry: dict) -> list[str]:
     ]
 
 
+# ── Budget handlers ────────────────────────────────────────────────
+
+
+def _fmt_budget_update(entry: dict) -> list[str]:
+    """``set_budget_amount`` is logged as ``budget UPDATE``. Renders
+    the per-period before/after diff captured by the staged
+    ``prior_amounts`` map."""
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    budget_name = params.get("budget_name", before.get("budget_name", ""))
+    account = params.get("account", before.get("account", ""))
+    new_amount = params.get("amount", "")
+
+    lines = [
+        f"{time_part}  UPDATE BUDGET",
+        f'{_INDENT}"{budget_name}"  account: {account}',
+    ]
+    prior = before.get("prior_amounts") or {}
+    if prior:
+        # Show before/after per period. ``prior_amounts`` is keyed by
+        # period number; sort numerically so the human reader sees
+        # period 0, 1, 2, … in order.
+        for p in sorted(prior, key=lambda k: int(k) if str(k).isdigit() else 0):
+            old = prior[p]
+            old_str = old if old is not None else "(unset)"
+            lines.append(
+                f"{_INDENT}period {p}: {old_str} → {new_amount}"
+            )
+    else:
+        lines.append(f"{_INDENT}amount: {new_amount}")
+    return lines
+
+
+def _fmt_budget_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    name = before.get("name", params.get("name", ""))
+    lines = [f'{time_part}  DELETE BUDGET  "{name}"']
+    if before:
+        np = before.get("num_periods")
+        ac = before.get("amount_count")
+        if np is not None:
+            lines.append(
+                f"{_INDENT}periods: {np}  amounts removed: {ac or 0}"
+            )
+    return lines
+
+
+# ── Scheduled-transaction handlers ─────────────────────────────────
+
+
+def _fmt_scheduled_transaction_update(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    name = before.get("name", "")
+    lines = [f'{time_part}  UPDATE SCHEDULED  "{name}"']
+    if "enabled" in params and params["enabled"] is not None:
+        old = before.get("enabled")
+        new = bool(params["enabled"])
+        if old is not None and old != new:
+            lines.append(f"{_INDENT}enabled: {old} → {new}")
+        else:
+            lines.append(f"{_INDENT}enabled: {new}")
+    if "end_date" in params and params["end_date"] is not None:
+        old = before.get("end_date")
+        new = params["end_date"] if params["end_date"] != "" else None
+        old_str = old or "(none)"
+        new_str = new or "(cleared)"
+        if old != new:
+            lines.append(f"{_INDENT}end_date: {old_str} → {new_str}")
+    return lines
+
+
+def _fmt_scheduled_transaction_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    before = entry.get("before_state") or {}
+    name = before.get("name", "")
+    lines = [f'{time_part}  DELETE SCHEDULED  "{name}"']
+    freq = before.get("frequency")
+    start = before.get("start_date")
+    instance_count = before.get("instance_count")
+    if freq:
+        lines.append(f"{_INDENT}frequency: {freq}  start: {start}")
+    if instance_count:
+        lines.append(
+            f"{_INDENT}had run {instance_count} time"
+            f"{'s' if instance_count != 1 else ''}"
+        )
+    return lines
+
+
 # ── Dispatch table ────────────────────────────────────────────────
 #
 # Key shape: (entity_type, operation). Both in their canonical forms —
@@ -889,6 +983,10 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("bill", "DELETE"): _fmt_bill_delete,
     ("entry", "CREATE"): _fmt_entry_create,
     ("price", "DELETE"): _fmt_price_delete,
+    ("budget", "UPDATE"): _fmt_budget_update,
+    ("budget", "DELETE"): _fmt_budget_delete,
+    ("scheduled_transaction", "UPDATE"): _fmt_scheduled_transaction_update,
+    ("scheduled_transaction", "DELETE"): _fmt_scheduled_transaction_delete,
 }
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -464,6 +464,215 @@ class TestResolveEntryField:
         assert _resolve_entry_field({"timestamp": "..."}, "anything") is None
 
 
+class TestBudgetAndScheduledAuditHandlers:
+    """Audit handlers for budgets and scheduled transactions.
+
+    Pre-fix, ``_AUDIT_HANDLERS`` had no entries for ``budget`` or
+    ``scheduled_transaction``. Every UPDATE / DELETE on those entities
+    rendered as an empty string — the bookkeeper had no way to see
+    what changed. The book methods also didn't stage before-state.
+    Both gaps closed in the same commit.
+    """
+
+    def test_budget_update_renders_per_period_diff(
+        self, temp_book_path, temp_log_dir,
+    ):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "budget",
+            "operation": "update",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {
+                "budget_name": "2026 Budget",
+                "account": "Expenses:Groceries",
+                "amount": "550.00",
+            },
+            "before_state": {
+                "budget_name": "2026 Budget",
+                "account": "Expenses:Groceries",
+                "prior_amounts": {0: "500.00", 1: None},
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "UPDATE BUDGET" in rendered
+        assert '"2026 Budget"' in rendered
+        assert "Expenses:Groceries" in rendered
+        assert "period 0: 500.00 → 550.00" in rendered
+        assert "period 1: (unset) → 550.00" in rendered
+
+    def test_budget_delete_renders_snapshot(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "budget",
+            "operation": "delete",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"name": "2026 Budget"},
+            "before_state": {
+                "name": "2026 Budget",
+                "num_periods": 12,
+                "amount_count": 8,
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'DELETE BUDGET  "2026 Budget"' in rendered
+        assert "periods: 12" in rendered
+        assert "amounts removed: 8" in rendered
+
+    def test_scheduled_update_enable_toggle(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "scheduled_transaction",
+            "operation": "update",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"guid": "abcdef01", "enabled": False},
+            "before_state": {
+                "name": "Monthly Rent",
+                "enabled": True,
+                "end_date": None,
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'UPDATE SCHEDULED  "Monthly Rent"' in rendered
+        assert "enabled: True → False" in rendered
+
+    def test_scheduled_update_end_date_clear(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "scheduled_transaction",
+            "operation": "update",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"guid": "abcdef01", "end_date": ""},
+            "before_state": {
+                "name": "Monthly Rent",
+                "enabled": True,
+                "end_date": "2026-12-31",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "end_date: 2026-12-31 → (cleared)" in rendered
+
+    def test_scheduled_delete_includes_history(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "scheduled_transaction",
+            "operation": "delete",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"guid": "abcdef01"},
+            "before_state": {
+                "name": "Monthly Rent",
+                "frequency": "monthly",
+                "start_date": "2026-01-01",
+                "instance_count": 4,
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'DELETE SCHEDULED  "Monthly Rent"' in rendered
+        assert "frequency: monthly  start: 2026-01-01" in rendered
+        assert "had run 4 times" in rendered
+
+
+class TestBudgetAndScheduledStaging:
+    """Verify the book methods actually stage before-state.
+
+    The audit handler tests above use synthetic entries to lock the
+    rendering contract; these tests run the real book methods and
+    assert that ``_consume_audit_before`` returns the expected staged
+    dict.
+    """
+
+    def test_set_budget_amount_stages_prior_amounts(self, budget_book):
+        from gnucash_mcp.book import GnuCashBook
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="2026 B", year=2026, num_periods=12)
+        # Initial set populates period 0
+        book.set_budget_amount(
+            budget_name="2026 B",
+            account="Expenses:Groceries",
+            amount="500",
+            period=0,
+        )
+        # Overwrite — staged before-state should carry the prior 500
+        book.set_budget_amount(
+            budget_name="2026 B",
+            account="Expenses:Groceries",
+            amount="600",
+            period=0,
+        )
+        before = book._consume_audit_before()
+        assert before is not None
+        assert before["account"] == "Expenses:Groceries"
+        # period key may be int or str depending on dict round-trip
+        prior = before["prior_amounts"]
+        # The prior amount before this last set was 500
+        assert any(
+            (str(v) == "500" or str(v) == "500.00")
+            for v in prior.values()
+        ), f"expected prior 500 in {prior}"
+
+    def test_delete_budget_stages_snapshot(self, budget_book):
+        from gnucash_mcp.book import GnuCashBook
+        book = GnuCashBook(str(budget_book))
+        book.create_budget(name="To Delete", year=2026, num_periods=12)
+        book.set_budget_amount(
+            budget_name="To Delete",
+            account="Expenses:Groceries",
+            amount="100",
+            period=0,
+        )
+        book._consume_audit_before()  # clear any staged state
+        book.delete_budget(name="To Delete")
+        before = book._consume_audit_before()
+        assert before is not None
+        assert before["name"] == "To Delete"
+        assert before["num_periods"] == 12
+        assert before["amount_count"] >= 1
+
+    def test_update_scheduled_stages_prior_state(self, scheduled_book):
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "100"},
+                {"account": "Assets:Checking", "amount": "-100"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb._consume_audit_before()  # clear staged state from create
+        gb.update_scheduled_transaction(sx["guid"], enabled=False)
+        before = gb._consume_audit_before()
+        assert before is not None
+        assert before["name"] == "Rent"
+        assert before["enabled"] is True
+
+    def test_delete_scheduled_stages_snapshot(self, scheduled_book):
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="To Delete",
+            description="x",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "50"},
+                {"account": "Assets:Checking", "amount": "-50"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        gb._consume_audit_before()
+        gb.delete_scheduled_transaction(sx["guid"])
+        before = gb._consume_audit_before()
+        assert before is not None
+        assert before["name"] == "To Delete"
+        assert before["frequency"] == "monthly"
+
+
 class TestDispatchTableDegradation:
     """Unknown (entity_type, operation) pairs must degrade gracefully.
 


### PR DESCRIPTION
## Summary

\`_AUDIT_HANDLERS\` had no entries for \`budget\` or \`scheduled_transaction\` — every UPDATE/DELETE rendered as an empty string. Book methods also didn't stage before-state. The bookkeeper was operating blind on the two areas they edit most often outside of transactions.

Both gaps closed:

- \`set_budget_amount\` stages \`prior_amounts\` (period → prior amount or None)
- \`delete_budget\` stages \`{name, num_periods, amount_count}\`
- \`update_scheduled_transaction\` stages \`{name, enabled, end_date}\`
- \`delete_scheduled_transaction\` stages the full \`_sx_to_dict\` output

Four new audit handlers render the diffs with the same \`"old → new"\` style as account/customer/vendor.

Severity: high (audit log was unreviewable for these operations).

## Test plan

- [x] Handler rendering tests: BUDGET update with per-period diff, BUDGET delete, SCHEDULED enable-toggle, SCHEDULED end-date clear, SCHEDULED delete with history
- [x] Staging tests: each book method actually stages the expected dict via \`_consume_audit_before\`
- [x] Existing 41 logging tests pass unchanged
- [x] Full suite: 1056 passed (same 2 pre-existing TestDeletePrice failures unrelated)