### PR TITLE
refactor(business): extract _compute_fx_gain_loss from pay_invoice

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -420,6 +420,180 @@ class BusinessMixin:
                 return s_quantity / s_value
         return None
 
+    def _compute_fx_gain_loss(
+        self,
+        book,
+        *,
+        inv,
+        is_bill: bool,
+        pay_acct,
+        payment_amount: Decimal,
+        pay_quantity: Decimal,
+        parsed_date: date,
+        exchange_rate: Decimal,
+        fx_account: str | None,
+        default_currency,
+    ) -> dict | None:
+        """Compute the realized FX gain/loss for a cross-currency payment.
+
+        When ``pay_invoice`` settles a foreign-currency invoice and the
+        exchange rate has moved between post-date and pay-date, the
+        actual amount received (customer) or spent (vendor) differs
+        from what was originally recorded as income/expense at posting.
+        That delta is realized FX gain or loss; this helper computes
+        it, converts to book-default currency, and prepares the split
+        that ``pay_invoice`` will append to the payment transaction.
+
+        Caller invariants: ``exchange_rate`` is non-None (the cross-
+        currency path is already taken); ``pay_quantity`` and
+        ``payment_amount`` have been quantized to their respective
+        commodities; ``inv.post_txn`` exists (the invoice is posted).
+
+        Args:
+            book: Open piecash book.
+            inv: Posted Invoice / Bill ORM object.
+            is_bill: True for vendor bills, False for customer invoices.
+            pay_acct: piecash Account being debited or credited
+                (the bank/cash side of the payment).
+            payment_amount: Payment value in invoice currency.
+            pay_quantity: Payment quantity in ``pay_acct.commodity``.
+            parsed_date: Payment date.
+            exchange_rate: The pay-date rate from invoice currency to
+                pay-account commodity (already applied to compute
+                ``pay_quantity``).
+            fx_account: Optional override account ref for the FX
+                gain/loss split. Resolved via
+                :meth:`_get_or_create_fx_account`.
+            default_currency: The book's default currency commodity.
+
+        Returns:
+            ``None`` when no FX split should be booked:
+
+            - No rate-at-post available (the post transaction had no
+              matching split and the price table has nothing on the
+              invoice's post date). Pay-side amount still records
+              correctly; FX delta is simply not surfaced.
+            - Realized delta is below the smallest representable unit
+              in default currency (e.g., < $0.01 USD, < ¥1 JPY).
+
+            Otherwise returns a dict::
+
+                {
+                    "split": piecash.Split,        # ready to append
+                    "fx_diff_default": Decimal,     # signed delta in default ccy
+                    "fx_acct": piecash.Account,     # account the split posts to
+                    "fx_notice": str | None,        # set when the matcher
+                                                    # found multiple candidates
+                                                    # and fell back to canonical
+                }
+
+            Sign convention on ``fx_diff_default``: positive means the
+            **pay-side commodity received more units than expected at
+            the post-date rate**. For customer invoices that's a gain;
+            for vendor bills it's a loss. The Split's ``quantity``
+            sign-flips appropriately so the account ends up credited
+            (gain) or debited (loss) in the conventional direction.
+        """
+        # Find the rate that was applied at posting (invoice currency
+        # → pay_acct.commodity). First try the post transaction's own
+        # splits — most accurate, because if the price table was re-
+        # quoted after posting the realized gain should use the
+        # original posting rate. When the post txn has no split in
+        # ``pay_acct.commodity`` (third-currency pay account case:
+        # post used a different non-invoice commodity for A/R or
+        # income), fall back to the price table at post-date.
+        rate_at_post = self._rate_from_post_transaction(
+            inv.post_txn, pay_acct.commodity,
+        )
+        if rate_at_post is None:
+            post_date_obj = inv.post_txn.post_date
+            if hasattr(post_date_obj, "date") and callable(
+                post_date_obj.date
+            ):
+                post_date_obj = post_date_obj.date()
+            rate_at_post = self._find_exchange_rate(
+                book,
+                from_commodity=inv.currency,
+                to_commodity=pay_acct.commodity,
+                as_of=post_date_obj,
+            )
+        if rate_at_post is None:
+            return None
+
+        # ``expected_at_post`` is in pay-account commodity (we'll
+        # subtract pay_quantity from it). Quantize to that commodity's
+        # smallest fraction.
+        expected_at_post = (
+            payment_amount * rate_at_post
+        ).quantize(_commodity_quantum(pay_acct.commodity))
+        fx_diff_pay = pay_quantity - expected_at_post
+
+        # Convert to the book default currency before booking — the FX
+        # account has commodity=default, and a quantity in any other
+        # commodity would be silently treated as default by every
+        # report that reads this account. Pre-fix triple-currency case
+        # (book=USD, invoice=EUR, pay=GBP): a £5 GBP gain landed on a
+        # USD-commodity FX account as quantity=5, rendered as "$5
+        # gain" — silently wrong.
+        if pay_acct.commodity != default_currency:
+            pay_to_default_rate = self._find_exchange_rate(
+                book,
+                from_commodity=pay_acct.commodity,
+                to_commodity=default_currency,
+                as_of=parsed_date,
+            )
+            if pay_to_default_rate is None:
+                raise ValueError(
+                    f"Realized FX gain/loss needs an exchange rate "
+                    f"from {pay_acct.commodity.mnemonic} to "
+                    f"{default_currency.mnemonic} on or near "
+                    f"{parsed_date} to convert the FX delta to the "
+                    f"book's default currency (the FX account's "
+                    f"commodity). Add a price with create_price, then "
+                    f"retry."
+                )
+            fx_diff_default = (
+                fx_diff_pay * pay_to_default_rate
+            ).quantize(_commodity_quantum(default_currency))
+        else:
+            fx_diff_default = fx_diff_pay
+
+        # Skip booking the FX split when the realized delta is below
+        # the smallest representable unit in the FX account's
+        # commodity (e.g., $0.01 for USD, ¥0 for JPY).
+        if abs(fx_diff_default) < _commodity_quantum(default_currency):
+            return None
+
+        fx_acct, fx_notice = self._get_or_create_fx_account(
+            book, fx_account=fx_account,
+        )
+
+        # Customer (is_bill=False): received more → gain → credit
+        # income (quantity = -fx_diff for gain, +|fx_diff| for loss).
+        # Vendor bill (is_bill=True): spent more → loss → debit income
+        # (quantity = +fx_diff for loss, -|fx_diff| for gain).
+        quantity_sign = 1 if is_bill else -1
+        is_loss = (
+            (is_bill and fx_diff_default > 0)
+            or (not is_bill and fx_diff_default < 0)
+        )
+        split = piecash.Split(
+            account=fx_acct,
+            value=Decimal("0"),
+            quantity=quantity_sign * fx_diff_default,
+            memo=(
+                f"FX {'loss' if is_loss else 'gain'} on invoice "
+                f"{inv.id}: post-rate {rate_at_post:.4f}, pay-rate "
+                f"{exchange_rate}"
+            ),
+        )
+        return {
+            "split": split,
+            "fx_diff_default": fx_diff_default,
+            "fx_acct": fx_acct,
+            "fx_notice": fx_notice,
+        }
+
     @staticmethod
     def _find_employee(book, employee_id: str):
         """Find an employee by their human-readable ID (e.g., '000001')."""
@@ -3082,115 +3256,28 @@ class BusinessMixin:
             # currency (so EUR/GBP/etc. balance is preserved) but
             # non-zero quantity in the FX account's commodity (book
             # default). Same account for both directions; sign
-            # determines gain vs loss.
+            # determines gain vs loss. Logic factored into
+            # :meth:`_compute_fx_gain_loss` so the four sign
+            # quadrants are testable as unit cases rather than only
+            # via end-to-end ``pay_invoice``.
             splits = [ar_ap_split, bank_split]
-            fx_gain_loss = None
-            fx_diff_default = Decimal("0")
-            fx_acct = None
-            fx_notice = None
+            fx_result: dict | None = None
             default_currency = self._require_default_currency(book)
             if exchange_rate is not None:
-                # Find the rate that was applied at posting from
-                # invoice currency → pay_acct.commodity. First try
-                # the post transaction's own splits (most accurate —
-                # if the price table was re-quoted after posting,
-                # the realized gain should use the original posting
-                # rate). When the post txn has no split in
-                # pay_acct.commodity (third-currency pay account
-                # case: the post used a different non-invoice
-                # commodity for A/R or income), fall back to the
-                # price table at post-date.
-                rate_at_post = self._rate_from_post_transaction(
-                    inv.post_txn, pay_acct.commodity,
+                fx_result = self._compute_fx_gain_loss(
+                    book,
+                    inv=inv,
+                    is_bill=is_bill,
+                    pay_acct=pay_acct,
+                    payment_amount=payment_amount,
+                    pay_quantity=pay_quantity,
+                    parsed_date=parsed_date,
+                    exchange_rate=exchange_rate,
+                    fx_account=fx_account,
+                    default_currency=default_currency,
                 )
-                if rate_at_post is None:
-                    post_date_obj = inv.post_txn.post_date
-                    if hasattr(post_date_obj, "date") and callable(
-                        post_date_obj.date
-                    ):
-                        post_date_obj = post_date_obj.date()
-                    rate_at_post = self._find_exchange_rate(
-                        book,
-                        from_commodity=inv.currency,
-                        to_commodity=pay_acct.commodity,
-                        as_of=post_date_obj,
-                    )
-                if rate_at_post is not None:
-                    # ``expected_at_post`` is in pay-account commodity
-                    # (we'll subtract pay_quantity from it). Quantize
-                    # to that commodity's smallest fraction.
-                    expected_at_post = (
-                        payment_amount * rate_at_post
-                    ).quantize(_commodity_quantum(pay_acct.commodity))
-                    # ``fx_diff`` is the realized delta in the
-                    # PAYMENT-ACCOUNT commodity (pay_quantity is in
-                    # that commodity). Convert to the book default
-                    # currency before booking — the FX account has
-                    # commodity=default, and a quantity in any other
-                    # commodity would be silently treated as default
-                    # by every report that reads this account.
-                    # Pre-fix triple-currency case (book=USD,
-                    # invoice=EUR, pay=GBP): a £5 GBP gain landed on
-                    # a USD-commodity FX account as quantity=5,
-                    # rendered as "$5 gain" — silently wrong.
-                    fx_diff_pay = pay_quantity - expected_at_post
-                    if pay_acct.commodity != default_currency:
-                        pay_to_default_rate = self._find_exchange_rate(
-                            book,
-                            from_commodity=pay_acct.commodity,
-                            to_commodity=default_currency,
-                            as_of=parsed_date,
-                        )
-                        if pay_to_default_rate is None:
-                            raise ValueError(
-                                f"Realized FX gain/loss needs an "
-                                f"exchange rate from "
-                                f"{pay_acct.commodity.mnemonic} to "
-                                f"{default_currency.mnemonic} on or "
-                                f"near {parsed_date} to convert the "
-                                f"FX delta to the book's default "
-                                f"currency (the FX account's "
-                                f"commodity). Add a price with "
-                                f"create_price, then retry."
-                            )
-                        fx_diff_default = (
-                            fx_diff_pay * pay_to_default_rate
-                        ).quantize(_commodity_quantum(default_currency))
-                    else:
-                        fx_diff_default = fx_diff_pay
-                    # Skip booking the FX split when the realized
-                    # delta is below the smallest representable unit
-                    # in the FX account's commodity (e.g., ¥0 for
-                    # JPY, $0.01 for USD).
-                    if abs(fx_diff_default) >= _commodity_quantum(
-                        default_currency
-                    ):
-                        fx_acct, fx_notice = self._get_or_create_fx_account(
-                            book, fx_account=fx_account,
-                        )
-                        # Customer (is_bill=False): received more →
-                        # gain → credit income (quantity = -fx_diff
-                        # for gain, +|fx_diff| for loss).
-                        # Vendor bill (is_bill=True): spent more →
-                        # loss → debit income (quantity = +fx_diff
-                        # for loss, -|fx_diff| for gain).
-                        quantity_sign = 1 if is_bill else -1
-                        is_loss = (
-                            (is_bill and fx_diff_default > 0)
-                            or (not is_bill and fx_diff_default < 0)
-                        )
-                        fx_gain_loss = piecash.Split(
-                            account=fx_acct,
-                            value=Decimal("0"),
-                            quantity=quantity_sign * fx_diff_default,
-                            memo=(
-                                f"FX {'loss' if is_loss else 'gain'} "
-                                f"on invoice {inv.id}: post-rate "
-                                f"{rate_at_post:.4f}, pay-rate "
-                                f"{exchange_rate}"
-                            ),
-                        )
-                        splits.append(fx_gain_loss)
+                if fx_result is not None:
+                    splits.append(fx_result["split"])
 
             txn = piecash.Transaction(
                 currency=inv.currency,
@@ -3227,7 +3314,8 @@ class BusinessMixin:
                 result["payment_account_amount"] = str(pay_quantity)
                 result["invoice_currency"] = inv.currency.mnemonic
                 result["payment_account_currency"] = pay_acct.commodity.mnemonic
-                if fx_gain_loss is not None:
+                if fx_result is not None:
+                    fx_diff_default = fx_result["fx_diff_default"]
                     direction = (
                         "loss" if (is_bill and fx_diff_default > 0)
                         or (not is_bill and fx_diff_default < 0)
@@ -3244,10 +3332,10 @@ class BusinessMixin:
                         ),
                         "currency": default_currency.mnemonic,
                         "direction": direction,
-                        "account": fx_acct.fullname,
+                        "account": fx_result["fx_acct"].fullname,
                     }
-                    if fx_notice is not None:
-                        result["fx_notice"] = fx_notice
+                    if fx_result["fx_notice"] is not None:
+                        result["fx_notice"] = fx_result["fx_notice"]
 
         return result
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3939,6 +3939,273 @@ class TestPayInvoice:
             )
 
 
+# ============== _compute_fx_gain_loss Unit Tests ==============
+
+
+class TestComputeFxGainLoss:
+    """Direct unit tests for ``_compute_fx_gain_loss``.
+
+    The four sign quadrants are already covered end-to-end via
+    ``pay_invoice`` in :class:`TestPayInvoice`. This class targets
+    the helper directly to lock its contract — the dict shape (or
+    ``None`` return), the FX delta value, and the split's
+    ``quantity`` sign — independently of the surrounding
+    ``pay_invoice`` plumbing. Pre-extraction this logic was 130
+    lines embedded inside a 441-line method; calling it from a unit
+    test required setting up the full payment pipeline.
+    """
+
+    def _setup_posted_eur_invoice(
+        self, gb, post_rate: str, post_date: str = "2026-03-10",
+        is_bill: bool = False,
+    ):
+        """Set up a posted foreign-currency document at the given
+        rate, returning identifiers the test can use to call
+        ``_compute_fx_gain_loss`` directly.
+
+        ``is_bill=False`` posts a customer invoice (A/R debit-
+        natural); ``is_bill=True`` posts a vendor bill (A/P credit-
+        natural). Both use a EUR commodity and a USD-default book.
+        """
+        import piecash
+        from datetime import date as _date
+
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = next(
+                (c for c in book.commodities if c.mnemonic == "EUR"),
+                None,
+            )
+            if eur is None:
+                eur = piecash.factories.create_currency_from_ISO("EUR")
+                book.session.add(eur)
+            ar_name = (
+                "Liabilities:Accounts Payable EUR" if is_bill
+                else "Assets:Accounts Receivable EUR"
+            )
+            if not any(a.fullname == ar_name for a in book.accounts):
+                parent_name = "Liabilities" if is_bill else "Assets"
+                parent = next(
+                    a for a in book.accounts if a.fullname == parent_name
+                )
+                book.session.add(piecash.Account(
+                    name=ar_name.split(":")[-1],
+                    type=("PAYABLE" if is_bill else "RECEIVABLE"),
+                    parent=parent, commodity=eur,
+                ))
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date.fromisoformat(post_date),
+                value=post_rate, source="user:test", type="nav",
+            ))
+            book.save()
+
+        if is_bill:
+            gb.create_vendor(name="Berlin Supplier", currency="EUR")
+            gb.create_bill(vendor_id="000001", currency="EUR",
+                           date_opened=post_date)
+            gb.add_bill_entry(bill_id="000001",
+                              account="Expenses:Office Supplies",
+                              description="EUR supplies",
+                              quantity="1", price="4500.00")
+            gb.post_invoice(invoice_id="000001",
+                            post_account=ar_name,
+                            post_date=post_date,
+                            owner_type="vendor")
+        else:
+            gb.create_customer(name="Berlin Digital", currency="EUR")
+            gb.create_invoice(customer_id="000001", currency="EUR",
+                              date_opened=post_date)
+            gb.add_invoice_entry(invoice_id="000001",
+                                 account="Income:Consulting",
+                                 description="EUR services",
+                                 quantity="1", price="4500.00")
+            gb.post_invoice(invoice_id="000001",
+                            post_account=ar_name,
+                            post_date=post_date)
+
+    def _add_pay_date_rate(
+        self, gb, rate_value: str, rate_date: str = "2026-03-20",
+    ):
+        """Add a EUR/USD price on the pay-date so the helper can
+        resolve the pay-date rate the same way pay_invoice does.
+        """
+        import piecash
+        from datetime import date as _date
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = next(c for c in book.commodities if c.mnemonic == "EUR")
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=_date.fromisoformat(rate_date),
+                value=rate_value, source="user:test", type="nav",
+            ))
+            book.save()
+
+    def _call_helper(
+        self, gb, *, is_bill: bool, pay_rate: Decimal,
+        parsed_date_str: str = "2026-03-20",
+    ) -> dict | None:
+        """Open a session, find the posted invoice/bill, call
+        ``_compute_fx_gain_loss`` with crafted inputs, and capture
+        the returned values into plain Python types BEFORE the
+        session closes — piecash ORM objects can't be touched
+        post-close (DetachedInstanceError on any attribute access).
+
+        Returns a serializable summary dict instead of the raw
+        ORM-tied return value::
+
+            {
+                "fx_diff_default": Decimal,
+                "split_quantity": Decimal,
+                "fx_acct_fullname": str,
+                "fx_notice": str | None,
+            }
+
+        or ``None`` when the helper returned ``None`` (no FX split).
+        """
+        from datetime import date as _date
+        ot = 4 if is_bill else 2
+        parsed_date = _date.fromisoformat(parsed_date_str)
+        with gb.open(readonly=False) as book:
+            inv = gb._find_invoice(book, "000001", owner_type=ot)
+            assert inv is not None
+            pay_acct = gb._resolve_account(book, "Assets:Checking")
+            assert pay_acct is not None
+            default_currency = gb._require_default_currency(book)
+            payment_amount = Decimal("4500.00")
+            pay_quantity = (payment_amount * pay_rate).quantize(
+                Decimal("0.01")
+            )
+            result = gb._compute_fx_gain_loss(
+                book,
+                inv=inv,
+                is_bill=is_bill,
+                pay_acct=pay_acct,
+                payment_amount=payment_amount,
+                pay_quantity=pay_quantity,
+                parsed_date=parsed_date,
+                exchange_rate=pay_rate,
+                fx_account=None,
+                default_currency=default_currency,
+            )
+            if result is None:
+                return None
+            # Capture every field as a plain Python value while the
+            # session is still open. ``fullname`` walks the parent
+            # chain via lazy load; ``quantity`` on the Split is
+            # cached on the instance so it survives detach, but
+            # we capture it here for consistency.
+            return {
+                "fx_diff_default": result["fx_diff_default"],
+                "split_quantity": Decimal(str(result["split"].quantity)),
+                "fx_acct_fullname": result["fx_acct"].fullname,
+                "fx_notice": result["fx_notice"],
+            }
+
+    # ── The four sign quadrants ───────────────────────────────────
+
+    def test_customer_invoice_rate_up_books_gain(self, business_book):
+        """Customer invoice: pay-rate > post-rate → received more
+        USD than booked at posting → realized GAIN. Split quantity
+        is negative (credit to credit-natural income account)."""
+        gb = GnuCashBook(str(business_book))
+        self._setup_posted_eur_invoice(gb, post_rate="1.10")
+        self._add_pay_date_rate(gb, rate_value="1.12")
+
+        result = self._call_helper(
+            gb, is_bill=False, pay_rate=Decimal("1.12"),
+        )
+
+        assert result is not None
+        # post: 4500 × 1.10 = 4950 expected USD
+        # pay:  4500 × 1.12 = 5040 actual USD
+        # delta = +90 (received more)
+        assert result["fx_diff_default"] == Decimal("90.00")
+        # Customer gain: quantity = -delta (credit to income).
+        assert result["split_quantity"] == Decimal("-90.00")
+        assert result["fx_acct_fullname"] == "Income:Foreign Exchange Gain/Loss"
+        assert result["fx_notice"] is None
+
+    def test_customer_invoice_rate_down_books_loss(self, business_book):
+        """Customer invoice: pay-rate < post-rate → received less
+        USD than booked at posting → realized LOSS. Split quantity
+        is positive (debit to credit-natural income account =
+        reduces income)."""
+        gb = GnuCashBook(str(business_book))
+        self._setup_posted_eur_invoice(gb, post_rate="1.12")
+        self._add_pay_date_rate(gb, rate_value="1.10")
+
+        result = self._call_helper(
+            gb, is_bill=False, pay_rate=Decimal("1.10"),
+        )
+
+        assert result is not None
+        # post: 4500 × 1.12 = 5040 expected USD
+        # pay:  4500 × 1.10 = 4950 actual USD
+        # delta = -90 (received less)
+        assert result["fx_diff_default"] == Decimal("-90.00")
+        # Customer loss: quantity = -delta = +90 (debit income).
+        assert result["split_quantity"] == Decimal("90.00")
+        assert result["fx_acct_fullname"] == "Income:Foreign Exchange Gain/Loss"
+
+    def test_vendor_bill_rate_down_books_gain(self, business_book):
+        """Vendor bill: pay-rate < post-rate → spent fewer USD than
+        booked at posting → realized GAIN. Split quantity is
+        negative (credit to credit-natural income account)."""
+        gb = GnuCashBook(str(business_book))
+        self._setup_posted_eur_invoice(gb, post_rate="1.12", is_bill=True)
+        self._add_pay_date_rate(gb, rate_value="1.10")
+
+        result = self._call_helper(
+            gb, is_bill=True, pay_rate=Decimal("1.10"),
+        )
+
+        assert result is not None
+        # post: 4500 × 1.12 = 5040 expected USD spent
+        # pay:  4500 × 1.10 = 4950 actual USD spent
+        # delta = -90 (spent less)
+        assert result["fx_diff_default"] == Decimal("-90.00")
+        # Vendor gain: quantity = +delta = -90 (credit income).
+        assert result["split_quantity"] == Decimal("-90.00")
+        assert result["fx_acct_fullname"] == "Income:Foreign Exchange Gain/Loss"
+
+    def test_vendor_bill_rate_up_books_loss(self, business_book):
+        """Vendor bill: pay-rate > post-rate → spent more USD than
+        booked at posting → realized LOSS. Split quantity is
+        positive (debit to credit-natural income account)."""
+        gb = GnuCashBook(str(business_book))
+        self._setup_posted_eur_invoice(gb, post_rate="1.10", is_bill=True)
+        self._add_pay_date_rate(gb, rate_value="1.12")
+
+        result = self._call_helper(
+            gb, is_bill=True, pay_rate=Decimal("1.12"),
+        )
+
+        assert result is not None
+        # post: 4500 × 1.10 = 4950 expected USD spent
+        # pay:  4500 × 1.12 = 5040 actual USD spent
+        # delta = +90 (spent more)
+        assert result["fx_diff_default"] == Decimal("90.00")
+        # Vendor loss: quantity = +delta = +90 (debit income).
+        assert result["split_quantity"] == Decimal("90.00")
+
+    # ── None-return cases ─────────────────────────────────────────
+
+    def test_returns_none_when_post_and_pay_rates_equal(
+        self, business_book,
+    ):
+        """When the rate hasn't moved, no FX split is booked.
+        Returns None so the caller skips appending."""
+        gb = GnuCashBook(str(business_book))
+        self._setup_posted_eur_invoice(gb, post_rate="1.10")
+        # Only one price on file — same rate at both dates.
+        result = self._call_helper(
+            gb, is_bill=False, pay_rate=Decimal("1.10"),
+        )
+        assert result is None
+
+
 # ============== Outstanding Invoices Tests ==============
 
 


### PR DESCRIPTION
## Summary

- Pulls 130 lines of realized FX gain/loss logic out of ``pay_invoice``'s body into a sibling helper ``_compute_fx_gain_loss`` on :class:``BusinessMixin``, parked next to ``_rate_from_post_transaction`` and ``_get_or_create_fx_account`` where the rest of the FX machinery already lives.
- Pure motion — same arithmetic, same account routing, same Split construction, same memo string. Bookkeeper verified byte-identical pre/post against the captured baseline.
- The whole point per [VERSION_1_3_PLAN.md](specs/VERSION_1_3_PLAN.md): makes the four FX sign quadrants tractable as direct unit tests rather than only via end-to-end ``pay_invoice`` flows.
- The deferred Stage 2 item from [PR #80](https://github.com/ninetails-io/gnucash-mcp/pull/80) — split out so the byte-identical-output claim could get its own pre/post snapshot discipline per ``feedback_before_after_testing.md``.

**Helper contract:**

``_compute_fx_gain_loss`` is called only when cross-currency (``exchange_rate is not None``). It returns ``None`` in two cases the caller treats identically (skip the append):

- No rate-at-post available (post txn had no matching split AND the price table has nothing on the invoice's post date).
- Realized delta below the smallest representable unit in default currency (sub-cent USD, sub-yen JPY).

Otherwise returns ``{split, fx_diff_default, fx_acct, fx_notice}``. ``pay_invoice`` reads ``fx_diff_default`` and ``fx_acct`` for the response payload's ``fx_realized`` block.

## Test plan

- [x] 1,130 tests passing (was 1,125 on develop + 5 new direct unit tests). Zero regressions.
- [x] New ``TestComputeFxGainLoss`` class covers all four sign quadrants directly:
  - ``test_customer_invoice_rate_up_books_gain``
  - ``test_customer_invoice_rate_down_books_loss``
  - ``test_vendor_bill_rate_down_books_gain``
  - ``test_vendor_bill_rate_up_books_loss``
  - ``test_returns_none_when_post_and_pay_rates_equal``
- [x] Existing end-to-end ``TestPayInvoice`` FX cases (gain/loss × customer/vendor, third-currency, same-rate, ambiguous-fx-notice, ``fx_account`` override, invalid-fx-account) all unchanged and passing.
- [x] Bookkeeper restored test book to pre-payment state, re-ran the exact pre-extraction ``pay_invoice`` call, diffed against ``specs/fx-extraction-baseline-before.txt``. Verdict: clean. Helper produces byte-identical FX splits, response dicts, balance deltas, memo strings. Cross-tool agreement holds. Investment valuations untouched.