### PR TITLE
fix(review): code-review followup II — final 7 high-severity items

### DIFF
--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -399,7 +399,26 @@ class BackupMixin:
             dest_conn = sqlite3.connect(str(backup_path))
             try:
                 source_conn.backup(dest_conn)
+            except Exception:
+                # Disk-full (or any other) failure mid-copy leaves
+                # a partial/empty file at backup_path. Pre-fix the
+                # try/finally only closed the connection — the
+                # truncated file stayed on disk and would surface
+                # in ``list_backups`` as a "valid backup" until the
+                # next ``PRAGMA integrity_check`` (which only runs
+                # in the success path). Best to fail loud: close
+                # the connection, unlink the partial file, and
+                # propagate the original exception.
+                dest_conn.close()
+                try:
+                    backup_path.unlink()
+                except OSError:
+                    pass
+                raise
             finally:
+                # Idempotent: safe to call after the explicit close
+                # in the except branch — sqlite3.connection.close()
+                # is no-op on a closed connection.
                 dest_conn.close()
 
         # Verify the backup with PRAGMA integrity_check before

--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -504,6 +504,33 @@ class BackupMixin:
                 f"Must be one of: {', '.join(sorted(_ALL_STAGE_NAMES))}"
             )
 
+        # Catastrophic-footgun guard. ``keep_last_n=0`` on the
+        # manual stage with ``dry_run=False`` deletes every
+        # human-marked backup the user has ever made, including
+        # "pre-tax-filing" / "pre-irreplaceable-thing" labels they
+        # explicitly preserved. Manual backups have unlimited
+        # retention BY DESIGN — this is the project's seatbelt
+        # against data loss. Refuse to wipe them all in one call;
+        # require the caller to step through deliberately (small
+        # keep_last_n + a label filter, or use ``dry_run=True`` to
+        # see the plan first). Auto-stage zero-retention is still
+        # allowed because those have policy-driven retention and
+        # the user can always rebuild them.
+        if (
+            stage == _MANUAL_STAGE_NAME
+            and keep_last_n == 0
+            and not dry_run
+        ):
+            raise ValueError(
+                "Refusing to delete every manual backup. Manual "
+                "backups have unlimited retention by design — they "
+                "include human-marked snapshots like "
+                "'pre-tax-filing' the user explicitly preserved. "
+                "Use dry_run=True to review the plan, or pass a "
+                "non-zero keep_last_n (e.g. keep_last_n=5 to keep "
+                "the 5 most recent manual backups)."
+            )
+
         all_backups = self.list_backups()
         by_stage: dict[str, list[dict]] = {}
         for entry in all_backups:

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -29,6 +29,29 @@ from gnucash_mcp.book._base import (
 from gnucash_mcp._format import _apply_limit
 
 
+def _commodity_quantum(commodity) -> Decimal:
+    """Smallest representable unit of a commodity, as a Decimal quantum.
+
+    Pre-fix, every cross-currency conversion in this module hardcoded
+    ``Decimal("0.01")`` — implicitly assuming 2-decimal currencies
+    (USD, EUR, GBP, CNY). The hardcode silently corrupts:
+
+    - **JPY** (``fraction=1``): a ¥1,234.50 conversion would round to
+      ¥1,234.50 stored, but JPY can't represent half-yen — every
+      cross-currency JPY transaction loses the rounding direction.
+    - **BHD / KWD** (``fraction=1000``, 3 decimals): a 100.123 BHD
+      input is silently rounded to 100.12, losing 3 mils per
+      conversion.
+
+    Now derives the quantum from ``commodity.fraction`` (piecash
+    stores 100 for USD, 1 for JPY, 1000 for BHD, 10000 for shares).
+    """
+    fraction = getattr(commodity, "fraction", 100)
+    if fraction <= 1:
+        return Decimal(1)
+    return Decimal(1) / Decimal(fraction)
+
+
 def _safe_date_posted(inv):
     """Read ``inv.date_posted`` defensively.
 
@@ -2562,7 +2585,7 @@ class BusinessMixin:
                         f"create_price, then retry."
                     )
                 return (value_in_invoice_ccy * rate).quantize(
-                    Decimal("0.01")
+                    _commodity_quantum(acct.commodity)
                 )
 
             # Build transaction splits
@@ -2929,7 +2952,9 @@ class BusinessMixin:
             # path didn't, so a USD A/R holding a EUR invoice was
             # liquidated in EUR-as-USD on payment.
             def _convert(amount, target_commodity):
-                """Convert invoice-currency amount to target commodity."""
+                """Convert invoice-currency amount to target commodity,
+                quantized to the target's smallest fraction (so JPY
+                stores whole yen, BHD stores 3 decimals, etc.)."""
                 if target_commodity == inv.currency:
                     return amount, None
                 rate = self._find_exchange_rate(
@@ -2951,7 +2976,9 @@ class BusinessMixin:
                         f"create_price, then retry."
                     )
                 return (
-                    (amount * rate).quantize(Decimal("0.01")),
+                    (amount * rate).quantize(
+                        _commodity_quantum(target_commodity)
+                    ),
                     rate,
                 )
 
@@ -3036,9 +3063,12 @@ class BusinessMixin:
                         as_of=post_date_obj,
                     )
                 if rate_at_post is not None:
+                    # ``expected_at_post`` is in pay-account commodity
+                    # (we'll subtract pay_quantity from it). Quantize
+                    # to that commodity's smallest fraction.
                     expected_at_post = (
                         payment_amount * rate_at_post
-                    ).quantize(Decimal("0.01"))
+                    ).quantize(_commodity_quantum(pay_acct.commodity))
                     # ``fx_diff`` is the realized delta in the
                     # PAYMENT-ACCOUNT commodity (pay_quantity is in
                     # that commodity). Convert to the book default
@@ -3072,10 +3102,16 @@ class BusinessMixin:
                             )
                         fx_diff_default = (
                             fx_diff_pay * pay_to_default_rate
-                        ).quantize(Decimal("0.01"))
+                        ).quantize(_commodity_quantum(default_currency))
                     else:
                         fx_diff_default = fx_diff_pay
-                    if abs(fx_diff_default) >= Decimal("0.01"):
+                    # Skip booking the FX split when the realized
+                    # delta is below the smallest representable unit
+                    # in the FX account's commodity (e.g., ¥0 for
+                    # JPY, $0.01 for USD).
+                    if abs(fx_diff_default) >= _commodity_quantum(
+                        default_currency
+                    ):
                         fx_acct, fx_notice = self._get_or_create_fx_account(
                             book, fx_account=fx_account,
                         )
@@ -3149,7 +3185,9 @@ class BusinessMixin:
                         # default currency — that's the account's
                         # commodity and the unit every report uses.
                         "amount": str(
-                            abs(fx_diff_default).quantize(Decimal("0.01"))
+                            abs(fx_diff_default).quantize(
+                                _commodity_quantum(default_currency)
+                            )
                         ),
                         "currency": default_currency.mnemonic,
                         "direction": direction,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -359,20 +359,28 @@ class BusinessMixin:
         return fx_acct, notice
 
     @staticmethod
-    def _rate_from_post_transaction(post_txn, invoice_currency):
-        """Derive the exchange rate that was applied at invoice-posting.
+    def _rate_from_post_transaction(post_txn, target_commodity):
+        """Derive the exchange rate from post_txn currency to
+        ``target_commodity`` by inspecting the post transaction's
+        splits for one whose account commodity matches the target.
+        The ratio of |quantity| (account commodity) to |value|
+        (transaction currency) is the rate that was in force at
+        posting.
 
-        Inspects the posting transaction's splits for one whose account
-        commodity differs from the invoice currency (the income, expense,
-        or A/R side that received the rate). The ratio of |quantity|
-        (account commodity) to |value| (transaction currency) is the
-        rate that was in force at posting.
+        Pre-fix this method took just ``(post_txn,
+        invoice_currency)`` and returned the rate of the FIRST
+        non-invoice-currency split — which in a multi-cross-currency
+        post (e.g., EUR invoice with USD income + GBP A/R) would
+        silently pick whichever split happened to come first. Now
+        requires an explicit target so the caller gets the rate they
+        actually want.
 
-        Returns the Decimal rate, or None if no cross-currency split
-        is present (same-currency post, or post predates the rate fix).
+        Returns the Decimal rate, or None if no matching split is
+        present (caller should fall back to the price table at
+        post-date).
         """
         for s in post_txn.splits:
-            if s.account.commodity == invoice_currency:
+            if s.account.commodity != target_commodity:
                 continue
             s_value = abs(Decimal(str(s.value)))
             s_quantity = abs(Decimal(str(s.quantity)))
@@ -2986,49 +2994,106 @@ class BusinessMixin:
                 )
 
             # Realized FX gain/loss: when cross-currency and the rate
-            # moved between post-date and pay-date, the USD actually
+            # moved between post-date and pay-date, the actual amount
             # received/spent differs from what was originally recorded
             # as income/expense. That delta is taxable FX gain (or
             # loss); book it to an auto-created Income:FX Gain/Loss
             # account. The split has value=0 in the transaction
             # currency (so EUR/GBP/etc. balance is preserved) but
-            # non-zero quantity in the book's default currency. Same
-            # account for both directions; sign determines gain vs
-            # loss.
+            # non-zero quantity in the FX account's commodity (book
+            # default). Same account for both directions; sign
+            # determines gain vs loss.
             splits = [ar_ap_split, bank_split]
             fx_gain_loss = None
-            fx_diff = Decimal("0")
+            fx_diff_default = Decimal("0")
             fx_acct = None
             fx_notice = None
+            default_currency = self._require_default_currency(book)
             if exchange_rate is not None:
+                # Find the rate that was applied at posting from
+                # invoice currency → pay_acct.commodity. First try
+                # the post transaction's own splits (most accurate —
+                # if the price table was re-quoted after posting,
+                # the realized gain should use the original posting
+                # rate). When the post txn has no split in
+                # pay_acct.commodity (third-currency pay account
+                # case: the post used a different non-invoice
+                # commodity for A/R or income), fall back to the
+                # price table at post-date.
                 rate_at_post = self._rate_from_post_transaction(
-                    inv.post_txn, inv.currency
+                    inv.post_txn, pay_acct.commodity,
                 )
+                if rate_at_post is None:
+                    post_date_obj = inv.post_txn.post_date
+                    if hasattr(post_date_obj, "date") and callable(
+                        post_date_obj.date
+                    ):
+                        post_date_obj = post_date_obj.date()
+                    rate_at_post = self._find_exchange_rate(
+                        book,
+                        from_commodity=inv.currency,
+                        to_commodity=pay_acct.commodity,
+                        as_of=post_date_obj,
+                    )
                 if rate_at_post is not None:
                     expected_at_post = (
                         payment_amount * rate_at_post
                     ).quantize(Decimal("0.01"))
-                    fx_diff = pay_quantity - expected_at_post
-                    if abs(fx_diff) >= Decimal("0.01"):
+                    # ``fx_diff`` is the realized delta in the
+                    # PAYMENT-ACCOUNT commodity (pay_quantity is in
+                    # that commodity). Convert to the book default
+                    # currency before booking — the FX account has
+                    # commodity=default, and a quantity in any other
+                    # commodity would be silently treated as default
+                    # by every report that reads this account.
+                    # Pre-fix triple-currency case (book=USD,
+                    # invoice=EUR, pay=GBP): a £5 GBP gain landed on
+                    # a USD-commodity FX account as quantity=5,
+                    # rendered as "$5 gain" — silently wrong.
+                    fx_diff_pay = pay_quantity - expected_at_post
+                    if pay_acct.commodity != default_currency:
+                        pay_to_default_rate = self._find_exchange_rate(
+                            book,
+                            from_commodity=pay_acct.commodity,
+                            to_commodity=default_currency,
+                            as_of=parsed_date,
+                        )
+                        if pay_to_default_rate is None:
+                            raise ValueError(
+                                f"Realized FX gain/loss needs an "
+                                f"exchange rate from "
+                                f"{pay_acct.commodity.mnemonic} to "
+                                f"{default_currency.mnemonic} on or "
+                                f"near {parsed_date} to convert the "
+                                f"FX delta to the book's default "
+                                f"currency (the FX account's "
+                                f"commodity). Add a price with "
+                                f"create_price, then retry."
+                            )
+                        fx_diff_default = (
+                            fx_diff_pay * pay_to_default_rate
+                        ).quantize(Decimal("0.01"))
+                    else:
+                        fx_diff_default = fx_diff_pay
+                    if abs(fx_diff_default) >= Decimal("0.01"):
                         fx_acct, fx_notice = self._get_or_create_fx_account(
                             book, fx_account=fx_account,
                         )
-                        # Customer (is_bill=False): we received MORE
-                        # USD than income recorded → gain → credit
-                        # income account (quantity = -fx_diff for a
-                        # gain, +|fx_diff| for a loss).
-                        # Vendor bill (is_bill=True): we spent MORE
-                        # USD than expense recorded → loss → debit
-                        # income account (quantity = +fx_diff for a
-                        # loss, -|fx_diff| for a gain).
+                        # Customer (is_bill=False): received more →
+                        # gain → credit income (quantity = -fx_diff
+                        # for gain, +|fx_diff| for loss).
+                        # Vendor bill (is_bill=True): spent more →
+                        # loss → debit income (quantity = +fx_diff
+                        # for loss, -|fx_diff| for gain).
                         quantity_sign = 1 if is_bill else -1
-                        is_loss = (is_bill and fx_diff > 0) or (
-                            not is_bill and fx_diff < 0
+                        is_loss = (
+                            (is_bill and fx_diff_default > 0)
+                            or (not is_bill and fx_diff_default < 0)
                         )
                         fx_gain_loss = piecash.Split(
                             account=fx_acct,
                             value=Decimal("0"),
-                            quantity=quantity_sign * fx_diff,
+                            quantity=quantity_sign * fx_diff_default,
                             memo=(
                                 f"FX {'loss' if is_loss else 'gain'} "
                                 f"on invoice {inv.id}: post-rate "
@@ -3075,12 +3140,18 @@ class BusinessMixin:
                 result["payment_account_currency"] = pay_acct.commodity.mnemonic
                 if fx_gain_loss is not None:
                     direction = (
-                        "loss" if (is_bill and fx_diff > 0)
-                        or (not is_bill and fx_diff < 0)
+                        "loss" if (is_bill and fx_diff_default > 0)
+                        or (not is_bill and fx_diff_default < 0)
                         else "gain"
                     )
                     result["fx_realized"] = {
-                        "amount": str(abs(fx_diff).quantize(Decimal("0.01"))),
+                        # Amount on the FX account is in the book's
+                        # default currency — that's the account's
+                        # commodity and the unit every report uses.
+                        "amount": str(
+                            abs(fx_diff_default).quantize(Decimal("0.01"))
+                        ),
+                        "currency": default_currency.mnemonic,
                         "direction": direction,
                         "account": fx_acct.fullname,
                     }

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -74,6 +74,26 @@ def _safe_date_posted(inv):
         return None
 
 
+def _safe_date_opened(inv):
+    """Read ``inv.date_opened`` defensively.
+
+    Same shape as ``_safe_date_posted`` but for the ``date_opened``
+    column. piecash's ``_DateTime`` TypeDecorator has the same
+    regex-parser failure mode on empty-string column values; the
+    bookkeeper's reproduction with ``date_posted`` is exactly
+    replicable on ``date_opened``. ``_invoice_to_dict``,
+    ``_invoice_to_compact_line``, and ``list_invoices`` all access
+    ``inv.date_opened.date()`` and would crash on a malformed row.
+    Wrapping the access lets every caller treat that field as
+    "unknown" gracefully.
+    """
+    try:
+        do = inv.date_opened
+        return do if do else None
+    except (ValueError, TypeError):
+        return None
+
+
 def _is_invoice_posted(inv) -> bool:
     """True iff ``inv`` has a real datetime in ``date_posted``.
 
@@ -448,6 +468,15 @@ class BusinessMixin:
             if p.commodity == from_commodity and p.currency == to_commodity:
                 days = (as_of - p_date).days
                 rate = Decimal(str(p.value))
+                # Skip zero-or-negative direct rates. The inverse
+                # branch already skips zero (would div-by-zero); the
+                # direct branch was missing the same guard, so a
+                # corrupt 0-or-negative price could propagate as the
+                # winning rate. Downstream pay_quantize-to-zero
+                # would then fire the new guard, but flagging at
+                # rate-lookup time gives a clearer signal.
+                if rate <= 0:
+                    continue
                 if days >= 0:
                     if best_before_direct is None or days < best_before_direct[0]:
                         best_before_direct = (days, rate)
@@ -457,7 +486,7 @@ class BusinessMixin:
             # Inverse: p.commodity == to, p.currency == from → rate = 1/p.value
             elif p.commodity == to_commodity and p.currency == from_commodity:
                 days = (as_of - p_date).days
-                if Decimal(str(p.value)) == 0:
+                if Decimal(str(p.value)) <= 0:
                     continue
                 rate = Decimal("1") / Decimal(str(p.value))
                 if days >= 0:
@@ -750,7 +779,10 @@ class BusinessMixin:
             "id": invoice.id,
             "type": "bill" if invoice.owner_type == 4 else "invoice",
             "owner_name": owner_name,
-            "date_opened": str(invoice.date_opened.date()) if invoice.date_opened else None,
+            "date_opened": (
+                str(_safe_date_opened(invoice).date())
+                if _safe_date_opened(invoice) else None
+            ),
             "date_posted": (
                 str(_safe_date_posted(invoice).date())
                 if _safe_date_posted(invoice) else None
@@ -777,10 +809,9 @@ class BusinessMixin:
         unambiguously. Bills get the ``BILL`` tag (was already there).
         """
         inv_type = "BILL" if invoice.owner_type == 4 else "INV"
+        opened = _safe_date_opened(invoice)
         date_str = (
-            str(invoice.date_opened.date())
-            if invoice.date_opened
-            else "n/a"
+            str(opened.date()) if opened else "n/a"
         )
         status = "posted" if _is_invoice_posted(invoice) else "open"
 
@@ -947,13 +978,27 @@ class BusinessMixin:
 
     @staticmethod
     def _calculate_lot_balance(lot) -> Decimal:
-        """Sum of split values in a lot.
+        """Sum of split values in a lot, skipping voided splits.
 
         For A/R lots: positive = outstanding receivable.
         For A/P lots: negative = outstanding payable.
+
+        Voided splits (``reconcile_state == 'v'``) are GnuCash's
+        zombie audit-trail records — value/quantity zeroed but the
+        row preserved. Filtering them here matches the void-aware
+        treatment ``unpost_invoice`` uses for "are there real
+        payments on this lot?" and the lot-listing helpers use for
+        active-position math. Pre-fix this method summed every
+        split (voided ones contribute zero so the SUM was right by
+        accident), which left the helper out of step with the rest
+        of the codebase's void semantics — a future caller might
+        reasonably check ``len(lot.splits)`` against this balance
+        and get inconsistent answers.
         """
         total = Decimal(0)
         for split in lot.splits:
+            if split.reconcile_state == "v":
+                continue
             total += Decimal(str(split.value))
         return total
 
@@ -2110,6 +2155,24 @@ class BusinessMixin:
             acct = self._resolve_account(book, account)
             if not acct:
                 raise ValueError(f"Account not found: {account}")
+            # Reject account types that break the posting math
+            # silently. Customer invoices recognize revenue → entry
+            # account must be INCOME (or a related credit-natural
+            # type). Pre-fix any account was accepted: an ASSET on
+            # an invoice entry would post as ``debit asset`` against
+            # ``debit A/R`` — both debits, balance violated, but
+            # piecash builds the transaction anyway because the
+            # split values still sum to zero in the value column.
+            # Reports then show no income but a phantom asset
+            # increase.
+            if acct.type != "INCOME":
+                raise ValueError(
+                    f"Invoice entry account must be INCOME (got "
+                    f"{acct.type} on '{account}'). Customer invoices "
+                    f"recognize revenue; non-INCOME accounts produce "
+                    f"valid-looking transactions with broken "
+                    f"posting math."
+                )
 
             q_num, q_denom = self._decimal_to_num_denom(qty)
             p_num, p_denom = self._decimal_to_num_denom(unit_price)
@@ -2212,6 +2275,19 @@ class BusinessMixin:
             acct = self._resolve_account(book, account)
             if not acct:
                 raise ValueError(f"Account not found: {account}")
+            # Bill entry accounts must be EXPENSE (typical line
+            # items) or ASSET (inventory purchases that capitalize
+            # rather than expense). LIABILITY/EQUITY/INCOME on a
+            # bill entry produces valid-looking transactions with
+            # broken posting math, same shape as the invoice-entry
+            # validation above.
+            if acct.type not in ("EXPENSE", "ASSET"):
+                raise ValueError(
+                    f"Bill entry account must be EXPENSE or ASSET "
+                    f"(got {acct.type} on '{account}'). EXPENSE for "
+                    f"normal line items, ASSET for inventory "
+                    f"purchases that capitalize."
+                )
 
             q_num, q_denom = self._decimal_to_num_denom(qty)
             p_num, p_denom = self._decimal_to_num_denom(unit_price)
@@ -2925,6 +3001,29 @@ class BusinessMixin:
                     f"Lot not found for invoice {invoice_id}"
                 )
 
+            # Refuse to pay against a voided posting transaction.
+            # GnuCash's void zeroes split values but preserves rows
+            # with ``reconcile_state='v'``. ``_calculate_lot_balance``
+            # would compute remaining=0 (post-fix it skips voided
+            # splits explicitly), and the lot would auto-close on
+            # save — leaving the new payment split assigned to a
+            # closed lot. Block the operation up front so the user
+            # has to ``unvoid_transaction`` (or unpost + re-post)
+            # first.
+            if inv.post_txn is not None:
+                voided_post = all(
+                    s.reconcile_state == "v"
+                    for s in inv.post_txn.splits
+                )
+                if voided_post:
+                    raise ValueError(
+                        f"Cannot pay invoice {invoice_id}: its "
+                        f"posting transaction has been voided. "
+                        f"Unvoid the posting transaction first "
+                        f"(or unpost the invoice and re-post), "
+                        f"then retry payment."
+                    )
+
             if is_bill:
                 owner = self._find_vendor_by_guid(
                     book, inv.owner_guid
@@ -2988,6 +3087,25 @@ class BusinessMixin:
             post_quantity, _post_rate = _convert(
                 payment_amount, post_acct.commodity,
             )
+
+            # Guard against extreme-rate-quantize-to-zero. With a
+            # tiny exchange rate (< quantum / payment_amount) the
+            # converted quantity rounds to zero — a "successful"
+            # payment that records nothing on the bank side and
+            # silently fails to clear the lot. Refuse to build a
+            # zero-quantity payment split.
+            if pay_quantity == 0 or post_quantity == 0:
+                raise ValueError(
+                    f"Cross-currency payment quantizes to zero in "
+                    f"the target commodity (payment_amount="
+                    f"{payment_amount} {inv.currency.mnemonic}, "
+                    f"pay_quantity={pay_quantity} "
+                    f"{pay_acct.commodity.mnemonic}, post_quantity="
+                    f"{post_quantity} {post_acct.commodity.mnemonic}). "
+                    f"Likely an extreme exchange rate; check the "
+                    f"price table for {inv.currency.mnemonic}/"
+                    f"{pay_acct.commodity.mnemonic}."
+                )
 
             if is_bill:
                 # Pay vendor bill: debit A/P (positive), credit bank (negative)
@@ -3742,15 +3860,6 @@ class BusinessMixin:
                         "bill_count": 0,
                     }
 
-                try:
-                    _, _, total = (
-                        self._get_invoice_entries_and_total(
-                            book, bill
-                        )
-                    )
-                except ValueError:
-                    total = Decimal(0)
-
                 balance = Decimal(0)
                 post_acct = book.session.query(
                     piecash.Account
@@ -3762,6 +3871,22 @@ class BusinessMixin:
                                 lot
                             )
                             break
+
+                try:
+                    _, _, total = (
+                        self._get_invoice_entries_and_total(
+                            book, bill
+                        )
+                    )
+                except ValueError:
+                    # Empty/corrupted entries — fall back to the
+                    # lot balance (computed above). Pre-fix this
+                    # silently substituted Decimal(0), which made
+                    # ``total_billed`` understate by the bill's
+                    # full amount on any data-corruption case. The
+                    # lot balance reflects the actual outstanding
+                    # liability so the vendor's row stays sane.
+                    total = abs(balance)
 
                 outstanding = abs(balance)
                 paid = total - outstanding

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3343,13 +3343,17 @@ class CoreMixin:
             # Stage pre-delete state for the audit log.
             self._stage_audit_before(_account_to_dict(account))
 
-            # Capture info before deletion. Short guid computed against
-            # the remaining accounts (the target is still present here).
-            short_guid = _unique_prefix(
-                account.guid, (a.guid for a in book.accounts)
-            )
+            # Capture info before deletion. Pre-fix the response
+            # included a short-prefix GUID computed against
+            # ``book.accounts`` BEFORE the delete — but the LLM
+            # would receive a handle pointing at a row that no
+            # longer exists. ``_resolve_guid`` would then raise
+            # "No account" on any subsequent attempt to use it.
+            # Returning ``fullname`` and ``status="deleted"`` is
+            # enough for the audit-log human reader and the LLM to
+            # confirm what was deleted; the short GUID was always
+            # unaddressable post-delete and just invited misuse.
             result = {
-                "guid": short_guid,
                 "fullname": account.fullname,
                 "status": "deleted",
             }

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3430,6 +3430,101 @@ class CoreMixin:
 
             return result
 
+    def _verify_transaction_state(
+        self,
+        book,
+        transaction,
+        *,
+        expected_description: str | None = None,
+        expected_date: date | None = None,
+        expected_notes: str | None = None,
+        expected_splits: list[dict] | None = None,
+    ) -> None:
+        """Re-load the transaction from disk and verify expected
+        fields landed. Closes the gap CLAUDE.md's "Every write is
+        verified" invariant calls out for ``update_transaction`` and
+        ``replace_splits``.
+
+        Pre-fix, both methods called ``book.save()`` and trusted the
+        result. piecash has historically silently no-op'd setattrs
+        on some slot-backed fields; without this round-trip the
+        thin response could lie about what's stored. Bypasses the
+        ORM identity map via ``session.expire`` so we read what's
+        actually on disk, not what we just put in the cache.
+
+        Raises RuntimeError on any mismatch.
+        """
+        book.session.expire(transaction)
+
+        if expected_description is not None:
+            actual_desc = transaction.description
+            if actual_desc != expected_description:
+                raise RuntimeError(
+                    f"Transaction write verification failed: "
+                    f"description on disk is {actual_desc!r}, "
+                    f"expected {expected_description!r}"
+                )
+
+        if expected_date is not None:
+            actual_date = transaction.post_date
+            if hasattr(actual_date, "date") and callable(actual_date.date):
+                actual_date = actual_date.date()
+            if actual_date != expected_date:
+                raise RuntimeError(
+                    f"Transaction write verification failed: "
+                    f"post_date on disk is {actual_date}, "
+                    f"expected {expected_date}"
+                )
+
+        if expected_notes is not None:
+            actual_notes = transaction.notes or ""
+            wanted = expected_notes if expected_notes else ""
+            if actual_notes != wanted:
+                raise RuntimeError(
+                    f"Transaction write verification failed: "
+                    f"notes on disk is {actual_notes!r}, "
+                    f"expected {wanted!r}"
+                )
+
+        if expected_splits is not None:
+            actual_splits = list(transaction.splits)
+            actual_by_acct = {}
+            for s in actual_splits:
+                actual_by_acct[s.account.fullname] = (
+                    Decimal(str(s.value)),
+                    Decimal(str(s.quantity)),
+                    s.memo or "",
+                )
+            if len(actual_splits) != len(expected_splits):
+                raise RuntimeError(
+                    f"Transaction write verification failed: "
+                    f"{len(actual_splits)} splits on disk, "
+                    f"expected {len(expected_splits)}"
+                )
+            for expected in expected_splits:
+                acct = expected["account"]
+                if acct not in actual_by_acct:
+                    raise RuntimeError(
+                        f"Transaction write verification failed: "
+                        f"split for {acct!r} not found post-save"
+                    )
+                actual_value, actual_qty, actual_memo = actual_by_acct[acct]
+                ev = _to_decimal(expected["amount"])
+                if actual_value != ev:
+                    raise RuntimeError(
+                        f"Transaction write verification failed: "
+                        f"split {acct!r} value on disk is "
+                        f"{actual_value}, expected {ev}"
+                    )
+                if "quantity" in expected:
+                    eq = _to_decimal(expected["quantity"])
+                    if actual_qty != eq:
+                        raise RuntimeError(
+                            f"Transaction write verification failed: "
+                            f"split {acct!r} quantity on disk is "
+                            f"{actual_qty}, expected {eq}"
+                        )
+
     def update_transaction(
         self,
         guid: str,
@@ -3553,6 +3648,20 @@ class CoreMixin:
                     raise ValueError(f"Account not found in transaction: {missing}")
 
             book.save()
+
+            # Verify the write landed — re-read the transaction from
+            # disk and compare each field we tried to set. Honors the
+            # ``Every write is verified`` invariant CLAUDE.md spells
+            # out; pre-fix, ``update_transaction`` skipped this and a
+            # piecash silent setattr no-op would have shipped a thin
+            # response that lied about what was stored.
+            self._verify_transaction_state(
+                book, transaction,
+                expected_description=description,
+                expected_date=trans_date,
+                expected_notes=notes,
+                expected_splits=splits,
+            )
 
             # Thin response — the LLM submitted the changes, so the only
             # fields worth echoing are enough for a quick sanity check
@@ -3715,6 +3824,12 @@ class CoreMixin:
 
             # 8. Save
             book.save()
+
+            # 8a. Verify the new splits landed — same invariant as
+            # update_transaction, just with the splits-only path.
+            self._verify_transaction_state(
+                book, transaction, expected_splits=splits,
+            )
 
             # 9. Build thin response.
             # - `splits` echo dropped (LLM just submitted them).

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3506,18 +3506,40 @@ class CoreMixin:
                     f"expected {len(expected_splits)}"
                 )
             for expected in expected_splits:
-                acct = expected["account"]
-                if acct not in actual_by_acct:
+                # Normalize the input account ref to canonical
+                # fullname before lookup. The book methods accept
+                # full path, ``%short`` GUID, or full 32-char GUID;
+                # post-save splits are keyed by ``Account.fullname``.
+                # Pre-fix this comparison was string-vs-string against
+                # the raw input, so a shortcut input like ``%77b59dd``
+                # raised a false "split not found post-save" RuntimeError
+                # even though the write had landed correctly.
+                # (Bookkeeper finding from PR #75 review.)
+                ref = expected["account"]
+                resolved = self._resolve_account(book, ref)
+                if resolved is None:
                     raise RuntimeError(
                         f"Transaction write verification failed: "
-                        f"split for {acct!r} not found post-save"
+                        f"could not resolve split account ref "
+                        f"{ref!r} (resolution returned None — the "
+                        f"account may have been deleted between "
+                        f"save and verify)"
                     )
-                actual_value, actual_qty, actual_memo = actual_by_acct[acct]
+                acct_fullname = resolved.fullname
+                if acct_fullname not in actual_by_acct:
+                    raise RuntimeError(
+                        f"Transaction write verification failed: "
+                        f"split for {acct_fullname!r} (input "
+                        f"ref {ref!r}) not found post-save"
+                    )
+                actual_value, actual_qty, actual_memo = (
+                    actual_by_acct[acct_fullname]
+                )
                 ev = _to_decimal(expected["amount"])
                 if actual_value != ev:
                     raise RuntimeError(
                         f"Transaction write verification failed: "
-                        f"split {acct!r} value on disk is "
+                        f"split {acct_fullname!r} value on disk is "
                         f"{actual_value}, expected {ev}"
                     )
                 if "quantity" in expected:
@@ -3525,8 +3547,8 @@ class CoreMixin:
                     if actual_qty != eq:
                         raise RuntimeError(
                             f"Transaction write verification failed: "
-                            f"split {acct!r} quantity on disk is "
-                            f"{actual_qty}, expected {eq}"
+                            f"split {acct_fullname!r} quantity on "
+                            f"disk is {actual_qty}, expected {eq}"
                         )
 
     def update_transaction(
@@ -3607,8 +3629,23 @@ class CoreMixin:
                 if total != Decimal("0"):
                     raise ValueError(f"Splits do not balance: total is {total}")
 
-                # Build a map of account -> split data
-                split_updates = {s["account"]: s for s in splits}
+                # Build a map of canonical-fullname → split data.
+                # Resolve any input refs (path, ``%short``, full GUID)
+                # to the canonical Account so the lookup against
+                # existing splits' ``account.fullname`` works for all
+                # three input shapes. Pre-fix this dict was keyed by
+                # the raw input string, so a shortcut input like
+                # ``%77b59dd`` produced "Account not found in
+                # transaction" even though the ref resolved cleanly.
+                split_updates = {}
+                for s in splits:
+                    ref = s["account"]
+                    resolved = self._resolve_account(book, ref)
+                    if resolved is None:
+                        raise ValueError(
+                            f"Account not found: {ref}"
+                        )
+                    split_updates[resolved.fullname] = s
 
                 trans_currency = transaction.currency
 

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -366,9 +366,18 @@ class ReconciliationMixin:
             # description (date)" plus the original splits from it.
             self._stage_audit_before(_transaction_to_dict(transaction))
 
-            # GnuCash slot keys for void info
+            # GnuCash slot keys for void info. Use a tz-aware
+            # local time (mirroring the audit-log convention) so a
+            # later reader can reconstruct "when was this voided"
+            # unambiguously across DST transitions and timezone
+            # changes. Pre-fix this stored a naive ``datetime.now()``
+            # whose interpretation depended on the host's current
+            # zone — same string would mean different absolute times
+            # before/after a DST shift.
             transaction["void-reason"] = reason
-            transaction["void-time"] = datetime.now().isoformat()
+            transaction["void-time"] = (
+                datetime.now().astimezone().isoformat()
+            )
 
             for split in transaction.splits:
                 split["void-former-value"] = str(split.value)

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -279,7 +279,19 @@ class SchedulingMixin:
 
             sx_guid = uuid.uuid4().hex
 
-            # Create template account under root_template
+            # Create template account under root_template. We flush
+            # this immediately because the SX row references its
+            # GUID via ``template_act_guid``. If any of the
+            # subsequent inserts (SX row, Recurrence, Slot) fail,
+            # the template account is already on disk — pre-fix the
+            # caller would retry with the same name and hit the
+            # duplicate-name check fine, but a "ghost" template
+            # account with no scheduled-transaction owner would sit
+            # under ``root_template`` forever.
+            #
+            # Wrap the whole sequence in try/except so partial-
+            # failure cleans up the orphan template account before
+            # propagating the error.
             template_acct = piecash.Account(
                 name=name,
                 type="BANK",
@@ -289,74 +301,87 @@ class SchedulingMixin:
             book.session.add(template_acct)
             book.session.flush()
 
-            # Insert ScheduledTransaction (blocked constructor)
-            book.session.execute(
-                ScheduledTransaction.__table__.insert().values(
-                    guid=sx_guid,
-                    name=name,
-                    enabled=1 if enabled else 0,
-                    start_date=parsed_start,
-                    end_date=parsed_end,
-                    last_occur=None,
-                    num_occur=0,
-                    rem_occur=0,
-                    auto_create=0,
-                    auto_notify=0,
-                    adv_creation=0,
-                    adv_notify=0,
-                    instance_count=0,
-                    template_act_guid=template_acct.guid,
+            try:
+                # Insert ScheduledTransaction (blocked constructor)
+                book.session.execute(
+                    ScheduledTransaction.__table__.insert().values(
+                        guid=sx_guid,
+                        name=name,
+                        enabled=1 if enabled else 0,
+                        start_date=parsed_start,
+                        end_date=parsed_end,
+                        last_occur=None,
+                        num_occur=0,
+                        rem_occur=0,
+                        auto_create=0,
+                        auto_notify=0,
+                        adv_creation=0,
+                        adv_notify=0,
+                        instance_count=0,
+                        template_act_guid=template_acct.guid,
+                    )
                 )
-            )
-            _verify_write(
-                book.session, ScheduledTransaction.__table__, sx_guid,
-                f"ScheduledTransaction '{name}'",
-            )
-
-            book.session.execute(
-                Recurrence.__table__.insert().values(
-                    obj_guid=sx_guid,
-                    recurrence_mult=rec_mult,
-                    recurrence_period_type=rec_period_type,
-                    recurrence_period_start=parsed_start,
-                    recurrence_weekend_adjust="none",
+                _verify_write(
+                    book.session, ScheduledTransaction.__table__, sx_guid,
+                    f"ScheduledTransaction '{name}'",
                 )
-            )
-            _verify_composite_write(
-                book.session, Recurrence.__table__,
-                {"obj_guid": sx_guid},
-                f"Recurrence for scheduled transaction '{name}'",
-            )
 
-            # Store split templates as JSON in a slot. Normalize `amount`
-            # through _to_decimal → str so the persisted JSON is always a
-            # clean decimal string, even if the caller handed us a float.
-            # Otherwise a float would survive json.dumps as a numeric
-            # literal, and every future instantiation would replay the
-            # IEEE-754 epsilon.
-            splits_json = json.dumps([
-                {
-                    "account": s["account"],
-                    "amount": str(_to_decimal(s["amount"])),
-                    "memo": s.get("memo", ""),
-                }
-                for s in splits
-            ])
-            book.session.execute(
-                Slot.__table__.insert().values(
-                    obj_guid=sx_guid,
-                    name="splits-json",
-                    slot_type=KVP_Type.KVP_TYPE_STRING,
-                    string_val=splits_json,
+                book.session.execute(
+                    Recurrence.__table__.insert().values(
+                        obj_guid=sx_guid,
+                        recurrence_mult=rec_mult,
+                        recurrence_period_type=rec_period_type,
+                        recurrence_period_start=parsed_start,
+                        recurrence_weekend_adjust="none",
+                    )
                 )
-            )
-            _verify_composite_write(
-                book.session, Slot.__table__,
-                {"obj_guid": sx_guid, "name": "splits-json"},
-                f"Splits slot for scheduled transaction '{name}'",
-            )
+                _verify_composite_write(
+                    book.session, Recurrence.__table__,
+                    {"obj_guid": sx_guid},
+                    f"Recurrence for scheduled transaction '{name}'",
+                )
 
-            book.save()
+                # Store split templates as JSON in a slot. Normalize
+                # `amount` through _to_decimal → str so the persisted
+                # JSON is always a clean decimal string, even if the
+                # caller handed us a float. Otherwise a float would
+                # survive json.dumps as a numeric literal, and every
+                # future instantiation would replay the IEEE-754
+                # epsilon.
+                splits_json = json.dumps([
+                    {
+                        "account": s["account"],
+                        "amount": str(_to_decimal(s["amount"])),
+                        "memo": s.get("memo", ""),
+                    }
+                    for s in splits
+                ])
+                book.session.execute(
+                    Slot.__table__.insert().values(
+                        obj_guid=sx_guid,
+                        name="splits-json",
+                        slot_type=KVP_Type.KVP_TYPE_STRING,
+                        string_val=splits_json,
+                    )
+                )
+                _verify_composite_write(
+                    book.session, Slot.__table__,
+                    {"obj_guid": sx_guid, "name": "splits-json"},
+                    f"Splits slot for scheduled transaction '{name}'",
+                )
+
+                book.save()
+            except Exception:
+                # Cleanup the orphan template account so a retry
+                # doesn't accumulate unowned template scaffolding.
+                # Swallow cleanup failures — the original error is
+                # what the caller needs to see.
+                try:
+                    book.session.delete(template_acct)
+                    book.save()
+                except Exception:
+                    pass
+                raise
 
             next_occ = self._next_occurrence(
                 parsed_start, frequency,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -811,6 +811,34 @@ def _fmt_invoice_pay(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_bill_post(entry: dict) -> list[str]:
+    """Bill POST — same shape as invoice POST but with the right
+    label so the audit log doesn't mis-categorize a vendor bill
+    as a customer invoice. Pre-fix the (invoice, POST) handler
+    fired for both because ``post_invoice`` accepts either."""
+    lines = _fmt_invoice_post(entry)
+    if lines:
+        lines[0] = lines[0].replace("POST INVOICE", "POST BILL")
+    return lines
+
+
+def _fmt_bill_unpost(entry: dict) -> list[str]:
+    """Bill UNPOST — same shape as invoice UNPOST with the right
+    label."""
+    lines = _fmt_invoice_unpost(entry)
+    if lines:
+        lines[0] = lines[0].replace("UNPOST INVOICE", "UNPOST BILL")
+    return lines
+
+
+def _fmt_bill_pay(entry: dict) -> list[str]:
+    """Bill PAY — same shape as invoice PAY with the right label."""
+    lines = _fmt_invoice_pay(entry)
+    if lines:
+        lines[0] = lines[0].replace("PAY INVOICE", "PAY BILL")
+    return lines
+
+
 def _fmt_bill_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -981,6 +1009,9 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("invoice", "PAY"): _fmt_invoice_pay,
     ("bill", "CREATE"): _fmt_bill_create,
     ("bill", "DELETE"): _fmt_bill_delete,
+    ("bill", "POST"): _fmt_bill_post,
+    ("bill", "UNPOST"): _fmt_bill_unpost,
+    ("bill", "PAY"): _fmt_bill_pay,
     ("entry", "CREATE"): _fmt_entry_create,
     ("price", "DELETE"): _fmt_price_delete,
     ("budget", "UPDATE"): _fmt_budget_update,
@@ -1328,7 +1359,22 @@ def audit_log(
                     else:
                         entry["result"] = "success"
                         if classification == "write":
-                            after = _extract_after_state(result, entity_type)
+                            # Invoice/bill polymorphism: post_invoice
+                            # / unpost_invoice / pay_invoice all carry
+                            # entity_type="invoice" on the decorator
+                            # but accept either kind. The response's
+                            # ``type`` field is the truth — swap
+                            # entity_type to ``bill`` when the call
+                            # operated on a vendor bill so the audit
+                            # log doesn't mis-categorize the entry.
+                            if (
+                                entity_type == "invoice"
+                                and result_data.get("type") == "bill"
+                            ):
+                                entry["entity_type"] = "bill"
+                            after = _extract_after_state(
+                                result, entry["entity_type"]
+                            )
                             if after:
                                 entry["entity_guid"] = after.get("guid")
                                 entry["after_state"] = after

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1241,6 +1241,25 @@ def audit_log(
             debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
             timestamp = datetime.now().astimezone().isoformat()
 
+            # Defense-in-depth: clear any previously-staged audit
+            # before-state at the TOP of the wrapper. The post-call
+            # consume (success branch) and the exception-path clear
+            # below are the primary cleanup paths, but if either one
+            # itself errors out (e.g., the book wrapper transiently
+            # unavailable), threading-local state can carry the
+            # previous tool's before-state into this one — and that
+            # tool would render an unrelated diff in its audit entry.
+            # Pre-clearing here means every tool starts with a clean
+            # threading-local slot regardless of what the previous
+            # call did.
+            if _get_book_func is not None:
+                try:
+                    pre_book = _get_book_func()
+                    if pre_book is not None:
+                        pre_book._consume_audit_before()
+                except Exception:
+                    pass
+
             # Normalize up front so pydantic models (e.g. list[SplitInput]
             # from the transaction-creating tools) become plain dicts before
             # they hit json.dumps in the debug line or the text-audit

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -310,6 +310,46 @@ class TestPruneBackups:
         assert by_stage["manual"] == 5  # untouched
         assert by_stage["session"] == 2  # pruned to keep_last_n
 
+    def test_prune_refuses_to_wipe_all_manual_backups(self, test_book: Path):
+        """``prune_backups(keep_last_n=0, dry_run=False, stage="manual")``
+        must raise rather than wipe every human-marked backup.
+
+        Manual backups have unlimited retention BY DESIGN — they
+        include "pre-tax-filing" / "pre-irreplaceable-thing"
+        snapshots the user explicitly preserved. A misbehaving LLM
+        concluding "let me clean up old backups" would otherwise
+        nuke every one in a single call.
+        """
+        book = GnuCashBook(str(test_book))
+        book.create_backup(stage="manual", label="precious")
+        book.create_backup(stage="manual", label="also-precious")
+
+        with pytest.raises(ValueError, match="Refusing to delete every manual backup"):
+            book.prune_backups(keep_last_n=0, stage="manual", dry_run=False)
+
+        # All manual backups still on disk after the refusal.
+        manual_count = sum(
+            1 for e in book.list_backups() if e["stage"] == "manual"
+        )
+        assert manual_count == 2
+
+    def test_prune_dry_run_with_zero_manual_still_allowed(
+        self, test_book: Path,
+    ):
+        """The guard fires only on the destructive path.
+        ``dry_run=True`` — even with keep_last_n=0 manual — must
+        still produce a plan (so the user can SEE what would be
+        deleted before opting in)."""
+        book = GnuCashBook(str(test_book))
+        book.create_backup(stage="manual", label="check")
+
+        result = book.prune_backups(
+            keep_last_n=0, stage="manual", dry_run=True,
+        )
+        assert result["dry_run"] is True
+        # Plan shows the 1 manual would be deleted.
+        assert len(result["would_delete"]) == 1
+
     def test_prune_explicit_manual_stage_works(self, test_book: Path):
         """Explicit stage='manual' DOES prune manual backups."""
         book = GnuCashBook(str(test_book))

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -126,6 +126,64 @@ class TestCreateBackup:
         assert "review" in label
         assert "2026" in label
 
+    def test_backup_partial_file_unlinked_on_copy_failure(
+        self, test_book: Path,
+    ):
+        """If the SQLite ``backup()`` call raises mid-copy, the
+        partial/empty destination file must be unlinked rather
+        than left on disk where ``list_backups`` would surface it
+        as a "valid" backup entry.
+
+        Forces the failure by patching the source connection's
+        ``backup`` method to raise — that's where the fix's new
+        ``except`` branch fires (closing dest_conn and unlinking
+        the partial file).
+        """
+        backups_dir = test_book.parent / f"{test_book.name}.mcp" / "backups"
+        book = GnuCashBook(str(test_book))
+
+        # Wrap piecash's source connection so .backup raises.
+        original_open = book.open
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def patched_open(*args, **kwargs):
+            with original_open(*args, **kwargs) as b:
+                real_connection = b.session.connection
+                real_conn_obj = real_connection().connection
+
+                # Replace source_conn.backup with a raiser via a
+                # proxy object.
+                class _RaisingSource:
+                    def __init__(self, real):
+                        self._real = real
+
+                    def backup(self, *a, **kw):
+                        raise OSError("simulated disk I/O error")
+
+                    def __getattr__(self, name):
+                        return getattr(self._real, name)
+
+                class _ConnWrapper:
+                    @property
+                    def connection(self):
+                        return _RaisingSource(real_conn_obj)
+
+                b.session.connection = lambda: _ConnWrapper()
+                yield b
+
+        with patch.object(book, "open", side_effect=patched_open):
+            with pytest.raises(OSError, match="simulated disk I/O error"):
+                book.create_backup(stage="manual", label="doomed")
+
+        # No partial file left behind.
+        if backups_dir.exists():
+            assert list(backups_dir.glob("*.gnucash")) == [], (
+                f"Partial backup file persisted: "
+                f"{list(backups_dir.glob('*.gnucash'))}"
+            )
+
     def test_two_backups_in_same_second_do_not_collide(
         self, test_book: Path,
     ):

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -5955,6 +5955,45 @@ class TestDeleteTransaction:
 class TestUpdateTransaction:
     """Tests for update_transaction method."""
 
+    def test_verify_transaction_state_catches_description_mismatch(
+        self, test_book: Path,
+    ):
+        """``_verify_transaction_state`` raises when on-disk state
+        diverges from expected. Pre-fix, ``update_transaction`` and
+        ``replace_splits`` skipped this round-trip — a piecash
+        silent setattr no-op (it has done so historically for
+        slot-backed fields) would have shipped a thin response that
+        lied about what landed.
+        """
+        gc_book = GnuCashBook(str(test_book))
+        with gc_book.open(readonly=False) as book:
+            txn = list(book.transactions)[0]
+            # Verifier raises when expected != on-disk state.
+            with pytest.raises(RuntimeError, match="description on disk"):
+                gc_book._verify_transaction_state(
+                    book, txn,
+                    expected_description="this is not the actual description",
+                )
+
+    def test_verify_transaction_state_catches_split_count_mismatch(
+        self, test_book: Path,
+    ):
+        """Verification catches the case where the on-disk split
+        count differs from what was supposed to land."""
+        gc_book = GnuCashBook(str(test_book))
+        with gc_book.open(readonly=False) as book:
+            txn = list(book.transactions)[0]
+            # Real txn has 2 splits; pass an "expected" with 3.
+            with pytest.raises(RuntimeError, match="splits on disk"):
+                gc_book._verify_transaction_state(
+                    book, txn,
+                    expected_splits=[
+                        {"account": "Assets:Checking", "amount": "0"},
+                        {"account": "Expenses:Groceries", "amount": "0"},
+                        {"account": "Expenses:Dining", "amount": "0"},
+                    ],
+                )
+
     def test_update_description_only(self, test_book: Path):
         """Should update only the description."""
         gc_book = GnuCashBook(str(test_book))

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6991,6 +6991,43 @@ class TestReconcileAccount:
 class TestVoidTransaction:
     """Tests for void_transaction method."""
 
+    def test_void_time_slot_is_timezone_aware(self, test_book: Path):
+        """The ``void-time`` slot must store a tz-aware ISO string
+        so a later reader can reconstruct the absolute void instant
+        across DST transitions and timezone changes. Pre-fix this
+        was naive ``datetime.now().isoformat()`` whose
+        interpretation depended on the host's current zone."""
+        from datetime import datetime as _dt
+        gc_book = GnuCashBook(str(test_book))
+        transactions = gc_book.list_transactions(compact=False)
+        guid = transactions[0]["guid"]
+
+        gc_book.void_transaction(guid=guid, reason="test")
+
+        # Read the raw value out of the slots table — the
+        # SlotString wrapper's repr contains the value but isn't
+        # itself directly parseable. Going through SQL gives us
+        # the stored ISO string verbatim.
+        from sqlalchemy import text
+        with gc_book.open(readonly=True) as book:
+            txn = next(
+                t for t in book.transactions if t.guid.startswith(guid[:8])
+            )
+            row = book.session.execute(
+                text(
+                    "SELECT string_val FROM slots "
+                    "WHERE obj_guid = :guid AND name = :name"
+                ),
+                {"guid": txn.guid, "name": "void-time"},
+            ).first()
+        void_time_str = row[0]
+        parsed = _dt.fromisoformat(void_time_str)
+        # Pre-fix the slot stored a NAIVE ``datetime.now()`` whose
+        # absolute meaning depended on the host's current zone.
+        assert parsed.tzinfo is not None, (
+            f"void-time must be tz-aware, got naive: {void_time_str!r}"
+        )
+
     def test_void_transaction_success(self, test_book: Path):
         """Should void a transaction."""
         gc_book = GnuCashBook(str(test_book))

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6100,13 +6100,21 @@ class TestUpdateTransaction:
             )
 
     def test_update_splits_account_not_found(self, test_book: Path):
-        """Should raise ValueError if split account not in transaction."""
+        """Nonexistent split account raises ValueError.
+
+        The post-shortcut-resolution refactor surfaces "Account not
+        found: <ref>" earlier (before the transaction-membership
+        check) when the ref doesn't resolve at all. Existing
+        accounts that aren't in this particular transaction still
+        fall through to the per-transaction "Account not found in
+        transaction" check below the resolution step.
+        """
         gc_book = GnuCashBook(str(test_book))
 
         transactions = gc_book.search_transactions("Groceries", compact=False)
         guid = transactions[0]["guid"]
 
-        with pytest.raises(ValueError, match="Account not found in transaction"):
+        with pytest.raises(ValueError, match="Account not found"):
             gc_book.update_transaction(
                 guid=guid,
                 splits=[
@@ -6214,6 +6222,104 @@ class TestUpdateTransaction:
 
 class TestReplaceSplits:
     """Tests for replace_splits method."""
+
+    def test_replace_splits_accepts_short_guid_account_refs(
+        self, test_book: Path,
+    ):
+        """``replace_splits`` accepts ``%xxxxxxx`` account shortcuts
+        (and full 32-char GUIDs) the same way every other tool does.
+        The new write verifier must resolve those refs before
+        comparing against the persisted ``Account.fullname``.
+
+        Pre-fix (bookkeeper finding from PR #75 review): the write
+        landed correctly but the verifier compared the raw input
+        ref to the canonical fullname, raising a false
+        ``RuntimeError`` like::
+
+            Transaction write verification failed: split for
+            '%77b59dd' not found post-save
+
+        Any LLM using shortcuts — which is the entire point of the
+        feature — would have hit this on every replace_splits call.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        # Find the grocery transaction.
+        transactions = gc_book.search_transactions(
+            "Weekly Groceries", compact=False,
+        )
+        guid = transactions[0]["guid"]
+
+        # Build the ``%`` shortcut form — same shape the tool layer
+        # emits and the LLM passes back. ``list_accounts`` returns
+        # the full 32-char GUID; the shortcut is "%" + the first 7
+        # chars (the bookkeeper's exact failing input format).
+        accounts_list = gc_book.list_accounts(compact=False)
+        groceries_full = next(
+            a["guid"] for a in accounts_list
+            if a["fullname"] == "Expenses:Groceries"
+        )
+        checking_full = next(
+            a["guid"] for a in accounts_list
+            if a["fullname"] == "Assets:Checking"
+        )
+        groceries_short = "%" + groceries_full[:7]
+        checking_short = "%" + checking_full[:7]
+
+        # Replace using shortcuts — pre-fix this raised RuntimeError
+        # in the verifier. Post-fix it should land cleanly.
+        result = gc_book.replace_splits(
+            guid=guid,
+            splits=[
+                {"account": groceries_short, "amount": "150.00"},
+                {"account": checking_short, "amount": "-150.00"},
+            ],
+        )
+        assert result["status"] == "splits_replaced"
+
+        # Confirm the splits are on the canonical accounts.
+        txn = gc_book.get_transaction(guid)
+        accts = {s["account"] for s in txn["splits"]}
+        assert "Expenses:Groceries" in accts
+        assert "Assets:Checking" in accts
+
+    def test_update_transaction_accepts_short_guid_account_refs(
+        self, test_book: Path,
+    ):
+        """``update_transaction`` had the same shortcut-resolution
+        gap as ``replace_splits`` — the input dict was keyed by raw
+        ref, so a ``%shortguid`` input never matched
+        ``split.account.fullname`` and raised "Account not found in
+        transaction" even when the ref resolved cleanly. Closed in
+        the same fix.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        transactions = gc_book.search_transactions(
+            "Weekly Groceries", compact=False,
+        )
+        guid = transactions[0]["guid"]
+
+        accounts_list = gc_book.list_accounts(compact=False)
+        groceries_full = next(
+            a["guid"] for a in accounts_list
+            if a["fullname"] == "Expenses:Groceries"
+        )
+        checking_full = next(
+            a["guid"] for a in accounts_list
+            if a["fullname"] == "Assets:Checking"
+        )
+        groceries_short = "%" + groceries_full[:7]
+        checking_short = "%" + checking_full[:7]
+
+        result = gc_book.update_transaction(
+            guid=guid,
+            splits=[
+                {"account": groceries_short, "amount": "75.00"},
+                {"account": checking_short, "amount": "-75.00"},
+            ],
+        )
+        assert result["status"] == "updated"
 
     def test_basic_replace_splits(self, test_book: Path):
         """Should replace splits with new accounts."""

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -5869,7 +5869,12 @@ class TestDeleteAccount:
         result = gc_book.delete_account("Expenses:To Delete")
 
         assert result["status"] == "deleted"
+        assert result["fullname"] == "Expenses:To Delete"
         assert gc_book.get_account("Expenses:To Delete") is None
+        # Pre-fix the response included a short-prefix ``guid`` that
+        # pointed at the just-deleted row (unresolvable). Now omitted
+        # so the LLM doesn't try to use a dangling handle.
+        assert "guid" not in result
 
     def test_delete_account_not_found(self, test_book: Path):
         """Should raise ValueError if account not found."""

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3136,6 +3136,119 @@ class TestPayInvoice:
         )
         assert fx_balance == Decimal("90")
 
+    def test_commodity_quantum_helper(self):
+        """``_commodity_quantum`` returns the right Decimal quantum
+        for each commodity fraction. Pre-fix every cross-currency
+        conversion in business.py hardcoded ``Decimal("0.01")``,
+        which silently corrupts JPY (whole-yen) and BHD/KWD
+        (3-decimal) currencies.
+        """
+        from gnucash_mcp.book.business import _commodity_quantum
+        from decimal import Decimal as D
+
+        class _Commodity:
+            def __init__(self, fraction):
+                self.fraction = fraction
+
+        # USD-class (2 decimals)
+        assert _commodity_quantum(_Commodity(100)) == D("0.01")
+        # JPY (0 decimals — whole yen)
+        assert _commodity_quantum(_Commodity(1)) == D(1)
+        # BHD/KWD (3 decimals)
+        assert _commodity_quantum(_Commodity(1000)) == D("0.001")
+        # Stocks/crypto (4 decimals)
+        assert _commodity_quantum(_Commodity(10000)) == D("0.0001")
+        # Defensive: no fraction attr → assume 2 decimals
+        class _NoFraction:
+            pass
+        assert _commodity_quantum(_NoFraction()) == D("0.01")
+
+    def test_jpy_payment_quantizes_to_whole_yen(
+        self, business_book,
+    ):
+        """A USD invoice paid from a JPY-denominated bank account
+        must quantize the JPY-side quantity to whole yen — JPY's
+        ``commodity.fraction`` is 1, no sub-yen units exist.
+
+        Pre-fix the hardcoded ``Decimal("0.01")`` quantize stored
+        ``¥1234.56``-shaped non-integer quantities on JPY accounts,
+        which is meaningless (and invalid GnuCash data — fraction=1
+        should reject sub-unit values).
+
+        Setup: USD-default book, $100 USD invoice paid from JPY
+        checking at rate 150.5 JPY/USD → expected ¥15,050 received
+        (quantized to 0 decimals).
+        """
+        import piecash
+        from datetime import date as _date
+
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            try:
+                jpy = piecash.factories.create_currency_from_ISO("JPY")
+                book.session.add(jpy)
+                book.flush()
+            except Exception:
+                jpy = next(
+                    c for c in book.commodities if c.mnemonic == "JPY"
+                )
+
+            # Verify our assumption about JPY's fraction.
+            assert jpy.fraction == 1, (
+                f"JPY should have fraction=1 (no sub-yen units); "
+                f"got {jpy.fraction}"
+            )
+
+            assets = next(
+                a for a in book.accounts if a.fullname == "Assets"
+            )
+            book.session.add(piecash.Account(
+                name="JPY Checking", type="BANK",
+                parent=assets, commodity=jpy,
+            ))
+            book.session.add(piecash.Price(
+                commodity=usd, currency=jpy,
+                date=_date(2026, 3, 10),
+                value="150.5", source="user:price", type="nav",
+            ))
+            book.save()
+
+        gb.create_customer(name="Tokyo Co", currency="USD")
+        gb.create_invoice(
+            customer_id="000001", currency="USD",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Consulting",
+            description="USD services",
+            quantity="1", price="100.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-03-10",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:JPY Checking",
+            amount="100.00",
+            payment_date="2026-03-10",
+        )
+
+        # JPY checking received $100 × 150.5 = ¥15,050 — but more
+        # importantly, the stored quantity must be whole-yen
+        # (no sub-unit fractional part). Pre-fix the hardcoded
+        # 0.01 quantize would have left a 0-decimal-padded
+        # ``¥15050.00``-shaped value on a fraction=1 commodity.
+        pay_qty = Decimal(result["payment_account_amount"])
+        assert pay_qty == Decimal("15050"), (
+            f"Expected ¥15050, got {pay_qty}"
+        )
+        # And the quantum exponent must be ≥ 0 (no fractional part).
+        assert pay_qty.as_tuple().exponent >= 0
+
     def test_rate_from_post_transaction_picks_target_commodity(self):
         """``_rate_from_post_transaction`` must inspect splits for one
         whose account commodity matches the target — not the first

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1298,6 +1298,22 @@ class TestDeleteBill:
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 
+    def test_rejects_non_income_account(self, business_book):
+        """Invoice entries must post to INCOME accounts. Pre-fix any
+        account type was accepted, producing transactions with
+        broken posting math (e.g., debit-asset against debit-A/R)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="must be INCOME"):
+            gb.add_invoice_entry(
+                invoice_id="000001",
+                account="Assets:Checking",  # ASSET — silently accepted pre-fix
+                description="Bad entry",
+                quantity="1",
+                price="500.00",
+            )
+
     def test_basic_entry(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_customer(name="Acme Corp")
@@ -1373,6 +1389,23 @@ class TestAddInvoiceEntry:
 
 class TestAddBillEntry:
     """Tests for add_bill_entry."""
+
+    def test_rejects_non_expense_or_asset_account(self, business_book):
+        """Bill entries must post to EXPENSE (line items) or ASSET
+        (inventory). LIABILITY/EQUITY/INCOME silently broke posting
+        math pre-fix."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        with pytest.raises(ValueError, match="must be EXPENSE or ASSET"):
+            gb.add_bill_entry(
+                bill_id="000001",
+                # PAYABLE — non-EXPENSE, non-ASSET, exists in fixture
+                account="Liabilities:Accounts Payable",
+                description="Bad entry",
+                quantity="1",
+                price="50.00",
+            )
 
     def test_basic_entry(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -3426,6 +3459,124 @@ class TestPayInvoice:
             account_name="Income:Foreign Exchange Gain/Loss"
         )
         assert fx_balance == Decimal("-6.50")
+
+    def test_pay_invoice_refuses_voided_posting_transaction(self, business_book):
+        """If the posting transaction was voided in GnuCash, paying
+        the invoice would compute remaining=0 against a zero'd lot,
+        auto-close the lot, and assign the new payment to a closed
+        lot. Now refused up front with a clear error pointing at
+        unvoid_transaction."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Services",
+            quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-03-10",
+        )
+        # Void the posting transaction.
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            post_txn_guid = inv.post_txn.guid
+        gb.void_transaction(guid=post_txn_guid, reason="test")
+
+        with pytest.raises(ValueError, match="posting transaction has been voided"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="500.00",
+                payment_date="2026-03-15",
+            )
+
+    def test_calculate_lot_balance_skips_voided_splits(self, business_book):
+        """``_calculate_lot_balance`` filters voided splits so the
+        helper agrees with the rest of the void-aware codebase."""
+        from gnucash_mcp.book.business import BusinessMixin
+        from decimal import Decimal as D
+
+        class _Split:
+            def __init__(self, value, reconcile_state):
+                self.value = value
+                self.reconcile_state = reconcile_state
+
+        class _Lot:
+            def __init__(self, splits):
+                self.splits = splits
+
+        # Mix of live and voided splits.
+        lot = _Lot([
+            _Split(D("100"), "n"),
+            _Split(D("0"), "v"),  # voided — must be skipped
+            _Split(D("-30"), "n"),
+        ])
+        assert BusinessMixin._calculate_lot_balance(lot) == D("70")
+
+    def test_safe_date_opened_handles_empty_string(self):
+        """``_safe_date_opened`` matches ``_safe_date_posted``'s
+        defensive contract — empty/malformed values surface as
+        None rather than crashing the regex parser."""
+        from gnucash_mcp.book.business import _safe_date_opened
+
+        class _EmptyInv:
+            @property
+            def date_opened(self):
+                # Mimic piecash's _DateTime regex parser raising
+                # on a malformed empty string.
+                raise ValueError("Couldn't parse datetime string")
+
+        class _NoneInv:
+            date_opened = None
+
+        class _ValidInv:
+            from datetime import datetime as _dt
+            date_opened = _dt(2026, 3, 10, 12, 0)
+
+        assert _safe_date_opened(_EmptyInv()) is None
+        assert _safe_date_opened(_NoneInv()) is None
+        # Valid datetime passes through unchanged
+        result = _safe_date_opened(_ValidInv())
+        assert result is not None
+        assert result.year == 2026
+
+    def test_find_exchange_rate_skips_zero_direct_price(self, business_book):
+        """Direct branch must skip rate=0 (and negative) prices —
+        previously only the inverse branch had this guard, leaving
+        a corrupt zero-direct price as a propagatable rate."""
+        import piecash
+        from datetime import date as _date
+
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            try:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+                book.flush()
+            except Exception:
+                eur = next(c for c in book.commodities if c.mnemonic == "EUR")
+            # Insert a corrupt zero-rate direct price.
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd, date=_date(2026, 3, 10),
+                value="0", source="user:price", type="nav",
+            ))
+            book.save()
+
+        with gb.open(readonly=True) as book:
+            usd = book.default_currency
+            eur = next(c for c in book.commodities if c.mnemonic == "EUR")
+            # No usable price → returns None (zero-rate skipped, no fallback).
+            rate = gb._find_exchange_rate(
+                book, from_commodity=eur, to_commodity=usd,
+                as_of=_date(2026, 3, 10),
+            )
+            assert rate is None
 
     def test_pay_invoice_converts_ar_quantity_when_ar_currency_differs(
         self, business_book,

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3136,6 +3136,184 @@ class TestPayInvoice:
         )
         assert fx_balance == Decimal("90")
 
+    def test_rate_from_post_transaction_picks_target_commodity(self):
+        """``_rate_from_post_transaction`` must inspect splits for one
+        whose account commodity matches the target — not the first
+        non-invoice-currency split it sees.
+
+        Pre-fix the helper took ``(post_txn, invoice_currency)`` and
+        returned the rate of the first cross-currency split, so a
+        post with EUR invoice + USD income + GBP A/R would return
+        the USD rate when the pay path needed the GBP rate.
+
+        Builds a fake post-txn with three splits (EUR/USD/GBP) and
+        asserts the helper returns the rate matching whichever target
+        is requested.
+        """
+        from gnucash_mcp.book.business import BusinessMixin
+        from decimal import Decimal as D
+
+        # Stand-in objects with the small surface the helper uses.
+        class _Commodity:
+            def __init__(self, mnemonic):
+                self.mnemonic = mnemonic
+
+        class _Account:
+            def __init__(self, commodity):
+                self.commodity = commodity
+
+        class _Split:
+            def __init__(self, account, value, quantity):
+                self.account = account
+                self.value = value
+                self.quantity = quantity
+
+        class _PostTxn:
+            def __init__(self, splits):
+                self.splits = splits
+
+        eur = _Commodity("EUR")
+        usd = _Commodity("USD")
+        gbp = _Commodity("GBP")
+        post = _PostTxn([
+            _Split(_Account(eur), D("100"), D("100")),    # invoice side, rate 1
+            _Split(_Account(usd), D("-100"), D("-110")),  # USD rate 1.10
+            _Split(_Account(gbp), D("-100"), D("-80")),   # GBP rate 0.80
+        ])
+
+        # Asking for USD must yield 1.10 (not 0.80, not the "first
+        # cross-currency split" semantics).
+        assert BusinessMixin._rate_from_post_transaction(
+            post, usd
+        ) == D("110") / D("100")
+        # Asking for GBP must yield 0.80.
+        assert BusinessMixin._rate_from_post_transaction(
+            post, gbp
+        ) == D("80") / D("100")
+        # Asking for a commodity the post doesn't reference returns
+        # None — caller falls back to the price table.
+        chf = _Commodity("CHF")
+        assert BusinessMixin._rate_from_post_transaction(
+            post, chf
+        ) is None
+
+    def test_fx_split_converts_to_default_when_pay_account_third_currency(
+        self, business_book,
+    ):
+        """When the payment account's commodity is neither the
+        invoice currency nor the book default — the truly tri-
+        currency case — the realized FX delta computed in
+        pay-account commodity must be converted to book default
+        before landing on the FX account.
+
+        Pre-fix, ``fx_diff`` lived in pay-account commodity and was
+        booked as the FX split's quantity, but the FX account's
+        commodity was book default. Reports aggregating the FX
+        account read GBP-as-USD silently.
+
+        Setup: USD-default book, EUR invoice, GBP checking.
+        Post Mar 10 at EUR→GBP=0.80 (€100 → £80 expected).
+        Pay Mar 20 at EUR→GBP=0.85 (£85 actually received) → £5
+        gain in GBP. With GBP→USD = 1.30 at pay-date, that's a
+        $6.50 gain that must land on the USD-commodity FX account.
+        """
+        import piecash
+        from datetime import date as _date
+
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            try:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+                book.flush()
+            except Exception:
+                eur = next(
+                    c for c in book.commodities if c.mnemonic == "EUR"
+                )
+            try:
+                gbp = piecash.factories.create_currency_from_ISO("GBP")
+                book.session.add(gbp)
+                book.flush()
+            except Exception:
+                gbp = next(
+                    c for c in book.commodities if c.mnemonic == "GBP"
+                )
+
+            assets = next(
+                a for a in book.accounts if a.fullname == "Assets"
+            )
+            book.session.add(piecash.Account(
+                name="GBP Checking", type="BANK",
+                parent=assets, commodity=gbp,
+            ))
+            book.session.add(piecash.Account(
+                name="A/R EUR", type="RECEIVABLE",
+                parent=assets, commodity=eur,
+            ))
+            # Two EUR/GBP rates — post-date and pay-date.
+            book.session.add(piecash.Price(
+                commodity=eur, currency=gbp,
+                date=_date(2026, 3, 10),
+                value="0.80", source="user:price", type="nav",
+            ))
+            book.session.add(piecash.Price(
+                commodity=eur, currency=gbp,
+                date=_date(2026, 3, 20),
+                value="0.85", source="user:price", type="nav",
+            ))
+            # EUR → USD rate so post_invoice can convert the income
+            # split's quantity to its USD-denominated commodity.
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2026, 3, 10),
+                value="1.10", source="user:price", type="nav",
+            ))
+            # GBP → USD rate so the FX delta converts to default.
+            book.session.add(piecash.Price(
+                commodity=gbp, currency=usd,
+                date=_date(2026, 3, 20),
+                value="1.30", source="user:price", type="nav",
+            ))
+            book.save()
+
+        gb.create_customer(name="London Client", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Consulting",
+            description="EUR services",
+            quantity="1", price="100.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:A/R EUR",
+            post_date="2026-03-10",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:GBP Checking",
+            amount="100.00",
+            payment_date="2026-03-20",
+        )
+
+        # GBP delta: £85 received vs £80 expected = £5 gain in GBP.
+        # Converted at GBP→USD=1.30 → $6.50 gain on the USD-commodity
+        # FX account.
+        assert result["fx_realized"]["direction"] == "gain"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("6.50")
+        assert result["fx_realized"]["currency"] == "USD"
+
+        # FX account balance: $6.50 credit (negative on credit-natural
+        # income) — measured in book default currency.
+        fx_balance = gb.get_balance(
+            account_name="Income:Foreign Exchange Gain/Loss"
+        )
+        assert fx_balance == Decimal("-6.50")
+
     def test_pay_invoice_converts_ar_quantity_when_ar_currency_differs(
         self, business_book,
     ):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -750,6 +750,55 @@ class TestDispatchTableDegradation:
         assert _format_audit_entry_text(entry) == ""
 
 
+class TestAuditEntityTypeBillSwap:
+    """``post_invoice`` / ``unpost_invoice`` / ``pay_invoice`` carry
+    ``entity_type="invoice"`` on the decorator but accept either
+    invoices or vendor bills. The audit log must render BILL when
+    the call operated on a bill — pre-fix every bill operation
+    showed up as "POST INVOICE" / "PAY INVOICE" in the log,
+    mis-categorizing the entry.
+    """
+
+    def test_bill_post_renders_as_post_bill(self):
+        """The dispatcher swaps entity_type to ``bill`` based on
+        the response's ``type`` field; the bill handler then
+        renders ``POST BILL`` instead of ``POST INVOICE``."""
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "bill",  # post-swap
+            "operation": "post",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"id": "B-001", "post_account": "Liabilities:A/P"},
+            "after_state": {
+                "type": "bill", "total": "500.00",
+                "post_date": "2026-03-10",
+                "transaction_guid": "abc12345",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "POST BILL" in rendered
+        assert "POST INVOICE" not in rendered
+
+    def test_bill_pay_renders_as_pay_bill(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "bill",
+            "operation": "pay",
+            "timestamp": "2026-04-30T18:00:00",
+            "params": {"id": "B-001", "payment_account": "Assets:Checking"},
+            "after_state": {
+                "type": "bill", "amount_paid": "500.00",
+                "remaining_balance": "0.00",
+                "transaction_guid": "abc12345",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "PAY BILL" in rendered
+        assert "PAY INVOICE" not in rendered
+
+
 class TestAuditBeforeStateLeak:
     """Defense-in-depth: a previous call's staged before-state must
     never leak into the next call's audit entry, regardless of how

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,20 +18,45 @@ from gnucash_mcp.logging_config import (
 
 
 class _StagedBook:
-    """Fake GnuCashBook that yields a pre-set before-state once.
+    """Fake GnuCashBook that simulates the real staging contract.
 
-    Used by tests that need to inject before_state into `@audit_log`
-    without opening a real book. Mirrors the contract of
-    `BaseGnuCashBook._consume_audit_before`: returns the staged dict
-    on first call, clears itself so subsequent calls return None.
+    Mirrors ``BaseGnuCashBook._stage_audit_before`` /
+    ``_consume_audit_before``: a write book method calls
+    ``_stage_audit_before(state)`` while its session is open, and
+    ``_consume_audit_before()`` returns and clears the staged state.
+
+    The constructor accepts a ``state`` arg as a convenience —
+    callers that don't want to wire up a custom staging callback
+    can pass it in and have it auto-stage on the first
+    ``_consume_audit_before`` AFTER the wrapper's pre-clear has
+    run. The audit decorator pre-clears at wrapper entry to defend
+    against leaks from prior calls; that pre-clear must NOT eat
+    the test fixture's intended state. We track whether the
+    pre-clear has fired so the test's intended state surfaces on
+    the post-call consume only.
     """
 
     def __init__(self, state: dict | None):
-        self._state = state
+        self._initial_state = state
+        self._staged: dict | None = None
+        self._pre_clear_done = False
+
+    def _stage_audit_before(self, state: dict | None) -> None:
+        self._staged = state
 
     def _consume_audit_before(self) -> dict | None:
-        state = self._state
-        self._state = None
+        if not self._pre_clear_done:
+            # Simulate the wrapper's pre-clear: returns whatever's
+            # currently staged. After this fires, the constructor's
+            # ``initial_state`` becomes available as the test's
+            # "staged-during-func" state.
+            self._pre_clear_done = True
+            stale = self._staged
+            self._staged = self._initial_state
+            return stale
+        # Subsequent consume: yield then clear (real staging contract).
+        state = self._staged
+        self._staged = None
         return state
 
 
@@ -723,6 +748,69 @@ class TestDispatchTableDegradation:
             "timestamp": "2026-04-21T12:34:56",
         }
         assert _format_audit_entry_text(entry) == ""
+
+
+class TestAuditBeforeStateLeak:
+    """Defense-in-depth: a previous call's staged before-state must
+    never leak into the next call's audit entry, regardless of how
+    the previous call exited.
+
+    Pre-fix, the wrapper consumed before-state on the success path
+    (post-func) and tried to consume on the exception path. If
+    either consume itself raised (e.g., book wrapper transiently
+    unavailable), the threading-local kept the staged state, and
+    the next decorated call would render an unrelated diff. The
+    fix adds a pre-clear at the TOP of the wrapper so every tool
+    starts with a clean slot.
+    """
+
+    def test_pre_clear_drops_leaked_before_state(
+        self, temp_book_path, temp_log_dir,
+    ):
+        """A second tool call must not see before-state staged by a
+        previous call that failed to consume it."""
+
+        class _RetainingBook:
+            def __init__(self):
+                self._staged = None
+
+            def _stage_audit_before(self, state):
+                self._staged = state
+
+            def _consume_audit_before(self):
+                state = self._staged
+                self._staged = None
+                return state
+
+        book = _RetainingBook()
+        # Pre-stage state as if a previous call had left it behind.
+        book._stage_audit_before({"description": "leaked from prior call"})
+        assert book._staged is not None
+
+        setup_logging(
+            book_path=str(temp_book_path),
+            debug=False,
+            get_book=lambda: book,
+        )
+
+        @audit_log(
+            classification="write", operation="create",
+            entity_type="transaction",
+        )
+        def fresh_call(description: str) -> str:
+            return json.dumps({"guid": "abcd1234", "description": description})
+
+        fresh_call(description="this call's own description")
+
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        txt_file = temp_log_dir / "audit" / f"{today}.txt"
+        content = txt_file.read_text()
+
+        # The leaked before-state's "description" must NOT appear in
+        # this call's audit entry.
+        assert "leaked from prior call" not in content
+        # Sanity: this call's own description still rendered.
+        assert "this call's own description" in content
 
 
 class TestAuditLogIntegration:

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -129,6 +129,46 @@ class TestCreateScheduled:
                 frequency="monthly",
             )
 
+    def test_torn_write_cleans_up_template_account(self, scheduled_book):
+        """If the SX-row insert fails after the template account
+        has already been flushed, the template account must be
+        deleted in cleanup. Pre-fix a "ghost" template account
+        with no scheduled-transaction owner persisted forever
+        under ``root_template``."""
+        from sqlalchemy import text
+        gb = GnuCashBook(str(scheduled_book))
+
+        # Patch the SX __table__.insert step to raise mid-sequence.
+        # The template account has been flushed at that point but
+        # the SX row hasn't landed.
+        from piecash.core.transaction import ScheduledTransaction
+
+        real_insert = ScheduledTransaction.__table__.insert
+        with patch.object(
+            ScheduledTransaction.__table__, "insert",
+            side_effect=RuntimeError("simulated mid-sequence failure"),
+        ):
+            with pytest.raises(RuntimeError, match="simulated"):
+                gb.create_scheduled_transaction(
+                    name="DoomedSX",
+                    description="Should not survive",
+                    splits=[
+                        {"account": "Expenses:Rent", "amount": "100.00"},
+                        {"account": "Assets:Checking", "amount": "-100.00"},
+                    ],
+                    start_date="2026-01-01",
+                    frequency="monthly",
+                )
+
+        # Template account must NOT be on disk under root_template.
+        with gb.open(readonly=True) as book:
+            template_names = [
+                a.name for a in book.root_template.children
+            ]
+        assert "DoomedSX" not in template_names, (
+            f"Template account survived torn-write: {template_names}"
+        )
+
     def test_invalid_account_error(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
         with pytest.raises(ValueError, match="Account not found"):


### PR DESCRIPTION
## Summary

Round 2 of the v1.2.1 code review. Closes the remaining 7 high-severity items from `specs/CODE_REVIEW.md`. Round 1 (PR #74) shipped 10 items including all 3 criticals + 5 highs; this batch finishes the rest. After this merges + bookkeeper signoff, **all 3 critical and all 12 high items from the review are closed.**

| # | Severity | Item | Commit |
|---|----------|------|--------|
| 7 | 🟠 high | FX account commodity vs. payment-account commodity mismatch (tri-currency case) | `79f66b8` |
| 10 | 🟠 high | `_rate_from_post_transaction` returns first cross-currency rate instead of target's | `79f66b8` |
| 9 | 🟠 high | Hardcoded `Decimal("0.01")` quantize breaks JPY (whole yen) / BHD / KWD (3 decimals) | `f69ce79` |
| 11 | 🟠 high | `update_transaction` + `replace_splits` skip `_verify_write` | `cf191d7` |
| 13 | 🟠 high | `delete_account` returns dangling short GUID handle | `37923f3` |
| 14 | 🟠 high | Audit `before_state` can leak across nested tool calls | `37923f3` |
| 15 | 🟠 high | `prune_backups(keep_last_n=0, manual)` wipes every manual backup | `41fd5f3` |

## Highlights

**Tri-currency FX (#7 + #10 paired).** Found one fix while testing the other; one branch fixes both because they share the same code path. ``pay_invoice`` now correctly handles book=USD, invoice=EUR, pay=GBP — converting the realized FX delta from pay-account commodity to book default and getting the right post-rate from a target-aware rate helper. Adds ``fx_realized.currency`` to the response so callers know what unit the amount is in.

**JPY / BHD precision (#9).** New `_commodity_quantum(commodity)` helper derives the right Decimal quantum from `commodity.fraction`. Five sites that hardcoded `0.01` now use the per-commodity quantum — JPY stores whole yen, BHD/KWD store 3 decimals.

**Write verification (#11).** New `_verify_transaction_state` bypasses the ORM identity map via `session.expire`, then re-reads each intended field from disk. Closes the gap CLAUDE.md's "Every write is verified" invariant called out for core's two transaction-mutation methods.

**delete_account (#13) returns `{fullname, status}` only** — no more dangling short GUID that points at a row no longer in the table.

**Audit pre-clear (#14).** Defense-in-depth pre-clear at wrapper entry. If a previous call's cleanup itself errored, the threading-local stale state can no longer leak into the next call's audit entry.

**Manual-backup wipe guard (#15).** `prune_backups(keep_last_n=0, dry_run=False, stage="manual")` now raises rather than nuking every human-marked snapshot. Dry-run-with-zero-manual still allowed (the user can SEE the plan before opting in).

## Test plan

- [x] **+9 new regression tests** across the suite — each one specifically exercises the failing scenario its fix addresses.
- [x] **Full suite: 1088 passed** (was 1079 after PR #74 merged; same 2 pre-existing `TestDeletePrice` failures unrelated and pre-date all of this work).
- [x] Multi-currency tri-currency case verified end-to-end (USD-default book + EUR invoice + GBP checking + EUR/GBP rate movement → £5 gain → $6.50 USD on FX account).
- [x] JPY end-to-end test verifies `Decimal.as_tuple().exponent >= 0` (no fractional yen).
- [x] All existing FX gain/loss + business + audit tests pass unchanged.

## Followups not in this batch

The CODE_REVIEW identified 26 medium and 18 low items beyond the 12 high. Those remain in `specs/CODE_REVIEW.md` for a future cycle. The 2 pre-existing `TestDeletePrice` failures still need their own investigation — independent of this work.

After this merges, the natural next step is **PR develop → main** for the announcement-ready release.