### PR TITLE
feat(currency): extract CurrencyMixin composed unconditionally into BaseGnuCashBook

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -24,6 +24,16 @@ from typing import Generator, Iterable
 
 import piecash
 
+# Re-exported for callers that still import these from ``_base``.
+# Canonical definitions live in ``_currency`` alongside the
+# CurrencyMixin that uses them; keeping the import path stable avoids
+# churn across the codebase.
+from gnucash_mcp.book._currency import (  # noqa: F401
+    CurrencyMixin,
+    _is_market_price,
+    _to_date,
+)
+
 # GnuCash stores GUIDs as lowercase hex (via uuid4().hex). We accept both
 # cases on input for ergonomics — users pasting from external tools may
 # have uppercase — and normalize to lowercase before hitting SQLite
@@ -35,37 +45,6 @@ debug_logger = logging.getLogger("gnucash_mcp.debug")
 
 
 # ── Module-level helpers ───────────────────────────────────────────
-
-
-def _to_date(dt: date | datetime) -> date:
-    """Convert a datetime or date to a date object.
-
-    piecash may return either datetime or date for price dates depending
-    on how the price was created. This normalizes to date.
-    """
-    if isinstance(dt, datetime):
-        return dt.date()
-    return dt
-
-
-def _is_market_price(price) -> bool:
-    """True iff ``price`` is a real market quote, not a piecash auto-
-    placeholder.
-
-    On any cross-currency transaction, piecash auto-creates a Price
-    row with ``type='transaction'`` capturing the effective rate of
-    that one transaction. These are bookkeeping artifacts, NOT
-    user-supplied market quotes — every helper that walks
-    ``book.prices`` to value holdings or pick exchange rates must
-    skip them, or they shadow real quotes the user has on file.
-
-    Centralized here so the four call sites (core's ``_rates_as_of``
-    and ``_collect_warnings``, reporting's ``_latest_market_rates``,
-    and business's ``_find_exchange_rate``) all answer the question
-    the same way. Adding ``"transaction-currency"`` or any future
-    placeholder type only needs one change.
-    """
-    return getattr(price, "type", None) != "transaction"
 
 
 def _to_decimal(value) -> Decimal:
@@ -670,12 +649,20 @@ def _upcoming_to_compact_line(
 # ── Base class ─────────────────────────────────────────────────────
 
 
-class BaseGnuCashBook:
+class BaseGnuCashBook(CurrencyMixin):
     """Thread-safe wrapper for piecash book operations.
 
     Holds the universal helpers used by every mixin. Module-specific
     mixins (AdminMixin, ReportingMixin, etc.) are combined with this
     base via `build_book_class` in gnucash_mcp.book.__init__.
+
+    Inherits from :class:`CurrencyMixin` so cross-commodity helpers
+    (``_rates_as_of``, ``_account_conversion_factors``,
+    ``_split_in_default_currency``, ``_market_value``,
+    ``_find_exchange_rate``) are available on every constructed
+    ``GnuCashBook`` regardless of which ``--modules`` are enabled.
+    Currency conversion is cross-cutting infrastructure, not a
+    feature flag.
     """
 
     # Tables that support GUID resolution. Each entry maps table

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -1,0 +1,346 @@
+"""Cross-commodity currency-conversion mixin.
+
+Composed into :class:`BaseGnuCashBook` unconditionally so every
+module — ``reporting``, ``budgets``, ``business``, ``core`` — gets
+the same conversion path regardless of which ``--modules`` the user
+enabled. Currency conversion is cross-cutting infrastructure, not a
+feature flag.
+
+Single source of truth for:
+
+- "What's the latest market price for commodity X in the book's
+  default currency?" — :meth:`CurrencyMixin._rates_as_of`.
+- "What factor converts each account's quantity to the default
+  currency?" — :meth:`CurrencyMixin._account_conversion_factors`.
+- "What's one split's value in the default currency?" —
+  :meth:`CurrencyMixin._split_in_default_currency`.
+- "What's a whole account's quantity worth, with a display annotation
+  and a cost-basis fallback when no rate is on file?" —
+  :meth:`CurrencyMixin._market_value`.
+- "What's the exchange rate between two non-default currencies near
+  some date?" — :meth:`CurrencyMixin._find_exchange_rate`.
+
+All helpers skip piecash's auto-created ``type='transaction'`` price
+placeholders via :func:`gnucash_mcp.book._base._is_market_price` —
+those rows capture the effective rate of one specific cross-currency
+transaction and would shadow real user-supplied market quotes.
+
+The indexed query primitive :meth:`CurrencyMixin._find_prices` is
+provided here for future call-site migration; the rate-collecting
+helpers above still walk ``book.prices`` directly today (the v1.3
+performance sweep replaces those walks).
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import piecash
+
+
+def _to_date(dt: date | datetime) -> date:
+    """Convert a datetime or date to a date object.
+
+    piecash may return either datetime or date for price dates depending
+    on how the price was created. This normalizes to date.
+    """
+    if isinstance(dt, datetime):
+        return dt.date()
+    return dt
+
+
+def _is_market_price(price) -> bool:
+    """True iff ``price`` is a real market quote, not a piecash auto-
+    placeholder.
+
+    On any cross-currency transaction, piecash auto-creates a Price
+    row with ``type='transaction'`` capturing the effective rate of
+    that one transaction. These are bookkeeping artifacts, NOT
+    user-supplied market quotes — every helper that walks
+    ``book.prices`` to value holdings or pick exchange rates must
+    skip them, or they shadow real quotes the user has on file.
+
+    Centralized here so every call site
+    (core's ``_collect_warnings``, this module's ``_rates_as_of`` and
+    ``_find_exchange_rate``, investments' price-delete safety check)
+    all answer the question the same way. Adding
+    ``"transaction-currency"`` or any future placeholder type only
+    needs one change.
+    """
+    return getattr(price, "type", None) != "transaction"
+
+
+class CurrencyMixin:
+    """Cross-commodity valuation helpers.
+
+    Composed into :class:`BaseGnuCashBook` so the methods are
+    available on every constructed ``GnuCashBook`` class — including
+    the ones built by ``build_book_class({"core", "budgets"})`` where
+    the reporting mixin is absent.
+    """
+
+    @staticmethod
+    def _find_prices(
+        book: piecash.Book,
+        *,
+        commodity_guid: str | None = None,
+        currency_guid: str | None = None,
+        market_only: bool = True,
+    ) -> list:
+        """Indexed lookup over ``book.prices``.
+
+        Replaces the ``for p in book.prices: if p.commodity == ...``
+        linear walks scattered across the codebase. The query hits
+        the SQLAlchemy session directly, ordered most-recent-first.
+
+        Args:
+            book: Open piecash book.
+            commodity_guid: When set, restrict to prices of this
+                commodity (the held instrument).
+            currency_guid: When set, restrict to prices denominated
+                in this currency (the quote side).
+            market_only: When True (default), skip piecash's
+                ``type='transaction'`` auto-placeholders via
+                :func:`_is_market_price`.
+
+        Returns:
+            List of :class:`piecash.core.commodity.Price` rows,
+            newest first.
+        """
+        from piecash.core.commodity import Price
+
+        q = book.session.query(Price)
+        if commodity_guid is not None:
+            q = q.filter(Price.commodity_guid == commodity_guid)
+        if currency_guid is not None:
+            q = q.filter(Price.currency_guid == currency_guid)
+        q = q.order_by(Price.date.desc())
+        prices = list(q)
+        if market_only:
+            prices = [p for p in prices if _is_market_price(p)]
+        return prices
+
+    def _rates_as_of(
+        self,
+        book: piecash.Book,
+        as_of: date | None = None,
+        default_currency: piecash.Commodity | None = None,
+    ) -> dict[str, Decimal]:
+        """Latest user-supplied rate per non-default-currency commodity.
+
+        Returns ``{commodity_guid: Decimal rate}``. Each rate is the
+        most recent market price (skipping ``type='transaction'``
+        auto-placeholders) of the commodity quoted in the book's
+        default currency.
+
+        Args:
+            book: Open piecash book.
+            as_of: When set, restrict to prices on or before this
+                date. When ``None`` (default), no upper bound — returns
+                the absolute latest rate per commodity, including
+                future-dated forecasts the bookkeeper has deliberately
+                written.
+            default_currency: The book's default currency. Computed
+                via :meth:`_require_default_currency` when ``None``.
+
+        Returns:
+            ``{commodity_guid: Decimal rate}``. Commodities without any
+            qualifying price don't appear; callers fall back to
+            ``split.value`` (cost basis) or skip the account.
+        """
+        if default_currency is None:
+            default_currency = self._require_default_currency(book)
+        latest: dict[str, tuple[date, Decimal]] = {}
+        for p in book.prices:
+            if p.currency != default_currency:
+                continue
+            if not _is_market_price(p):
+                continue
+            p_date = _to_date(p.date)
+            if as_of is not None and p_date > as_of:
+                continue
+            key = p.commodity.guid
+            existing = latest.get(key)
+            if existing is None or p_date > existing[0]:
+                latest[key] = (p_date, Decimal(str(p.value)))
+        return {guid: rate for guid, (_d, rate) in latest.items()}
+
+    def _account_conversion_factors(
+        self,
+        book: piecash.Book,
+    ) -> dict[str, Decimal | None]:
+        """Map ``{account_guid: factor}`` for default-currency conversion.
+
+        ``factor * split.quantity = amount in default currency``.
+
+        - ``Decimal("1")`` — the account is already in default currency.
+        - A non-unit ``Decimal`` — the most recent market rate for the
+          account's commodity in default currency.
+        - ``None`` — no rate on file. Callers should fall back to
+          ``split.value`` (transaction-currency amount), which equals
+          cost basis for default-currency-denominated investment buys
+          and degrades gracefully for foreign-currency holdings.
+
+        Template accounts (under ``book.root_template``) are excluded
+        from the map — they're scheduled-transaction scaffolding, not
+        user-facing accounts.
+        """
+        default_currency = self._require_default_currency(book)
+        rates = self._rates_as_of(book, default_currency=default_currency)
+        template_guids = self._template_account_guids(book)
+        factors: dict[str, Decimal | None] = {}
+        for acct in book.accounts:
+            if acct.guid in template_guids:
+                continue
+            if acct.commodity == default_currency:
+                factors[acct.guid] = Decimal("1")
+            else:
+                factors[acct.guid] = rates.get(acct.commodity.guid)
+        return factors
+
+    @staticmethod
+    def _split_in_default_currency(
+        split,
+        account,
+        factor: Decimal | None,
+    ) -> Decimal:
+        """Value a single split in the book's default currency.
+
+        Uses ``factor * quantity`` when a factor is available. Falls
+        back to ``split.value`` otherwise — correct for STOCK/MUTUAL
+        splits whose transaction currency is the book default, and a
+        reasonable cost-basis approximation for other cases.
+        """
+        if factor is not None:
+            return Decimal(str(split.quantity)) * factor
+        return Decimal(str(split.value))
+
+    def _market_value(
+        self,
+        account,
+        quantity: Decimal,
+        *,
+        rates: dict[str, Decimal],
+        default_currency: piecash.Commodity,
+        today: date | None = None,
+        with_cost_fallback: bool = True,
+    ) -> tuple[Decimal, str | None]:
+        """Value an account-level quantity with a display annotation.
+
+        Used by ``get_book_summary``'s per-account display where the
+        annotation tells the LLM whether the number came from a market
+        rate or a cost-basis fallback. Sibling to
+        :meth:`_split_in_default_currency` — same conversion model,
+        different aggregation level.
+
+        Args:
+            account: piecash Account whose commodity is being valued.
+            quantity: Quantity in ``account.commodity``, already summed
+                by the caller.
+            rates: ``{commodity_guid: Decimal}`` map from
+                :meth:`_rates_as_of`. Passed in (not re-fetched) so
+                callers control the price-map build once per report.
+            default_currency: The book's default currency commodity.
+            today: Cost-basis fallback ignores splits dated after this
+                so trajectory snapshots don't pick up future-dated
+                buys. When ``None``, no date filter is applied.
+            with_cost_fallback: When True (default), missing rate falls
+                back to summing ``split.value`` across the account
+                (cost basis). When False, missing rate returns
+                ``Decimal("0")`` with a ``"no price data"`` note —
+                useful for callers that want a clear empty signal
+                instead of a silent cost-basis substitute.
+
+        Returns:
+            ``(value_in_default_currency, display_note)``.
+            ``display_note`` is ``None`` for default-currency accounts.
+        """
+        if account.commodity == default_currency:
+            return quantity, None
+        sym = account.commodity.mnemonic
+        rate = rates.get(account.commodity.guid)
+        if rate is not None:
+            return quantity * rate, f"{quantity} {sym} @ {rate}"
+        if not with_cost_fallback:
+            return Decimal("0"), f"{quantity} {sym} — no price data"
+        cost_basis = Decimal("0")
+        for s in account.splits:
+            if today is None or s.transaction.post_date <= today:
+                cost_basis += Decimal(str(s.value))
+        return cost_basis, f"{quantity} {sym} — no price data"
+
+    @staticmethod
+    def _find_exchange_rate(
+        book: piecash.Book,
+        from_commodity: piecash.Commodity,
+        to_commodity: piecash.Commodity,
+        as_of: date,
+    ) -> Decimal | None:
+        """Cross-currency rate near ``as_of``.
+
+        ``1 unit of from_commodity == rate units of to_commodity``.
+
+        Preference order:
+
+        1. Direct price (``commodity=from, currency=to``) dated on or
+           before ``as_of``, closest to ``as_of``.
+        2. Inverse price (``commodity=to, currency=from``) dated on or
+           before, closest. Returned as ``1 / p.value``.
+        3. Direct after ``as_of``, closest.
+        4. Inverse after ``as_of``, closest.
+
+        Skips piecash's auto-created ``type='transaction'`` rows —
+        those are 1.0 placeholders generated on cross-currency invoice
+        post and would mask the absence of a real market rate.
+
+        Skips zero-or-negative prices on either branch (the inverse
+        branch needs the guard to avoid div-by-zero; the direct branch
+        gets the same guard for consistent failure signaling).
+
+        Returns:
+            Decimal rate, or ``None`` when no usable price exists in
+            either direction.
+        """
+        if from_commodity == to_commodity:
+            return Decimal("1")
+
+        best_before_direct: tuple[int, Decimal] | None = None
+        best_after_direct: tuple[int, Decimal] | None = None
+        best_before_inverse: tuple[int, Decimal] | None = None
+        best_after_inverse: tuple[int, Decimal] | None = None
+
+        for p in book.prices:
+            if not _is_market_price(p):
+                continue
+            p_date = _to_date(p.date)
+            if p.commodity == from_commodity and p.currency == to_commodity:
+                days = (as_of - p_date).days
+                rate = Decimal(str(p.value))
+                if rate <= 0:
+                    continue
+                if days >= 0:
+                    if best_before_direct is None or days < best_before_direct[0]:
+                        best_before_direct = (days, rate)
+                else:
+                    if best_after_direct is None or -days < best_after_direct[0]:
+                        best_after_direct = (-days, rate)
+            elif p.commodity == to_commodity and p.currency == from_commodity:
+                days = (as_of - p_date).days
+                if Decimal(str(p.value)) <= 0:
+                    continue
+                rate = Decimal("1") / Decimal(str(p.value))
+                if days >= 0:
+                    if best_before_inverse is None or days < best_before_inverse[0]:
+                        best_before_inverse = (days, rate)
+                else:
+                    if best_after_inverse is None or -days < best_after_inverse[0]:
+                        best_after_inverse = (-days, rate)
+
+        for candidate in (
+            best_before_direct,
+            best_before_inverse,
+            best_after_direct,
+            best_after_inverse,
+        ):
+            if candidate is not None:
+                return candidate[1]
+        return None

--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -793,18 +793,11 @@ class BudgetsMixin:
             # parent has children in non-default-currency commodities
             # (e.g., USD-default book with a EUR ``Expenses:Travel``
             # leaf), summing raw ``split.quantity`` would treat 100
-            # EUR + 100 USD as 200 in the parent's row. Use the same
-            # market-rate lookup as the reporting suite, gracefully
-            # falling back to raw quantity when reporting helpers
-            # aren't available (e.g., ``--modules budgets`` without
-            # ``reporting``).
-            factors_fn = getattr(
-                self, "_account_conversion_factors", None,
-            )
-            split_in_default = getattr(
-                self, "_split_in_default_currency", None,
-            )
-            factors = factors_fn(book) if factors_fn else None
+            # EUR + 100 USD as 200 in the parent's row. The conversion
+            # helpers live on the unconditionally-composed
+            # :class:`CurrencyMixin`, so they're available regardless
+            # of which ``--modules`` are enabled.
+            factors = self._account_conversion_factors(book)
 
             # Calculate actuals from transactions
             actuals: dict[str, Decimal] = {}
@@ -816,13 +809,10 @@ class BudgetsMixin:
                     rollup_target = rollup_map.get(acct_name)
                     if rollup_target is None:
                         continue
-                    if factors is not None and split_in_default is not None:
-                        amount = split_in_default(
-                            split, split.account,
-                            factors.get(split.account.guid),
-                        )
-                    else:
-                        amount = Decimal(str(split.quantity))
+                    amount = self._split_in_default_currency(
+                        split, split.account,
+                        factors.get(split.account.guid),
+                    )
                     if split.account.type == "EXPENSE" and amount > 0:
                         actuals[rollup_target] = actuals.get(
                             rollup_target, Decimal("0")

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -20,8 +20,6 @@ from decimal import Decimal
 import piecash
 
 from gnucash_mcp.book._base import (
-    _is_market_price,
-    _to_date,
     _to_decimal,
     _verify_composite_write,
     _verify_write,
@@ -429,80 +427,6 @@ class BusinessMixin:
             s_quantity = abs(Decimal(str(s.quantity)))
             if s_value > 0:
                 return s_quantity / s_value
-        return None
-
-    @staticmethod
-    def _find_exchange_rate(book, from_commodity, to_commodity, as_of: date):
-        """Look up an exchange rate from book.prices for a cross-currency
-        payment: 1 unit of ``from_commodity`` equals how many of
-        ``to_commodity`` on or near ``as_of``.
-
-        Prefers prices on or before ``as_of`` (most recent). Falls back to
-        the earliest price after ``as_of`` if none exist before. Accepts
-        inverse prices (e.g., a USD→EUR price can resolve EUR→USD by
-        inversion).
-
-        Skips prices with ``type='transaction'`` — those are auto-
-        created at 1.0 by piecash when a cross-currency invoice is
-        posted without an explicit rate, and would mask the absence of
-        a real user-supplied rate.
-
-        Returns a Decimal rate, or None if no usable (non-transaction)
-        price exists in either direction.
-        """
-        if from_commodity == to_commodity:
-            return Decimal("1")
-
-        best_before_direct = None   # (days_before, Decimal rate)
-        best_after_direct = None    # (days_after, Decimal rate)
-        best_before_inverse = None
-        best_after_inverse = None
-
-        for p in book.prices:
-            # Skip piecash's auto-created post-invoice default rates.
-            if not _is_market_price(p):
-                continue
-
-            p_date = _to_date(p.date)
-            # Direct: p.commodity == from, p.currency == to → rate = p.value
-            if p.commodity == from_commodity and p.currency == to_commodity:
-                days = (as_of - p_date).days
-                rate = Decimal(str(p.value))
-                # Skip zero-or-negative direct rates. The inverse
-                # branch already skips zero (would div-by-zero); the
-                # direct branch was missing the same guard, so a
-                # corrupt 0-or-negative price could propagate as the
-                # winning rate. Downstream pay_quantize-to-zero
-                # would then fire the new guard, but flagging at
-                # rate-lookup time gives a clearer signal.
-                if rate <= 0:
-                    continue
-                if days >= 0:
-                    if best_before_direct is None or days < best_before_direct[0]:
-                        best_before_direct = (days, rate)
-                else:
-                    if best_after_direct is None or -days < best_after_direct[0]:
-                        best_after_direct = (-days, rate)
-            # Inverse: p.commodity == to, p.currency == from → rate = 1/p.value
-            elif p.commodity == to_commodity and p.currency == from_commodity:
-                days = (as_of - p_date).days
-                if Decimal(str(p.value)) <= 0:
-                    continue
-                rate = Decimal("1") / Decimal(str(p.value))
-                if days >= 0:
-                    if best_before_inverse is None or days < best_before_inverse[0]:
-                        best_before_inverse = (days, rate)
-                else:
-                    if best_after_inverse is None or -days < best_after_inverse[0]:
-                        best_after_inverse = (-days, rate)
-
-        # Priority: before-direct > before-inverse > after-direct > after-inverse
-        for candidate in (
-            best_before_direct, best_before_inverse,
-            best_after_direct, best_after_inverse,
-        ):
-            if candidate is not None:
-                return candidate[1]
         return None
 
     @staticmethod

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -245,41 +245,6 @@ class CoreMixin:
         results.sort(key=lambda r: r["account"])
         return results
 
-    def _rates_as_of(
-        self,
-        book: piecash.Book,
-        as_of: date,
-        default_currency: piecash.Commodity,
-    ) -> dict[str, Decimal]:
-        """For each non-default-currency commodity, return the most
-        recent user-supplied price (in default currency) on or before
-        ``as_of``. Skips piecash's auto-created
-        ``type='transaction'`` placeholder prices the same way the
-        rest of the codebase does — those are post-invoice
-        bookkeeping artifacts, not market quotes.
-
-        Returns ``{commodity_guid: rate}``. Commodities without a
-        price <= as_of don't appear; callers should fall back to
-        skipping that account for trajectory purposes (or use cost
-        basis, depending on the caller's contract).
-        """
-        latest: dict[str, tuple[date, Decimal]] = {}
-        for p in book.prices:
-            if p.currency != default_currency:
-                continue
-            if not _is_market_price(p):
-                continue
-            p_date = p.date
-            if hasattr(p_date, "date") and callable(p_date.date):
-                p_date = p_date.date()
-            if p_date > as_of:
-                continue
-            cguid = p.commodity.guid
-            prev = latest.get(cguid)
-            if prev is None or p_date > prev[0]:
-                latest[cguid] = (p_date, Decimal(str(p.value)))
-        return {k: v[1] for k, v in latest.items()}
-
     # Asset-side and liability-side type sets used by the net-worth
     # computation. Mirrors the existing in-summary breakdown — the
     # asset section iterates these types into per-leaf rows; the
@@ -342,7 +307,7 @@ class CoreMixin:
         # the rationale; both paths converge on this behavior so the
         # "now" anchor agrees with balance_sheet by construction.
         if as_of >= date.today():
-            rates = self._latest_market_rates(book)
+            rates = self._rates_as_of(book)
         else:
             rates = self._rates_as_of(book, as_of, default_currency)
 
@@ -1484,33 +1449,10 @@ class CoreMixin:
             # two surfaces agree on which price is "current" for
             # every commodity — including the bookkeeper's
             # intentional future-dated yfinance forecast entries.
-            # Helper already excludes piecash auto-created
-            # ``type='transaction'`` prices (cross-currency
-            # placeholders, not market quotes).
-            latest_prices: dict[str, Decimal] = self._latest_market_rates(book)
-
-            def _market_value(account, quantity: Decimal) -> tuple[Decimal, str | None]:
-                """Return (USD value, note) for an account's quantity.
-
-                ``note`` is None for default-currency accounts, a formatted
-                "N.NNN SYM @ $X.XX" string for priced foreign-currency
-                accounts, and a "no price data" marker otherwise.
-                """
-                if account.commodity == default_currency:
-                    return quantity, None
-                sym = account.commodity.mnemonic
-                rate = latest_prices.get(account.commodity.guid)
-                if rate is not None:
-                    return (quantity * rate), f"{quantity} {sym} @ {rate}"
-                # Fallback: cost basis from split values (transaction currency).
-                # Same today filter as the balance computation —
-                # without it, future-dated buys would inflate cost
-                # basis past the as-of-today snapshot.
-                cost_basis = Decimal("0")
-                for s in account.splits:
-                    if s.transaction.post_date <= today:
-                        cost_basis += Decimal(str(s.value))
-                return cost_basis, f"{quantity} {sym} — no price data"
+            # ``_rates_as_of(book)`` (no upper bound) already excludes
+            # piecash auto-created ``type='transaction'`` prices
+            # (cross-currency placeholders, not market quotes).
+            latest_prices: dict[str, Decimal] = self._rates_as_of(book)
 
             # --- Account stats ---
             asset_types = {"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"}
@@ -1554,7 +1496,12 @@ class CoreMixin:
 
                 if account.type in asset_types:
                     if is_leaf and balance != 0:
-                        usd_value, note = _market_value(account, balance)
+                        usd_value, note = self._market_value(
+                            account, balance,
+                            rates=latest_prices,
+                            default_currency=default_currency,
+                            today=today,
+                        )
                         asset_leaves.append((leaf, usd_value, note))
                 elif account.type == "CREDIT":
                     if is_leaf:
@@ -1569,12 +1516,22 @@ class CoreMixin:
                 elif account.type == "RECEIVABLE":
                     if is_leaf and balance != 0:
                         # A/R is debit-natural: positive balance = owed to us.
-                        usd_value, _ = _market_value(account, balance)
+                        usd_value, _ = self._market_value(
+                            account, balance,
+                            rates=latest_prices,
+                            default_currency=default_currency,
+                            today=today,
+                        )
                         receivable_accts.append((leaf, usd_value))
                 elif account.type == "PAYABLE":
                     if is_leaf and balance != 0:
                         # A/P is credit-natural: negate for "what we owe".
-                        usd_value, _ = _market_value(account, -balance)
+                        usd_value, _ = self._market_value(
+                            account, -balance,
+                            rates=latest_prices,
+                            default_currency=default_currency,
+                            today=today,
+                        )
                         payable_accts.append((leaf, usd_value))
                 elif account.type == "INCOME":
                     income_total += 1

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -26,7 +26,7 @@ from decimal import Decimal, InvalidOperation
 
 import piecash
 
-from gnucash_mcp.book._base import _is_market_price, _to_decimal
+from gnucash_mcp.book._base import _to_decimal
 from gnucash_mcp._format import _format_number
 
 # Account-type groups used across the reports. Defined at module level
@@ -222,95 +222,6 @@ class ReportingMixin:
         if target_depth >= len(path):
             return account
         return path[target_depth]
-
-    # ── Cross-commodity conversion helpers ────────────────────────────
-    #
-    # For reports that aggregate asset balances across accounts with
-    # different commodities (e.g. USD Checking + VTSAX shares + EUR
-    # Savings), split.quantity lives in each account's own commodity
-    # and can't be summed directly. Convert each account's quantity
-    # to the book's default currency at the latest user-supplied
-    # market price before aggregating. Fallback: split.value (which
-    # is in the transaction currency, generally the book default for
-    # USD-denominated investment buys) is used when no price is on
-    # file — that yields cost basis, which is a reasonable default
-    # when no market price has been loaded.
-
-    def _latest_market_rates(
-        self, book: piecash.Book
-    ) -> dict[str, Decimal]:
-        """Return {commodity_guid: Decimal} — latest user-supplied
-        price for each non-default-currency commodity in the book
-        currency. Skips piecash's auto-created ``type='transaction'``
-        prices (they capture the effective rate of a cross-currency
-        txn; we want explicit market prices).
-        """
-        default_currency = self._require_default_currency(book)
-        latest: dict[str, tuple] = {}  # guid → (date, Decimal rate)
-        for p in book.prices:
-            if p.currency != default_currency:
-                continue
-            if not _is_market_price(p):
-                continue
-            p_date = p.date
-            if hasattr(p_date, "date") and callable(p_date.date):
-                p_date = p_date.date()
-            key = p.commodity.guid
-            existing = latest.get(key)
-            if existing is None or p_date > existing[0]:
-                latest[key] = (p_date, Decimal(str(p.value)))
-        return {guid: rate for guid, (_date, rate) in latest.items()}
-
-    def _account_conversion_factors(
-        self, book: piecash.Book
-    ) -> dict[str, Decimal | None]:
-        """Return {account_guid: Decimal factor or None}.
-
-        ``factor * split.quantity = amount in default currency``.
-        A factor of 1 means the account is already in the default
-        currency. ``None`` means no rate is available — callers
-        should fall back to ``split.value`` (transaction-currency
-        amount), which correctly reflects cost basis for USD-
-        denominated investment buys.
-
-        Template accounts (under ``book.root_template``) are
-        excluded from the map. Today no caller looks up template
-        GUIDs in the result — they all start from
-        ``_resolve_account``-validated GUIDs that already exclude
-        templates — so this is hygiene rather than a bug fix.
-        Keeps the map honest about what it represents (user
-        chart only) and prevents a future caller from accidentally
-        getting a factor for scaffolding.
-        """
-        default_currency = self._require_default_currency(book)
-        rates = self._latest_market_rates(book)
-        template_guids = self._template_account_guids(book)
-        factors: dict[str, Decimal | None] = {}
-        for acct in book.accounts:
-            if acct.guid in template_guids:
-                continue
-            if acct.commodity == default_currency:
-                factors[acct.guid] = Decimal("1")
-            else:
-                factors[acct.guid] = rates.get(acct.commodity.guid)
-        return factors
-
-    @staticmethod
-    def _split_in_default_currency(
-        split,
-        account,
-        factor: Decimal | None,
-    ) -> Decimal:
-        """Value a single split in the book's default currency.
-
-        Uses ``factor * quantity`` when a factor is available. Falls
-        back to ``split.value`` otherwise — correct for STOCK/MUTUAL
-        splits whose transaction currency is the book default, and a
-        reasonable cost-basis approximation for other cases.
-        """
-        if factor is not None:
-            return Decimal(str(split.quantity)) * factor
-        return Decimal(str(split.value))
 
     # ── SQL-filtered split iterator ───────────────────────────────────
 
@@ -579,9 +490,10 @@ class ReportingMixin:
             default_currency = self._require_default_currency(book)
             # Latest market rates keyed by commodity guid — same data
             # ``_market_value`` in get_book_summary uses for the per-
-            # account display. ``_latest_market_rates`` already excludes
-            # piecash auto-created ``type='transaction'`` prices.
-            latest_rates = self._latest_market_rates(book)
+            # account display. ``_rates_as_of(book)`` (no date filter)
+            # already excludes piecash auto-created ``type='transaction'``
+            # prices.
+            latest_rates = self._rates_as_of(book)
 
             assets: dict[str, dict] = {}
             liabilities: dict[str, dict] = {}

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -4,7 +4,7 @@ import pytest
 from decimal import Decimal
 from pathlib import Path
 
-from gnucash_mcp.book import GnuCashBook
+from gnucash_mcp.book import GnuCashBook, build_book_class
 
 
 # ============== TestCreateBudget ==============
@@ -733,6 +733,122 @@ class TestGetBudgetReport:
         by_acct = {a["account"]: a for a in report["accounts"]}
         # Parent rollup: 100 USD + (100 EUR × 1.10) = 210 USD.
         # Pre-fix, raw quantity sum produced 200.
+        assert Decimal(by_acct["Expenses:Travel"]["actual"]) == Decimal("210")
+
+    def test_cross_currency_rollup_without_reporting_module(
+        self, budget_book: Path,
+    ):
+        """Cross-currency budget rollup must work on a ``--modules
+        core,budgets`` build with no reporting mixin loaded.
+
+        Pre-fix, the conversion helpers
+        (``_account_conversion_factors`` / ``_split_in_default_currency``)
+        lived on ReportingMixin; budgets reached them via
+        ``getattr(self, ..., None)`` and silently degraded to raw
+        ``split.quantity`` sums when reporting was disabled — the
+        same bug class v1.2.1 fixed for the reports themselves, now
+        hiding behind a feature flag.
+
+        After the v1.3 Stage 1 work, currency helpers live on
+        :class:`CurrencyMixin` composed into :class:`BaseGnuCashBook`
+        unconditionally. This test exercises the
+        ``{"core","budgets"}`` build path explicitly to confirm a
+        100 EUR + 100 USD spend rolls up as 210 USD on a budgeted
+        USD parent (not 200).
+        """
+        import piecash
+        from datetime import date as _date
+        from piecash._common import GnucashException
+        from piecash import factories
+
+        # Use the default-build GnuCashBook to seed the data — write
+        # path needs the full toolkit. The currency-mixin assertion
+        # is on the *read* path (`get_budget_report`) using the
+        # restricted-module build below.
+        gc = GnuCashBook(str(budget_book))
+        with gc.open(readonly=False) as b:
+            usd = b.default_currency
+            try:
+                eur = factories.create_currency_from_ISO("EUR")
+                b.session.add(eur)
+                b.flush()
+            except (GnucashException, Exception):
+                eur = next(
+                    (c for c in b.commodities if c.mnemonic == "EUR"), None,
+                )
+                if eur is None:
+                    raise
+
+            expenses = next(
+                a for a in b.accounts if a.fullname == "Expenses"
+            )
+            checking = next(
+                a for a in b.accounts if a.fullname == "Assets:Checking"
+            )
+            travel = piecash.Account(
+                name="Travel", type="EXPENSE", parent=expenses,
+                commodity=usd, placeholder=True,
+            )
+            europe = piecash.Account(
+                name="Europe", type="EXPENSE", parent=travel,
+                commodity=eur,
+            )
+            us = piecash.Account(
+                name="US", type="EXPENSE", parent=travel, commodity=usd,
+            )
+            piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date(2026, 1, 1),
+                value=Decimal("1.10"),
+                source="user:price", type="last",
+            )
+            piecash.Transaction(
+                currency=usd, description="Hotel in Berlin",
+                post_date=_date(2026, 1, 10),
+                splits=[
+                    piecash.Split(
+                        account=checking, value=Decimal("-110"),
+                        quantity=Decimal("-110"),
+                    ),
+                    piecash.Split(
+                        account=europe, value=Decimal("110"),
+                        quantity=Decimal("100"),
+                    ),
+                ],
+            )
+            piecash.Transaction(
+                currency=usd, description="Hotel in Boston",
+                post_date=_date(2026, 1, 15),
+                splits=[
+                    piecash.Split(
+                        account=checking, value=Decimal("-100"),
+                    ),
+                    piecash.Split(
+                        account=us, value=Decimal("100"),
+                    ),
+                ],
+            )
+            b.save()
+        gc.create_budget(name="Travel Budget", year=2026, num_periods=12)
+        gc.set_budget_amount(
+            budget_name="Travel Budget",
+            account="Expenses:Travel", amount="500", period=0,
+        )
+
+        # ── The actual assertion: query via the restricted build ──
+        BookClass = build_book_class({"core", "budgets"})
+        # Sanity: this build must NOT carry ReportingMixin's namespace.
+        assert "ReportingMixin" not in {
+            base.__name__ for base in BookClass.__mro__
+        }, "Test setup: build_book_class leaked ReportingMixin"
+
+        restricted = BookClass(str(budget_book))
+        report = restricted.get_budget_report(
+            compact=False,
+            budget_name="Travel Budget", period=0,
+        )
+        by_acct = {a["account"]: a for a in report["accounts"]}
+        # 100 USD + (100 EUR × 1.10) = 210 USD. Raw quantity sum = 200.
         assert Decimal(by_acct["Expenses:Travel"]["actual"]) == Decimal("210")
 
     def test_report_nonexistent_budget_raises(self, budget_book: Path):


### PR DESCRIPTION
## Summary

- Extracts the cross-commodity conversion helpers (``_rates_as_of``, ``_account_conversion_factors``, ``_split_in_default_currency``, ``_market_value``, ``_find_exchange_rate``) into a new ``book/_currency.py`` module containing ``CurrencyMixin``.
- ``BaseGnuCashBook`` now inherits from ``CurrencyMixin`` directly, so the helpers are present on every constructed ``GnuCashBook`` class regardless of ``--modules``. Currency conversion is now cross-cutting infrastructure, not a feature flag.
- Closes the v1.2.1-retrospective hole where ``book/budgets.py`` reached the helpers via ``getattr(self, "_account_conversion_factors", None)`` and silently degraded to raw ``split.quantity`` sums when the reporting module was disabled — the same bug class v1.2.1 fixed for the reports themselves, hiding behind ``--modules``.
- Unified ``_latest_market_rates(book)`` and ``_rates_as_of(book, as_of, ccy)`` into one signature with ``as_of=None`` (latest, unbounded) as the default. Replaced the 22-line ``_market_value`` closure inside ``get_book_summary`` with three ``self._market_value(...)`` call sites; the rates map is still collected once outside the loop and threaded in, so the price-map caching is preserved.
- Stage 1 of [VERSION_1_3_PLAN.md](specs/VERSION_1_3_PLAN.md)'s "Suggested ordering".

## Test plan

- [x] All 1,116 existing tests still pass (no regressions).
- [x] New regression test ``test_cross_currency_rollup_without_reporting_module`` builds via ``build_book_class({"core","budgets"})``, asserts ``ReportingMixin`` is not in the MRO, then verifies a 100 EUR + 100 USD spend rolls up as 210 USD on a budgeted parent (raw quantity sum was 200). 1,117 passing total.
- [x] Bookkeeper live-verified against Alex (USD-default) — six tools byte-identical pre/post: ``get_book_summary``, ``balance_sheet``, ``net_worth`` (current + past), ``cash_flow``, ``spending_by_category``, ``income_by_source``. Pre/post snapshots saved at ``specs/refactor-baselines-before.txt``.
- [x] Bookkeeper live-verified against Lin Wei (CNY-default) — cross-tool agreement on every multi-currency holding (Moutai, CSI300, ChiNext, CATL valuations agree across ``get_book_summary`` and ``balance_sheet``).