### PR TITLE
feat(v1.3): stage 2 quick wins — reconcile bulk mode, validator extraction, helper unification

### DIFF
--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_EVEN, Decimal
 
 import piecash
+from dateutil.relativedelta import relativedelta
 from piecash._common import Recurrence
 from piecash.budget import Budget, BudgetAmount
 
@@ -279,8 +280,6 @@ class BudgetsMixin:
         Raises:
             ValueError: If period_num is out of range.
         """
-        from dateutil.relativedelta import relativedelta
-
         if period_num < 0 or period_num >= budget.num_periods:
             raise ValueError(
                 f"Period {period_num} out of range "

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -52,44 +52,35 @@ def _commodity_quantum(commodity) -> Decimal:
     return Decimal(1) / Decimal(fraction)
 
 
-def _safe_date_posted(inv):
-    """Read ``inv.date_posted`` defensively.
+def _safe_invoice_date(inv, attr: str):
+    """Read an invoice datetime column defensively.
 
-    Returns the datetime (or whatever the ORM gives back) when
-    the column holds a real value, or ``None`` when the column
-    is NULL, empty, or malformed enough that piecash's
-    ``_DateTime`` TypeDecorator raises ``ValueError`` on access.
+    Returns the datetime when the named column holds a real value,
+    or ``None`` when it's NULL, empty, or malformed enough that
+    piecash's ``_DateTime`` TypeDecorator raises ``ValueError`` on
+    access.
 
-    The bookkeeper hit this on Alex Chen-Morales's book: a
-    freshly auto-id'd bill's ``date_posted`` came back as ``''``
-    in SQL. SQLAlchemy's regex-based DATETIME parser raises
-    "Couldn't parse datetime string" when reading that — a hard
-    crash on a never-posted document. Wrapping the access lets
-    every caller treat the document as not-posted gracefully.
+    The bookkeeper hit the underlying piecash bug on Alex
+    Chen-Morales's book: a freshly auto-id'd bill's
+    ``date_posted`` came back as ``''`` in SQL. SQLAlchemy's
+    regex-based DATETIME parser raises "Couldn't parse datetime
+    string" when reading that — a hard crash on a never-posted
+    document. Same failure mode applies verbatim to
+    ``date_opened`` (and any future ``_DateTime``-typed column on
+    invoices). One helper, parameterized on the attribute name,
+    covers every caller.
+
+    Args:
+        inv: piecash Invoice / Bill ORM object.
+        attr: Attribute name — typically ``"date_posted"`` or
+            ``"date_opened"``.
+
+    Returns:
+        Datetime when populated and parseable, ``None`` otherwise.
     """
     try:
-        dp = inv.date_posted
-        return dp if dp else None
-    except (ValueError, TypeError):
-        return None
-
-
-def _safe_date_opened(inv):
-    """Read ``inv.date_opened`` defensively.
-
-    Same shape as ``_safe_date_posted`` but for the ``date_opened``
-    column. piecash's ``_DateTime`` TypeDecorator has the same
-    regex-parser failure mode on empty-string column values; the
-    bookkeeper's reproduction with ``date_posted`` is exactly
-    replicable on ``date_opened``. ``_invoice_to_dict``,
-    ``_invoice_to_compact_line``, and ``list_invoices`` all access
-    ``inv.date_opened.date()`` and would crash on a malformed row.
-    Wrapping the access lets every caller treat that field as
-    "unknown" gracefully.
-    """
-    try:
-        do = inv.date_opened
-        return do if do else None
+        value = getattr(inv, attr)
+        return value if value else None
     except (ValueError, TypeError):
         return None
 
@@ -98,11 +89,11 @@ def _is_invoice_posted(inv) -> bool:
     """True iff ``inv`` has a real datetime in ``date_posted``.
 
     Single chokepoint for "is this document posted?" across the
-    business module. Built on ``_safe_date_posted`` so the
+    business module. Built on ``_safe_invoice_date`` so the
     tolerant semantics (None / "" / unparseable values all read
     as not-posted) apply uniformly.
     """
-    return _safe_date_posted(inv) is not None
+    return _safe_invoice_date(inv, "date_posted") is not None
 
 
 def _format_vendor_spending_compact(
@@ -803,12 +794,12 @@ class BusinessMixin:
             "type": "bill" if invoice.owner_type == 4 else "invoice",
             "owner_name": owner_name,
             "date_opened": (
-                str(_safe_date_opened(invoice).date())
-                if _safe_date_opened(invoice) else None
+                str(_safe_invoice_date(invoice, "date_opened").date())
+                if _safe_invoice_date(invoice, "date_opened") else None
             ),
             "date_posted": (
-                str(_safe_date_posted(invoice).date())
-                if _safe_date_posted(invoice) else None
+                str(_safe_invoice_date(invoice, "date_posted").date())
+                if _safe_invoice_date(invoice, "date_posted") else None
             ),
             "notes": invoice.notes or "",
             "active": bool(invoice.active),
@@ -832,7 +823,7 @@ class BusinessMixin:
         unambiguously. Bills get the ``BILL`` tag (was already there).
         """
         inv_type = "BILL" if invoice.owner_type == 4 else "INV"
-        opened = _safe_date_opened(invoice)
+        opened = _safe_invoice_date(invoice, "date_opened")
         date_str = (
             str(opened.date()) if opened else "n/a"
         )
@@ -2825,7 +2816,7 @@ class BusinessMixin:
             # to see what they unposted ("was posted: 2026-04-01,
             # post_account: Assets:Receivables:..."). Read pre-clear
             # so the values are still set on the ORM object.
-            prev_post_date = _safe_date_posted(inv)
+            prev_post_date = _safe_invoice_date(inv, "date_posted")
             prev_post_account = (
                 inv.post_account.fullname if inv.post_account else None
             )
@@ -3750,7 +3741,7 @@ class BusinessMixin:
                     if c:
                         owner_name = c.name
 
-                posted_dt = _safe_date_posted(inv)
+                posted_dt = _safe_invoice_date(inv, "date_posted")
                 # Resolve the due date through the same three-step
                 # chain the warnings collector uses, so the bookkeeper
                 # sees identical numbers in both places.
@@ -3850,12 +3841,12 @@ class BusinessMixin:
 
             bills = query.all()
 
-            # Filter by date range. ``_safe_date_posted`` returns
+            # Filter by date range. ``_safe_invoice_date`` returns
             # None for records where date_posted is missing or
             # malformed (empty-string state) — those drop out.
             filtered_bills = []
             for b in bills:
-                posted = _safe_date_posted(b)
+                posted = _safe_invoice_date(b, "date_posted")
                 if posted is None:
                     continue
                 if parsed_start <= posted.date() <= parsed_end:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2661,6 +2661,98 @@ class CoreMixin:
 
         return warnings
 
+    def _validate_transaction_splits(
+        self,
+        book: piecash.Book,
+        splits: list[dict],
+        trans_currency: piecash.Commodity,
+    ) -> list[dict]:
+        """Validate splits and pre-resolve accounts — before any mutation.
+
+        Single chokepoint for the input-shape rules that both
+        ``create_transaction`` and ``update_transaction`` enforce:
+
+        - Splits sum to zero (in transaction currency).
+        - Every ``account`` reference resolves to a real Account
+          (accepts path, ``%short``, or full GUID).
+        - For each split, the ``quantity`` is either implicit
+          (account commodity == transaction currency, in which case
+          ``quantity == value``) or explicit (cross-currency, caller
+          must supply ``quantity`` with the same sign as ``value``).
+
+        Pre-extraction, ``update_transaction`` interleaved these
+        checks with the mutation loop — the first split would have
+        ``split.value`` reassigned BEFORE the sibling split's
+        cross-currency quantity was validated, so a bad-input
+        update could leave the transaction in a partial state if
+        the session didn't rollback cleanly. Validating everything
+        up-front makes the subsequent mutation pass effectively
+        infallible.
+
+        Args:
+            book: Open piecash book.
+            splits: Input splits (each with ``account``, ``amount``,
+                optionally ``quantity`` and ``memo``).
+            trans_currency: piecash Commodity to validate sign-and-
+                quantity rules against. For create this is the
+                user-supplied or default currency; for update this
+                is the existing transaction's currency (update does
+                not allow changing currency).
+
+        Returns:
+            List of dicts (same order as input) with keys
+            ``account`` (resolved piecash Account), ``value``
+            (Decimal), ``quantity`` (Decimal), ``memo`` (string or
+            ``None``), ``original_ref`` (raw input ref — preserved
+            for error messages downstream).
+
+        Raises:
+            ValueError on imbalance, account not found, cross-
+            currency split missing ``quantity``, or value/quantity
+            sign mismatch.
+        """
+        total = Decimal("0")
+        for split in splits:
+            total += _to_decimal(split["amount"])
+        if total != Decimal("0"):
+            raise ValueError(f"Splits do not balance: total is {total}")
+
+        resolved: list[dict] = []
+        for split in splits:
+            ref = split["account"]
+            account = self._resolve_account(book, ref)
+            if not account:
+                raise ValueError(f"Account not found: {ref}")
+
+            value = _to_decimal(split["amount"])
+            if account.commodity == trans_currency:
+                quantity = value
+            elif "quantity" in split:
+                quantity = _to_decimal(split["quantity"])
+                if quantity * value < 0:
+                    raise ValueError(
+                        f"Split for '{ref}': quantity and value "
+                        f"must have same sign "
+                        f"(got value={value}, quantity={quantity})"
+                    )
+            else:
+                raise ValueError(
+                    f"Split for '{ref}' requires 'quantity' "
+                    f"because account commodity "
+                    f"({account.commodity.mnemonic}) differs from "
+                    f"transaction currency ({trans_currency.mnemonic})"
+                )
+
+            resolved.append({
+                "account": account,
+                "value": value,
+                "quantity": quantity,
+                "memo": split.get("memo"),
+                "original_ref": ref,
+            })
+
+        return resolved
+
     def create_transaction(
         self,
         description: str,
@@ -2755,15 +2847,17 @@ class CoreMixin:
             if len(splits) < 2:
                 raise ValueError("Transaction must have at least 2 splits")
 
-            # Validate balance (using "amount" as transaction-currency value).
-            # _to_decimal routes through str() so a float that slipped past
-            # the pydantic boundary decimalizes via shortest-repr instead of
-            # embedding IEEE-754 epsilon in the sum.
-            total = Decimal("0")
-            for split in splits:
-                total += _to_decimal(split["amount"])
-            if total != Decimal("0"):
-                raise ValueError(f"Splits do not balance: total is {total}")
+            # Sum-to-zero / account-resolution / cross-currency
+            # sign-and-quantity checks live in the shared validator
+            # paired with update_transaction. Splits sum is computed
+            # with ``_to_decimal`` (str-routed) so a float that slipped
+            # past the pydantic boundary decimalizes via shortest-repr
+            # rather than embedding IEEE-754 epsilon in the sum.
+            #
+            # Currency resolution still happens here (create accepts
+            # ``currency=`` user input; update reuses the existing
+            # transaction's currency) so the validator gets the right
+            # ``trans_currency`` to compare account commodities against.
 
             proposed_amounts = [abs(_to_decimal(s["amount"])) for s in splits]
 
@@ -2810,13 +2904,19 @@ class CoreMixin:
             else:
                 trans_currency = self._get_or_create_currency(book, currency)
 
+            # Shared validator: sum-to-zero, account resolution,
+            # cross-currency quantity/sign. Returns pre-resolved
+            # piecash Accounts + Decimal value/quantity per split,
+            # so the placeholder check and Split construction below
+            # are pure motion against validated data.
+            validated = self._validate_transaction_splits(
+                book, splits, trans_currency,
+            )
+
             piecash_splits = []
             resolved_accounts = []
-            for split in splits:
-                account = self._resolve_account(book, split["account"])
-                if not account:
-                    raise ValueError(f"Account not found: {split['account']}")
-
+            for v in validated:
+                account = v["account"]
                 if account.placeholder:
                     children_hint = ", ".join(
                         c.fullname for c in account.children
@@ -2828,27 +2928,6 @@ class CoreMixin:
                     )
 
                 resolved_accounts.append(account)
-                value = _to_decimal(split["amount"])
-
-                # Determine quantity (same-currency: equals value;
-                # cross-currency: caller must provide and sign-match).
-                if account.commodity == trans_currency:
-                    quantity = value
-                elif "quantity" in split:
-                    quantity = _to_decimal(split["quantity"])
-                    if quantity * value < 0:
-                        raise ValueError(
-                            f"Split for '{split['account']}': quantity and value "
-                            f"must have same sign "
-                            f"(got value={value}, quantity={quantity})"
-                        )
-                else:
-                    raise ValueError(
-                        f"Split for '{split['account']}' requires 'quantity' "
-                        f"because account commodity "
-                        f"({account.commodity.mnemonic}) differs from "
-                        f"transaction currency ({trans_currency.mnemonic})"
-                    )
 
                 # Don't construct piecash.Split objects during dry_run —
                 # adding to the session would stage a write even if we
@@ -2857,9 +2936,9 @@ class CoreMixin:
                     piecash_splits.append(
                         piecash.Split(
                             account=account,
-                            value=value,
-                            quantity=quantity,
-                            memo=split.get("memo", ""),
+                            value=v["value"],
+                            quantity=v["quantity"],
+                            memo=v["memo"] or "",
                         )
                     )
 
@@ -3654,68 +3733,46 @@ class CoreMixin:
 
             # Update splits if provided
             if splits is not None:
-                # Validate splits balance to zero
-                total = Decimal("0")
-                for split in splits:
-                    total += _to_decimal(split["amount"])
-                if total != Decimal("0"):
-                    raise ValueError(f"Splits do not balance: total is {total}")
-
-                # Build a map of canonical-fullname → split data.
-                # Resolve any input refs (path, ``%short``, full GUID)
-                # to the canonical Account so the lookup against
-                # existing splits' ``account.fullname`` works for all
-                # three input shapes. Pre-fix this dict was keyed by
-                # the raw input string, so a shortcut input like
-                # ``%77b59dd`` produced "Account not found in
-                # transaction" even though the ref resolved cleanly.
-                split_updates = {}
-                for s in splits:
-                    ref = s["account"]
-                    resolved = self._resolve_account(book, ref)
-                    if resolved is None:
-                        raise ValueError(
-                            f"Account not found: {ref}"
-                        )
-                    split_updates[resolved.fullname] = s
-
                 trans_currency = transaction.currency
 
-                # Update existing splits
+                # Validate everything up-front via the shared validator:
+                # sum-to-zero, account resolution (path / %short / full
+                # GUID), cross-currency quantity/sign. Pre-extraction
+                # the validation interleaved with mutation — the first
+                # split's ``value`` was reassigned before the sibling's
+                # cross-currency quantity was checked, so a bad-input
+                # update could leave the transaction in a partial state
+                # if the session didn't rollback cleanly. Now the
+                # mutation pass below is effectively infallible.
+                validated = self._validate_transaction_splits(
+                    book, splits, trans_currency,
+                )
+
+                # Build a map keyed by resolved-account-fullname so we
+                # can match against existing splits' ``account.fullname``.
+                split_updates = {
+                    v["account"].fullname: v for v in validated
+                }
+                # Preserve raw input dicts so ``memo`` updates (which
+                # the validator doesn't carry) still apply.
+                raw_by_fullname = {
+                    v["account"].fullname: raw
+                    for v, raw in zip(validated, splits)
+                }
+
+                # Update existing splits — pure mutation, validated above.
                 for split in transaction.splits:
                     account_name = split.account.fullname
                     if account_name in split_updates:
-                        update = split_updates[account_name]
-                        new_value = _to_decimal(update["amount"])
-                        split.value = new_value
-
-                        # Determine quantity
-                        if split.account.commodity == trans_currency:
-                            split.quantity = new_value
-                        elif "quantity" in update:
-                            new_quantity = _to_decimal(update["quantity"])
-                            if new_quantity * new_value < 0:
-                                raise ValueError(
-                                    f"Split for '{account_name}': quantity and value "
-                                    f"must have same sign "
-                                    f"(got value={new_value}, quantity={new_quantity})"
-                                )
-                            split.quantity = new_quantity
-                        else:
-                            raise ValueError(
-                                f"Split for '{account_name}' requires 'quantity' "
-                                f"because account commodity "
-                                f"({split.account.commodity.mnemonic}) differs from "
-                                f"transaction currency ({trans_currency.mnemonic})"
-                            )
-
-                        # Update memo if provided
-                        if "memo" in update:
-                            split.memo = update["memo"]
-
+                        v = split_updates[account_name]
+                        split.value = v["value"]
+                        split.quantity = v["quantity"]
+                        raw = raw_by_fullname[account_name]
+                        if "memo" in raw:
+                            split.memo = raw["memo"]
                         del split_updates[account_name]
 
-                # Check if all provided accounts were found
+                # Check if all provided accounts were found in the txn.
                 if split_updates:
                     missing = list(split_updates.keys())[0]
                     raise ValueError(f"Account not found in transaction: {missing}")

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -16,6 +16,7 @@ from datetime import date
 from decimal import Decimal
 
 import piecash
+from piecash.core.commodity import Price
 from piecash.core.transaction import Lot
 
 from gnucash_mcp.book._base import (
@@ -210,7 +211,6 @@ class InvestmentsMixin:
             # Indexed query — pre-fix this walked every price in the book
             # for every create_price call. On a book with thousands of
             # historical prices that's a measurable hot path.
-            from piecash.core.commodity import Price
             candidates = book.session.query(Price).filter_by(
                 commodity_guid=comm.guid,
                 currency_guid=resolved_currency.guid,
@@ -298,7 +298,6 @@ class InvestmentsMixin:
             # The date filter stays in Python because piecash's date
             # column is a DateTime under the hood; comparing on the
             # date portion is awkward in raw SQLAlchemy.
-            from piecash.core.commodity import Price
             filters = {"commodity_guid": comm.guid}
             if source is not None:
                 filters["source"] = source
@@ -396,7 +395,6 @@ class InvestmentsMixin:
             # Indexed query: filter by commodity_guid up front so we
             # don't iterate every price in the book. Currency filter
             # stays in Python because it's optional.
-            from piecash.core.commodity import Price
             candidates = book.session.query(Price).filter_by(
                 commodity_guid=comm.guid,
             ).all()
@@ -497,7 +495,6 @@ class InvestmentsMixin:
                 currency = self._require_default_currency(book).mnemonic
 
             # Indexed query — only iterate prices for this commodity.
-            from piecash.core.commodity import Price
             candidates = book.session.query(Price).filter_by(
                 commodity_guid=comm.guid,
             ).all()
@@ -941,7 +938,6 @@ class InvestmentsMixin:
                 # session). Indexed by commodity so we don't iterate
                 # every price in the book.
                 commodity = lot.account.commodity
-                from piecash.core.commodity import Price
                 candidates = book.session.query(Price).filter_by(
                     commodity_guid=commodity.guid,
                 ).all()

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -243,23 +243,75 @@ class ReconciliationMixin:
         account_name: str,
         statement_date: date,
         statement_balance: str,
-        split_guids: list[str],
+        split_guids: list[str] | None = None,
+        *,
+        reconcile_all: bool = False,
+        through_date: date | None = None,
     ) -> dict:
         """Reconcile multiple splits against a statement balance.
 
+        Two operating modes:
+
+        - **Targeted** (``split_guids=[...]``, ``reconcile_all=False``):
+          reconcile exactly the listed splits. Use when statement and
+          book disagree and the caller needs to pick a subset.
+        - **Bulk** (``reconcile_all=True``): reconcile every
+          unreconciled split on the account. The common case for
+          OFX-import workflows — one tool call, no GUID round-trip.
+          Pass ``through_date`` to restrict to splits on or before
+          a specific date; by default no date filter is applied
+          (the bookkeeper-validated semantics — pre-fix this
+          defaulted to ``statement_date`` and silently excluded
+          payment splits dated after the statement, which the
+          tester hit on a CareCredit payoff). Reject if
+          ``split_guids`` is also given to avoid ambiguity.
+
+        Both modes verify the resulting reconciled balance ties to
+        ``statement_balance`` before mutating; mismatch raises with
+        the discrepancy amount.
+
         Args:
-            account_name: Full account path.
+            account_name: Account reference (path, ``%short`` GUID,
+                or full 32-char GUID).
             statement_date: Statement ending date.
-            statement_balance: Expected balance from statement (as string).
-            split_guids: List of split GUIDs to mark as reconciled.
+            statement_balance: Expected balance from statement
+                (as string).
+            split_guids: List of split GUIDs to mark reconciled
+                (8+ char prefixes accepted). Required for targeted
+                mode; omit (or pass ``None``) for bulk mode.
+            reconcile_all: When True, reconcile every unreconciled
+                split on the account (optionally bounded by
+                ``through_date``). Mutually exclusive with a
+                non-empty ``split_guids``.
+            through_date: Optional upper-date filter for bulk mode.
+                When set, only splits with
+                ``transaction.post_date <= through_date`` are
+                included. When ``None`` (default), no date filter
+                is applied — every unreconciled split gets
+                reconciled, regardless of date.
 
         Returns:
-            Dict with reconciliation results.
+            Dict with reconciliation results: ``splits_reconciled``,
+            ``new_reconciled_balance``, ``status``.
 
         Raises:
-            ValueError: If account not found, split not found, or balance mismatch.
+            ValueError: If account not found, mode ambiguous, split
+                not found, split on wrong account, or balance
+                mismatch.
         """
         expected_balance = _to_decimal(statement_balance)
+
+        if reconcile_all and split_guids:
+            raise ValueError(
+                "Cannot combine reconcile_all=True with split_guids. "
+                "Use either bulk mode (reconcile_all=True) or targeted "
+                "mode (split_guids=[...]), not both."
+            )
+        if not reconcile_all and not split_guids:
+            raise ValueError(
+                "Must provide split_guids for targeted reconciliation, "
+                "or set reconcile_all=True for bulk mode."
+            )
 
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
@@ -274,20 +326,45 @@ class ReconciliationMixin:
             splits_to_reconcile = []
             reconciling_total = Decimal("0")
 
-            for guid in split_guids:
-                split = self._find_split(book, guid)
-                if not split:
-                    raise ValueError(f"Split not found: {guid}")
-                if split.account.fullname != account_name:
-                    raise ValueError(
-                        f"Split {guid} belongs to account '{split.account.fullname}', "
-                        f"not '{account_name}'"
-                    )
-                if split.reconcile_state == "y":
-                    raise ValueError(f"Split {guid} is already reconciled")
+            if reconcile_all:
+                # Walk the account's own splits — by construction every
+                # entry is on this account, so no membership check
+                # needed. Apply the optional date filter only when the
+                # caller explicitly set ``through_date``; the default
+                # is "every unreconciled split, no date bound" so the
+                # bookkeeper can match a statement balance regardless
+                # of when payments cleared.
+                for split in account.splits:
+                    if split.reconcile_state == "y":
+                        continue
+                    if (
+                        through_date is not None
+                        and split.transaction.post_date > through_date
+                    ):
+                        continue
+                    splits_to_reconcile.append(split)
+                    reconciling_total += split.quantity
+            else:
+                for guid in split_guids:
+                    split = self._find_split(book, guid)
+                    if not split:
+                        raise ValueError(f"Split not found: {guid}")
+                    # Compare by GUID against the resolved account so
+                    # ``account_name`` accepts ``%short`` and full-GUID
+                    # input. Pre-fix the check compared against the raw
+                    # input string, rejecting any shortcut form even
+                    # when it resolved to the right account.
+                    if split.account.guid != account.guid:
+                        raise ValueError(
+                            f"Split {guid} belongs to account "
+                            f"'{split.account.fullname}', not "
+                            f"'{account.fullname}'"
+                        )
+                    if split.reconcile_state == "y":
+                        raise ValueError(f"Split {guid} is already reconciled")
 
-                splits_to_reconcile.append(split)
-                reconciling_total += split.quantity
+                    splits_to_reconcile.append(split)
+                    reconciling_total += split.quantity
 
             # Quantize both sides to the account commodity's
             # smallest fraction before comparing. Pre-fix a user

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -18,9 +18,11 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 import piecash
+from dateutil.relativedelta import relativedelta
 from piecash._common import Recurrence
 from piecash.core.transaction import ScheduledTransaction
 from piecash.kvp import KVP_Type, Slot
+from sqlalchemy import text
 
 from gnucash_mcp.book._base import (
     _guid_prefix_map,
@@ -85,8 +87,6 @@ class SchedulingMixin:
         Returns:
             Next occurrence date, or None if past end_date.
         """
-        from dateutil.relativedelta import relativedelta
-
         if after is None:
             after = date.today()
 
@@ -172,8 +172,6 @@ class SchedulingMixin:
         'splits-json' on the ScheduledTransaction.
         """
         import json
-
-        from sqlalchemy import text
 
         row = book.session.execute(
             text(

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -85,27 +85,80 @@ def register(mcp, get_book) -> None:
         account: str,
         statement_date: str,
         statement_balance: str,
-        split_guids: Annotated[list[str], Field(description="List of split GUIDs to mark as reconciled (8+ char prefixes accepted)")],
+        split_guids: Annotated[
+            list[str] | None,
+            Field(
+                description=(
+                    "List of split GUIDs to reconcile (8+ char prefixes "
+                    "accepted). Required for targeted mode; omit when "
+                    "using reconcile_all=true."
+                ),
+                default=None,
+            ),
+        ] = None,
+        reconcile_all: Annotated[
+            bool,
+            Field(
+                description=(
+                    "When true, reconcile every unreconciled split on "
+                    "the account. Avoids the ~300-token GUID round-"
+                    "trip for OFX-import workflows. Pass through_date "
+                    "to add an upper-date filter; by default no date "
+                    "filter is applied. Mutually exclusive with "
+                    "split_guids."
+                ),
+                default=False,
+            ),
+        ] = False,
+        through_date: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional upper-date filter for reconcile_all "
+                    "(YYYY-MM-DD). When set, only splits with "
+                    "post_date <= through_date are included. Default "
+                    "is no filter — every unreconciled split is "
+                    "reconciled regardless of date."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> str:
-        """Reconcile multiple splits against a statement balance.
+        """Reconcile splits against a statement balance.
 
-        Marks all specified splits as reconciled if the resulting balance matches
-        the statement balance. This is an atomic operation - either all splits are
-        reconciled or none are.
+        Two modes:
+
+        - **Targeted** (`split_guids=[...]`): reconcile exactly the
+          listed splits. Use when statement and book disagree and
+          you need to pick a subset.
+        - **Bulk** (`reconcile_all=true`): reconcile every
+          unreconciled split on the account. One call, no GUID
+          round-trip — the common case for OFX-import workflows.
+          By default no date filter is applied; pass through_date
+          to restrict to splits on or before a specific date.
+
+        Both modes verify the resulting reconciled balance ties to
+        statement_balance before mutating; mismatch rejects with
+        the discrepancy amount.
 
         Args:
             account: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID
             statement_date: Statement ending date (YYYY-MM-DD)
             statement_balance: Expected balance from statement (as string, e.g., '1234.56')
-            split_guids: List of split GUIDs to mark as reconciled (8+ char prefixes accepted)
+            split_guids: List of split GUIDs to reconcile (targeted mode). Omit for bulk mode.
+            reconcile_all: When true, reconcile all unreconciled splits up to through_date.
+            through_date: Date filter for bulk mode (YYYY-MM-DD); defaults to statement_date.
         """
         book = get_book()
         stmt_date = date.fromisoformat(statement_date)
+        through = date.fromisoformat(through_date) if through_date else None
         result = book.reconcile_account(
             account_name=account,
             statement_date=stmt_date,
             statement_balance=statement_balance,
             split_guids=split_guids,
+            reconcile_all=reconcile_all,
+            through_date=through,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6219,6 +6219,58 @@ class TestUpdateTransaction:
         assert result["status"] == "updated"
         assert result["description"] == "Updated Groceries"
 
+    def test_update_splits_validates_before_mutating(
+        self, multi_currency_book: Path,
+    ):
+        """Bad input on the second split must NOT leave the first
+        split's value already mutated. v1.3 Stage 2: validation is
+        now extracted into ``_validate_transaction_splits`` and runs
+        before any ``split.value`` assignment. Pre-extraction the
+        mutation loop interleaved validation with writes — the first
+        split's value was reassigned before the sibling's
+        cross-currency quantity was checked, so a rejected update
+        could leave partial state if the session didn't roll back.
+        """
+        gc_book = GnuCashBook(str(multi_currency_book))
+
+        # Find the cross-currency transfer (USD checking → EUR savings).
+        txns = gc_book.search_transactions("Transfer to EUR", compact=False)
+        assert txns, "Test setup: cross-currency transfer not found"
+        tx = txns[0]
+        checking_split = next(
+            s for s in tx["splits"] if s["account"] == "Assets:Checking"
+        )
+        eur_split = next(
+            s for s in tx["splits"] if s["account"] == "Assets:Euro Savings"
+        )
+        original_checking_value = checking_split["value"]
+        original_eur_value = eur_split["value"]
+
+        # Submit an update where the EUR split's quantity is missing —
+        # validator must reject before either split is touched. Pre-fix,
+        # the checking split's value would have been mutated to -2200
+        # already by the time the EUR-split error fired.
+        with pytest.raises(ValueError, match="requires 'quantity'"):
+            gc_book.update_transaction(
+                guid=tx["guid"],
+                splits=[
+                    {"account": "Assets:Checking", "amount": "-2200"},
+                    # No quantity provided for the cross-currency split.
+                    {"account": "Assets:Euro Savings", "amount": "2200"},
+                ],
+            )
+
+        # Re-read and confirm original values are intact.
+        after = gc_book.get_transaction(tx["guid"])
+        after_checking = next(
+            s for s in after["splits"] if s["account"] == "Assets:Checking"
+        )
+        after_eur = next(
+            s for s in after["splits"] if s["account"] == "Assets:Euro Savings"
+        )
+        assert after_checking["value"] == original_checking_value
+        assert after_eur["value"] == original_eur_value
+
 
 class TestReplaceSplits:
     """Tests for replace_splits method."""
@@ -7043,6 +7095,211 @@ class TestReconcileAccount:
                     statement_balance="0",
                     split_guids=[expense_split],
                 )
+
+    def test_reconcile_account_accepts_short_guid_account_ref(
+        self, test_book: Path,
+    ):
+        """``account_name`` must accept ``%shortguid`` form like every
+        other tool. Pre-fix, the per-split membership check compared
+        against the raw input string, so a valid short-GUID reference
+        resolved correctly via ``_resolve_account`` but then rejected
+        every one of its own splits with "belongs to account X, not
+        %xxxxxxx" — flagged three times in production.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        # Build a short GUID for Assets:Checking, then reconcile via it.
+        with gc_book.open(readonly=True) as book:
+            checking = next(
+                a for a in book.accounts if a.fullname == "Assets:Checking"
+            )
+            short = gc_book._account_short_guid(book, checking)
+
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        total = sum(
+            (Decimal(s["amount"]) for s in unreconciled["splits"]),
+            Decimal("0"),
+        )
+        guids = [s["guid"] for s in unreconciled["splits"]]
+
+        # The actual assertion: shortcut + targeted mode together.
+        result = gc_book.reconcile_account(
+            account_name=short,
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(total),
+            split_guids=guids,
+        )
+        assert result["status"] == "reconciled"
+        assert result["splits_reconciled"] == len(guids)
+
+    def test_reconcile_all_bulk_mode(self, test_book: Path):
+        """``reconcile_all=True`` reconciles every unreconciled split
+        on the account whose post_date is on or before through_date
+        (defaulting to statement_date), in one tool call. Avoids the
+        ~300-token GUID round-trip the bookkeeper hit on every
+        reconciliation in production.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        total = sum(
+            (Decimal(s["amount"]) for s in unreconciled["splits"]),
+            Decimal("0"),
+        )
+        expected_count = len(unreconciled["splits"])
+
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(total),
+            reconcile_all=True,
+        )
+        assert result["status"] == "reconciled"
+        assert result["splits_reconciled"] == expected_count
+
+        # Verify all splits are now in 'y' state.
+        unreconciled_after = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        assert unreconciled_after["splits"] == []
+
+    def test_reconcile_all_no_default_date_filter(self, test_book: Path):
+        """Bulk mode must NOT default to a date filter — the
+        bookkeeper's CareCredit payoff scenario had payment splits
+        dated AFTER the statement_date, and the test fixture's
+        analogue is splits across Jan 1 / 15 / 20 reconciled against
+        a Jan 10 statement. Pre-fix the default ``through_date =
+        statement_date`` excluded Jan 15 and Jan 20 splits silently;
+        post-fix every unreconciled split is included regardless of
+        date when no ``through_date`` is passed.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        unreconciled_all = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        total = sum(
+            (Decimal(s["amount"]) for s in unreconciled_all["splits"]),
+            Decimal("0"),
+        )
+        expected_count = len(unreconciled_all["splits"])
+        # The test fixture has at least one split AFTER the early
+        # statement date; if not, this assertion documents the gap.
+        early_cutoff = date(2024, 1, 10)
+        after_cutoff = [
+            s for s in unreconciled_all["splits"]
+            if date.fromisoformat(s["date"]) > early_cutoff
+        ]
+        assert after_cutoff, (
+            "Test setup: expected at least one split after the "
+            "early statement date to exercise the no-default-filter "
+            "behavior."
+        )
+
+        # statement_date is BEFORE some splits, but no through_date
+        # is passed — every unreconciled split must be included.
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=early_cutoff,
+            statement_balance=str(total),
+            reconcile_all=True,
+        )
+        assert result["splits_reconciled"] == expected_count
+
+    def test_reconcile_all_respects_through_date(self, test_book: Path):
+        """When ``through_date`` is set, ``reconcile_all`` only touches
+        splits on or before it. Lets the user reconcile a statement
+        window while leaving post-statement transactions unreconciled.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        # The test_book fixture has transactions on 2024-01-01,
+        # 2024-01-15, and 2024-01-20. Reconcile only through Jan 16.
+        cutoff = date(2024, 1, 16)
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False, as_of_date=cutoff,
+        )
+        total = sum(
+            (Decimal(s["amount"]) for s in unreconciled["splits"]),
+            Decimal("0"),
+        )
+        expected_count = len(unreconciled["splits"])
+        assert expected_count >= 1, "Test setup: expected at least one split through cutoff"
+
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(total),
+            reconcile_all=True,
+            through_date=cutoff,
+        )
+        assert result["splits_reconciled"] == expected_count
+
+        # Post-cutoff splits should still be unreconciled.
+        unreconciled_after = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        assert len(unreconciled_after["splits"]) >= 1
+
+    def test_reconcile_all_rejects_combined_with_split_guids(
+        self, test_book: Path,
+    ):
+        """Passing both ``reconcile_all=True`` and a non-empty
+        ``split_guids`` is ambiguous — reject loudly rather than
+        silently picking one.
+        """
+        gc_book = GnuCashBook(str(test_book))
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        guids = [s["guid"] for s in unreconciled["splits"]]
+
+        with pytest.raises(ValueError, match="Cannot combine reconcile_all"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 31),
+                statement_balance="0",
+                split_guids=guids,
+                reconcile_all=True,
+            )
+
+    def test_reconcile_account_requires_one_of_modes(self, test_book: Path):
+        """Calling with neither ``split_guids`` nor ``reconcile_all=True``
+        must reject with a clear error rather than silently
+        reconciling zero splits.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Must provide split_guids"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 31),
+                statement_balance="0",
+            )
+
+    def test_reconcile_all_bulk_balance_mismatch(self, test_book: Path):
+        """Bulk mode must verify against the statement balance just
+        like targeted mode. A wrong balance rejects with the
+        discrepancy, no mutation.
+        """
+        gc_book = GnuCashBook(str(test_book))
+
+        with pytest.raises(ValueError, match="Balance mismatch"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 31),
+                statement_balance="9999999.99",
+                reconcile_all=True,
+            )
+        # No mutation occurred.
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        assert len(unreconciled["splits"]) >= 1
 
 
 class TestVoidTransaction:

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3558,11 +3558,16 @@ class TestPayInvoice:
         ])
         assert BusinessMixin._calculate_lot_balance(lot) == D("70")
 
-    def test_safe_date_opened_handles_empty_string(self):
-        """``_safe_date_opened`` matches ``_safe_date_posted``'s
-        defensive contract — empty/malformed values surface as
-        None rather than crashing the regex parser."""
-        from gnucash_mcp.book.business import _safe_date_opened
+    def test_safe_invoice_date_handles_empty_string(self):
+        """``_safe_invoice_date`` covers both date_opened and
+        date_posted with one parameterized helper — empty/malformed
+        values surface as None rather than crashing the regex
+        parser. Generalized in v1.3 from the two separate
+        ``_safe_date_opened`` / ``_safe_date_posted`` helpers; one
+        helper, one set of semantics, parameterized on the
+        attribute name.
+        """
+        from gnucash_mcp.book.business import _safe_invoice_date
 
         class _EmptyInv:
             @property
@@ -3571,19 +3576,26 @@ class TestPayInvoice:
                 # on a malformed empty string.
                 raise ValueError("Couldn't parse datetime string")
 
+            @property
+            def date_posted(self):
+                raise ValueError("Couldn't parse datetime string")
+
         class _NoneInv:
             date_opened = None
+            date_posted = None
 
         class _ValidInv:
             from datetime import datetime as _dt
             date_opened = _dt(2026, 3, 10, 12, 0)
+            date_posted = _dt(2026, 3, 15, 9, 30)
 
-        assert _safe_date_opened(_EmptyInv()) is None
-        assert _safe_date_opened(_NoneInv()) is None
-        # Valid datetime passes through unchanged
-        result = _safe_date_opened(_ValidInv())
-        assert result is not None
-        assert result.year == 2026
+        # Both attribute paths behave identically.
+        for attr in ("date_opened", "date_posted"):
+            assert _safe_invoice_date(_EmptyInv(), attr) is None
+            assert _safe_invoice_date(_NoneInv(), attr) is None
+            result = _safe_invoice_date(_ValidInv(), attr)
+            assert result is not None
+            assert result.year == 2026
 
     def test_find_exchange_rate_skips_zero_direct_price(self, business_book):
         """Direct branch must skip rate=0 (and negative) prices —


### PR DESCRIPTION
## Summary

Four independent items from [VERSION_1_3_PLAN.md](specs/VERSION_1_3_PLAN.md)'s "Suggested ordering" section 2-5, bundled as the pre-headline-feature warm-up. Includes the merge of develop (Stage 1 / currency-mixin) to reconcile the overlapping touches in ``budgets.py``, ``business.py``, and ``core.py``.

**reconcile_account UX (bookkeeper-flagged, three findings):**

- ``reconcile_all=True`` bulk mode: reconciles every unreconciled split on the account in one tool call. Avoids the ~300-token GUID round-trip the bookkeeper hit on every reconciliation in production (108 splits → ~1,100 chars of GUIDs echoed back).
- ``through_date`` parameter: optional upper-date filter for bulk mode. The bookkeeper's CareCredit payoff scenario flagged that defaulting ``through_date`` to ``statement_date`` silently excluded payment splits dated after the statement — so the default is now ``None`` (no filter; reconcile every unreconciled split). Pass ``through_date`` to opt in.
- Account shortcut acceptance: the per-split membership check now compares against the resolved ``account.guid`` instead of the raw input string, so ``%xxxxxxx`` shortcuts in the ``account`` parameter work the same as every other tool.

**update_transaction validation parity:**

Extracted ``_validate_transaction_splits`` into a shared helper that both ``create_transaction`` and ``update_transaction`` call BEFORE any mutation. Pre-extraction, update interleaved validation with the mutation loop — the first split's ``value`` was reassigned before the sibling's cross-currency quantity was checked, so a bad-input update could leave the transaction in a partial state.

**_safe_date_posted / _safe_date_opened → _safe_invoice_date:**

Two helpers with byte-identical bodies collapsed into one parameterized helper ``_safe_invoice_date(inv, attr)``. Seven call sites updated.

**Module-level imports cleanup:**

Hoisted inline imports flagged by predecessor notes: ``from piecash.core.commodity import Price`` (5 sites in investments), ``from dateutil.relativedelta import relativedelta`` (budgets + scheduling), ``from sqlalchemy import text`` (scheduling).

**Deferred:** ``_compute_fx_gain_loss`` extraction from ``pay_invoice`` — the one pure refactor in Stage 2 that claims byte-identical output, gets its own branch with pre/post snapshot discipline.

## Test plan

- [x] 1,125 tests passing post-merge of develop (was 1,117 after Stage 1 + 8 new in Stage 2). Zero regressions.
- [x] 6 new ``reconcile_account`` tests covering shortcut acceptance, bulk mode, through_date filter, no-default-filter regression (bookkeeper-flagged), mode exclusivity, missing-mode rejection.
- [x] 1 new ``update_transaction`` test confirms partial-mutation prevention.
- [x] 1 consolidated ``_safe_invoice_date`` test exercising both ``date_opened`` and ``date_posted`` attributes.
- [x] Bookkeeper live-verified the bug-fix scenarios per [specs/1_3_BOOKKEEPER_NOTES.md](specs/1_3_BOOKKEEPER_NOTES.md).