### PR TITLE
fix(business): convert A/R quantity in pay_invoice + FX quadrant tests

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2912,44 +2912,61 @@ class BusinessMixin:
             owner_name = owner.name if owner else ""
             txn_desc = description or owner_name
 
-            # Cross-currency payment: if the payment account's commodity
-            # differs from the invoice currency, find the exchange rate
-            # from book.prices and compute the payment account's quantity.
-            # The transaction currency stays as the invoice currency, so
-            # all split ``value``s remain in invoice currency (the
-            # transaction balances in EUR for an EUR invoice); the pay
-            # account's ``quantity`` reflects the actual USD/GBP/whatever
-            # amount deposited or withdrawn.
-            exchange_rate = None
-            pay_quantity = payment_amount
-            if pay_acct.commodity != inv.currency:
-                exchange_rate = self._find_exchange_rate(
+            # Cross-currency payment: when the payment account's
+            # commodity OR the A/R/A/P account's commodity differs
+            # from the invoice currency, find the exchange rate from
+            # book.prices and convert quantity. The transaction
+            # currency stays as the invoice currency so all split
+            # ``value``s remain in invoice currency (transaction
+            # balances in EUR for an EUR invoice); each account's
+            # ``quantity`` reflects the actual amount in its own
+            # commodity.
+            #
+            # Pre-fix, ``pay_invoice`` only converted the bank-side
+            # quantity. ``post_invoice`` correctly converted the A/R
+            # side via ``_qty_for_split(post_acct, ...)``; the pay
+            # path didn't, so a USD A/R holding a EUR invoice was
+            # liquidated in EUR-as-USD on payment.
+            def _convert(amount, target_commodity):
+                """Convert invoice-currency amount to target commodity."""
+                if target_commodity == inv.currency:
+                    return amount, None
+                rate = self._find_exchange_rate(
                     book,
                     from_commodity=inv.currency,
-                    to_commodity=pay_acct.commodity,
+                    to_commodity=target_commodity,
                     as_of=parsed_date,
                 )
-                if exchange_rate is None:
+                if rate is None:
                     raise ValueError(
-                        f"Cross-currency payment requires an exchange rate: "
-                        f"invoice currency {inv.currency.mnemonic} differs "
-                        f"from payment account commodity "
-                        f"{pay_acct.commodity.mnemonic}, and no matching "
-                        f"price was found in the book for "
-                        f"{inv.currency.mnemonic}/{pay_acct.commodity.mnemonic} "
-                        f"on or near {parsed_date}. Add a price with "
+                        f"Cross-currency payment requires an exchange "
+                        f"rate: invoice currency "
+                        f"{inv.currency.mnemonic} differs from account "
+                        f"commodity {target_commodity.mnemonic}, and "
+                        f"no matching price was found in the book for "
+                        f"{inv.currency.mnemonic}/"
+                        f"{target_commodity.mnemonic} on or near "
+                        f"{parsed_date}. Add a price with "
                         f"create_price, then retry."
                     )
-                pay_quantity = (payment_amount * exchange_rate).quantize(
-                    Decimal("0.01")
+                return (
+                    (amount * rate).quantize(Decimal("0.01")),
+                    rate,
                 )
+
+            pay_quantity, exchange_rate = _convert(
+                payment_amount, pay_acct.commodity,
+            )
+            post_quantity, _post_rate = _convert(
+                payment_amount, post_acct.commodity,
+            )
 
             if is_bill:
                 # Pay vendor bill: debit A/P (positive), credit bank (negative)
                 ar_ap_split = piecash.Split(
                     account=post_acct,
                     value=payment_amount,
-                    quantity=payment_amount,
+                    quantity=post_quantity,
                     memo="",
                     action="Payment",
                 )
@@ -2964,7 +2981,7 @@ class BusinessMixin:
                 ar_ap_split = piecash.Split(
                     account=post_acct,
                     value=-payment_amount,
-                    quantity=-payment_amount,
+                    quantity=-post_quantity,
                     memo="",
                     action="Payment",
                 )

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3001,6 +3001,220 @@ class TestPayInvoice:
         fx_balance = gb.get_balance(account_name="Income:Foreign Exchange Gain/Loss")
         assert fx_balance == Decimal("90")
 
+    def _add_eur_ap_and_price(self, gb, rate_date, rate_value):
+        """Helper for vendor-bill FX tests: EUR A/P + EUR/USD price.
+
+        Mirrors ``_add_eur_ar_and_price`` but creates an A/P account
+        (PAYABLE type) so vendor-bill posting/paying can be exercised
+        in a EUR-denominated workflow.
+        """
+        import piecash
+        from datetime import date as _date
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = None
+            for c in book.commodities:
+                if c.mnemonic == "EUR":
+                    eur = c
+                    break
+            if eur is None:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+            if not any(
+                a.fullname == "Liabilities:Accounts Payable EUR"
+                for a in book.accounts
+            ):
+                liabs = next(
+                    a for a in book.accounts if a.fullname == "Liabilities"
+                )
+                book.session.add(piecash.Account(
+                    name="Accounts Payable EUR", type="PAYABLE",
+                    parent=liabs, commodity=eur,
+                ))
+            parsed = (
+                rate_date if isinstance(rate_date, _date)
+                else _date.fromisoformat(rate_date)
+            )
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd, date=parsed,
+                value=str(rate_value), source="user:test", type="nav",
+            ))
+            book.save()
+
+    def test_cross_currency_fx_gain_on_vendor_bill_payment(
+        self, business_book,
+    ):
+        """Pay-date rate LOWER than post-date rate on a vendor bill →
+        we paid LESS USD than expected → FX gain.
+
+        Post €4500 bill on Mar 10 at rate 1.12 → expense recorded as
+        $5,040. Pay on Mar 20 at rate 1.10 → only $4,950 actually
+        leaves checking. We saved $90 on the spread → gain of $90,
+        booked to Income:Foreign Exchange Gain/Loss as a credit
+        (income increases). Pre-fix, the four-quadrant FX sign
+        convention had no test for the vendor-bill side at all —
+        only customer-invoice gain/loss were covered.
+        """
+        gb = GnuCashBook(str(business_book))
+
+        self._add_eur_ap_and_price(gb, "2026-03-10", "1.12")
+        self._add_eur_ap_and_price(gb, "2026-03-20", "1.10")
+
+        gb.create_vendor(name="Berlin Vendor", currency="EUR")
+        gb.create_bill(vendor_id="000001", currency="EUR",
+                       date_opened="2026-03-10")
+        gb.add_bill_entry(bill_id="000001",
+                          account="Expenses:Office Supplies",
+                          description="EUR purchase",
+                          quantity="1", price="4500.00")
+        gb.post_invoice(invoice_id="000001",
+                        post_account="Liabilities:Accounts Payable EUR",
+                        post_date="2026-03-10")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+
+        # We paid only $4,950 from checking (vs. $5,040 expected at
+        # post-rate) → gain of $90.
+        assert Decimal(result["payment_account_amount"]) == Decimal("4950.00")
+        assert "fx_realized" in result
+        assert result["fx_realized"]["direction"] == "gain"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("90.00")
+
+        # FX Gain/Loss is credit-natural; a gain credits → stored
+        # negative.
+        fx_balance = gb.get_balance(
+            account_name="Income:Foreign Exchange Gain/Loss"
+        )
+        assert fx_balance == Decimal("-90")
+
+    def test_cross_currency_fx_loss_on_vendor_bill_payment(
+        self, business_book,
+    ):
+        """Pay-date rate HIGHER than post-date rate on a vendor bill →
+        we paid MORE USD than expected → FX loss.
+
+        Post €4500 bill on Mar 10 at rate 1.10 → expense recorded as
+        $4,950. Pay on Mar 20 at rate 1.12 → $5,040 actually leaves
+        checking. We overpaid by $90 → loss of $90, booked to
+        Income:Foreign Exchange Gain/Loss as a debit (income
+        reduced).
+        """
+        gb = GnuCashBook(str(business_book))
+
+        self._add_eur_ap_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ap_and_price(gb, "2026-03-20", "1.12")
+
+        gb.create_vendor(name="Berlin Vendor", currency="EUR")
+        gb.create_bill(vendor_id="000001", currency="EUR",
+                       date_opened="2026-03-10")
+        gb.add_bill_entry(bill_id="000001",
+                          account="Expenses:Office Supplies",
+                          description="EUR purchase",
+                          quantity="1", price="4500.00")
+        gb.post_invoice(invoice_id="000001",
+                        post_account="Liabilities:Accounts Payable EUR",
+                        post_date="2026-03-10")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+
+        assert Decimal(result["payment_account_amount"]) == Decimal("5040.00")
+        assert result["fx_realized"]["direction"] == "loss"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("90.00")
+
+        # FX loss debits the credit-natural account → stored
+        # positive.
+        fx_balance = gb.get_balance(
+            account_name="Income:Foreign Exchange Gain/Loss"
+        )
+        assert fx_balance == Decimal("90")
+
+    def test_pay_invoice_converts_ar_quantity_when_ar_currency_differs(
+        self, business_book,
+    ):
+        """When the A/R account's commodity differs from the invoice
+        currency, ``pay_invoice`` must convert the A/R-side quantity
+        the same way ``post_invoice`` does. Pre-fix, only the
+        bank-side quantity was converted; the A/R-side stayed in
+        invoice-currency units, leaving a residual balance the bank
+        had already paid for.
+
+        Setup: USD-default book, USD A/R account, EUR invoice,
+        EUR/USD = 1.10. Post a €4,500 invoice → A/R debited 4,950
+        USD. Pay €4,500 from USD checking → A/R must credit 4,950
+        USD (not 4,500), leaving the A/R balance at exactly zero.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gb = GnuCashBook(str(business_book))
+        # Add EUR commodity + price + a USD A/R account specifically.
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            try:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+                book.flush()
+            except Exception:
+                eur = next(
+                    c for c in book.commodities if c.mnemonic == "EUR"
+                )
+            assets = next(
+                a for a in book.accounts if a.fullname == "Assets"
+            )
+            book.session.add(piecash.Account(
+                name="A/R USD", type="RECEIVABLE",
+                parent=assets, commodity=usd,
+            ))
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2026, 3, 10),
+                value="1.10", source="user:test", type="nav",
+            ))
+            book.save()
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Consulting",
+            description="EUR services",
+            quantity="1", price="4500.00",
+        )
+        # Post into the USD A/R account — invoice in EUR, A/R in USD
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:A/R USD",
+            post_date="2026-03-10",
+        )
+
+        ar_after_post = gb.get_balance(account_name="Assets:A/R USD")
+        # Post correctly converts: €4500 × 1.10 = $4,950 USD debited
+        assert ar_after_post == Decimal("4950")
+
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-10",
+        )
+
+        # A/R must be ZERO after payment. Pre-fix, the A/R-side
+        # quantity stayed at -4500 (raw EUR value treated as USD on
+        # the USD-commodity account), leaving $450 floating.
+        ar_after_pay = gb.get_balance(account_name="Assets:A/R USD")
+        assert ar_after_pay == Decimal("0")
+
     def test_cross_currency_same_rate_no_fx_split(self, business_book):
         """Post and pay at the identical rate → no FX split, no FX account."""
         gb = GnuCashBook(str(business_book))


### PR DESCRIPTION
## Summary

Two changes in one branch — they share the same code path and the tests need both to lock the contract.

**1. pay_invoice now converts the A/R-side quantity.** \`post_invoice\` correctly applied \`_qty_for_split(post_acct, ar_ap_value)\` when the A/R commodity differed from the invoice currency. \`pay_invoice\` only converted the bank side. A USD A/R holding a EUR invoice was posted at \$4,950 USD but the pay path credited only €4,500 (treated as \$4,500 on the USD account), leaving \$450 floating in A/R after "full" payment.

**2. FX gain/loss sign convention now has all four quadrant tests.** Pre-fix, only \`customer-invoice gain\` and \`customer-invoice loss\` were tested. The vendor-bill side (gain/loss) had no coverage at all — the four-quadrant matrix the review flagged was actually two-of-four. All four directions now locked.

Severity: high (silent A/R drift on cross-currency books; sign convention untested for vendor side).

## Test plan

- [x] Regression: \`test_pay_invoice_converts_ar_quantity_when_ar_currency_differs\` — USD A/R + EUR invoice + EUR/USD=1.10 + €4,500 payment → A/R balance is exactly 0
- [x] FX quadrant: \`test_cross_currency_fx_gain_on_vendor_bill_payment\` — paid less USD than expected → gain credits income
- [x] FX quadrant: \`test_cross_currency_fx_loss_on_vendor_bill_payment\` — overpaid → loss debits income
- [x] All 224 existing business tests pass + 3 new = 227
- [x] Same 2 pre-existing TestDeletePrice failures unrelated