### PR TITLE
feat(business): employee expense vouchers (Stage 3 #1)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -253,6 +253,30 @@ class BusinessMixin:
         from piecash.business.person import Vendor
         return book.session.query(Vendor).filter_by(guid=guid).first()
 
+    @staticmethod
+    def _find_employee_by_guid(book, guid: str):
+        """Find an employee by GUID (indexed)."""
+        from piecash.business.person import Employee
+        return book.session.query(Employee).filter_by(guid=guid).first()
+
+    @staticmethod
+    def _find_invoice_owner_by_guid(book, owner_type: int, guid: str):
+        """Find any invoice/bill/voucher owner by their (type, guid)
+        pair. Picks the right table to query based on owner_type.
+
+        ``invoices.owner_guid`` is a generic FK — the row points at
+        the customer/vendor/employee table depending on
+        ``owner_type``. Centralizing the picker keeps the three-way
+        dispatch out of every callsite that needs the owner's name.
+        """
+        if owner_type == 2:
+            return BusinessMixin._find_customer_by_guid(book, guid)
+        if owner_type == 4:
+            return BusinessMixin._find_vendor_by_guid(book, guid)
+        if owner_type == 5:
+            return BusinessMixin._find_employee_by_guid(book, guid)
+        return None
+
     # Path for the auto-created realized-FX-gain/loss income account.
     # Single credit-natural account: positive balance = net gain, negative
     # = net loss across the period. Named to match GAAP convention
@@ -607,21 +631,16 @@ class BusinessMixin:
         ``None`` → ``None`` (caller wants no filter).
         ``"customer"`` → 2.
         ``"vendor"`` → 4.
+        ``"employee"`` → 5.
 
         Anything else raises ``ValueError`` with a message that
-        names the valid options *and* explicitly calls out
-        ``"employee"`` as not yet supported. Employee expense
-        vouchers (``owner_type=5`` in piecash) are explicitly out
-        of scope for the 1.2.x business module — see the
-        ``delete_employee`` docstring's reference to
-        ``counter_exp_voucher``. Pre-fix, an LLM passing
-        ``owner_type="employee"`` would silently fall through to
-        the unfiltered lookup and discover the limitation only
-        via a confusing downstream error (e.g. a cross-sequence
-        ID-collision message that suggests "customer or vendor"
-        without mentioning employee at all). The upfront
-        rejection saves the LLM a tool call and frames the
-        limitation cleanly.
+        names the three valid options. ``"employee"`` (added in
+        v1.3 with the vouchers feature) is the third counterparty
+        type in piecash's invoice/bill/voucher polymorphic
+        table — see ``counter_exp_voucher`` in piecash's Book
+        model. Pre-vouchers this returned a "not yet supported"
+        error explicitly to give the LLM a useful hint; now it's
+        a first-class type.
         """
         if owner_type is None:
             return None
@@ -630,15 +649,10 @@ class BusinessMixin:
         if owner_type == "vendor":
             return 4
         if owner_type == "employee":
-            raise ValueError(
-                "owner_type='employee' is not yet supported. "
-                "Employee expense vouchers are out of scope for "
-                "the 1.2.x business module. Use 'customer' or "
-                "'vendor'."
-            )
+            return 5
         raise ValueError(
             f"Invalid owner_type {owner_type!r}. "
-            f"Must be 'customer' or 'vendor'."
+            f"Must be 'customer', 'vendor', or 'employee'."
         )
 
     @staticmethod
@@ -717,14 +731,23 @@ class BusinessMixin:
             return matches[0] if matches else None
 
         candidates = []
+        # Three-way label dispatch — collisions can now include
+        # vouchers since v1.3 added the third owner_type.
+        _COLLISION_LABELS = {
+            2: "customer invoice",
+            4: "vendor bill",
+            5: "employee voucher",
+        }
         for m in matches:
-            label = "vendor bill" if m.owner_type == 4 else "customer invoice"
+            label = _COLLISION_LABELS.get(
+                m.owner_type, f"unknown owner_type={m.owner_type}",
+            )
             currency = m.currency.mnemonic if m.currency else "?"
             candidates.append(f"{label} (currency={currency})")
         raise ValueError(
             f"Found {len(matches)} documents with ID {invoice_id!r}: "
-            f"{', '.join(candidates)}. Pass owner_type='customer' "
-            f"or 'vendor' to disambiguate."
+            f"{', '.join(candidates)}. Pass owner_type='customer', "
+            f"'vendor', or 'employee' to disambiguate."
         )
 
     @staticmethod
@@ -889,7 +912,9 @@ class BusinessMixin:
         result = {
             "guid": invoice.guid,
             "id": invoice.id,
-            "type": "bill" if invoice.owner_type == 4 else "invoice",
+            "type": BusinessMixin._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                invoice.owner_type, "invoice"
+            ),
             "owner_name": owner_name,
             "date_opened": (
                 str(_safe_invoice_date(invoice, "date_opened").date())
@@ -920,21 +945,21 @@ class BusinessMixin:
         Currency is shown when present so multi-currency books read
         unambiguously. Bills get the ``BILL`` tag (was already there).
         """
-        inv_type = "BILL" if invoice.owner_type == 4 else "INV"
+        inv_type = self._OWNER_TYPE_TO_COMPACT_TAG.get(
+            invoice.owner_type, "INV"
+        )
         opened = _safe_invoice_date(invoice, "date_opened")
         date_str = (
             str(opened.date()) if opened else "n/a"
         )
         status = "posted" if _is_invoice_posted(invoice) else "open"
 
-        # Owner lookup — vendors and customers share the same
-        # ``owner_guid`` namespace (different table, but same handle
-        # shape). Picking the right finder by ``owner_type`` matches
-        # how every other code path in this file resolves it.
-        if invoice.owner_type == 4:
-            owner = self._find_vendor_by_guid(book, invoice.owner_guid)
-        else:
-            owner = self._find_customer_by_guid(book, invoice.owner_guid)
+        # Owner lookup — customers/vendors/employees share the
+        # same ``owner_guid`` namespace shape across three tables.
+        # ``_find_invoice_owner_by_guid`` dispatches on owner_type.
+        owner = self._find_invoice_owner_by_guid(
+            book, invoice.owner_type, invoice.owner_guid,
+        )
         owner_name = owner.name if owner else "?"
 
         # Total: sum of (quantity * price) across entries. Falls back
@@ -1223,7 +1248,7 @@ class BusinessMixin:
         """
         from sqlalchemy import text
 
-        is_bill = inv.owner_type == 4
+        is_bill = self._is_bill_side(inv.owner_type)
         if is_bill:
             rows = book.session.execute(
                 text("SELECT * FROM entries WHERE bill = :guid"),
@@ -1967,7 +1992,49 @@ class BusinessMixin:
             "counter_attr": "counter_bill",
             "find_owner_method": "_find_vendor",
         },
+        5: {  # employee expense voucher
+            "owner_label": "Employee",
+            "doc_label": "Voucher",
+            "owner_id_key": "employee_id",
+            "doc_id_param": "voucher_id",
+            "counter_attr": "counter_exp_voucher",
+            "find_owner_method": "_find_employee",
+        },
     }
+
+    # ── Owner-type label helpers ─────────────────────────────────
+    # The legacy two-way "is_bill = owner_type == 4" idiom doesn't
+    # extend cleanly to three counterparty types. These small
+    # helpers replace the binary check with a three-way lookup so
+    # rendering / dispatch code stays readable.
+
+    # Response ``type`` field — lowercase, used by the audit log
+    # decorator to swap entity_type for the post/pay/unpost
+    # polymorphism.
+    _OWNER_TYPE_TO_RESPONSE_TYPE = {2: "invoice", 4: "bill", 5: "voucher"}
+
+    # Compact-line type tag (short, all-caps). Invoices stay "INV"
+    # for backward compat with existing render tests; bills /
+    # vouchers get explicit tags.
+    _OWNER_TYPE_TO_COMPACT_TAG = {2: "INV", 4: "BILL", 5: "VCHR"}
+
+    # Audit log entity_type — matches the (entity_type, operation)
+    # dispatch table in logging_config.py.
+    _OWNER_TYPE_TO_AUDIT_ENTITY = {
+        2: "invoice",
+        4: "bill",
+        5: "voucher",
+    }
+
+    @staticmethod
+    def _is_bill_side(owner_type: int) -> bool:
+        """Bills (4) and vouchers (5) both represent "company owes
+        someone" semantics — same posting direction, same entry
+        column group (``b_*``), same allowed account types. The
+        legacy code used ``inv.owner_type == 4`` to mean this; the
+        rename to ``_is_bill_side`` captures the truth.
+        """
+        return owner_type in (4, 5)
 
     def _create_business_document(
         self,
@@ -2231,6 +2298,49 @@ class BusinessMixin:
             doc_id=bill_id,
         )
 
+    def create_voucher(
+        self,
+        employee_id: str,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+        voucher_id: str | None = None,
+    ) -> dict:
+        """Create an employee expense voucher.
+
+        A voucher is the document an employee submits for
+        reimbursement of out-of-pocket business expenses. Posts as
+        a liability ("company owes employee") just like a vendor
+        bill, then ``pay_invoice`` settles it from a cash account.
+
+        Args:
+            employee_id: Employee ID (e.g., '000001').
+            date_opened: Date in ISO format. Defaults to today.
+            notes: Optional notes.
+            currency: ISO currency code. Defaults to the employee's
+                currency, falling back to the book's default. Pass
+                explicitly to override.
+            term: Billterm name (e.g., 'Net 30'). Optional —
+                vouchers rarely use payment terms but the field
+                accepts them for symmetry with bills.
+            voucher_id: Custom voucher number. If omitted,
+                auto-generates from the book's
+                ``counter_exp_voucher``.
+
+        Returns:
+            Dict with guid, id, employee_id, status.
+        """
+        return self._create_business_document(
+            owner_type=5,
+            owner_id=employee_id,
+            date_opened=date_opened,
+            notes=notes,
+            currency=currency,
+            term=term,
+            doc_id=voucher_id,
+        )
+
     # owner_type → per-document config table for ``_add_entry``.
     # Same dispatch idiom as ``_BUSINESS_DOC_CONFIG`` for create —
     # one row per document kind, the helper below stays generic.
@@ -2260,6 +2370,26 @@ class BusinessMixin:
                 "ASSET for inventory purchases that capitalize."
             ),
         },
+        5: {  # employee expense voucher
+            # Voucher entries route through the SAME ``b_*`` columns
+            # and ``bill`` FK as vendor bills — GnuCash's schema
+            # collapses "company owes someone" semantics into one
+            # column group regardless of whether the someone is a
+            # vendor or an employee. Only owner_type on the parent
+            # row distinguishes them.
+            "label": "Voucher",
+            "id_param": "voucher_id",
+            "twin_method": "add_invoice_entry",
+            "twin_label": "customer invoice",
+            "allowed_types": frozenset({"EXPENSE", "ASSET"}),
+            "type_error_msg": (
+                "Voucher entry account must be EXPENSE or ASSET "
+                "(got {got} on '{path}'). EXPENSE for normal "
+                "reimbursable expenses (meals, supplies, travel); "
+                "ASSET for employee-purchased inventory that "
+                "capitalizes."
+            ),
+        },
     }
 
     def _add_entry(
@@ -2284,7 +2414,12 @@ class BusinessMixin:
         from piecash.business.invoice import Entry
 
         cfg = self._ENTRY_CONFIG[owner_type]
-        is_bill = owner_type == 4
+        # Both vendor bills (4) and employee expense vouchers (5)
+        # route through the ``b_*`` column group and the ``bill``
+        # FK — GnuCash's schema treats them as the same "company
+        # owes someone" shape. Only owner_type on the parent row
+        # distinguishes them.
+        is_bill_side = owner_type in (4, 5)
         qty = _to_decimal(quantity)
         unit_price = _to_decimal(price)
 
@@ -2326,8 +2461,10 @@ class BusinessMixin:
             # The Entries table has parallel ``i_*`` (invoice side)
             # and ``b_*`` (bill side) column groups. Exactly one
             # group carries values for any given entry; the other
-            # is zeroed/NULL.
-            if is_bill:
+            # is zeroed/NULL. Voucher entries (owner_type=5) share
+            # the ``b_*`` / ``bill`` group with vendor bills — see
+            # ``is_bill_side`` above.
+            if is_bill_side:
                 values = dict(
                     i_acct=None, i_price_num=0, i_price_denom=1,
                     invoice=None,
@@ -2447,6 +2584,42 @@ class BusinessMixin:
             price=price,
         )
 
+    def add_voucher_entry(
+        self,
+        voucher_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+    ) -> dict:
+        """Add a line item entry to an employee expense voucher.
+
+        Voucher entries are typically one-per-expense-category
+        (meals, supplies, travel, etc.) on a single submission. The
+        underlying storage uses the same ``b_*`` column group as
+        vendor bills — see ``_add_entry``.
+
+        Args:
+            voucher_id: Voucher ID (e.g., '000001').
+            account: Expense account full path (e.g.,
+                'Expenses:Meals & Entertainment'). Must be an
+                EXPENSE or ASSET account.
+            description: Line item description.
+            quantity: Quantity as string (e.g., '1').
+            price: Unit price as string (e.g., '42.50').
+
+        Returns:
+            Dict with guid, voucher_id, total, status.
+        """
+        return self._add_entry(
+            owner_type=5,
+            doc_id=voucher_id,
+            account=account,
+            description=description,
+            quantity=quantity,
+            price=price,
+        )
+
     def list_invoices(
         self,
         owner_type: str | None = None,
@@ -2503,10 +2676,9 @@ class BusinessMixin:
                 # from the dict shape in Phase 3C.
                 results = []
                 for i in invoices:
-                    if i.owner_type == 4:
-                        o = self._find_vendor_by_guid(book, i.owner_guid)
-                    else:
-                        o = self._find_customer_by_guid(book, i.owner_guid)
+                    o = self._find_invoice_owner_by_guid(
+                        book, i.owner_type, i.owner_guid,
+                    )
                     results.append(
                         self._invoice_to_dict(
                             i, owner_name=o.name if o else None,
@@ -2551,7 +2723,7 @@ class BusinessMixin:
             if not inv:
                 raise ValueError(f"Invoice/bill not found: {invoice_id}")
 
-            is_bill = inv.owner_type == 4
+            is_bill = self._is_bill_side(inv.owner_type)
 
             # Get entries via raw SQL since ORM relationship doesn't
             # work for vendor bills (bill column is VARCHAR, not FK)
@@ -2696,7 +2868,7 @@ class BusinessMixin:
                     f"Invoice {invoice_id} is already posted"
                 )
 
-            is_bill = inv.owner_type == 4
+            is_bill = self._is_bill_side(inv.owner_type)
 
             post_acct = self._resolve_account(book, post_account)
             if not post_acct:
@@ -2848,7 +3020,9 @@ class BusinessMixin:
 
             result = {
                 "id": inv.id,
-                "type": "bill" if is_bill else "invoice",
+                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                ),
                 "status": "posted",
                 "total": str(grand_total),
                 "post_date": str(parsed_date),
@@ -2907,7 +3081,7 @@ class BusinessMixin:
                     f"Invoice {invoice_id} is not posted"
                 )
 
-            is_bill = inv.owner_type == 4
+            is_bill = self._is_bill_side(inv.owner_type)
             doc_label = "Bill" if is_bill else "Invoice"
 
             # Capture before-state for the audit log: the user wants
@@ -2920,7 +3094,9 @@ class BusinessMixin:
             )
             self._stage_audit_before({
                 "id": inv.id,
-                "type": "bill" if is_bill else "invoice",
+                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                ),
                 "date_posted": (
                     str(prev_post_date.date()) if prev_post_date else None
                 ),
@@ -2982,7 +3158,9 @@ class BusinessMixin:
 
             return {
                 "id": inv.id,
-                "type": "bill" if is_bill else "invoice",
+                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                ),
                 "status": "unposted",
             }
 
@@ -3074,7 +3252,7 @@ class BusinessMixin:
                     f"post it before recording payment"
                 )
 
-            is_bill = inv.owner_type == 4
+            is_bill = self._is_bill_side(inv.owner_type)
 
             pay_acct = self._resolve_account(book, payment_account)
             if not pay_acct:
@@ -3301,7 +3479,9 @@ class BusinessMixin:
 
             result = {
                 "id": inv.id,
-                "type": "bill" if is_bill else "invoice",
+                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                ),
                 "status": "paid",
                 "amount_paid": str(payment_amount),
                 "remaining_balance": str(abs(remaining)),
@@ -3375,15 +3555,43 @@ class BusinessMixin:
         """
         return self._delete_invoice_or_bill(bill_id, owner_type=4)
 
+    def delete_voucher(self, voucher_id: str) -> dict:
+        """Delete an unposted employee expense voucher.
+
+        Automatically removes associated entries. Posted vouchers
+        cannot be deleted — unpost first via ``unpost_invoice``,
+        then delete.
+
+        Args:
+            voucher_id: Voucher ID (e.g., '000001').
+
+        Returns:
+            Dict with id, guid, entries_deleted, status.
+
+        Raises:
+            ValueError: If voucher not found or is posted.
+        """
+        return self._delete_invoice_or_bill(voucher_id, owner_type=5)
+
     def _delete_invoice_or_bill(self, doc_id: str, owner_type: int) -> dict:
-        """Shared implementation for delete_invoice and delete_bill."""
+        """Shared implementation for delete_invoice / delete_bill /
+        delete_voucher.
+
+        owner_type 2 (invoice) uses the ``invoice`` entry FK; 4
+        (bill) and 5 (voucher) both use the ``bill`` entry FK —
+        GnuCash's schema collapses bill-side semantics into one
+        column group.
+        """
         from sqlalchemy import func, select
         from piecash.business.invoice import Entry, Invoice
 
         from gnucash_mcp.book._base import _verify_delete
 
-        type_label = "Bill" if owner_type == 4 else "Invoice"
-        entry_fk = "bill" if owner_type == 4 else "invoice"
+        _TYPE_LABELS = {2: "Invoice", 4: "Bill", 5: "Voucher"}
+        type_label = _TYPE_LABELS[owner_type]
+        # Bills (4) and vouchers (5) both write to the ``bill`` FK
+        # column on entries — see ``_add_entry`` is_bill_side.
+        entry_fk = "invoice" if owner_type == 2 else "bill"
         entry_fk_col = getattr(Entry.__table__.c, entry_fk)
 
         with self.open(readonly=False) as book:
@@ -3709,7 +3917,7 @@ class BusinessMixin:
 
             results = []
             for inv in invoices:
-                is_bill = inv.owner_type == 4
+                is_bill = self._is_bill_side(inv.owner_type)
 
                 post_acc_guid = inv.post_acc_guid
                 post_acct = book.session.query(
@@ -3770,7 +3978,9 @@ class BusinessMixin:
                 )
                 results.append({
                     "id": inv.id,
-                    "type": "bill" if is_bill else "invoice",
+                    "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                ),
                     "owner_name": owner_name,
                     "currency": currency,
                     "date_posted": (

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2760,15 +2760,15 @@ class BusinessMixin:
                 for e in entries
             )
 
-            owner_name = None
-            if is_bill:
-                vendor = self._find_vendor_by_guid(book, inv.owner_guid)
-                if vendor:
-                    owner_name = vendor.name
-            else:
-                customer = self._find_customer_by_guid(book, inv.owner_guid)
-                if customer:
-                    owner_name = customer.name
+            # Three-way owner lookup — vouchers route to employees,
+            # bills to vendors, invoices to customers. Pre-fix this
+            # was a binary "is_bill → vendor else customer" check
+            # that returned None for vouchers because employees
+            # weren't in the dispatch.
+            owner = self._find_invoice_owner_by_guid(
+                book, inv.owner_type, inv.owner_guid,
+            )
+            owner_name = owner.name if owner else None
 
             result = self._invoice_to_dict(
                 inv, entries=entries, owner_name=owner_name,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -877,13 +877,78 @@ def _fmt_bill_delete(entry: dict) -> list[str]:
     return lines
 
 
+# ── Voucher formatters ───────────────────────────────────────
+# Vouchers (employee expense reimbursements) share the
+# post/unpost/pay lifecycle code path with bills — the audit log
+# decorator swaps entity_type from "invoice" to "voucher" when the
+# response's ``type`` field is "voucher" (see the decorator's
+# polymorphism block). These formatters mirror the bill ones with
+# the right label.
+
+
+def _fmt_voucher_post(entry: dict) -> list[str]:
+    lines = _fmt_invoice_post(entry)
+    if lines:
+        lines[0] = lines[0].replace("POST INVOICE", "POST VOUCHER")
+    return lines
+
+
+def _fmt_voucher_unpost(entry: dict) -> list[str]:
+    lines = _fmt_invoice_unpost(entry)
+    if lines:
+        lines[0] = lines[0].replace("UNPOST INVOICE", "UNPOST VOUCHER")
+    return lines
+
+
+def _fmt_voucher_pay(entry: dict) -> list[str]:
+    lines = _fmt_invoice_pay(entry)
+    if lines:
+        lines[0] = lines[0].replace("PAY INVOICE", "PAY VOUCHER")
+    return lines
+
+
+def _fmt_voucher_create(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    voucher_id = after.get("id", "")
+    employee_id = after.get("employee_id", params.get("employee_id", ""))
+    return [
+        f"{time_part}  CREATE VOUCHER  id:{voucher_id}",
+        f"{_INDENT}employee: {employee_id}",
+    ]
+
+
+def _fmt_voucher_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state")
+
+    lines = [
+        f"{time_part}  DELETE VOUCHER  "
+        f"id:{params.get('voucher_id', '')}"
+    ]
+    if after:
+        entries = after.get("entries_deleted", 0)
+        if entries:
+            lines.append(f"{_INDENT}entries removed: {entries}")
+    return lines
+
+
 def _fmt_entry_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
     after = entry.get("after_state") or {}
     desc = after.get("description", params.get("description", ""))
     total = after.get("total", "")
-    inv_id = params.get("invoice_id", "") or params.get("bill_id", "")
+    # Entry can belong to an invoice / bill / voucher — the params
+    # carry whichever ID key the tool wrapper used. First-match
+    # wins; all three are mutually exclusive in practice.
+    inv_id = (
+        params.get("invoice_id", "")
+        or params.get("bill_id", "")
+        or params.get("voucher_id", "")
+    )
     return [
         f"{time_part}  CREATE ENTRY",
         f'{_INDENT}"{desc}"  total: {total}  on: {inv_id}',
@@ -1025,6 +1090,11 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("bill", "POST"): _fmt_bill_post,
     ("bill", "UNPOST"): _fmt_bill_unpost,
     ("bill", "PAY"): _fmt_bill_pay,
+    ("voucher", "CREATE"): _fmt_voucher_create,
+    ("voucher", "DELETE"): _fmt_voucher_delete,
+    ("voucher", "POST"): _fmt_voucher_post,
+    ("voucher", "UNPOST"): _fmt_voucher_unpost,
+    ("voucher", "PAY"): _fmt_voucher_pay,
     ("entry", "CREATE"): _fmt_entry_create,
     ("price", "DELETE"): _fmt_price_delete,
     ("budget", "UPDATE"): _fmt_budget_update,
@@ -1385,19 +1455,22 @@ def audit_log(
                     else:
                         entry["result"] = "success"
                         if classification == "write":
-                            # Invoice/bill polymorphism: post_invoice
-                            # / unpost_invoice / pay_invoice all carry
+                            # Invoice/bill/voucher polymorphism:
+                            # post_invoice / unpost_invoice /
+                            # pay_invoice all carry
                             # entity_type="invoice" on the decorator
-                            # but accept either kind. The response's
-                            # ``type`` field is the truth — swap
-                            # entity_type to ``bill`` when the call
-                            # operated on a vendor bill so the audit
-                            # log doesn't mis-categorize the entry.
+                            # but accept any of the three kinds.
+                            # The response's ``type`` field is the
+                            # truth — swap entity_type to match so
+                            # the audit log doesn't mis-categorize.
                             if (
                                 entity_type == "invoice"
-                                and result_data.get("type") == "bill"
+                                and result_data.get("type")
+                                in {"bill", "voucher"}
                             ):
-                                entry["entity_type"] = "bill"
+                                entry["entity_type"] = (
+                                    result_data["type"]
+                                )
                             after = _extract_after_state(
                                 result, entry["entity_type"]
                             )

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -300,6 +300,12 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_employee",
         "update_employee",
         "delete_employee",
+        # Employee expense vouchers (v1.3). Lifecycle (post /
+        # unpost / pay) flows through the polymorphic invoice
+        # tools in freelancer with owner_type='employee'.
+        "create_voucher",
+        "add_voucher_entry",
+        "delete_voucher",
         "create_billterm",
         "list_billterms",
         "vendor_spending_report",
@@ -654,7 +660,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (88 tools).
+                       for every module (91 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -190,23 +190,28 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
     """Enforce the Freelancer/Business module split at the
     ``owner_type`` boundary.
 
-    Shared-lifecycle invoice/bill tools (post_invoice, unpost_invoice,
-    pay_invoice, list_invoices, get_invoice, get_outstanding_invoices)
-    live in the Freelancer module because customer-facing invoicing is
-    the natural Freelancer surface. Vendor bills travel through the
-    same tools via ``owner_type='vendor'`` dispatch — but the Business
-    module owns vendor management. A user with only Freelancer loaded
-    should never be able to touch vendor bills.
+    Shared-lifecycle invoice/bill/voucher tools (post_invoice,
+    unpost_invoice, pay_invoice, list_invoices, get_invoice,
+    get_outstanding_invoices) live in the Freelancer module
+    because customer-facing invoicing is the natural Freelancer
+    surface. Vendor bills (``owner_type='vendor'``) and employee
+    expense vouchers (``owner_type='employee'``) travel through
+    the same tools via owner_type dispatch — but the Business
+    module owns BOTH vendor and employee management. A user with
+    only Freelancer loaded should never be able to touch either.
 
-    Two cases:
+    Three cases:
 
-    - **Explicit ``owner_type='vendor'`` without Business loaded:**
-      reject with a clear error. The user is explicitly asking for
-      vendor-side behavior they didn't enable.
+    - **Explicit ``owner_type='vendor'`` or ``'employee'`` without
+      Business loaded:** reject with a clear error. The user is
+      explicitly asking for behavior they didn't enable.
     - **``owner_type`` omitted or ``'customer'`` without Business:**
-      coerce to ``'customer'``. The tool only sees customer entities.
-      Any vendor-ID collision is treated as "not found" at the
-      lookup layer (book methods filter on owner_type).
+      coerce to ``'customer'``. The tool only sees customer
+      entities. Any vendor/employee-ID collision is treated as
+      "not found" at the lookup layer (book methods filter on
+      owner_type).
+    - **Business loaded:** pass through unchanged; all three halves
+      available.
 
     Returns the (possibly coerced) owner_type the book method should
     receive. Caller passes the return value through to ``book.X(...,
@@ -218,7 +223,7 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
     from gnucash_mcp.server import is_module_enabled
 
     if is_module_enabled("business"):
-        return owner_type  # Both halves available; no gating.
+        return owner_type  # All three halves available; no gating.
 
     if owner_type == "vendor":
         raise ValueError(
@@ -226,6 +231,14 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
             "Restart the server with --modules=...,Business to access "
             "vendor bills, or omit owner_type to operate on customer "
             "invoices only."
+        )
+    if owner_type == "employee":
+        raise ValueError(
+            "owner_type='employee' requires the Business module. "
+            "Employee expense vouchers live with employee "
+            "management, which the Business module owns. Restart "
+            "the server with --modules=...,Business or omit "
+            "owner_type to operate on customer invoices only."
         )
     return "customer"
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -469,6 +469,92 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="voucher")
+    def create_voucher(
+        employee_id: str,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+        voucher_id: str | None = None,
+    ) -> str:
+        """Create an employee expense voucher.
+
+        A voucher is the document an employee submits for
+        reimbursement of out-of-pocket business expenses. It
+        behaves like a vendor bill: post creates the obligation
+        (debit expense accounts, credit A/P), pay settles it from
+        a cash account.
+
+        Args:
+            employee_id: Employee ID (e.g., "000001").
+            date_opened: Date in ISO format (YYYY-MM-DD). Defaults to today.
+            notes: Optional notes.
+            currency: ISO currency code. Defaults to the employee's
+                currency, falling back to the book's default.
+            term: Billterm name (e.g., "Net 30"). Optional —
+                vouchers rarely use payment terms.
+            voucher_id: Custom voucher number. If omitted,
+                auto-generates from the book's voucher counter.
+        """
+        book = get_book()
+        result = book.create_voucher(
+            employee_id=employee_id, date_opened=date_opened,
+            notes=notes, currency=currency, term=term,
+            voucher_id=voucher_id,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="entry")
+    def add_voucher_entry(
+        voucher_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+    ) -> str:
+        """Add a line item to an employee expense voucher.
+
+        The voucher must not be posted yet. Each entry is typically
+        a separate expense category (meals, supplies, travel).
+        Account must be EXPENSE or ASSET.
+
+        Args:
+            voucher_id: Voucher ID (e.g., "000001").
+            account: Expense account path (e.g.,
+                "Expenses:Meals & Entertainment").
+            description: Line item description.
+            quantity: Quantity as decimal string (e.g., "1").
+            price: Unit price as decimal string (e.g., "42.50").
+        """
+        book = get_book()
+        result = book.add_voucher_entry(
+            voucher_id=voucher_id, account=account,
+            description=description, quantity=quantity, price=price,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="delete", entity_type="voucher")
+    def delete_voucher(voucher_id: str) -> str:
+        """Delete an unposted employee expense voucher.
+
+        Automatically removes associated entries. Posted vouchers
+        cannot be deleted — unpost first via ``unpost_invoice``,
+        then delete.
+
+        Args:
+            voucher_id: Voucher ID (e.g., "000001").
+        """
+        book = get_book()
+        result = book.delete_voucher(voucher_id=voucher_id)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="read")
     def list_invoices(
         owner_type: str | None = None,

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1295,6 +1295,236 @@ class TestDeleteBill:
             gb.delete_bill(bill_id="NOPE")
 
 
+class TestCreateVoucher:
+    """Tests for create_voucher — employee expense reimbursement.
+
+    Routes through ``_create_business_document`` with owner_type=5,
+    so the cross-currency / billterm / custom-id / counter
+    behaviors all come for free from the bill path. These tests
+    pin the voucher-specific surface: response shape, the
+    employee_id key, the auto-generated counter, and rejection
+    paths.
+    """
+
+    def test_basic_creation(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        result = gb.create_voucher(employee_id="000001")
+        assert result["status"] == "created"
+        assert result["employee_id"] == "000001"
+        # Voucher counter starts at 0; first auto-id is 000001.
+        assert result["id"] == "000001"
+        assert len(result["guid"]) == 32
+
+    def test_employee_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Employee not found"):
+            gb.create_voucher(employee_id="999999")
+
+    def test_custom_voucher_id(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        result = gb.create_voucher(
+            employee_id="000001", voucher_id="VCHR-2026-001",
+        )
+        assert result["id"] == "VCHR-2026-001"
+
+    def test_duplicate_voucher_id_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001", voucher_id="V1")
+        with pytest.raises(ValueError, match="already exists"):
+            gb.create_voucher(employee_id="000001", voucher_id="V1")
+
+    def test_voucher_counter_independent_from_bill_counter(self, business_book):
+        """Vouchers use ``counter_exp_voucher``, bills use
+        ``counter_bill``. The two sequences should be independent
+        — a voucher created after a bill should NOT inherit the
+        bill's counter value."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_employee(name="Maria Garcia")
+        # Bill #1 — counter_bill goes to 1.
+        bill = gb.create_bill(vendor_id="000001")
+        assert bill["id"] == "000001"
+        # Voucher #1 — counter_exp_voucher goes to 1, independent.
+        voucher = gb.create_voucher(employee_id="000001")
+        assert voucher["id"] == "000001"
+
+    def test_inherits_employee_currency(self, business_book):
+        """Currency resolution: voucher inherits the employee's
+        currency by default (same rule bills/invoices use for
+        vendor/customer)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia", currency="USD")
+        result = gb.create_voucher(employee_id="000001")
+        full = gb.get_invoice(result["id"], owner_type="employee")
+        assert full["currency"] == "USD"
+
+
+class TestAddVoucherEntry:
+    """Tests for add_voucher_entry.
+
+    Voucher entries use the same ``b_*`` column group as bill
+    entries (GnuCash schema collapses bill-side semantics). These
+    tests pin the voucher-specific surface: account type
+    validation, response shape, twin-method error messaging.
+    """
+
+    def test_basic_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        result = gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Pens and notebooks",
+            quantity="1",
+            price="42.50",
+        )
+        assert result["status"] == "created"
+        assert result["voucher_id"] == "000001"
+        assert result["total"] == "42.50"
+
+    def test_multiple_entries_one_voucher(self, business_book):
+        """Vouchers are typically multi-line — a single expense
+        report covers groceries, gas, meals, etc."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        e1 = gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Supplies",
+            quantity="1", price="50.00",
+        )
+        e2 = gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Client lunch",
+            quantity="1", price="100.00",
+        )
+        assert e1["guid"] != e2["guid"]
+
+    def test_income_account_rejected(self, business_book):
+        """Voucher entries take EXPENSE/ASSET only — same as
+        bills. INCOME would invert the posting math."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        with pytest.raises(ValueError, match="EXPENSE or ASSET"):
+            gb.add_voucher_entry(
+                voucher_id="000001",
+                account="Income:Sales",
+                description="Wrong direction",
+                quantity="1", price="100",
+            )
+
+    def test_voucher_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.add_voucher_entry(
+                voucher_id="NOPE",
+                account="Expenses:Office Supplies",
+                description="x",
+                quantity="1", price="1",
+            )
+
+
+class TestDeleteVoucher:
+    """Tests for delete_voucher. Mirrors delete_bill but with
+    employee + voucher semantics."""
+
+    def test_delete_unposted_voucher(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        result = gb.delete_voucher(voucher_id="000001")
+        assert result["status"] == "deleted"
+        assert result["id"] == "000001"
+        assert result["type"] == "voucher"
+
+    def test_delete_with_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Supplies", quantity="1", price="50",
+        )
+        result = gb.delete_voucher(voucher_id="000001")
+        assert result["status"] == "deleted"
+        assert result["entries_deleted"] == 1
+
+
+class TestVoucherLifecycle:
+    """End-to-end: create voucher → add entries → post → pay.
+    Vouchers travel through the polymorphic post_invoice /
+    pay_invoice path with owner_type='employee'.
+
+    This is the load-bearing test: if any seam between voucher
+    create and the bill-shaped lifecycle code is misrouted, it
+    surfaces here.
+    """
+
+    def test_post_voucher_via_polymorphic_path(self, business_book):
+        """post_invoice with owner_type='employee' debits the
+        expense accounts, credits A/P. Same math as a bill, same
+        polymorphic tool."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Pens", quantity="1", price="50.00",
+        )
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="employee",
+        )
+        # The polymorphism handler returns type='voucher' so the
+        # audit log can dispatch correctly.
+        assert result["type"] == "voucher"
+        # A/P is credited — piecash signs liability balances as
+        # negative (signed quantity convention: credits subtract).
+        ap_balance = gb.get_balance("Liabilities:Accounts Payable")
+        assert ap_balance == Decimal("-50.00")
+        # Expense account is debited (positive expense balance).
+        exp_balance = gb.get_balance("Expenses:Office Supplies")
+        assert exp_balance == Decimal("50.00")
+
+    def test_pay_voucher_via_polymorphic_path(self, business_book):
+        """pay_invoice with owner_type='employee' debits A/P,
+        credits the payment account — net effect: cash leaves the
+        company, A/P returns to zero."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria Garcia")
+        gb.create_voucher(employee_id="000001")
+        gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Pens", quantity="1", price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="employee",
+        )
+        # Pay $50 from Checking.
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="50.00",
+            owner_type="employee",
+        )
+        # A/P back to zero; Checking down $50 from opening 10000.
+        assert gb.get_balance("Liabilities:Accounts Payable") == Decimal("0.00")
+        assert gb.get_balance("Assets:Checking") == Decimal("9950.00")
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 
@@ -1700,47 +1930,38 @@ class TestInvoiceBillIdCollision:
 class TestOwnerTypeValidation:
     """Centralized rejection of invalid ``owner_type`` values.
 
-    The bookkeeper hit this on a session where an LLM passed
-    ``owner_type="employee"``. Pre-fix, the value silently fell
-    through to no-filter and the LLM saw a confusing
-    cross-sequence ID-collision error suggesting "customer or
-    vendor" — never explaining that "employee" is the actual
-    problem. Upfront validation saves the LLM a tool call and
-    frames the limitation cleanly.
+    Pre-v1.3 the validator explicitly rejected ``"employee"`` with
+    a "not yet supported" message because vouchers weren't built
+    yet. v1.3 added vouchers; ``"employee"`` is now a first-class
+    type returning 5 (alongside customer=2, vendor=4). The
+    validator still rejects typos / unknown strings with a clear
+    options list.
     """
-
-    def test_employee_owner_type_rejected_with_clear_message(
-        self, business_book,
-    ):
-        """The headline scenario: ``owner_type="employee"`` is
-        explicitly out of scope for the 1.2.x business module
-        (employee expense vouchers are a 1.3 thing). Reject
-        upfront with a message that says so."""
-        gb = GnuCashBook(str(business_book))
-        with pytest.raises(ValueError) as exc_info:
-            gb.get_invoice("000001", owner_type="employee")
-        msg = str(exc_info.value)
-        assert "employee" in msg.lower()
-        assert "not yet supported" in msg
-        # Hint at the valid options so the LLM doesn't have to
-        # call back blindly.
-        assert "customer" in msg
-        assert "vendor" in msg
 
     def test_typo_owner_type_rejected_with_valid_options(
         self, business_book,
     ):
-        """Typos like ``"custmer"`` (missing 'o') get the same
-        upfront rejection. Pre-fix they silently fell through to
-        no-filter."""
+        """Typos like ``"custmer"`` (missing 'o') get the upfront
+        rejection. The error names all three valid options so the
+        LLM doesn't have to call back blindly."""
         gb = GnuCashBook(str(business_book))
         with pytest.raises(ValueError) as exc_info:
             gb.get_invoice("000001", owner_type="custmer")
         msg = str(exc_info.value)
         assert "Invalid owner_type" in msg
         assert "'custmer'" in msg
+        # All three valid options should appear in the hint.
         assert "customer" in msg
         assert "vendor" in msg
+        assert "employee" in msg
+
+    def test_employee_owner_type_accepted(self, business_book):
+        """v1.3 invariant: ``owner_type="employee"`` is now valid
+        and returns 5 from ``_parse_owner_type``. The function-
+        level test is here; the end-to-end voucher exercise is in
+        TestCreateVoucher / TestVoucherLifecycle."""
+        from gnucash_mcp.book.business import BusinessMixin
+        assert BusinessMixin._parse_owner_type("employee") == 5
 
     def test_none_owner_type_still_works(self, business_book):
         """``None`` means "no filter" — the existing semantic
@@ -1752,31 +1973,11 @@ class TestOwnerTypeValidation:
         inv = gb.get_invoice("000001", owner_type=None)
         assert inv["type"] == "invoice"
 
-    def test_post_invoice_rejects_employee_owner_type(
-        self, business_book,
-    ):
-        """All four entrypoints share the same validator; verify
-        ``post_invoice`` specifically since the bookkeeper's
-        report mentioned posting an invoice with employee
-        owner_type."""
-        gb = GnuCashBook(str(business_book))
-        gb.create_customer(name="Acme Corp")
-        gb.create_invoice(customer_id="000001")
-        gb.add_invoice_entry(
-            invoice_id="000001", account="Income:Sales",
-            description="x", quantity="1", price="100",
-        )
-        with pytest.raises(ValueError, match="not yet supported"):
-            gb.post_invoice(
-                invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
-                owner_type="employee",
-            )
-
     def test_pay_invoice_rejects_typo_owner_type(
         self, business_book,
     ):
-        """Symmetry: ``pay_invoice`` validates too."""
+        """``pay_invoice`` shares the same validator — typos get
+        rejected here too."""
         gb = GnuCashBook(str(business_book))
         gb.create_customer(name="Acme Corp")
         with pytest.raises(ValueError, match="Invalid owner_type"):
@@ -1787,15 +1988,6 @@ class TestOwnerTypeValidation:
                 owner_type="venddor",  # typo
             )
 
-    def test_unpost_invoice_rejects_employee(self, business_book):
-        """Symmetry: ``unpost_invoice`` (added in this same
-        patch) validates too."""
-        gb = GnuCashBook(str(business_book))
-        with pytest.raises(ValueError, match="not yet supported"):
-            gb.unpost_invoice(
-                invoice_id="000001", owner_type="employee",
-            )
-
     def test_list_invoices_rejects_invalid_owner_type(
         self, business_book,
     ):
@@ -1803,14 +1995,6 @@ class TestOwnerTypeValidation:
         gb = GnuCashBook(str(business_book))
         with pytest.raises(ValueError, match="Invalid owner_type"):
             gb.list_invoices(owner_type="bogus")
-
-    def test_get_outstanding_invoices_rejects_invalid_owner_type(
-        self, business_book,
-    ):
-        """The other read with owner_type also validates."""
-        gb = GnuCashBook(str(business_book))
-        with pytest.raises(ValueError, match="not yet supported"):
-            gb.get_outstanding_invoices(owner_type="employee")
 
 
 # ============== Post Invoice Tests ==============

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,10 +80,11 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 88 — same
-        as pre-Core-chop, just partitioned across more keys."""
+        """Total tools across all sub-modules should be 91 — 88
+        post-module-restructure + 3 voucher tools added in v1.3
+        (create_voucher, add_voucher_entry, delete_voucher)."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 88
+        assert total == 91
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -229,7 +230,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 87 tools."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 91
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -261,12 +262,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 91
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 87 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 91
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

First of four Stage 3 headline features. Adds employee expense
vouchers — the document an employee submits to get reimbursed
for out-of-pocket business expenses. Routes through
``_create_business_document`` so cross-currency / billterm /
custom-ID / auto-counter behaviors come for free from the bill
path. The voucher polymorphism extends the existing
invoice/bill dispatch in ``post_invoice`` / ``pay_invoice`` /
etc. with a third ``owner_type=5`` (``"employee"``).

- **Three new tools**: ``create_voucher``, ``add_voucher_entry``,
  ``delete_voucher`` — all in the Business module
- **Owner-type validator update** (intra-PR coupling per the
  spec): ``_parse_owner_type`` now accepts ``"employee"`` → 5
  instead of rejecting with a "not yet supported" message
- **Polymorphic lifecycle** flows through existing tools: post /
  unpost / pay all dispatch on ``owner_type`` via the same code
  path bills use; the audit log decorator's polymorphism handler
  was extended to recognize ``type='voucher'`` in responses and
  swap entity_type accordingly
- **Module gating**: ``_gate_owner_type`` rejects
  ``owner_type='employee'`` when Business isn't loaded —
  symmetric with the existing vendor gating
- **Tool count**: 88 → 91

## Test plan

- [x] 1,141 unit tests pass (was 1,127; +14 new across
  TestCreateVoucher, TestAddVoucherEntry, TestDeleteVoucher,
  TestVoucherLifecycle)
- [x] TestOwnerTypeValidation rewritten — old "rejects employee"
  tests removed, new ``test_employee_owner_type_accepted`` added
- [x] Live demo against Alex Chen-Morales (he has one employee
  on the books — Maria Garcia equivalent)
- [x] Bookkeeper review (deferred — Steve will run separately)