### PR TITLE
perf(core): get_book_summary decomposition — render extraction + materialize-once

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1390,6 +1390,195 @@ class CoreMixin:
             return f"({months} months behind)"
         return f"({days_behind} days behind)"
 
+    # ── Section renderers ─────────────────────────────────────────────
+    #
+    # Each ``_render_*`` helper consumes the data produced by its
+    # paired ``_collect_*`` / ``_*_metrics`` / ``_*_headline`` /
+    # ``_*_trajectory`` method and returns a ``list[str]`` of lines
+    # to append to the summary (or ``[]`` to omit the section
+    # entirely — absence-as-signal, per the spec).
+    #
+    # Pre-extraction the render block was one long sequence inside
+    # ``get_book_summary``. Pulling each section into its own helper
+    # mirrors the data layer's decomposition and makes adding or
+    # modifying a section a one-method change instead of surgery
+    # through the render block. Each helper is self-contained — no
+    # cross-section state — so the rendering order in
+    # ``get_book_summary`` becomes a one-glance read.
+
+    @staticmethod
+    def _render_warnings(warnings: list[str]) -> list[str]:
+        """Render the Warnings section.
+
+        Section is omitted when there are no warnings — the spec
+        explicitly calls out not printing "Warnings: none." Empty
+        list signals "section absent" to the caller.
+        """
+        if not warnings:
+            return []
+        out = ["Warnings:"]
+        for msg in warnings:
+            out.append(f"  ⚠ {msg}")
+        return out
+
+    def _render_reconciliation(
+        self, reconciliation: list[dict],
+    ) -> list[str]:
+        """Render the Reconciliation section.
+
+        Three buckets per the data spec:
+
+        1. **STALE** (reconciled but > ``_RECONCILE_WARN_DAYS``
+           behind) — render individually with the through-date and
+           a "(N days/months behind) ⚠" lag suffix. Per-account
+           payload (how stale, scope of work) can't be aggregated.
+        2. **CURRENT** (reconciled within window) — collapse into
+           "<N> accounts current". Identical-across-accounts
+           payload compresses to a count.
+        3. **NEVER RECONCILED** (activity but no 'y' splits) —
+           collapse into "<N> account(s) never reconciled ⚠".
+
+        Each collapse line omitted when its count is zero
+        (absence-as-signal). Section omitted entirely when
+        reconciliation is empty.
+        """
+        if not reconciliation:
+            return []
+        stale: list[dict] = []
+        current_count = 0
+        never_count = 0
+        for entry in reconciliation:
+            if entry["status"] == "never reconciled":
+                never_count += 1
+            elif entry["days_behind"] > self._RECONCILE_WARN_DAYS:
+                stale.append(entry)
+            else:
+                current_count += 1
+
+        out = ["Reconciliation:"]
+        for entry in stale:
+            leaf = entry["account"].split(":")[-1]
+            lag = self._format_reconciliation_lag(entry["days_behind"])
+            # Sub-line shape: "47 splits unreconciled since
+            # 2025-12-30 (4 months behind) ⚠". The split count
+            # tells the LLM the *scope* of the reconciliation
+            # work — 12 splits is one sitting; 400 needs a
+            # month-by-month strategy.
+            n = entry["unreconciled_count"]
+            if n > 0 and "latest_y_date" in entry:
+                plural = "s" if n != 1 else ""
+                since = entry["latest_y_date"]
+                out.append(
+                    f"  {leaf}: {n} split{plural} "
+                    f"unreconciled since {since} {lag} ⚠"
+                )
+            else:
+                out.append(
+                    f"  {leaf}: {entry['status']} {lag} ⚠"
+                )
+        if current_count:
+            plural = "s" if current_count != 1 else ""
+            out.append(f"  {current_count} account{plural} current")
+        if never_count:
+            plural = "s" if never_count != 1 else ""
+            out.append(
+                f"  {never_count} account{plural} never reconciled ⚠"
+            )
+        return out
+
+    @staticmethod
+    def _render_net_worth_trajectory(
+        trajectory: list[dict], currency: str,
+    ) -> list[str]:
+        """Render the Net worth trajectory section.
+
+        Surfaces acceleration and trend breaks that a single
+        net-worth number can't. Empty trajectory = book has no
+        transactions or every anchor predates the data range →
+        omit the section.
+        """
+        if not trajectory:
+            return []
+        out = ["Net worth trajectory:"]
+        for entry in trajectory:
+            out.append(
+                f"  {entry['label']}: {currency} "
+                f"{int(entry['net_worth']):,}"
+            )
+        return out
+
+    def _render_monthly_net(self, monthly: list[dict]) -> list[str]:
+        """Render the Monthly net (last 6 months) section.
+
+        Surfaces seasonality and recent anomalies. Empty list = no
+        income/expense activity in the window → omit the section.
+        MTD entries get a "(MTD)" suffix on the label.
+        """
+        if not monthly:
+            return []
+        out = ["Monthly net (last 6 months):"]
+        for entry in monthly:
+            label = entry["label"]
+            if entry["is_mtd"]:
+                label += " (MTD)"
+            out.append(
+                f"  {label}: {self._format_monthly_net(entry['net'])}"
+            )
+        return out
+
+    def _render_runway(
+        self, runway: dict | None, currency: str,
+    ) -> list[str]:
+        """Render the Runway line.
+
+        Liquid assets / daily burn → days. The single most
+        actionable personal-finance number that doesn't appear on
+        standard financial statements. ``None`` = no expense data in
+        the burn window → omit section. ``negative_liquid`` flag
+        renders the special 0-days-with-warning line.
+        """
+        if runway is None:
+            return []
+        if runway.get("negative_liquid"):
+            return ["Runway: 0 days — liquid position is negative ⚠"]
+        days = runway["runway_days"]
+        liquid = int(runway["liquid"])
+        burn = int(runway["daily_burn"])
+        warn = " ⚠" if days < self._RUNWAY_WARN_DAYS else ""
+        return [
+            f"Runway: {days} days{warn} "
+            f"({currency} {liquid:,} liquid / "
+            f"{currency} {burn:,}/day burn)"
+        ]
+
+    def _render_budget(self, budget: dict | None) -> list[str]:
+        """Render the Budget headline line.
+
+        One line for the budget covering today. ``None`` = no
+        budget exists or none covers today → omit. Variance
+        over ``_BUDGET_WARN_VARIANCE_PCT`` earns ⚠ (spending
+        ahead of pace).
+        """
+        if budget is None:
+            return []
+        used = int(budget["used_pct"])
+        elapsed = int(budget["elapsed_pct"])
+        variance = int(budget["variance_pct"])
+        if variance > 0:
+            variance_str = f"(+{variance}% over pace)"
+        elif variance < 0:
+            variance_str = f"({-variance}% under pace)"
+        else:
+            variance_str = "(on pace)"
+        warn = (
+            " ⚠" if variance > self._BUDGET_WARN_VARIANCE_PCT else ""
+        )
+        return [
+            f"Budget ({budget['name']}): "
+            f"{used}% used / {elapsed}% elapsed "
+            f"{variance_str}{warn}"
+        ]
+
     def get_book_summary(self) -> str:
         """Return a compact text summary of the entire book.
 
@@ -1661,14 +1850,8 @@ class CoreMixin:
             # there's data integrity trouble or stale prices
             # informing the rest of the summary, the LLM should see
             # that BEFORE reading numbers that depend on them.
-            # Section omitted entirely when no warnings — absence
-            # is the signal; the spec explicitly calls out not
-            # printing "Warnings: none."
             warnings = self._collect_warnings(book)
-            if warnings:
-                lines.append("Warnings:")
-                for msg in warnings:
-                    lines.append(f"  ⚠ {msg}")
+            lines.extend(self._render_warnings(warnings))
 
             lines.append(f"Accounts: {total_accounts} total")
 
@@ -1719,160 +1902,28 @@ class CoreMixin:
             lines.append(f"Income: {income_active} active ({income_total} total)")
             lines.append(f"Expenses: {expense_active} active ({expense_total} total)")
 
-            # Reconciliation: per-account state for reconcilable
-            # account types. Section omitted entirely when the book
-            # has no reconcilable activity (no header line either —
-            # absence is the signal, per the spec's principle).
-            #
-            # Render shape splits the per-account list into THREE
-            # buckets, each carrying a distinct payload class:
-            #
-            # 1. STALE (reconciled at some point but >45 days behind)
-            #    — render individually with their through-date and
-            #    a "(N days/months behind) ⚠" lag suffix. The
-            #    information *how stale is each one* is per-account
-            #    and can't be aggregated. These are the lines a
-            #    bookkeeper LLM actually acts on.
-            # 2. CURRENT (reconciled within 45 days) — collapse into
-            #    a single "<N> accounts current" line. Each
-            #    individual through-date carries the same payload
-            #    ("this one's fine"), repeated; the count preserves
-            #    the affirmative signal without paying per-account
-            #    for it.
-            # 3. NEVER RECONCILED (activity but no 'y' splits) —
-            #    collapse into "<N> account(s) never reconciled ⚠".
-            #    Same logic as the current bucket: identical
-            #    per-line content compresses to a count.
-            #
-            # The principle: per-account-distinct information stays
-            # per-account; identical-across-accounts information
-            # collapses. A 50-account power-user book emits ~3-5
-            # lines; an Alex-sized book emits ~3-5 lines. Signal
-            # density is uniform regardless of book size.
-            #
-            # Each collapse line is omitted when its count is zero
-            # (absence-as-signal): a book with no current accounts
-            # never sees "0 accounts current."
+            # Reconciliation, trajectory, monthly net, runway, budget:
+            # each section's data collector lives in its own method;
+            # the matching ``_render_*`` helper renders the section
+            # (or returns ``[]`` to omit it — absence-as-signal). See
+            # the helpers for the per-section spec and warning
+            # thresholds.
             reconciliation = self._account_reconciliation_status(book)
-            if reconciliation:
-                stale: list[dict] = []
-                current_count = 0
-                never_count = 0
-                for entry in reconciliation:
-                    if entry["status"] == "never reconciled":
-                        never_count += 1
-                    elif entry["days_behind"] > self._RECONCILE_WARN_DAYS:
-                        stale.append(entry)
-                    else:
-                        current_count += 1
+            lines.extend(self._render_reconciliation(reconciliation))
 
-                lines.append("Reconciliation:")
-                for entry in stale:
-                    leaf = entry["account"].split(":")[-1]
-                    lag = self._format_reconciliation_lag(entry["days_behind"])
-                    # Sub-line shape: "47 splits unreconciled since
-                    # 2025-12-30 (4 months behind) ⚠". The split
-                    # count tells the LLM the *scope* of the
-                    # reconciliation work — 12 splits is one
-                    # sitting; 400 needs a month-by-month strategy.
-                    # Pre-fix the line was just "through DATE (4
-                    # months behind)" which gave staleness without
-                    # scope.
-                    n = entry["unreconciled_count"]
-                    if n > 0 and "latest_y_date" in entry:
-                        plural = "s" if n != 1 else ""
-                        since = entry["latest_y_date"]
-                        lines.append(
-                            f"  {leaf}: {n} split{plural} "
-                            f"unreconciled since {since} {lag} ⚠"
-                        )
-                    else:
-                        lines.append(
-                            f"  {leaf}: {entry['status']} {lag} ⚠"
-                        )
-                if current_count:
-                    plural = "s" if current_count != 1 else ""
-                    lines.append(
-                        f"  {current_count} account{plural} current"
-                    )
-                if never_count:
-                    plural = "s" if never_count != 1 else ""
-                    lines.append(
-                        f"  {never_count} account{plural} never reconciled ⚠"
-                    )
-
-            # Net worth trajectory (12mo / 6mo / 3mo / 1mo ago, now).
-            # Surfaces acceleration and trend breaks that a single
-            # net-worth number can't. Empty list = book has no
-            # transactions or every anchor predates the data range
-            # → omit the section entirely.
             trajectory = self._net_worth_trajectory(book, first_date)
-            if trajectory:
-                lines.append("Net worth trajectory:")
-                for entry in trajectory:
-                    lines.append(
-                        f"  {entry['label']}: {currency} "
-                        f"{int(entry['net_worth']):,}"
-                    )
+            lines.extend(
+                self._render_net_worth_trajectory(trajectory, currency)
+            )
 
-            # Monthly net income (last 6 months). Surfaces seasonality
-            # and recent anomalies. Empty list = no income/expense
-            # activity in the window → omit the section entirely.
             monthly = self._monthly_net_income(book, months=6)
-            if monthly:
-                lines.append("Monthly net (last 6 months):")
-                for entry in monthly:
-                    label = entry["label"]
-                    if entry["is_mtd"]:
-                        label += " (MTD)"
-                    lines.append(
-                        f"  {label}: {self._format_monthly_net(entry['net'])}"
-                    )
+            lines.extend(self._render_monthly_net(monthly))
 
-            # Runway: liquid assets / daily burn → days. The single
-            # most actionable personal-finance number that doesn't
-            # appear on standard financial statements. None = no
-            # expense data in the burn window → omit section.
             runway = self._runway_metrics(book, default_currency)
-            if runway is not None:
-                if runway.get("negative_liquid"):
-                    lines.append(
-                        "Runway: 0 days — liquid position is negative ⚠"
-                    )
-                else:
-                    days = runway["runway_days"]
-                    liquid = int(runway["liquid"])
-                    burn = int(runway["daily_burn"])
-                    warn = " ⚠" if days < self._RUNWAY_WARN_DAYS else ""
-                    lines.append(
-                        f"Runway: {days} days{warn} "
-                        f"({currency} {liquid:,} liquid / "
-                        f"{currency} {burn:,}/day burn)"
-                    )
+            lines.extend(self._render_runway(runway, currency))
 
-            # Budget headline: one line for the budget covering today.
-            # None = no budget exists or none covers today → omit.
-            # Variance > +10% earns ⚠ (spending ahead of pace).
             budget = self._budget_headline(book)
-            if budget is not None:
-                used = int(budget["used_pct"])
-                elapsed = int(budget["elapsed_pct"])
-                variance = int(budget["variance_pct"])
-                if variance > 0:
-                    variance_str = f"(+{variance}% over pace)"
-                elif variance < 0:
-                    variance_str = f"({-variance}% under pace)"
-                else:
-                    variance_str = "(on pace)"
-                warn = (
-                    " ⚠" if variance > self._BUDGET_WARN_VARIANCE_PCT
-                    else ""
-                )
-                lines.append(
-                    f"Budget ({budget['name']}): "
-                    f"{used}% used / {elapsed}% elapsed "
-                    f"{variance_str}{warn}"
-                )
+            lines.extend(self._render_budget(budget))
 
             lines.append(f"Transactions: {total_txns}")
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -118,7 +118,7 @@ class CoreMixin:
     _LAST_ENTRY_WARN_DAYS = 14
 
     def _account_reconciliation_status(
-        self, book: piecash.Book,
+        self, book: piecash.Book, accounts: list,
     ) -> list[dict]:
         """Per-account reconciliation freshness for the book summary.
 
@@ -162,7 +162,7 @@ class CoreMixin:
         today = date.today()
 
         results: list[dict] = []
-        for account in book.accounts:
+        for account in accounts:
             if account.type == "ROOT":
                 continue
             if account.guid in template_guids:
@@ -260,6 +260,7 @@ class CoreMixin:
         book: piecash.Book,
         as_of: date,
         default_currency: piecash.Commodity,
+        accounts: list,
     ) -> Decimal:
         """Net worth in book-default currency as of ``as_of``.
 
@@ -314,14 +315,14 @@ class CoreMixin:
         # is_leaf: an account with no children. Compute the parent
         # set once and check membership per account.
         parent_guids: set[str] = set()
-        for a in book.accounts:
+        for a in accounts:
             if a.parent and a.parent.type != "ROOT":
                 parent_guids.add(a.parent.guid)
 
         assets_total = Decimal("0")
         liabilities_total = Decimal("0")
 
-        for account in book.accounts:
+        for account in accounts:
             if account.type == "ROOT":
                 continue
             if account.guid in template_guids:
@@ -371,6 +372,7 @@ class CoreMixin:
         self,
         book: piecash.Book,
         first_date: date | None,
+        accounts: list,
     ) -> list[dict]:
         """Five-point net-worth trajectory: 12mo / 6mo / 3mo / 1mo
         ago and now. Implements GET_BOOK_SUMMARY_SPEC §2.
@@ -427,7 +429,7 @@ class CoreMixin:
             {
                 "label": label,
                 "net_worth": self._compute_net_worth_at(
-                    book, anchor_date, default_currency,
+                    book, anchor_date, default_currency, accounts,
                 ).quantize(Decimal("1")),
             }
             for anchor_date, label in anchors
@@ -514,6 +516,7 @@ class CoreMixin:
         self,
         book: piecash.Book,
         transactions: list,
+        accounts: list,
     ) -> list[str]:
         """Collect warnings for the consolidated Warnings section.
         Implements GET_BOOK_SUMMARY_SPEC §5.
@@ -585,7 +588,7 @@ class CoreMixin:
 
         # ── 1. Data integrity: Imbalance / Orphan accounts ──
         integrity: list[str] = []
-        for account in book.accounts:
+        for account in accounts:
             if account.type == "ROOT":
                 continue
             name = account.name
@@ -622,7 +625,7 @@ class CoreMixin:
                     book, today, default_currency,
                 )
                 low_cash_entries: list[tuple[Decimal, str]] = []
-                for account in book.accounts:
+                for account in accounts:
                     if account.type not in ("BANK", "CASH"):
                         continue
                     if account.placeholder:
@@ -786,7 +789,7 @@ class CoreMixin:
         stale_prices: list[str] = []
         try:
             in_use: set = set()
-            for a in book.accounts:
+            for a in accounts:
                 if a.type != "ROOT":
                     in_use.add(a.commodity.guid)
 
@@ -1126,6 +1129,7 @@ class CoreMixin:
         book: piecash.Book,
         default_currency: piecash.Commodity,
         transactions: list,
+        accounts: list,
     ) -> dict | None:
         """Compute runway: how many days the household could survive
         on current liquid assets at current burn rate if income
@@ -1180,7 +1184,7 @@ class CoreMixin:
 
         # --- Liquid assets pass over book.accounts ---
         liquid = Decimal("0")
-        for account in book.accounts:
+        for account in accounts:
             if account.type == "ROOT":
                 continue
             if account.guid in template_guids:
@@ -1645,9 +1649,16 @@ class CoreMixin:
             # creates flat templates — but tolerates deeper nesting now.
             template_guids = self._template_account_guids(book)
 
+            # Materialize the account list once. CODE_REVIEW noted 7-10
+            # passes over ``book.accounts`` between this method and the
+            # sub-helpers it calls; threading the in-memory list collapses
+            # each pass from "hydrate the ORM collection then iterate" to
+            # "iterate the already-hydrated Python list."
+            accounts = list(book.accounts)
+
             # --- Collect parent GUIDs (placeholder containers) ---
             parent_guids = set()
-            for account in book.accounts:
+            for account in accounts:
                 if account.parent and account.parent.type != "ROOT":
                     parent_guids.add(account.parent.guid)
 
@@ -1680,7 +1691,7 @@ class CoreMixin:
             expense_total = 0
             total_accounts = 0
 
-            for account in book.accounts:
+            for account in accounts:
                 if account.type == "ROOT":
                     continue
                 if account.guid in template_guids:
@@ -1868,7 +1879,7 @@ class CoreMixin:
             # there's data integrity trouble or stale prices
             # informing the rest of the summary, the LLM should see
             # that BEFORE reading numbers that depend on them.
-            warnings = self._collect_warnings(book, transactions)
+            warnings = self._collect_warnings(book, transactions, accounts)
             lines.extend(self._render_warnings(warnings))
 
             lines.append(f"Accounts: {total_accounts} total")
@@ -1926,10 +1937,14 @@ class CoreMixin:
             # (or returns ``[]`` to omit it — absence-as-signal). See
             # the helpers for the per-section spec and warning
             # thresholds.
-            reconciliation = self._account_reconciliation_status(book)
+            reconciliation = self._account_reconciliation_status(
+                book, accounts,
+            )
             lines.extend(self._render_reconciliation(reconciliation))
 
-            trajectory = self._net_worth_trajectory(book, first_date)
+            trajectory = self._net_worth_trajectory(
+                book, first_date, accounts,
+            )
             lines.extend(
                 self._render_net_worth_trajectory(trajectory, currency)
             )
@@ -1938,7 +1953,7 @@ class CoreMixin:
             lines.extend(self._render_monthly_net(monthly))
 
             runway = self._runway_metrics(
-                book, default_currency, transactions,
+                book, default_currency, transactions, accounts,
             )
             lines.extend(self._render_runway(runway, currency))
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -510,7 +510,11 @@ class CoreMixin:
     # are likely producing inaccurate net-worth and runway numbers.
     _STALE_PRICE_DAYS = 30
 
-    def _collect_warnings(self, book: piecash.Book) -> list[str]:
+    def _collect_warnings(
+        self,
+        book: piecash.Book,
+        transactions: list,
+    ) -> list[str]:
         """Collect warnings for the consolidated Warnings section.
         Implements GET_BOOK_SUMMARY_SPEC §5.
 
@@ -611,7 +615,7 @@ class CoreMixin:
         # activity (no daily-burn signal to compare against).
         low_cash: list[str] = []
         try:
-            daily_burn = self._daily_expense_burn(book)
+            daily_burn = self._daily_expense_burn(book, transactions)
             if daily_burn > 0:
                 template_guids = self._template_account_guids(book)
                 rates = self._rates_as_of(
@@ -942,7 +946,11 @@ class CoreMixin:
             + stale_prices
         )
 
-    def _budget_headline(self, book: piecash.Book) -> dict | None:
+    def _budget_headline(
+        self,
+        book: piecash.Book,
+        transactions: list,
+    ) -> dict | None:
         """One-line headline for the budget covering today, if any.
         Implements GET_BOOK_SUMMARY_SPEC §6.
 
@@ -1048,7 +1056,7 @@ class CoreMixin:
         # stored negative; flip to a positive contribution to match
         # the spend-vs-target framing.
         actuals = Decimal("0")
-        for txn in book.transactions:
+        for txn in transactions:
             if txn.post_date < period_start or txn.post_date > period_end:
                 continue
             for s in txn.splits:
@@ -1082,6 +1090,7 @@ class CoreMixin:
     def _daily_expense_burn(
         self,
         book: piecash.Book,
+        transactions: list,
         days: int | None = None,
     ) -> Decimal:
         """Average daily EXPENSE outflow over the last ``days`` days.
@@ -1092,6 +1101,10 @@ class CoreMixin:
         Both want the same number — extracting the helper guarantees
         they agree.
 
+        ``transactions`` is the pre-materialized list ``get_book_summary``
+        builds once and threads through every sub-helper that walks
+        post-date — same list, no per-helper re-fetch.
+
         Returns ``Decimal("0")`` when no expense activity in window
         — caller treats that as "no daily-burn signal."
         """
@@ -1100,7 +1113,7 @@ class CoreMixin:
         today = date.today()
         window_start = today - timedelta(days=days)
         expenses = Decimal("0")
-        for txn in book.transactions:
+        for txn in transactions:
             if txn.post_date < window_start or txn.post_date > today:
                 continue
             for s in txn.splits:
@@ -1112,6 +1125,7 @@ class CoreMixin:
         self,
         book: piecash.Book,
         default_currency: piecash.Commodity,
+        transactions: list,
     ) -> dict | None:
         """Compute runway: how many days the household could survive
         on current liquid assets at current burn rate if income
@@ -1226,7 +1240,7 @@ class CoreMixin:
         # section's "less than 1 day of burn" threshold and runway's
         # divisor-of-liquid agree by construction.
         daily_burn = self._daily_expense_burn(
-            book, days=self._RUNWAY_BURN_DAYS,
+            book, transactions, days=self._RUNWAY_BURN_DAYS,
         )
 
         if daily_burn <= 0:
@@ -1248,7 +1262,10 @@ class CoreMixin:
         }
 
     def _monthly_net_income(
-        self, book: piecash.Book, months: int = 6,
+        self,
+        book: piecash.Book,
+        transactions: list,
+        months: int = 6,
     ) -> list[dict]:
         """Per-month net income for the last ``months`` calendar
         months. Implements GET_BOOK_SUMMARY_SPEC §3.
@@ -1319,11 +1336,12 @@ class CoreMixin:
         window_end = month_ends[-1]
         has_activity = False
 
-        # Single pass over book.transactions. Index math: the bucket
-        # for a transaction is (year_delta * 12 + month_delta) from
-        # the window start. O(transactions); the date-range gate
-        # short-circuits transactions outside the window.
-        for txn in book.transactions:
+        # Single pass over the materialized transactions list. Index
+        # math: the bucket for a transaction is
+        # (year_delta * 12 + month_delta) from the window start.
+        # O(transactions); the date-range gate short-circuits
+        # transactions outside the window.
+        for txn in transactions:
             d = txn.post_date
             if d < window_start or d > window_end:
                 continue
@@ -1850,7 +1868,7 @@ class CoreMixin:
             # there's data integrity trouble or stale prices
             # informing the rest of the summary, the LLM should see
             # that BEFORE reading numbers that depend on them.
-            warnings = self._collect_warnings(book)
+            warnings = self._collect_warnings(book, transactions)
             lines.extend(self._render_warnings(warnings))
 
             lines.append(f"Accounts: {total_accounts} total")
@@ -1916,13 +1934,15 @@ class CoreMixin:
                 self._render_net_worth_trajectory(trajectory, currency)
             )
 
-            monthly = self._monthly_net_income(book, months=6)
+            monthly = self._monthly_net_income(book, transactions, months=6)
             lines.extend(self._render_monthly_net(monthly))
 
-            runway = self._runway_metrics(book, default_currency)
+            runway = self._runway_metrics(
+                book, default_currency, transactions,
+            )
             lines.extend(self._render_runway(runway, currency))
 
-            budget = self._budget_headline(book)
+            budget = self._budget_headline(book, transactions)
             lines.extend(self._render_budget(budget))
 
             lines.append(f"Transactions: {total_txns}")


### PR DESCRIPTION
## Summary

Plan item 5 in [VERSION_1_3_PLAN.md](specs/VERSION_1_3_PLAN.md)'s "Suggested ordering": ``get_book_summary`` decomposition. Three commits, one PR.

**1. ``refactor(core): extract _render_* helpers``** — pulls the six conditional render sections out of ``get_book_summary``'s render block into ``_render_*(data) -> list[str]`` helpers mirroring the six data collectors (``_collect_warnings``, ``_account_reconciliation_status``, ``_net_worth_trajectory``, ``_monthly_net_income``, ``_runway_metrics``, ``_budget_headline``). The 80-line reconciliation render in particular collapses from nested conditionals in ``get_book_summary`` to one focused method. Inline sections without data-collector pairs (header, last-entry, assets/liabs, scheduled, business, commodities) stay inline per the plan.

**2. ``perf(core): materialize book.transactions once``** — pre-fix, ``_collect_warnings``, ``_budget_headline``, ``_runway_metrics``, ``_monthly_net_income``, and ``_daily_expense_burn`` each walked ``book.transactions`` from scratch. The materialized list is now threaded through. Same ``_collect_create_signals`` pattern v1.1 introduced on the write side, applied to the read side.

**3. ``perf(core): materialize book.accounts once``** — CODE_REVIEW noted 7-10 passes over ``book.accounts`` in ``get_book_summary``. Inline scans collapsed; ``accounts`` threaded through ``_collect_warnings`` (three internal scans), ``_account_reconciliation_status``, ``_runway_metrics``, ``_net_worth_trajectory`` → ``_compute_net_worth_at``. The trajectory win is the biggest single one — up to 5 anchor dates each calling ``_compute_net_worth_at``, which previously walked ``book.accounts`` twice (parent-GUID set + main loop), so up to **10 ORM sweeps per trajectory call** now zero.

**Plan item 4 (single-pass ``_collect_warnings``) skipped** — already landed in commit ``5073b60`` ("more polish") during v1.2.1's pre-release cleanup. The body at lines 796-845 is already a single pass over ``book.prices`` producing both ``in_use`` and ``by_commodity_latest``; the comment even documents the pre-fix two-pass version. Stale plan content; nothing to do.

**Performance**: invisible on a Lin Wei-sized book; significant at 50K transactions. Net-worth trajectory was the worst offender pre-fix.

## Test plan

- [x] 1,130 tests passing (unchanged across all three commits). Zero regressions.
- [x] Each commit verified independently — section-render extraction, transactions threading, accounts threading.
- [x] Same iteration order, same per-helper logic, same output. No bookkeeper baseline needed — the test suite is the regression gate.