### PR TITLE
refactor(base): extract _is_market_price predicate

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -48,6 +48,26 @@ def _to_date(dt: date | datetime) -> date:
     return dt
 
 
+def _is_market_price(price) -> bool:
+    """True iff ``price`` is a real market quote, not a piecash auto-
+    placeholder.
+
+    On any cross-currency transaction, piecash auto-creates a Price
+    row with ``type='transaction'`` capturing the effective rate of
+    that one transaction. These are bookkeeping artifacts, NOT
+    user-supplied market quotes — every helper that walks
+    ``book.prices`` to value holdings or pick exchange rates must
+    skip them, or they shadow real quotes the user has on file.
+
+    Centralized here so the four call sites (core's ``_rates_as_of``
+    and ``_collect_warnings``, reporting's ``_latest_market_rates``,
+    and business's ``_find_exchange_rate``) all answer the question
+    the same way. Adding ``"transaction-currency"`` or any future
+    placeholder type only needs one change.
+    """
+    return getattr(price, "type", None) != "transaction"
+
+
 def _to_decimal(value) -> Decimal:
     """Safe Decimal construction for user-supplied monetary values.
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 import piecash
 
 from gnucash_mcp.book._base import (
+    _is_market_price,
     _to_date,
     _to_decimal,
     _verify_composite_write,
@@ -410,7 +411,7 @@ class BusinessMixin:
 
         for p in book.prices:
             # Skip piecash's auto-created post-invoice default rates.
-            if p.type == "transaction":
+            if not _is_market_price(p):
                 continue
 
             p_date = _to_date(p.date)

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -34,6 +34,7 @@ from gnucash_mcp.book._base import (
     _account_to_compact_line,
     _account_to_dict,
     _guid_prefix_map,
+    _is_market_price,
     _split_to_compact_dict,
     _split_to_dict,
     _to_decimal,
@@ -256,7 +257,7 @@ class CoreMixin:
         for p in book.prices:
             if p.currency != default_currency:
                 continue
-            if p.type == "transaction":
+            if not _is_market_price(p):
                 continue
             p_date = p.date
             if hasattr(p_date, "date") and callable(p_date.date):
@@ -815,7 +816,7 @@ class CoreMixin:
             cutoff = today - timedelta(days=self._STALE_PRICE_DAYS)
             by_commodity_latest: dict[str, date] = {}
             for p in book.prices:
-                if p.type == "transaction":
+                if not _is_market_price(p):
                     continue
                 p_date = p.date
                 if hasattr(p_date, "date") and callable(p_date.date):

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -26,7 +26,7 @@ from decimal import Decimal, InvalidOperation
 
 import piecash
 
-from gnucash_mcp.book._base import _to_decimal
+from gnucash_mcp.book._base import _is_market_price, _to_decimal
 from gnucash_mcp._format import _format_number
 
 # Account-type groups used across the reports. Defined at module level
@@ -250,7 +250,7 @@ class ReportingMixin:
         for p in book.prices:
             if p.currency != default_currency:
                 continue
-            if p.type == "transaction":
+            if not _is_market_price(p):
                 continue
             p_date = p.date
             if hasattr(p_date, "date") and callable(p_date.date):

--- a/tests/test_float_precision.py
+++ b/tests/test_float_precision.py
@@ -471,3 +471,39 @@ class TestScalarAmountsAcceptFloat:
             price_date=date(2026, 3, 15),
         )
         assert result["status"] in ("created", "updated")
+
+
+class TestIsMarketPriceHelper:
+    """Contract tests for the ``_is_market_price`` predicate.
+
+    Centralizing the ``type='transaction'`` check used to live as
+    inline conditionals in four places (core's ``_rates_as_of`` and
+    ``_collect_warnings``, reporting's ``_latest_market_rates``,
+    business's ``_find_exchange_rate``). All four now route through
+    this single predicate so adding any future placeholder type
+    (e.g., the auto-fx-account work later in this branch) only needs
+    one change.
+    """
+
+    def test_user_quote_is_market(self):
+        from gnucash_mcp.book._base import _is_market_price
+
+        class _Price:
+            type = "nav"
+        assert _is_market_price(_Price()) is True
+
+    def test_transaction_placeholder_is_not_market(self):
+        from gnucash_mcp.book._base import _is_market_price
+
+        class _Price:
+            type = "transaction"
+        assert _is_market_price(_Price()) is False
+
+    def test_missing_type_attr_treated_as_market(self):
+        """Defensive: an ORM row without ``type`` shouldn't be
+        silently skipped — better to value it than to under-count."""
+        from gnucash_mcp.book._base import _is_market_price
+
+        class _Price:
+            pass
+        assert _is_market_price(_Price()) is True


### PR DESCRIPTION
## Summary

The \`if p.type == "transaction": continue\` skip pattern lived in four places: \`core._rates_as_of\`, \`core._collect_warnings\`, \`reporting._latest_market_rates\`, and \`business._find_exchange_rate\`. piecash auto-creates these rows on every cross-currency transaction, and any helper that walks \`book.prices\` for valuation must skip them or they shadow real user-supplied quotes.

Centralized as \`_base._is_market_price(price)\`. Defensive: a row without a \`type\` attribute is treated as a real market quote rather than silently skipped.

Severity: medium (refactor — flagged by predecessor 4.6 + 1M-context notes; never DRY'd until now).

## Test plan

- [x] Three contract tests for the helper (user quote, transaction placeholder, missing-attr)
- [x] All four call sites converted; \`grep 'p.type == "transaction"'\` returns nothing
- [x] Full suite passes (1050 + 3 new = 1053; same 2 pre-existing TestDeletePrice failures)