### PR TITLE
fix(budgets): convert foreign-currency children to default in rollup

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -763,6 +763,23 @@ class BudgetsMixin:
                     if existing is None or len(acct_name) > len(existing):
                         rollup_map[desc.fullname] = acct_name
 
+            # Cross-currency conversion: when a budgeted account
+            # parent has children in non-default-currency commodities
+            # (e.g., USD-default book with a EUR ``Expenses:Travel``
+            # leaf), summing raw ``split.quantity`` would treat 100
+            # EUR + 100 USD as 200 in the parent's row. Use the same
+            # market-rate lookup as the reporting suite, gracefully
+            # falling back to raw quantity when reporting helpers
+            # aren't available (e.g., ``--modules budgets`` without
+            # ``reporting``).
+            factors_fn = getattr(
+                self, "_account_conversion_factors", None,
+            )
+            split_in_default = getattr(
+                self, "_split_in_default_currency", None,
+            )
+            factors = factors_fn(book) if factors_fn else None
+
             # Calculate actuals from transactions
             actuals: dict[str, Decimal] = {}
             for transaction in book.transactions:
@@ -773,7 +790,13 @@ class BudgetsMixin:
                     rollup_target = rollup_map.get(acct_name)
                     if rollup_target is None:
                         continue
-                    amount = split.quantity
+                    if factors is not None and split_in_default is not None:
+                        amount = split_in_default(
+                            split, split.account,
+                            factors.get(split.account.guid),
+                        )
+                    else:
+                        amount = Decimal(str(split.quantity))
                     if split.account.type == "EXPENSE" and amount > 0:
                         actuals[rollup_target] = actuals.get(
                             rollup_target, Decimal("0")

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -550,6 +550,115 @@ class TestGetBudgetReport:
         assert Decimal(by_acct["Expenses:Utilities"]["actual"]) == Decimal("65")
         assert Decimal(by_acct["Expenses:Utilities:Electric"]["actual"]) == Decimal("95")
 
+    def test_parent_rollup_converts_foreign_currency_children(
+        self, budget_book: Path,
+    ):
+        """When a budgeted parent has foreign-currency descendants,
+        the rollup must convert their actuals to the book default
+        currency via the latest market rate. Pre-fix, raw
+        ``split.quantity`` was summed — 100 EUR + 100 USD became 200
+        in the parent's row.
+
+        Reuses the budget_book fixture (USD-default), adds a EUR
+        commodity, a EUR-denominated ``Expenses:Travel:Europe`` leaf,
+        a USD-default-currency ``Expenses:Travel:US`` sibling, plus
+        a price for EUR (1 EUR = 1.10 USD). Then a 100 EUR Europe
+        spend + 100 USD US spend should roll up as 110 + 100 = 210
+        USD on the ``Travel`` parent — not 200.
+        """
+        import piecash
+        from datetime import date as _date
+        from piecash._common import GnucashException
+        from piecash import factories
+
+        gc = GnuCashBook(str(budget_book))
+        with gc.open(readonly=False) as b:
+            usd = b.default_currency
+            try:
+                eur = factories.create_currency_from_ISO("EUR")
+                b.session.add(eur)
+                b.flush()
+            except (GnucashException, Exception):
+                eur = next(
+                    (c for c in b.commodities if c.mnemonic == "EUR"), None,
+                )
+                if eur is None:
+                    raise
+
+            expenses = next(
+                a for a in b.accounts if a.fullname == "Expenses"
+            )
+            checking = next(
+                a for a in b.accounts if a.fullname == "Assets:Checking"
+            )
+
+            travel = piecash.Account(
+                name="Travel", type="EXPENSE", parent=expenses,
+                commodity=usd, placeholder=True,
+            )
+            europe = piecash.Account(
+                name="Europe", type="EXPENSE", parent=travel,
+                commodity=eur,
+            )
+            us = piecash.Account(
+                name="US", type="EXPENSE", parent=travel, commodity=usd,
+            )
+            # Price: 1 EUR = 1.10 USD (commodity=EUR, currency=USD)
+            piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2026, 1, 1),
+                value=Decimal("1.10"),
+                source="user:price", type="last",
+            )
+            b.save()
+
+            # 100 EUR Europe spend (transaction is in USD currency for
+            # the Checking side; cross-currency split has value=110 USD,
+            # quantity=100 EUR on the Europe leg)
+            piecash.Transaction(
+                currency=usd, description="Hotel in Berlin",
+                post_date=_date(2026, 1, 10),
+                splits=[
+                    piecash.Split(
+                        account=checking, value=Decimal("-110"),
+                        quantity=Decimal("-110"),
+                    ),
+                    piecash.Split(
+                        account=europe, value=Decimal("110"),
+                        quantity=Decimal("100"),  # 100 EUR
+                    ),
+                ],
+            )
+            piecash.Transaction(
+                currency=usd, description="Hotel in Boston",
+                post_date=_date(2026, 1, 15),
+                splits=[
+                    piecash.Split(
+                        account=checking, value=Decimal("-100"),
+                    ),
+                    piecash.Split(
+                        account=us, value=Decimal("100"),
+                    ),
+                ],
+            )
+            b.save()
+
+        gc.create_budget(
+            name="Travel Budget", year=2026, num_periods=12,
+        )
+        gc.set_budget_amount(
+            budget_name="Travel Budget",
+            account="Expenses:Travel", amount="500", period=0,
+        )
+        report = gc.get_budget_report(
+            compact=False,
+            budget_name="Travel Budget", period=0,
+        )
+        by_acct = {a["account"]: a for a in report["accounts"]}
+        # Parent rollup: 100 USD + (100 EUR × 1.10) = 210 USD.
+        # Pre-fix, raw quantity sum produced 200.
+        assert Decimal(by_acct["Expenses:Travel"]["actual"]) == Decimal("210")
+
     def test_report_nonexistent_budget_raises(self, budget_book: Path):
         """Reporting on nonexistent budget raises ValueError."""
         book = GnuCashBook(str(budget_book))


### PR DESCRIPTION
## Summary

\`get_budget_report\` summed raw \`split.quantity\` across descendants of a budgeted parent. A USD-default book with a EUR child of \`Expenses:Travel\` summed 100 EUR + 100 USD as 200 — silently wrong by the exchange-rate spread. The reporting suite was fixed for this in v1.2.1 (\`_split_in_default_currency\`); budgets weren't.

Now reuses the same helpers via \`getattr\`, so the conversion happens whenever the reporting module is loaded (the default).

Severity: medium (cross-currency books only; USD-only books unaffected).

## Test plan

- [x] Regression: 100 EUR + 100 USD spend with 1 EUR = 1.10 USD price rolls up as 210
- [x] Existing 32 budget tests pass unchanged
- [x] Same 2 pre-existing TestDeletePrice failures unrelated