### PR TITLE
feat(modules): role-aligned module restructure with group aliases

### DIFF
--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -581,9 +581,45 @@ Usage: gnucash-mcp [OPTIONS]
 
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
-                       Default: core (15 tools). Use "all" for all 70 tools.
-                       Available: core, reconciliation, reporting, budgets,
-                       scheduling, investments, business, admin
+                       Default: core (26 tools, always-on). Use "all"
+                       for every module (88 tools).
+
+                       Modules (role-aligned, flat partition; pick
+                       what fits your workflow):
+                         core         The ledger + balance_sheet +
+                                      slots + audit log + backups.
+                                      Always on.
+                         personal     Budgets, scheduling,
+                                      reconciliation, lifestyle
+                                      reports (net_worth,
+                                      spending_by_category, cash_flow,
+                                      income_by_source,
+                                      debt_payoff_plan).
+                                      [NOTE: not yet a group alias;
+                                       compose its members directly
+                                       for now: budgets,scheduling,
+                                       reconciliation,reporting]
+                         budgets      Budget creation + variance.
+                         scheduling   Recurring transactions.
+                         reconciliation
+                                      Bank-statement reconciliation.
+                         reporting    Analytical reports (net_worth,
+                                      cash_flow, spending/income
+                                      breakdowns, debt_payoff_plan).
+                         portfolio    Commodities + prices —
+                                      the multi-currency primitive.
+                         investor     Tax-lot management.
+                         freelancer   Customer invoicing.
+                         business     Vendor + employee management +
+                                      vendor bills (additive to
+                                      freelancer for full business
+                                      workflow).
+
+                       Example: --modules=freelancer for a solo
+                       invoicer; --modules=budgets,scheduling,reporting
+                       for a personal-finance user;
+                       --modules=freelancer,business for a small
+                       business with vendor management.
   --debug              Enable debug logging (MCP protocol traffic, timing)
   --noaudit            Disable audit logging
   -h, --help           Show this help message

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -80,6 +80,22 @@ SAFETY:
 # ---------------------------------------------------------------------------
 # Tool module definitions — controls which tools are advertised via --modules
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# MODULE_GROUPS — composition aliases that expand to one or more modules.
+#
+# Lets ``--modules=core`` (or any group name) expand to a set of underlying
+# module keys. Today the dict is empty — no behavior change vs. the
+# pre-restructure baseline. Populated in subsequent commits as the
+# role-aligned partition (Core / Personal / Portfolio / Investor /
+# Freelancer / Business) takes shape.
+#
+# Expansion is single-pass (groups don't reference other groups). The
+# partition is deliberately flat; if nesting becomes useful later we'll
+# add cycle detection then.
+# ---------------------------------------------------------------------------
+MODULE_GROUPS: dict[str, list[str]] = {}
+
+
 TOOL_MODULES: dict[str, list[str]] = {
     "core": [
         "get_book_summary",
@@ -258,11 +274,23 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
         if "all" in enabled_modules:
             enabled_modules = set(TOOL_MODULES.keys())
         else:
+            # Expand any MODULE_GROUPS aliases to their constituent
+            # module names. Single-pass (groups don't reference other
+            # groups). Names that aren't groups pass through unchanged.
+            expanded: set[str] = set()
+            for name in enabled_modules:
+                if name in MODULE_GROUPS:
+                    expanded.update(MODULE_GROUPS[name])
+                else:
+                    expanded.add(name)
+            enabled_modules = expanded
+
+            known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
             unknown = enabled_modules - set(TOOL_MODULES.keys())
             if unknown:
                 print(
                     f"Warning: Unknown module(s): {', '.join(sorted(unknown))}. "
-                    f"Available: {', '.join(sorted(TOOL_MODULES.keys()))}, all",
+                    f"Available: {', '.join(sorted(known))}, all",
                     file=sys.stderr,
                 )
             enabled_modules.add("core")

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -93,7 +93,17 @@ SAFETY:
 # partition is deliberately flat; if nesting becomes useful later we'll
 # add cycle detection then.
 # ---------------------------------------------------------------------------
-MODULE_GROUPS: dict[str, list[str]] = {}
+MODULE_GROUPS: dict[str, list[str]] = {
+    # ``core`` expands to its eight ledger sub-modules. Always-on
+    # (force-added in _apply_module_filter), so a user with no
+    # --modules flag gets all eight. Users can ALSO pick individual
+    # sub-modules — e.g. ``--modules=accounts`` is valid but doesn't
+    # change the fact that core is loaded too.
+    "core": [
+        "summary", "accounts", "transactions", "slots",
+        "audit", "backup", "balance_sheet", "diagnostic",
+    ],
+}
 
 
 # ---------------------------------------------------------------------------
@@ -113,31 +123,43 @@ MODULE_GROUPS: dict[str, list[str]] = {}
 # of the same module."
 # ---------------------------------------------------------------------------
 MODULE_BACKED_BY: dict[str, set[str]] = {
-    "core": {"core", "reconciliation", "reporting", "admin", "backup"},
+    # Core sub-modules — each maps to the legacy tool-file / mixin
+    # name(s) that host its tools. summary/accounts/transactions/
+    # balance_sheet are largely served by ``core.py`` and
+    # ``reporting.py`` (balance_sheet specifically); slots/audit by
+    # ``admin.py``; backup by ``backup.py``; the void/unvoid pair in
+    # transactions by ``reconciliation.py``. The diagnostic
+    # sub-module's one tool registers inline in server.py, so it
+    # needs no backing file.
+    "summary": {"core"},
+    "accounts": {"core"},
+    "transactions": {"core", "reconciliation"},
+    "slots": {"admin"},
+    "audit": {"admin"},
+    "backup": {"backup"},
+    "balance_sheet": {"reporting"},
+    "diagnostic": set(),
     # ``portfolio`` (prices / commodities) and ``investor`` (tax lots)
     # are the two halves of what used to be the ``investments`` module.
-    # Both back onto the same InvestmentsMixin / tools/investments.py —
-    # the mixin layer stays unchanged; only the tool-surface partition
-    # splits along the prices/lots axis.
     "portfolio": {"investments"},
     "investor": {"investments"},
     # ``freelancer`` (customer-facing invoicing) and ``business``
     # (vendor + employee management, vendor bills) split the legacy
-    # ``business`` module along persona lines. Both back onto the
-    # same BusinessMixin / tools/business.py. Shared-lifecycle tools
-    # (post/unpost/pay_invoice, list/get_invoice, get_outstanding_invoices)
-    # live in freelancer with runtime owner_type gating that rejects
-    # vendor-side use when ``business`` isn't loaded.
+    # ``business`` module along persona lines.
     "freelancer": {"business"},
     "business": {"business"},
 }
 
 
 TOOL_MODULES: dict[str, list[str]] = {
-    "core": [
-        # Orientation
+    # ── Core ledger sub-modules (composed via MODULE_GROUPS["core"]) ──
+    # Each is independently selectable via --modules but normally all
+    # eight are loaded together because the ``core`` group alias is
+    # always force-added.
+    "summary": [
         "get_book_summary",
-        # Account CRUD
+    ],
+    "accounts": [
         "list_accounts",
         "get_account",
         "get_balance",
@@ -145,7 +167,8 @@ TOOL_MODULES: dict[str, list[str]] = {
         "update_account",
         "move_account",
         "delete_account",
-        # Transaction CRUD
+    ],
+    "transactions": [
         "list_transactions",
         "get_transaction",
         "create_transaction",
@@ -153,29 +176,40 @@ TOOL_MODULES: dict[str, list[str]] = {
         "delete_transaction",
         "replace_splits",
         "search_transactions",
-        # Void / unvoid — couples with delete_transaction
-        # (delete refuses posted documents and points at void)
+        # Void / unvoid live here — they're the audit-preserving
+        # erasure path for transactions, paired with delete_transaction
+        # (which refuses posted documents and points at void).
         "void_transaction",
         "unvoid_transaction",
-        # Balance sheet — THE canonical accounting report; the
-        # ledger primitives wouldn't be complete without it.
-        # Analytical reports stay in the reporting module.
-        "balance_sheet",
-        # Account slot CRUD — metadata used by multiple modules
-        # (APR / credit_limit / statement-close on credit accounts)
+    ],
+    "slots": [
+        # Per-account metadata used by multiple modules — APR,
+        # credit_limit, statement-close-day, minimum_payment.
         "get_account_slots",
         "set_account_slot",
         "delete_account_slot",
-        # Audit log reader (transparency surface)
+    ],
+    "audit": [
         "get_audit_log",
-        # Backups (auto-snapshot hook is always-on regardless;
-        # these expose the manual control surface)
+    ],
+    "backup": [
+        # Auto-snapshot hook is always-on regardless; these expose
+        # the manual control surface for inspecting / pruning the
+        # snapshot history.
         "create_backup",
         "list_backups",
         "prune_backups",
-        # Server diagnostic — was --debug-only; now unconditional
-        # so users can always check loaded modules / tool count /
-        # version without restarting in debug mode.
+    ],
+    "balance_sheet": [
+        # THE canonical accounting report — Assets, Liabilities,
+        # Equity reconciling to zero. Analytical reports (cash flow,
+        # spending breakdowns, net worth time series) stay in the
+        # ``reporting`` module.
+        "balance_sheet",
+    ],
+    "diagnostic": [
+        # Server config introspection — loaded modules, tool count,
+        # version. Always available regardless of --debug.
         "get_server_config",
     ],
     "reconciliation": [
@@ -377,49 +411,81 @@ def is_module_enabled(name: str) -> bool:
 def _apply_module_filter(modules_str: str | None) -> list[str]:
     """Enable the requested modules and remove tools not in that set.
 
-    For extracted modules (admin, ...) this also lazy-imports the matching
-    gnucash_mcp/tools/<name>.py and calls its register() function — so
-    disabled extracted modules never parse their tool definitions.
+    For extracted modules this also lazy-imports the matching
+    ``gnucash_mcp/tools/<name>.py`` and calls its ``register()``
+    function — so disabled extracted modules never parse their tool
+    definitions.
 
     Args:
-        modules_str: Comma-separated module names, "all", or None (core only).
+        modules_str: Comma-separated module/group names, ``"all"``,
+            or ``None`` (core only).
 
     Returns:
-        Sorted list of module names that were actually loaded.
+        Sorted list of TOOL_MODULES sub-module names that were
+        actually loaded. ``_LOADED_MODULES`` (the global) holds the
+        same set plus the group names that expanded into it, so
+        ``is_module_enabled("core")`` works alongside
+        ``is_module_enabled("transactions")``.
     """
     if modules_str is None:
-        enabled_modules = {"core"}
+        requested = {"core"}
     else:
-        enabled_modules = {m.strip() for m in modules_str.split(",")}
-        if "all" in enabled_modules:
-            enabled_modules = set(TOOL_MODULES.keys())
-        else:
-            # Expand any MODULE_GROUPS aliases to their constituent
-            # module names. Single-pass (groups don't reference other
-            # groups). Names that aren't groups pass through unchanged.
-            expanded: set[str] = set()
-            for name in enabled_modules:
-                if name in MODULE_GROUPS:
-                    expanded.update(MODULE_GROUPS[name])
-                else:
-                    expanded.add(name)
-            enabled_modules = expanded
+        requested = {m.strip() for m in modules_str.split(",")}
 
-            known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
-            unknown = enabled_modules - set(TOOL_MODULES.keys())
-            if unknown:
-                print(
-                    f"Warning: Unknown module(s): {', '.join(sorted(unknown))}. "
-                    f"Available: {', '.join(sorted(known))}, all",
-                    file=sys.stderr,
-                )
-            enabled_modules.add("core")
+    if "all" in requested:
+        enabled_modules = set(TOOL_MODULES.keys())
+        groups_used: list[str] = ["all"]
+    else:
+        # ``core`` is always-on. Force-add before group expansion so
+        # the eight core sub-modules come along even when the user
+        # passes only e.g. ``--modules=reporting``.
+        requested.add("core")
 
-    # Keep only known module names. ``backup`` no longer needs a
-    # force-add — its tools moved into Core, so the auto-snapshot
-    # hook plus the three manual tools are always available via
-    # Core's tool list.
+        # Expand groups single-pass. Groups don't reference other
+        # groups (deliberate flat partition); if that changes,
+        # cycle-detection lands here.
+        enabled_modules: set[str] = set()
+        groups_used = []
+        for name in requested:
+            if name in MODULE_GROUPS:
+                enabled_modules.update(MODULE_GROUPS[name])
+                groups_used.append(name)
+            else:
+                enabled_modules.add(name)
+
+        # Warn on names that don't resolve to a known sub-module.
+        known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
+        all_referenced = requested | enabled_modules
+        unknown = all_referenced - known - {"all"}
+        if unknown:
+            print(
+                f"Warning: Unknown module(s): {', '.join(sorted(unknown))}. "
+                f"Available: {', '.join(sorted(known))}, all",
+                file=sys.stderr,
+            )
+
+    # Keep only known sub-module names. Group expansion above may
+    # have introduced names that aren't TOOL_MODULES keys if the
+    # group def is stale; filter them out before lookup.
     enabled_modules &= set(TOOL_MODULES.keys())
+
+    # Build a group-aware display string for get_server_config.
+    # Groups render as ``group[member1, member2, ...]``; standalone
+    # sub-modules (not covered by any group the user requested)
+    # render bare.
+    accounted_for: set[str] = set()
+    display_parts: list[str] = []
+    for group_name in sorted(groups_used):
+        if group_name == "all":
+            display_parts.append("all")
+            accounted_for.update(enabled_modules)
+            continue
+        members = sorted(MODULE_GROUPS.get(group_name, []))
+        display_parts.append(f"{group_name}[{', '.join(members)}]")
+        accounted_for.update(members)
+    standalone = sorted(enabled_modules - accounted_for)
+    display_parts.extend(standalone)
+    _server_state["modules_display"] = ", ".join(display_parts)
 
     # Expand each enabled module to its backing tool-files (per
     # MODULE_BACKED_BY; default 1:1). Lazy-load any backing files
@@ -447,9 +513,15 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
 
     # Snapshot the enabled set for tool wrappers that gate behavior
     # on module availability (e.g., owner_type='vendor' on Freelancer
-    # tools when Business isn't loaded).
+    # tools when Business isn't loaded). Also register any group
+    # whose members are fully loaded — that way
+    # ``is_module_enabled("core")`` works alongside the
+    # individual sub-module checks.
     _LOADED_MODULES.clear()
     _LOADED_MODULES.update(enabled_modules)
+    for group_name, members in MODULE_GROUPS.items():
+        if set(members) <= enabled_modules:
+            _LOADED_MODULES.add(group_name)
 
     return sorted(enabled_modules)
 
@@ -586,19 +658,25 @@ Options:
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):
-                         core         The ledger + balance_sheet +
-                                      slots + audit log + backups.
-                                      Always on.
-                         personal     Budgets, scheduling,
-                                      reconciliation, lifestyle
-                                      reports (net_worth,
-                                      spending_by_category, cash_flow,
-                                      income_by_source,
-                                      debt_payoff_plan).
-                                      [NOTE: not yet a group alias;
-                                       compose its members directly
-                                       for now: budgets,scheduling,
-                                       reconciliation,reporting]
+
+                       Core sub-modules — always loaded via the
+                       ``core`` group alias; selectable individually
+                       too:
+                         summary      get_book_summary dashboard.
+                         accounts     Account CRUD + balance/list.
+                         transactions Transaction CRUD + search +
+                                      void/unvoid.
+                         slots        Per-account metadata (APR,
+                                      credit_limit, statement-close).
+                         audit        get_audit_log reader.
+                         backup       Manual backup CRUD (the
+                                      auto-snapshot hook runs
+                                      unconditionally).
+                         balance_sheet
+                                      THE canonical accounting report.
+                         diagnostic   get_server_config introspection.
+
+                       Optional modules:
                          budgets      Budget creation + variance.
                          scheduling   Recurring transactions.
                          reconciliation
@@ -619,7 +697,8 @@ Options:
                        invoicer; --modules=budgets,scheduling,reporting
                        for a personal-finance user;
                        --modules=freelancer,business for a small
-                       business with vendor management.
+                       business with vendor management. ``core`` is
+                       always added regardless.
   --debug              Enable debug logging (MCP protocol traffic, timing)
   --noaudit            Disable audit logging
   -h, --help           Show this help message
@@ -716,9 +795,15 @@ Logs are stored alongside the book file:
         except Exception:
             pass  # Book may be locked — don't block startup
 
-    # Populate runtime state and conditionally register debug tool
+    # Populate runtime state and conditionally register debug tool.
+    # ``modules_display`` was set by ``_apply_module_filter`` with
+    # group-aware rendering (``core[summary, accounts, ...], reporting``
+    # rather than the flat list of 8+ sub-modules). Fall back to a
+    # bare join if the display key wasn't set for some reason.
     tool_count = len(mcp._tool_manager._tools)
-    modules_display = ", ".join(loaded_modules)
+    modules_display = _server_state.get(
+        "modules_display", ", ".join(loaded_modules)
+    )
     _server_state.update({
         "modules": modules_display,
         "tool_count": tool_count,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -96,9 +96,33 @@ SAFETY:
 MODULE_GROUPS: dict[str, list[str]] = {}
 
 
+# ---------------------------------------------------------------------------
+# MODULE_BACKED_BY — per public-module, the set of legacy tool-file /
+# mixin names needed to back its tools.
+#
+# Pre-restructure the mapping was 1:1 (module ``X`` → tool file
+# ``tools/X.py`` → mixin ``XMixin``). The restructure breaks that:
+# Core's 26 tools include void/unvoid (from ``reconciliation.py``),
+# the slot tools + audit log (from ``admin.py``), and the backup tools
+# (from ``backup.py``). The mixin classes still live in their original
+# files; this dict tells ``_apply_module_filter`` which tool files to
+# lazy-load AND ``main()`` which mixins to compose for the requested
+# module set.
+#
+# An entry missing from this dict means "1:1 — uses the legacy name
+# of the same module."
+# ---------------------------------------------------------------------------
+MODULE_BACKED_BY: dict[str, set[str]] = {
+    "core": {"core", "reconciliation", "reporting", "admin", "backup"},
+    # Other modules unchanged for now — populated as splits land.
+}
+
+
 TOOL_MODULES: dict[str, list[str]] = {
     "core": [
+        # Orientation
         "get_book_summary",
+        # Account CRUD
         "list_accounts",
         "get_account",
         "get_balance",
@@ -106,6 +130,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "update_account",
         "move_account",
         "delete_account",
+        # Transaction CRUD
         "list_transactions",
         "get_transaction",
         "create_transaction",
@@ -113,18 +138,39 @@ TOOL_MODULES: dict[str, list[str]] = {
         "delete_transaction",
         "replace_splits",
         "search_transactions",
+        # Void / unvoid — couples with delete_transaction
+        # (delete refuses posted documents and points at void)
+        "void_transaction",
+        "unvoid_transaction",
+        # Balance sheet — THE canonical accounting report; the
+        # ledger primitives wouldn't be complete without it.
+        # Analytical reports stay in the reporting module.
+        "balance_sheet",
+        # Account slot CRUD — metadata used by multiple modules
+        # (APR / credit_limit / statement-close on credit accounts)
+        "get_account_slots",
+        "set_account_slot",
+        "delete_account_slot",
+        # Audit log reader (transparency surface)
+        "get_audit_log",
+        # Backups (auto-snapshot hook is always-on regardless;
+        # these expose the manual control surface)
+        "create_backup",
+        "list_backups",
+        "prune_backups",
+        # Server diagnostic — was --debug-only; now unconditional
+        # so users can always check loaded modules / tool count /
+        # version without restarting in debug mode.
+        "get_server_config",
     ],
     "reconciliation": [
         "get_unreconciled_splits",
         "set_reconcile_state",
         "reconcile_account",
-        "void_transaction",
-        "unvoid_transaction",
     ],
     "reporting": [
         "spending_by_category",
         "income_by_source",
-        "balance_sheet",
         "net_worth",
         "cash_flow",
         "debt_payoff_plan",
@@ -158,17 +204,6 @@ TOOL_MODULES: dict[str, list[str]] = {
         "calculate_lot_gain",
         "close_lot",
         "delete_price",
-    ],
-    "admin": [
-        "get_account_slots",
-        "set_account_slot",
-        "delete_account_slot",
-        "get_audit_log",
-    ],
-    "backup": [
-        "create_backup",
-        "list_backups",
-        "prune_backups",
     ],
     "business": [
         "create_customer",
@@ -244,14 +279,43 @@ def _validate_tool_modules() -> None:
         )
 
 
+# Track which ``gnucash_mcp.tools.<file>`` modules have already had
+# their ``register()`` called. The old heuristic — "skip if any tool
+# from this module is already registered" — broke after the
+# restructure: post-rebucket, ``void_transaction`` is in Core's tool
+# list but lives in ``tools/reconciliation.py``. With reconciliation
+# loaded first, ``any(t in registered for t in TOOL_MODULES['core'])``
+# returns True (because void_transaction is registered) — so
+# ``tools/core.py`` would never load, and create_transaction et al.
+# would never register. Tracking files explicitly avoids the false
+# positive.
+_loaded_tool_files: set[str] = set()
+
+
 def _lazy_load_tool_module(module_name: str) -> None:
-    """Import and register an extracted tool module if not already loaded."""
-    expected_tools = TOOL_MODULES.get(module_name, [])
-    # Idempotent: skip if any tool from this module is already registered
-    if any(t in mcp._tool_manager._tools for t in expected_tools):
+    """Import and register an extracted tool module if not already loaded.
+
+    ``module_name`` is the tool-file name under ``gnucash_mcp.tools``
+    (matches the legacy module name; the public TOOL_MODULES keys may
+    differ post-restructure).
+    """
+    if module_name in _loaded_tool_files:
         return
     tool_mod = importlib.import_module(f"gnucash_mcp.tools.{module_name}")
     tool_mod.register(mcp, get_book)
+    _loaded_tool_files.add(module_name)
+
+
+def _reset_lazy_load_state() -> None:
+    """Reset the ``_loaded_tool_files`` tracker.
+
+    Test-only helper. Production code never calls this. Tests that
+    manipulate ``mcp._tool_manager._tools`` directly (e.g. clearing it
+    between cases) must also reset the lazy-load tracker, otherwise
+    subsequent ``_lazy_load_tool_module`` calls become no-ops while
+    the registry is empty.
+    """
+    _loaded_tool_files.clear()
 
 
 def _apply_module_filter(modules_str: str | None) -> list[str]:
@@ -295,21 +359,24 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
                 )
             enabled_modules.add("core")
 
-    # `backup` is never optional — the auto-snapshot hook protects
-    # every user against data loss regardless of what modules they
-    # asked for, and the three manual tools (create_backup /
-    # list_backups / prune_backups) are small enough to always
-    # advertise. Treat it the same way as `core`.
-    enabled_modules.add("backup")
-
-    # Keep only known module names
+    # Keep only known module names. ``backup`` no longer needs a
+    # force-add — its tools moved into Core, so the auto-snapshot
+    # hook plus the three manual tools are always available via
+    # Core's tool list.
     enabled_modules &= set(TOOL_MODULES.keys())
 
-    # Lazy-load any enabled extracted modules
+    # Expand each enabled module to its backing tool-files (per
+    # MODULE_BACKED_BY; default 1:1). Lazy-load any backing files
+    # that are extracted.
+    backing_files: set[str] = set()
+    for mod_name in enabled_modules:
+        backing_files.update(
+            MODULE_BACKED_BY.get(mod_name, {mod_name})
+        )
     extracted = extracted_modules()
-    for mod_name in sorted(enabled_modules):
-        if mod_name in extracted:
-            _lazy_load_tool_module(mod_name)
+    for file_name in sorted(backing_files):
+        if file_name in extracted:
+            _lazy_load_tool_module(file_name)
 
     # Build the set of tool names to keep
     keep: set[str] = set()
@@ -400,15 +467,14 @@ def accounts_resource() -> str:
 # get_audit_log moved to gnucash_mcp/tools/admin.py.
 
 
-# ============== Debug Tool (conditionally registered) ==============
+# ============== Server Diagnostic Tool ==============
 
 
 def _get_server_config_impl() -> str:
     """Return current server configuration and runtime state.
 
-    Only available when the server is started with --debug.
-    Reports loaded modules, tool count, book path, and version
-    so the client can verify its own tool inventory.
+    Reports loaded modules, tool count, book path, debug mode,
+    and version so the client can verify its own tool inventory.
     """
     from gnucash_mcp import __version__
     lines = [
@@ -422,6 +488,22 @@ def _get_server_config_impl() -> str:
     if dc_ok is False:
         lines.append("Warning: Book has no default currency set")
     return "\n".join(lines)
+
+
+# Register get_server_config unconditionally at import time so it
+# survives _apply_module_filter's keep-set pass (Core's tool list
+# includes it). Previously gated behind --debug; now always
+# available as a diagnostic surface.
+@mcp.tool()
+@safe_tool
+def get_server_config() -> str:
+    """Get the server's loaded configuration.
+
+    Returns loaded modules, tool count, book path, debug mode,
+    and version. Use this to verify which tools are available in
+    this session.
+    """
+    return _get_server_config_impl()
 
 
 # ============== Main ==============
@@ -501,7 +583,19 @@ Logs are stored alongside the book file:
     # import), leave the existing instance alone; otherwise subsequent
     # get_book() calls will use this class.
     global _book_class
-    _book_class = build_book_class(set(loaded_modules))
+    # Expand each loaded module to its backing mixin set. With the
+    # Core restructure (void/unvoid + admin tools + backups migrated
+    # into Core), the mixin layer still owns those methods in their
+    # original files — Core needs CoreMixin + ReconciliationMixin +
+    # AdminMixin + BackupMixin composed together to back its 26
+    # tools. ``MODULE_BACKED_BY`` provides the mapping; modules not
+    # listed there default to 1:1 (the legacy convention).
+    backing_mixins: set[str] = set()
+    for mod_name in loaded_modules:
+        backing_mixins.update(
+            MODULE_BACKED_BY.get(mod_name, {mod_name})
+        )
+    _book_class = build_book_class(backing_mixins)
 
     # Check book health (non-fatal)
     currency_ok = None
@@ -535,27 +629,12 @@ Logs are stored alongside the book file:
         "default_currency_ok": currency_ok,
     })
 
-    if debug_flag:
-        # Register the debug-only diagnostic tool
-        @mcp.tool()
-        @safe_tool
-        def get_server_config() -> str:
-            """Get the server's loaded configuration.
-
-            Returns loaded modules, tool count, book path, debug mode,
-            and version. Only available when server is started with --debug.
-            Use this to verify which tools are available in this session.
-            """
-            return _get_server_config_impl()
-
-        # Update tool count to include the newly registered tool
-        _server_state["tool_count"] = len(mcp._tool_manager._tools)
+    # get_server_config is now registered unconditionally at module
+    # import time (see above), so no per-run conditional registration
+    # is needed here.
+    if debug_flag or _debug_mode:
         debug_log(f"Modules: {modules_display}")
-        debug_log(f"Tools loaded: {_server_state['tool_count']}")
-    else:
-        if _debug_mode:
-            debug_log(f"Modules: {modules_display}")
-            debug_log(f"Tools loaded: {tool_count}")
+        debug_log(f"Tools loaded: {tool_count}")
 
     mcp.run()
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -114,7 +114,13 @@ MODULE_GROUPS: dict[str, list[str]] = {}
 # ---------------------------------------------------------------------------
 MODULE_BACKED_BY: dict[str, set[str]] = {
     "core": {"core", "reconciliation", "reporting", "admin", "backup"},
-    # Other modules unchanged for now — populated as splits land.
+    # ``portfolio`` (prices / commodities) and ``investor`` (tax lots)
+    # are the two halves of what used to be the ``investments`` module.
+    # Both back onto the same InvestmentsMixin / tools/investments.py —
+    # the mixin layer stays unchanged; only the tool-surface partition
+    # splits along the prices/lots axis.
+    "portfolio": {"investments"},
+    "investor": {"investments"},
 }
 
 
@@ -191,19 +197,26 @@ TOOL_MODULES: dict[str, list[str]] = {
         "update_scheduled_transaction",
         "delete_scheduled_transaction",
     ],
-    "investments": [
+    # ``investments`` split into ``portfolio`` (the multi-currency
+    # primitive: commodities + prices) and ``investor`` (tax-lot
+    # management). A multi-currency household without a brokerage
+    # picks portfolio without investor; a single-currency investor
+    # picks the inverse.
+    "portfolio": [
         "list_commodities",
         "create_commodity",
         "create_price",
         "get_prices",
         "get_latest_price",
+        "delete_price",
+    ],
+    "investor": [
         "create_lot",
         "list_lots",
         "get_lot",
         "assign_split_to_lot",
         "calculate_lot_gain",
         "close_lot",
-        "delete_price",
     ],
     "business": [
         "create_customer",
@@ -264,12 +277,20 @@ def _validate_tool_modules() -> None:
             f"Add them to the appropriate module."
         )
 
-    # Phantom check is scoped to modules that ship their tools in server.py
-    # (the non-extracted ones). Extracted modules' tools are loaded lazily.
+    # Phantom check is scoped to modules whose backing tool files
+    # aren't extracted (i.e., tools ship at server.py import time
+    # rather than lazy-load). A module's backing files come from
+    # MODULE_BACKED_BY when set, otherwise default 1:1 to the module
+    # name itself. ``portfolio`` and ``investor`` back onto the
+    # extracted ``investments`` file, so their tools are lazy-loaded
+    # despite the module names being new.
     extracted = extracted_modules()
     expected_now = set()
     for mod_name, tools in TOOL_MODULES.items():
-        if mod_name not in extracted:
+        backing = MODULE_BACKED_BY.get(mod_name, {mod_name})
+        if not (backing & extracted):
+            # No backing file is extracted → tools must register at
+            # import time; expect them to be present already.
             expected_now.update(tools)
     phantom = expected_now - registered
     if phantom:

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -121,6 +121,15 @@ MODULE_BACKED_BY: dict[str, set[str]] = {
     # splits along the prices/lots axis.
     "portfolio": {"investments"},
     "investor": {"investments"},
+    # ``freelancer`` (customer-facing invoicing) and ``business``
+    # (vendor + employee management, vendor bills) split the legacy
+    # ``business`` module along persona lines. Both back onto the
+    # same BusinessMixin / tools/business.py. Shared-lifecycle tools
+    # (post/unpost/pay_invoice, list/get_invoice, get_outstanding_invoices)
+    # live in freelancer with runtime owner_type gating that rejects
+    # vendor-side use when ``business`` isn't loaded.
+    "freelancer": {"business"},
+    "business": {"business"},
 }
 
 
@@ -218,36 +227,47 @@ TOOL_MODULES: dict[str, list[str]] = {
         "calculate_lot_gain",
         "close_lot",
     ],
-    "business": [
+    # ``business`` split into ``freelancer`` (customer-facing
+    # invoicing — the natural surface for a solo consultant) and
+    # ``business`` (vendor + employee management, vendor bills —
+    # additive to freelancer for full small-business workflow). The
+    # shared-lifecycle tools (post/unpost/pay_invoice, list/get_invoice,
+    # get_outstanding_invoices) live in freelancer because customer
+    # invoicing is the dominant use case; runtime owner_type gating
+    # (see _gate_owner_type in tools/_helpers.py) rejects vendor-side
+    # use when business isn't loaded.
+    "freelancer": [
         "create_customer",
         "list_customers",
         "get_customer",
         "update_customer",
-        "create_vendor",
-        "list_vendors",
-        "get_vendor",
-        "update_vendor",
-        "create_employee",
-        "list_employees",
-        "get_employee",
-        "update_employee",
-        "create_billterm",
-        "list_billterms",
+        "delete_customer",
         "create_invoice",
-        "create_bill",
         "add_invoice_entry",
-        "add_bill_entry",
         "list_invoices",
         "get_invoice",
         "post_invoice",
         "unpost_invoice",
         "pay_invoice",
         "delete_invoice",
-        "delete_bill",
-        "delete_customer",
-        "delete_vendor",
-        "delete_employee",
         "get_outstanding_invoices",
+    ],
+    "business": [
+        "create_vendor",
+        "list_vendors",
+        "get_vendor",
+        "update_vendor",
+        "delete_vendor",
+        "create_bill",
+        "add_bill_entry",
+        "delete_bill",
+        "create_employee",
+        "list_employees",
+        "get_employee",
+        "update_employee",
+        "delete_employee",
+        "create_billterm",
+        "list_billterms",
         "vendor_spending_report",
     ],
 }
@@ -339,6 +359,21 @@ def _reset_lazy_load_state() -> None:
     _loaded_tool_files.clear()
 
 
+# Snapshot of which public module names are enabled in the current
+# run. Populated by ``_apply_module_filter``; read by tool wrappers
+# that need to gate behavior on module availability (e.g., the
+# Freelancer-side shared-lifecycle invoice tools reject
+# ``owner_type='vendor'`` when ``business`` isn't loaded).
+_LOADED_MODULES: set[str] = set()
+
+
+def is_module_enabled(name: str) -> bool:
+    """True iff the given public module is in the current run's
+    enabled set. Tool wrappers call this to gate per-module behavior.
+    """
+    return name in _LOADED_MODULES
+
+
 def _apply_module_filter(modules_str: str | None) -> list[str]:
     """Enable the requested modules and remove tools not in that set.
 
@@ -409,6 +444,12 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
     for tool_name in list(mcp._tool_manager._tools.keys()):
         if tool_name not in keep:
             mcp.remove_tool(tool_name)
+
+    # Snapshot the enabled set for tool wrappers that gate behavior
+    # on module availability (e.g., owner_type='vendor' on Freelancer
+    # tools when Business isn't loaded).
+    _LOADED_MODULES.clear()
+    _LOADED_MODULES.update(enabled_modules)
 
     return sorted(enabled_modules)
 

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -186,6 +186,50 @@ def _json(obj) -> str:
     )
 
 
+def _gate_owner_type(owner_type: str | None) -> str | None:
+    """Enforce the Freelancer/Business module split at the
+    ``owner_type`` boundary.
+
+    Shared-lifecycle invoice/bill tools (post_invoice, unpost_invoice,
+    pay_invoice, list_invoices, get_invoice, get_outstanding_invoices)
+    live in the Freelancer module because customer-facing invoicing is
+    the natural Freelancer surface. Vendor bills travel through the
+    same tools via ``owner_type='vendor'`` dispatch — but the Business
+    module owns vendor management. A user with only Freelancer loaded
+    should never be able to touch vendor bills.
+
+    Two cases:
+
+    - **Explicit ``owner_type='vendor'`` without Business loaded:**
+      reject with a clear error. The user is explicitly asking for
+      vendor-side behavior they didn't enable.
+    - **``owner_type`` omitted or ``'customer'`` without Business:**
+      coerce to ``'customer'``. The tool only sees customer entities.
+      Any vendor-ID collision is treated as "not found" at the
+      lookup layer (book methods filter on owner_type).
+
+    Returns the (possibly coerced) owner_type the book method should
+    receive. Caller passes the return value through to ``book.X(...,
+    owner_type=...)``.
+
+    Imports server lazily to avoid an import-time cycle (server.py
+    imports from tools.* via lazy-load).
+    """
+    from gnucash_mcp.server import is_module_enabled
+
+    if is_module_enabled("business"):
+        return owner_type  # Both halves available; no gating.
+
+    if owner_type == "vendor":
+        raise ValueError(
+            "owner_type='vendor' requires the Business module. "
+            "Restart the server with --modules=...,Business to access "
+            "vendor bills, or omit owner_type to operate on customer "
+            "invoices only."
+        )
+    return "customer"
+
+
 def safe_tool(func: Callable) -> Callable:
     """Decorator that wraps tool functions with comprehensive error handling.
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -6,7 +6,7 @@ Registered only when the 'business' module is enabled via --modules.
 import json
 
 from gnucash_mcp.logging_config import audit_log
-from gnucash_mcp.tools._helpers import _json, safe_tool
+from gnucash_mcp.tools._helpers import _gate_owner_type, _json, safe_tool
 
 
 def register(mcp, get_book) -> None:
@@ -490,6 +490,7 @@ def register(mcp, get_book) -> None:
                    at 250. Compact output appends a truncation notice
                    when results are clipped.
         """
+        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.list_invoices(
             owner_type=owner_type,
@@ -520,6 +521,7 @@ def register(mcp, get_book) -> None:
                         "vendor" for bills. Useful when an invoice and
                         bill share the same ID (independent counters).
         """
+        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.get_invoice(invoice_id=id, owner_type=owner_type)
         return _json(result)
@@ -548,6 +550,7 @@ def register(mcp, get_book) -> None:
             description: Description for the posting transaction. Optional.
             owner_type: "customer" or "vendor" for disambiguation when IDs collide.
         """
+        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.post_invoice(
             invoice_id=id,
@@ -579,6 +582,7 @@ def register(mcp, get_book) -> None:
             owner_type: "customer" or "vendor" for disambiguation
                 when IDs collide.
         """
+        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.unpost_invoice(
             invoice_id=id,
@@ -626,6 +630,7 @@ def register(mcp, get_book) -> None:
                 realized FX gain/loss (cross-currency payments only).
                 Accepts a full path, %short GUID, or full 32-char GUID.
         """
+        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.pay_invoice(
             invoice_id=id,
@@ -744,6 +749,19 @@ def register(mcp, get_book) -> None:
             vendor_id: Filter by specific vendor ID.
             verbose: If true, return full JSON details.
         """
+        owner_type = _gate_owner_type(owner_type)
+        # When Business isn't loaded, vendor_id is also a vendor-only
+        # surface — reject it the same way an explicit
+        # owner_type='vendor' is rejected. _gate_owner_type already
+        # handled owner_type; vendor_id needs its own check.
+        if vendor_id is not None:
+            from gnucash_mcp.server import is_module_enabled
+            if not is_module_enabled("business"):
+                raise ValueError(
+                    "vendor_id filtering requires the Business module. "
+                    "Restart with --modules=...,Business to access "
+                    "vendor bills."
+                )
         book = get_book()
         result = book.get_outstanding_invoices(
             owner_type=owner_type,

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -5,6 +5,7 @@ import pytest
 from gnucash_mcp.book import extracted_modules
 from gnucash_mcp.server import (
     MODULE_BACKED_BY,
+    MODULE_GROUPS,
     TOOL_MODULES,
     _apply_module_filter,
     _get_server_config_impl,
@@ -14,6 +15,21 @@ from gnucash_mcp.server import (
     _validate_tool_modules,
     mcp,
 )
+
+
+def _core_tool_names() -> set[str]:
+    """Union of tool names across the eight ``core`` sub-modules.
+
+    Pre-Core-chop, tests asserted against ``TOOL_MODULES["core"]``
+    directly. Post-chop, ``core`` is a MODULE_GROUPS alias — there is
+    no flat list any more. This helper preserves the assertion
+    shape without re-spelling the eight sub-module names at every
+    callsite.
+    """
+    names: set[str] = set()
+    for sub in MODULE_GROUPS["core"]:
+        names.update(TOOL_MODULES[sub])
+    return names
 
 
 class TestToolModulesMapping:
@@ -57,29 +73,37 @@ class TestToolModulesMapping:
                 assert tool not in seen, f"{tool} appears in multiple modules"
                 seen.add(tool)
 
-    def test_core_module_count(self):
-        """Core module should have 26 tools after the restructure
-        (15 original + 2 void/unvoid migrated from reconciliation +
-        3 slot tools + audit log from admin + 3 backup tools)."""
-        assert len(TOOL_MODULES["core"]) == 26
+    def test_core_group_resolves_to_26_tools(self):
+        """The ``core`` group expands to 26 tools across its eight
+        sub-modules (summary 1 + accounts 7 + transactions 9 + slots
+        3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1)."""
+        assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all modules should be 88 — 87 pre-
-        restructure + ``get_server_config`` (promoted from
-        ``--debug``-only conditional to unconditional Core tool)."""
+        """Total tools across all sub-modules should be 88 — same
+        as pre-Core-chop, just partitioned across more keys."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
         assert total == 88
 
     def test_expected_modules_exist(self):
-        """All expected module names should be present after the
-        restructure. ``admin`` and ``backup`` have dissolved (their
-        tools migrated into Core)."""
+        """All expected sub-module names should be present after the
+        Core-chop. ``core`` is no longer a TOOL_MODULES key — it's
+        a MODULE_GROUPS alias expanding to the eight sub-modules."""
         expected = {
-            "core", "reconciliation", "reporting", "budgets",
+            # Core sub-modules
+            "summary", "accounts", "transactions", "slots",
+            "audit", "backup", "balance_sheet", "diagnostic",
+            # Optional modules
+            "reconciliation", "reporting", "budgets",
             "scheduling", "portfolio", "investor",
             "freelancer", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
+        # And ``core`` is the group alias.
+        assert set(MODULE_GROUPS["core"]) == {
+            "summary", "accounts", "transactions", "slots",
+            "audit", "backup", "balance_sheet", "diagnostic",
+        }
 
     def test_validate_tool_modules_passes(self):
         """Validation should pass with the current mapping."""
@@ -208,29 +232,29 @@ class TestApplyModuleFilter:
         assert len(self._tool_names()) == 88
 
     def test_none_defaults_to_core_only(self):
-        """No --modules flag defaults to core. Backups, audit log,
-        and slot tools all live in Core post-restructure, so the
-        force-add of a separate backup module is gone."""
+        """No --modules flag defaults to the ``core`` group, which
+        expands to all eight ledger sub-modules. Backups, audit log,
+        and slot tools all live in their own sub-modules under
+        ``core``."""
         _apply_module_filter(None)
         remaining = self._tool_names()
-        expected = set(TOOL_MODULES["core"])
+        expected = _core_tool_names()
         assert remaining == expected
 
     def test_core_plus_reporting(self):
-        """--modules=core,reporting loads both."""
+        """--modules=core,reporting loads the eight core sub-modules
+        plus reporting."""
         _apply_module_filter("core,reporting")
         remaining = self._tool_names()
-        expected = (
-            set(TOOL_MODULES["core"])
-            | set(TOOL_MODULES["reporting"])
-        )
+        expected = _core_tool_names() | set(TOOL_MODULES["reporting"])
         assert remaining == expected
 
     def test_core_always_included(self):
-        """Even if only 'reporting' is specified, core is always included."""
+        """Even if only 'reporting' is specified, the ``core`` group
+        is force-added — all eight ledger sub-modules come along."""
         _apply_module_filter("reporting")
         remaining = self._tool_names()
-        assert set(TOOL_MODULES["core"]).issubset(remaining)
+        assert _core_tool_names().issubset(remaining)
         assert set(TOOL_MODULES["reporting"]).issubset(remaining)
 
     def test_all_modules_combined(self):
@@ -252,20 +276,30 @@ class TestApplyModuleFilter:
         assert "Unknown module" in captured.err
 
     def test_unknown_module_still_loads_core(self, capsys):
-        """Unknown modules should not prevent core from loading."""
+        """Unknown modules should not prevent the ``core`` group from
+        loading."""
         _apply_module_filter("nonexistent")
         remaining = self._tool_names()
-        assert set(TOOL_MODULES["core"]).issubset(remaining)
+        assert _core_tool_names().issubset(remaining)
 
     def test_whitespace_in_module_names(self):
         """Whitespace around module names should be stripped."""
         _apply_module_filter("core , reporting")
         remaining = self._tool_names()
-        expected = (
-            set(TOOL_MODULES["core"])
-            | set(TOOL_MODULES["reporting"])
-        )
+        expected = _core_tool_names() | set(TOOL_MODULES["reporting"])
         assert remaining == expected
+
+    def test_individual_core_submodule_selectable(self):
+        """A user can pick a single Core sub-module by name. The
+        ``core`` group is still force-added, so all eight ledger
+        sub-modules end up loaded — but the test confirms the
+        sub-module name is a valid input that doesn't trip the
+        unknown-module warning."""
+        _apply_module_filter("accounts")
+        remaining = self._tool_names()
+        # accounts is in the group anyway; just verify it loaded.
+        assert "list_accounts" in remaining
+        assert "create_account" in remaining
 
     def test_portfolio_and_investor_split(self):
         """``portfolio`` (commodities + prices) and ``investor``
@@ -303,27 +337,35 @@ class TestApplyModuleFilter:
         assert remaining == registered
 
     def test_returns_loaded_modules_sorted(self):
-        """Return value should be sorted list of actually loaded modules."""
+        """Return value is a sorted list of actually loaded
+        sub-modules. The ``core`` group is always force-added, so all
+        eight ledger sub-modules + the requested ones are present.
+        Group names themselves don't appear in the return value —
+        callers derive groupings via ``MODULE_GROUPS`` if needed."""
         result = _apply_module_filter("reporting,budgets")
-        # core is always added; result is sorted.
-        assert result == ["budgets", "core", "reporting"]
+        # Eight Core sub-modules + budgets + reporting = 10 entries.
+        expected = sorted(set(MODULE_GROUPS["core"]) | {"budgets", "reporting"})
+        assert result == expected
 
     def test_returns_all_modules_for_all(self):
         """'all' should return all module names sorted."""
         result = _apply_module_filter("all")
         assert result == sorted(TOOL_MODULES.keys())
 
-    def test_returns_core_for_none(self):
-        """None returns just core. Backup/admin tools migrated INTO
-        core, so no separate force-load is needed."""
+    def test_returns_core_submodules_for_none(self):
+        """None returns the eight ledger sub-modules — the result of
+        expanding the always-on ``core`` group."""
         result = _apply_module_filter(None)
-        assert result == ["core"]
+        assert result == sorted(MODULE_GROUPS["core"])
 
     def test_returns_excludes_unknown_modules(self):
-        """Unknown module names should not appear in return value."""
+        """Unknown module names should not appear in return value.
+        The ``core`` group's sub-modules are always present even
+        when the user-supplied list contained only garbage."""
         result = _apply_module_filter("reporting,nonexistent")
         assert "nonexistent" not in result
-        assert "core" in result
+        # One representative Core sub-module is enough.
+        assert "accounts" in result
         assert "reporting" in result
 
 
@@ -353,21 +395,18 @@ class TestExtractedModuleLazyLoading:
     _ALWAYS_REGISTERED_INLINE = {"get_server_config"}
 
     def test_extracted_modules_are_not_registered_at_import(self):
-        """Tools from extracted modules must not be present at import
-        time, excluding the always-registered-inline set. Iterates
-        only the modules that still have a TOOL_MODULES entry (admin
-        and backup dissolved as module names; their tool files
-        survive)."""
-        for mod_name in extracted_modules():
-            if mod_name not in TOOL_MODULES:
-                continue
-            for tool_name in TOOL_MODULES[mod_name]:
-                if tool_name in self._ALWAYS_REGISTERED_INLINE:
-                    continue
-                assert tool_name not in mcp._tool_manager._tools, (
-                    f"{tool_name} from extracted module '{mod_name}' "
-                    f"was registered at import — defeats lazy loading."
-                )
+        """No tool from any TOOL_MODULES entry — except the
+        always-registered-inline set — should be present at import
+        time. Defeats lazy loading if any extracted-file tool sneaks
+        a registration into module-import side effects."""
+        all_tools: set[str] = set()
+        for tools in TOOL_MODULES.values():
+            all_tools.update(tools)
+        for tool_name in sorted(all_tools - self._ALWAYS_REGISTERED_INLINE):
+            assert tool_name not in mcp._tool_manager._tools, (
+                f"{tool_name} was registered at import time — "
+                f"defeats lazy loading."
+            )
 
     def test_enabling_extracted_module_registers_its_tools(self):
         """Enabling 'reporting' via _apply_module_filter registers
@@ -452,11 +491,12 @@ class TestGetServerConfig:
         lines = output.strip().split("\n")
         assert len(lines) == 5
 
-    def test_registered_in_core_unconditionally(self):
-        """get_server_config moved into Core during the restructure
-        and is registered at server import time, regardless of
-        --debug. Always available as a diagnostic surface."""
-        assert "get_server_config" in TOOL_MODULES["core"]
+    def test_registered_in_diagnostic_unconditionally(self):
+        """get_server_config lives in the ``diagnostic`` sub-module
+        (always loaded via the ``core`` group alias) and is registered
+        at server import time, regardless of --debug. Always available
+        as a diagnostic surface."""
+        assert "get_server_config" in TOOL_MODULES["diagnostic"]
         assert "get_server_config" in mcp._tool_manager._tools
 
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -4,9 +4,12 @@ import pytest
 
 from gnucash_mcp.book import extracted_modules
 from gnucash_mcp.server import (
+    MODULE_BACKED_BY,
     TOOL_MODULES,
     _apply_module_filter,
     _get_server_config_impl,
+    _loaded_tool_files,
+    _reset_lazy_load_state,
     _server_state,
     _validate_tool_modules,
     mcp,
@@ -30,14 +33,14 @@ class TestToolModulesMapping:
         registered = set(mcp._tool_manager._tools.keys())
         assert registered.issubset(all_mapped)
 
-    def test_every_module_is_extracted(self):
-        """Every TOOL_MODULES key has a corresponding mixin + tools file.
-
-        Before the final core extraction some tools shipped at module level
-        in server.py (non-extracted modules). That transition state is done —
-        every module is now lazy-loaded via gnucash_mcp/tools/<name>.py.
+    def test_every_tool_file_is_known(self):
+        """Every tools/<file>.py corresponds to a key in _MIXIN_MAP via
+        ``extracted_modules()``. Post-restructure, ``extracted_modules()``
+        is a superset of ``TOOL_MODULES.keys()`` — the dissolved
+        ``admin`` and ``backup`` modules still have their tool files
+        (their tools migrated INTO Core, not away from the filesystem).
         """
-        assert extracted_modules() == set(TOOL_MODULES.keys())
+        assert extracted_modules() >= set(TOOL_MODULES.keys())
 
     def test_no_duplicate_tools_across_modules(self):
         """No tool should appear in more than one module."""
@@ -48,27 +51,25 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_module_count(self):
-        """Core module should have 15 tools."""
-        assert len(TOOL_MODULES["core"]) == 15
+        """Core module should have 26 tools after the restructure
+        (15 original + 2 void/unvoid migrated from reconciliation +
+        3 slot tools + audit log from admin + 3 backup tools)."""
+        assert len(TOOL_MODULES["core"]) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all modules should be 87.
-
-        87 = 78 pre-Employee + 4 Employee CRUD (1.2.0) +
-        5 from the 1.2.1 patch:
-        - ``unpost_invoice``, ``delete_price`` (cleanup paths);
-        - ``update_customer``, ``update_vendor``, ``update_employee``
-          (so people don't have to open GnuCash to fix a typo).
-        """
+        """Total tools across all modules should be 88 — 87 pre-
+        restructure + ``get_server_config`` (promoted from
+        ``--debug``-only conditional to unconditional Core tool)."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 87
+        assert total == 88
 
     def test_expected_modules_exist(self):
-        """All expected module names should be present."""
+        """All expected module names should be present after the
+        restructure. ``admin`` and ``backup`` have dissolved (their
+        tools migrated into Core)."""
         expected = {
             "core", "reconciliation", "reporting", "budgets",
-            "scheduling", "investments", "admin", "business",
-            "backup",
+            "scheduling", "investments", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
 
@@ -78,81 +79,101 @@ class TestToolModulesMapping:
 
 
 class TestToolFileVsModulesMapping:
-    """Each ``tools/<module>.py`` file's ``@mcp.tool()`` decorations
-    must match the corresponding entry in ``TOOL_MODULES`` exactly.
+    """The union of every ``@mcp.tool()`` decoration across every
+    ``tools/<file>.py`` must equal the union of every tool name in
+    ``TOOL_MODULES``.
 
     Bug class this prevents: a tool added with ``@mcp.tool()`` in
-    ``tools/<module>.py`` but missing from ``TOOL_MODULES`` gets
-    *registered* during lazy-load, then immediately *removed* by
+    ``tools/<file>.py`` but missing from any ``TOOL_MODULES`` entry
+    gets *registered* during lazy-load, then immediately *removed* by
     ``_apply_module_filter``'s "drop anything not in the keep set"
-    step. The tool is invisible at runtime even though the
-    decorator fired and the function exists. Symptom is "I bounced
-    the server, the new tool still doesn't show up" — and the
-    earlier ``test_registered_tools_are_a_subset_of_mapped`` check
-    silently passes because the unmapped tool was already removed
-    by the filter.
+    step. The tool is invisible at runtime even though the decorator
+    fired and the function exists. The reverse — a name in
+    ``TOOL_MODULES`` that no file actually defines — is just as bad:
+    silently kept in the ``keep`` set, never registered, "this tool
+    is in the docs but doesn't work."
 
-    The reverse — a name in ``TOOL_MODULES`` that no file actually
-    defines — is just as bad: ``_apply_module_filter`` will
-    silently keep the missing tool in its ``keep`` set without
-    error, but ``mcp.remove_tool`` won't be called on a non-
-    existent tool, so the symptom is just "this tool is in the
-    docs but doesn't work."
-
-    Both omissions slipped through PR #62 (``unpost_invoice`` and
-    ``delete_price`` defined but not in ``TOOL_MODULES``) before
-    Claude Chat caught them mid-test. This class locks the
-    contract.
+    Pre-restructure this was a per-module 1:1 check (each
+    ``tools/<X>.py`` matched ``TOOL_MODULES[X]`` exactly). The Core
+    restructure broke that bijection — Core's 26 tools span
+    ``tools/core.py`` + ``tools/reconciliation.py`` +
+    ``tools/admin.py`` + ``tools/backup.py``. The contract is now
+    bidirectional-totality: every decorated tool maps to some
+    TOOL_MODULES entry, every TOOL_MODULES entry maps to some
+    decorated tool. Many-to-many.
     """
 
     @pytest.fixture(autouse=True)
     def save_and_restore_tools(self):
         original = dict(mcp._tool_manager._tools)
+        original_loaded = set(_loaded_tool_files)
         yield
         mcp._tool_manager._tools.clear()
         mcp._tool_manager._tools.update(original)
+        _reset_lazy_load_state()
+        _loaded_tool_files.update(original_loaded)
 
-    @pytest.mark.parametrize("module_name", sorted(TOOL_MODULES.keys()))
-    def test_module_file_decorations_match_mapping(
-        self, module_name: str,
-    ):
-        """For each module: load it, capture the tool names that
-        actually got registered, compare to ``TOOL_MODULES[name]``."""
-        from gnucash_mcp.book import extracted_modules
+    def test_every_decorated_tool_is_mapped(self):
+        """Load every tools/<file>.py and verify that each registered
+        tool name appears in at least one ``TOOL_MODULES`` entry.
+        Catches @mcp.tool() decorations the developer forgot to file
+        in the public mapping."""
         from gnucash_mcp.server import _lazy_load_tool_module
 
-        # Skip non-extracted modules (their tools register at server
-        # import time, not via the lazy-load path). Extracted modules
-        # are the ones with a tools/<name>.py file.
-        if module_name not in extracted_modules():
-            pytest.skip(f"{module_name!r} is not an extracted module")
-
-        # Reset to a clean slate so we can attribute new registrations
-        # to this specific module's load.
+        # Load every extracted module on a clean slate.
         mcp._tool_manager._tools.clear()
-        before = set(mcp._tool_manager._tools.keys())
-        _lazy_load_tool_module(module_name)
-        after = set(mcp._tool_manager._tools.keys())
-        actually_registered = after - before
+        _reset_lazy_load_state()
+        for file_name in sorted(extracted_modules()):
+            _lazy_load_tool_module(file_name)
+        registered = set(mcp._tool_manager._tools.keys())
 
-        mapped = set(TOOL_MODULES[module_name])
+        all_mapped: set[str] = set()
+        for tools in TOOL_MODULES.values():
+            all_mapped.update(tools)
 
-        unmapped = actually_registered - mapped
+        unmapped = registered - all_mapped
         assert not unmapped, (
-            f"Module {module_name!r}: tools have @mcp.tool() in "
-            f"tools/{module_name}.py but are missing from "
-            f"TOOL_MODULES[{module_name!r}]: {sorted(unmapped)}. "
-            f"Add them to the mapping or _apply_module_filter will "
-            f"silently remove them after registration."
+            f"Tools decorated in tools/*.py but missing from any "
+            f"TOOL_MODULES entry: {sorted(unmapped)}. "
+            f"Add them to the appropriate module or "
+            f"_apply_module_filter will silently remove them after "
+            f"registration."
         )
 
-        phantom = mapped - actually_registered
+    # Tools registered inline in server.py at import time (not via
+    # the lazy-load path through tools/<file>.py). Currently just the
+    # server-diagnostic surface; if more inline tools are added in
+    # the future they need to be listed here for the
+    # bidirectional-totality check to pass.
+    _ALWAYS_REGISTERED_INLINE = {"get_server_config"}
+
+    def test_every_mapped_tool_is_decorated(self):
+        """Every name in TOOL_MODULES must be defined as
+        ``@mcp.tool()`` somewhere under ``tools/`` OR be in the
+        always-registered-inline set (currently just
+        ``get_server_config``). Catches the reverse error —
+        TOOL_MODULES references a tool name that doesn't exist."""
+        from gnucash_mcp.server import _lazy_load_tool_module
+
+        mcp._tool_manager._tools.clear()
+        _reset_lazy_load_state()
+        for file_name in sorted(extracted_modules()):
+            _lazy_load_tool_module(file_name)
+        registered = set(mcp._tool_manager._tools.keys())
+        # Inline-registered tools are gone from the registry after
+        # the clear above. Re-add them logically for the comparison.
+        registered |= self._ALWAYS_REGISTERED_INLINE
+
+        all_mapped: set[str] = set()
+        for tools in TOOL_MODULES.values():
+            all_mapped.update(tools)
+
+        phantom = all_mapped - registered
         assert not phantom, (
-            f"Module {module_name!r}: TOOL_MODULES[{module_name!r}] "
-            f"lists tools that aren't defined in "
-            f"tools/{module_name}.py: {sorted(phantom)}. "
-            f"Either add the @mcp.tool() in the file or remove the "
-            f"name from the mapping."
+            f"TOOL_MODULES lists tools that aren't defined in any "
+            f"tools/*.py: {sorted(phantom)}. "
+            f"Either add the @mcp.tool() in the appropriate file "
+            f"or remove the name from TOOL_MODULES."
         )
 
 
@@ -163,9 +184,12 @@ class TestApplyModuleFilter:
     def save_and_restore_tools(self):
         """Save tool state before test, restore after."""
         original = dict(mcp._tool_manager._tools)
+        original_loaded = set(_loaded_tool_files)
         yield
         mcp._tool_manager._tools.clear()
         mcp._tool_manager._tools.update(original)
+        _reset_lazy_load_state()
+        _loaded_tool_files.update(original_loaded)
 
     def _tool_names(self):
         return set(mcp._tool_manager._tools.keys())
@@ -173,28 +197,24 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 87 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 87
+        assert len(self._tool_names()) == 88
 
     def test_none_defaults_to_core_only(self):
-        """No --modules flag defaults to core + backup.
-
-        ``backup`` is always added (alongside ``core``) so every
-        user's book gets auto-snapshot protection and on-demand
-        backup tools regardless of their ``--modules`` choice.
-        """
+        """No --modules flag defaults to core. Backups, audit log,
+        and slot tools all live in Core post-restructure, so the
+        force-add of a separate backup module is gone."""
         _apply_module_filter(None)
         remaining = self._tool_names()
-        expected = set(TOOL_MODULES["core"]) | set(TOOL_MODULES["backup"])
+        expected = set(TOOL_MODULES["core"])
         assert remaining == expected
 
     def test_core_plus_reporting(self):
-        """--modules=core,reporting loads both + backup (always)."""
+        """--modules=core,reporting loads both."""
         _apply_module_filter("core,reporting")
         remaining = self._tool_names()
         expected = (
             set(TOOL_MODULES["core"])
             | set(TOOL_MODULES["reporting"])
-            | set(TOOL_MODULES["backup"])
         )
         assert remaining == expected
 
@@ -209,12 +229,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 87
+        assert len(self._tool_names()) == 88
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 87 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 87
+        assert len(self._tool_names()) == 88
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""
@@ -236,7 +256,6 @@ class TestApplyModuleFilter:
         expected = (
             set(TOOL_MODULES["core"])
             | set(TOOL_MODULES["reporting"])
-            | set(TOOL_MODULES["backup"])
         )
         assert remaining == expected
 
@@ -263,8 +282,8 @@ class TestApplyModuleFilter:
     def test_returns_loaded_modules_sorted(self):
         """Return value should be sorted list of actually loaded modules."""
         result = _apply_module_filter("reporting,budgets")
-        # core and backup are both always added; result is sorted.
-        assert result == ["backup", "budgets", "core", "reporting"]
+        # core is always added; result is sorted.
+        assert result == ["budgets", "core", "reporting"]
 
     def test_returns_all_modules_for_all(self):
         """'all' should return all module names sorted."""
@@ -272,9 +291,10 @@ class TestApplyModuleFilter:
         assert result == sorted(TOOL_MODULES.keys())
 
     def test_returns_core_for_none(self):
-        """None returns core + backup (both are unconditional)."""
+        """None returns just core. Backup/admin tools migrated INTO
+        core, so no separate force-load is needed."""
         result = _apply_module_filter(None)
-        assert result == ["backup", "core"]
+        assert result == ["core"]
 
     def test_returns_excludes_unknown_modules(self):
         """Unknown module names should not appear in return value."""
@@ -287,52 +307,82 @@ class TestApplyModuleFilter:
 class TestExtractedModuleLazyLoading:
     """Verify that extracted module tools are lazy-loaded on demand.
 
-    Extracted modules (see `extracted_modules()` — 'admin' initially)
-    are NOT registered at server.py import time. Their tools only
-    appear in the FastMCP registry after `_apply_module_filter` enables
-    them or `_lazy_load_tool_module` is called directly.
+    Extracted modules (see `extracted_modules()`) are NOT registered
+    at server.py import time. Their tools only appear in the FastMCP
+    registry after `_apply_module_filter` enables them or
+    `_lazy_load_tool_module` is called directly.
     """
 
     @pytest.fixture(autouse=True)
     def save_and_restore_tools(self):
         original = dict(mcp._tool_manager._tools)
+        original_loaded = set(_loaded_tool_files)
         yield
         mcp._tool_manager._tools.clear()
         mcp._tool_manager._tools.update(original)
+        _reset_lazy_load_state()
+        _loaded_tool_files.update(original_loaded)
+
+    # See TestToolFileVsModulesMapping above. ``get_server_config``
+    # is registered inline at server.py import (server diagnostic;
+    # always available regardless of module set). All other Core
+    # tools are lazy-loaded through tools/<file>.py.
+    _ALWAYS_REGISTERED_INLINE = {"get_server_config"}
 
     def test_extracted_modules_are_not_registered_at_import(self):
-        """Tools from extracted modules must not be present at import time."""
+        """Tools from extracted modules must not be present at import
+        time, excluding the always-registered-inline set. Iterates
+        only the modules that still have a TOOL_MODULES entry (admin
+        and backup dissolved as module names; their tool files
+        survive)."""
         for mod_name in extracted_modules():
+            if mod_name not in TOOL_MODULES:
+                continue
             for tool_name in TOOL_MODULES[mod_name]:
+                if tool_name in self._ALWAYS_REGISTERED_INLINE:
+                    continue
                 assert tool_name not in mcp._tool_manager._tools, (
                     f"{tool_name} from extracted module '{mod_name}' "
                     f"was registered at import — defeats lazy loading."
                 )
 
     def test_enabling_extracted_module_registers_its_tools(self):
-        """Enabling 'admin' via _apply_module_filter registers all admin tools."""
-        _apply_module_filter("admin")
-        for tool_name in TOOL_MODULES["admin"]:
+        """Enabling 'reporting' via _apply_module_filter registers
+        all reporting tools."""
+        _reset_lazy_load_state()
+        mcp._tool_manager._tools.clear()
+        _apply_module_filter("reporting")
+        for tool_name in TOOL_MODULES["reporting"]:
             assert tool_name in mcp._tool_manager._tools
 
     def test_all_loads_every_extracted_module(self):
-        """--modules=all lazy-loads all extracted modules."""
+        """--modules=all lazy-loads all extracted modules. The
+        always-registered-inline set is excluded from the comparison
+        — those tools were registered at server import, gone after
+        the registry clear, and not re-registered by lazy-load."""
+        _reset_lazy_load_state()
+        mcp._tool_manager._tools.clear()
         _apply_module_filter("all")
         all_expected = set()
         for tools in TOOL_MODULES.values():
             all_expected.update(tools)
+        all_expected -= self._ALWAYS_REGISTERED_INLINE
         assert set(mcp._tool_manager._tools.keys()) == all_expected
 
     def test_lazy_load_is_idempotent(self):
         """Enabling an extracted module twice does not duplicate tools."""
-        _apply_module_filter("admin")
+        _reset_lazy_load_state()
+        mcp._tool_manager._tools.clear()
+        _apply_module_filter("reporting")
         count_after_first = len(mcp._tool_manager._tools)
-        _apply_module_filter("admin")
+        _apply_module_filter("reporting")
         assert len(mcp._tool_manager._tools) == count_after_first
 
 
 class TestGetServerConfig:
-    """Tests for the debug-only get_server_config tool."""
+    """Tests for get_server_config — promoted from --debug-only to
+    an unconditional Core diagnostic tool during the module
+    restructure."""
 
     @pytest.fixture(autouse=True)
     def save_and_restore_state(self):
@@ -379,9 +429,9 @@ class TestGetServerConfig:
         lines = output.strip().split("\n")
         assert len(lines) == 5
 
-    def test_not_registered_by_default(self):
-        """get_server_config should not be in TOOL_MODULES or registered at import time."""
-        all_module_tools = set()
-        for tools in TOOL_MODULES.values():
-            all_module_tools.update(tools)
-        assert "get_server_config" not in all_module_tools
+    def test_registered_in_core_unconditionally(self):
+        """get_server_config moved into Core during the restructure
+        and is registered at server import time, regardless of
+        --debug. Always available as a diagnostic surface."""
+        assert "get_server_config" in TOOL_MODULES["core"]
+        assert "get_server_config" in mcp._tool_manager._tools

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -33,14 +33,21 @@ class TestToolModulesMapping:
         registered = set(mcp._tool_manager._tools.keys())
         assert registered.issubset(all_mapped)
 
-    def test_every_tool_file_is_known(self):
-        """Every tools/<file>.py corresponds to a key in _MIXIN_MAP via
-        ``extracted_modules()``. Post-restructure, ``extracted_modules()``
-        is a superset of ``TOOL_MODULES.keys()`` — the dissolved
-        ``admin`` and ``backup`` modules still have their tool files
-        (their tools migrated INTO Core, not away from the filesystem).
+    def test_every_tool_module_backs_onto_extracted_files(self):
+        """Every TOOL_MODULES key must back onto extracted-module
+        files. After the restructure the relationship is no longer
+        ``TOOL_MODULES.keys() ⊆ extracted_modules()``: ``portfolio``
+        and ``investor`` are new public modules that don't have
+        their own tool files (they're slices of the legacy
+        ``investments`` file, mapped via MODULE_BACKED_BY).
         """
-        assert extracted_modules() >= set(TOOL_MODULES.keys())
+        for mod_name in TOOL_MODULES:
+            backing = MODULE_BACKED_BY.get(mod_name, {mod_name})
+            assert backing <= extracted_modules(), (
+                f"TOOL_MODULES[{mod_name!r}] backs onto "
+                f"{sorted(backing - extracted_modules())} which "
+                f"aren't extracted modules"
+            )
 
     def test_no_duplicate_tools_across_modules(self):
         """No tool should appear in more than one module."""
@@ -69,7 +76,7 @@ class TestToolModulesMapping:
         tools migrated into Core)."""
         expected = {
             "core", "reconciliation", "reporting", "budgets",
-            "scheduling", "investments", "business",
+            "scheduling", "portfolio", "investor", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
 
@@ -259,17 +266,32 @@ class TestApplyModuleFilter:
         )
         assert remaining == expected
 
-    def test_investments_module_tools(self):
-        """Investments module should include commodity and lot tools."""
-        _apply_module_filter("investments")
+    def test_portfolio_and_investor_split(self):
+        """``portfolio`` (commodities + prices) and ``investor``
+        (tax lots) used to be one ``investments`` module. After the
+        split they're independently selectable: a multi-currency
+        household without a brokerage picks portfolio alone."""
+        # portfolio alone — price tools yes, lot tools no
+        _apply_module_filter("portfolio")
         remaining = self._tool_names()
         assert "list_commodities" in remaining
+        assert "create_price" in remaining
+        assert "create_lot" not in remaining
+        assert "calculate_lot_gain" not in remaining
+        # Core always loaded
+        assert "list_accounts" in remaining
+        # Non-selected modules not present
+        assert "spending_by_category" not in remaining
+
+        # investor alone — lot tools yes, price tools no
+        _reset_lazy_load_state()
+        mcp._tool_manager._tools.clear()
+        _apply_module_filter("investor")
+        remaining = self._tool_names()
         assert "create_lot" in remaining
         assert "calculate_lot_gain" in remaining
-        # Core should also be present
-        assert "list_accounts" in remaining
-        # Non-selected modules should not be present
-        assert "spending_by_category" not in remaining
+        assert "list_commodities" not in remaining
+        assert "create_price" not in remaining
 
     def test_filter_is_subtractive(self):
         """Filtering should only remove tools, never add non-existent ones."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -76,7 +76,8 @@ class TestToolModulesMapping:
         tools migrated into Core)."""
         expected = {
             "core", "reconciliation", "reporting", "budgets",
-            "scheduling", "portfolio", "investor", "business",
+            "scheduling", "portfolio", "investor",
+            "freelancer", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
 
@@ -457,3 +458,59 @@ class TestGetServerConfig:
         --debug. Always available as a diagnostic surface."""
         assert "get_server_config" in TOOL_MODULES["core"]
         assert "get_server_config" in mcp._tool_manager._tools
+
+
+class TestOwnerTypeGating:
+    """The Freelancer module hosts the shared-lifecycle invoice
+    tools (post/unpost/pay_invoice, list/get_invoice,
+    get_outstanding_invoices). Those tools dispatch on owner_type to
+    handle both customer invoices AND vendor bills — but the Business
+    module owns vendor management. Runtime gating in
+    ``_gate_owner_type`` enforces the split: a Freelancer-only user
+    can't reach vendor bills through the shared tools.
+    """
+
+    @pytest.fixture(autouse=True)
+    def save_and_restore_modules(self):
+        from gnucash_mcp.server import _LOADED_MODULES
+        original = set(_LOADED_MODULES)
+        yield
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update(original)
+
+    def test_business_loaded_passes_through(self):
+        """With business enabled, _gate_owner_type returns its input
+        unchanged — both halves of the polymorphic dispatch work."""
+        from gnucash_mcp.server import _LOADED_MODULES
+        from gnucash_mcp.tools._helpers import _gate_owner_type
+
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update({"core", "freelancer", "business"})
+        assert _gate_owner_type("customer") == "customer"
+        assert _gate_owner_type("vendor") == "vendor"
+        assert _gate_owner_type(None) is None
+
+    def test_business_absent_coerces_to_customer(self):
+        """Without business, omitted or 'customer' owner_type is
+        coerced to 'customer' explicitly so the book-layer lookup
+        filters out vendor bills."""
+        from gnucash_mcp.server import _LOADED_MODULES
+        from gnucash_mcp.tools._helpers import _gate_owner_type
+
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update({"core", "freelancer"})
+        assert _gate_owner_type(None) == "customer"
+        assert _gate_owner_type("customer") == "customer"
+
+    def test_business_absent_rejects_explicit_vendor(self):
+        """Without business, an explicit owner_type='vendor' raises
+        a clear error rather than silently coercing or returning
+        not-found from the book layer."""
+        import pytest
+        from gnucash_mcp.server import _LOADED_MODULES
+        from gnucash_mcp.tools._helpers import _gate_owner_type
+
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update({"core", "freelancer"})
+        with pytest.raises(ValueError, match="requires the Business module"):
+            _gate_owner_type("vendor")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -21,12 +21,15 @@ def _load_all_extracted_tool_modules():
     we force-load all modules and bind each registered tool's underlying
     function back onto the server module namespace.
 
-    Teardown removes the tools we added from the FastMCP registry so
-    later test modules (notably test_modules.py) see a clean state where
-    extracted tools are absent at import — preserving the lazy-loading
-    assertions.
+    Teardown removes the tools we added from the FastMCP registry AND
+    resets ``_loaded_tool_files`` so later test modules (notably
+    test_modules.py) see a clean state where extracted tools are absent
+    at import — preserving the lazy-loading assertions. Without the
+    lazy-load reset, subsequent ``_apply_module_filter`` calls in other
+    test modules would become no-ops while the registry sits empty.
     """
     pre_tools = dict(server_module.mcp._tool_manager._tools)
+    server_module._reset_lazy_load_state()
     server_module._apply_module_filter("all")
     for name, tool in server_module.mcp._tool_manager._tools.items():
         if not hasattr(server_module, name):
@@ -37,6 +40,7 @@ def _load_all_extracted_tool_modules():
     added = set(server_module.mcp._tool_manager._tools.keys()) - set(pre_tools.keys())
     for name in added:
         del server_module.mcp._tool_manager._tools[name]
+    server_module._reset_lazy_load_state()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Restructures the public module surface from the legacy
``core/admin/backup/investments/business`` partition into a
role-aligned set with MODULE_GROUPS composition aliases. Same 88
tools, no observable behavior change at the tool layer — purely
how ``--modules`` selects them.

- **MODULE_GROUPS foundation**: lets a module name expand to a set
  of sub-modules at filter time. Flat partition for now;
  cycle-detection lands if nesting becomes useful.
- **Core merge**: ``void_transaction`` / ``unvoid_transaction`` /
  the slot tools / ``get_audit_log`` / backup CRUD /
  ``balance_sheet`` all migrate into Core. ``admin`` and the old
  ``backup`` module dissolve as public names; their tool files
  survive and back onto Core sub-modules via MODULE_BACKED_BY.
- **Investments → Portfolio + Investor**: a multi-currency
  household without a brokerage can now pick ``portfolio``
  (commodities + prices) without dragging in tax-lot tooling.
- **Business → Freelancer + Business**: customer-facing invoicing
  (``freelancer``) splits from vendor + employee management
  (``business``). The shared-lifecycle tools
  (post/unpost/pay/list/get_invoice, get_outstanding_invoices)
  live in Freelancer with runtime ``owner_type`` gating —
  Freelancer-only users get a clear error if they pass
  ``owner_type='vendor'``.
- **Core chop**: ``core`` itself becomes a MODULE_GROUPS alias
  expanding to eight sub-modules (summary, accounts, transactions,
  slots, audit, backup, balance_sheet, diagnostic). Each is
  independently selectable but the group is always force-added,
  so the eight ledger primitives stay on by default.
- **get_server_config rendering**: now shows the group expansion.
  ``--modules=freelancer`` reports
  ``core[accounts, audit, backup, balance_sheet, diagnostic, slots, summary, transactions], freelancer``
  instead of a flat 9-name list — surfaces what's actually loaded
  inside the ``core`` group.
- **--help text** rewritten with Core sub-modules + Optional
  modules sections and persona-anchored examples.

## Test plan

- [x] 1,130 unit tests pass (was 1,129; added Core-group +
      owner_type-gating coverage)
- [x] Live bookkeeper review on Alex Chen-Morales:
  - [x] ``get_server_config`` renders cleanly across six
        ``--modules`` configurations (default, freelancer,
        personal-finance, small-business, all, individual
        sub-module picks)
  - [x] ``get_book_summary`` + ``balance_sheet`` + ``net_worth``
        all agree on USD 189,055.03 to the penny
  - [x] Receivables reconcile against outstanding invoices: USD
        7,000 + EUR-converted 4,908.96 + CAD-converted 3,675 =
        15,583.96 (matches dashboard)
  - [x] Migrated tools work in new homes (list_backups,
        get_account_slots, get_audit_log, list_commodities,
        list_lots, get_latest_price)
  - [x] Polymorphic owner_type tools resolve both halves under
        ``--modules=all`` (29 customer invoices, 5 vendor bills)
  - [x] ``is_module_enabled("core")`` returns True when all eight
        sub-modules are loaded (preserves gate contract)