### PR TITLE
feat(business): credit notes (Stage 3 #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,25 @@ existed.
   (`entity.addr_addr1 = "..."`) on update.
 - **Slot ORM conflicts**: polymorphic relationships on the Slot
   table make direct ORM queries fail. Use raw SQL via
-  `sqlalchemy.text()` for slot reads/deletes.
+  `sqlalchemy.text()` for slot reads/deletes. For slot **writes
+  and per-entity reads**, the `entity[key] = value` /
+  `entity[key]` accessors work — piecash handles the polymorphism
+  internally. Use `_slot_value_str(...)` from `book/_base.py` to
+  extract a stable string from typed slot wrappers
+  (`SlotString`, `SlotInt64`, etc.).
+- **Slot key naming convention**: bare keys for universal
+  financial concepts (`apr`, `credit_limit`,
+  `statement_close_day`, `reward_rate`); namespaced
+  `gnc-mcp/<key>` prefix for tool-specific state where collisions
+  with another tool's convention are plausible (e.g.
+  `gnc-mcp/applies-to-invoice` for our credit-note linkage).
+  Test for which side: *could a reasonable developer arrive at
+  this exact key independently?* Yes → bare. No → namespaced.
+  Path-style keys (containing `/`) create hierarchical sub-slots
+  in GnuCash's KVP store; that's what the namespace prefix
+  exploits. The `_SLOT_KEY_RE` validator in `book/admin.py`
+  gates USER input to flat keys only — internal slot keys set
+  by book methods bypass that gate by design.
 - **KVP_Type enum**: `SlotType` TypeDecorator expects `KVP_Type`
   enum values (e.g., `KVP_Type.KVP_TYPE_STRING`), not raw ints.
 - **Detached instances**: ORM object attributes are only accessible

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -48,6 +48,26 @@ debug_logger = logging.getLogger("gnucash_mcp.debug")
 # ── Module-level helpers ───────────────────────────────────────────
 
 
+def _slot_value_str(value) -> str:
+    """Stringify a piecash slot value to a stable ``str``.
+
+    piecash returns either a typed wrapper with a ``.value``
+    attribute (``SlotString``, ``SlotInt64``, etc.) or the raw
+    value depending on slot type. Centralizing the access keeps
+    every caller agreeing on the same extraction.
+
+    Hoisted to ``_base`` from ``admin`` in v1.3 — the credit-note
+    slot helpers in ``BusinessMixin`` need the same access pattern,
+    and a sideways import from ``business`` into ``admin`` would
+    add a coupling that doesn't reflect the dependency direction
+    (admin is the slot-tool mixin; business is also a slot
+    consumer; both should pull a shared utility from ``_base``).
+    """
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
 def _to_decimal(value) -> Decimal:
     """Safe Decimal construction for user-supplied monetary values.
 

--- a/src/gnucash_mcp/book/admin.py
+++ b/src/gnucash_mcp/book/admin.py
@@ -7,30 +7,22 @@ statement close day, etc. Values are stored as strings.
 
 import re
 
+from gnucash_mcp.book._base import _slot_value_str  # noqa: F401  (re-exported for callers)
+
 # Slot keys with embedded ``/`` create hierarchical sub-slots in
-# GnuCash's KVP store rather than flat keys. The MCP-facing tools
-# only manage flat keys (``apr``, ``credit_limit``, ``minimum_payment``,
-# etc.), so we restrict input to a safe alphabet up-front. Pre-fix
-# a key like ``credit/limit`` silently created a sub-slot under
-# ``credit`` — invisible to ``get_account_slots`` keyed lookups.
+# GnuCash's KVP store rather than flat keys. The MCP-facing
+# account-slot tools only manage flat keys (``apr``,
+# ``credit_limit``, ``minimum_payment``, etc.), so we restrict
+# user input to a safe alphabet up-front. Pre-fix a key like
+# ``credit/limit`` silently created a sub-slot under ``credit`` —
+# invisible to ``get_account_slots`` keyed lookups.
+#
+# Note: internal slot keys (set by our own book methods, not
+# accepted from users) can and do use ``/`` for namespacing —
+# see the ``gnc-mcp/...`` convention in
+# ``BusinessMixin._APPLIES_TO_SLOT_KEY``. This regex gates
+# USER input only.
 _SLOT_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-
-
-def _slot_value_str(value) -> str:
-    """Stringify a piecash slot value to a stable str.
-
-    piecash returns either a typed wrapper with a ``.value``
-    attribute or the raw value depending on slot type. The
-    single-key path and the all-keys path of ``get_account_slots``
-    used to handle these differently — single-key fell back to
-    ``str(value)`` when ``.value`` was missing, all-keys assumed
-    ``.value`` always present and would AttributeError on the
-    first row that didn't have it. Centralizing the access
-    makes both paths agree.
-    """
-    if hasattr(value, "value"):
-        return str(value.value)
-    return str(value)
 
 
 class AdminMixin:

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2579,18 +2579,27 @@ class BusinessMixin:
                 f"Credit note not found: {credit_note_id}"
             )
         if not self._get_is_credit_note(inv):
-            # Found the ID but it's a regular invoice/bill — name
-            # the right tool to use instead so the LLM can correct
-            # course in one hop.
-            entry_tool = (
-                "add_invoice_entry"
-                if inv.owner_type == 2
-                else "add_bill_entry"
+            # Found the ID but it's a regular invoice/bill/voucher.
+            # Name the right tool to use instead so the LLM can
+            # correct course in one hop. Three-way dispatch
+            # (Copilot PR #87 review): the legacy binary "INV vs
+            # BILL" branch would have suggested add_bill_entry /
+            # delete_bill for a voucher (owner_type=5) — wrong.
+            _ENTRY_TOOLS = {
+                2: "add_invoice_entry",
+                4: "add_bill_entry",
+                5: "add_voucher_entry",
+            }
+            _DELETE_TOOLS = {
+                2: "delete_invoice",
+                4: "delete_bill",
+                5: "delete_voucher",
+            }
+            entry_tool = _ENTRY_TOOLS.get(
+                inv.owner_type, "add_invoice_entry",
             )
-            delete_tool = (
-                "delete_invoice"
-                if inv.owner_type == 2
-                else "delete_bill"
+            delete_tool = _DELETE_TOOLS.get(
+                inv.owner_type, "delete_invoice",
             )
             raise ValueError(
                 f"{self._doc_label_for(inv.owner_type)} "
@@ -2727,6 +2736,19 @@ class BusinessMixin:
                         f"{source_owner.id!r}, not {owner_id!r}. "
                         f"Credit notes must apply to a document "
                         f"from the same customer/vendor."
+                    )
+                # Source must be a regular invoice/bill, not
+                # itself a credit note. Credit-note-against-
+                # credit-note is semantically meaningless: a
+                # credit reverses a posted document; chaining
+                # them doesn't represent anything in real
+                # bookkeeping. (Copilot PR #87 review.)
+                if self._get_is_credit_note(source):
+                    raise ValueError(
+                        f"Source {applies_to_invoice_id} is "
+                        f"itself a credit note. Link credit "
+                        f"notes to regular invoices or bills, "
+                        f"not to other credit notes."
                     )
                 source_currency_mnemonic = (
                     source.currency.mnemonic
@@ -4295,6 +4317,32 @@ class BusinessMixin:
 
             post_acct = cn.post_account
 
+            # Cross-currency apply isn't supported here — the
+            # netting transaction is in the post account's
+            # commodity, so the document currency must match.
+            # In practice every well-formed book has per-currency
+            # A/R accounts (Alex has 'Accounts Receivable',
+            # 'Accounts Receivable EUR', 'Accounts Receivable
+            # CAD'), so EUR documents post to EUR A/R and the
+            # commodity equals the document currency. The case
+            # this catches: someone deliberately posted a EUR
+            # invoice to a USD A/R account (unusual, but
+            # ``post_invoice`` supports it via FX rates). For
+            # those, apply_credit_note rejects with a clear
+            # message rather than silently producing wrong split
+            # values. (Copilot PR #87 review.)
+            if cn.currency_guid != post_acct.commodity.guid:
+                raise ValueError(
+                    f"Cross-currency apply not supported: credit "
+                    f"note currency {cn.currency.mnemonic!r} "
+                    f"differs from post account commodity "
+                    f"{post_acct.commodity.mnemonic!r}. The "
+                    f"netting transaction must be in the post "
+                    f"account's commodity. Most books have "
+                    f"per-currency A/R accounts; check that the "
+                    f"credit note was posted to the right one."
+                )
+
             # Resolve lots by GUID — same pattern as pay_invoice.
             cn_lot = next(
                 (l for l in post_acct.lots if l.guid == cn.post_lot_guid),
@@ -4350,6 +4398,25 @@ class BusinessMixin:
                         f"({target_remaining}). Use {max_apply} "
                         f"or less."
                     )
+
+            # Quantize the apply amount to the post account's
+            # commodity. Defensive guard against a sub-quantum
+            # amount (e.g. ``amount="0.001"`` on a USD account
+            # with 0.01 quantum) producing a no-op netting
+            # transaction that reports success while moving
+            # nothing. Same shape as the cross-currency
+            # quantize-to-zero guard in pay_invoice.
+            # (Copilot PR #87 review.)
+            quantum_pre = _commodity_quantum(post_acct.commodity)
+            apply_amount = apply_amount.quantize(quantum_pre)
+            if apply_amount == 0:
+                raise ValueError(
+                    f"Apply amount quantizes to zero in "
+                    f"{post_acct.commodity.mnemonic} "
+                    f"(quantum={quantum_pre}). Pass an amount "
+                    f"at or above the account's smallest "
+                    f"divisible unit."
+                )
 
             # Build the netting transaction:
             #   Customer side: cn_lot gets +apply_amount (settles

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -164,18 +164,25 @@ def _format_vendor_spending_compact(
 
 
 def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
-    """Render outstanding invoices/bills as a one-line-per-doc string.
+    """Render outstanding invoices/bills/credit-notes as a
+    one-line-per-doc string.
 
     Format per row:
 
         000028  Berlin Digital GmbH  EUR 4,200  posted:2026-02-01  due:2026-03-03  55 days past due
         000011  BookkeepingCo (BILL)  USD 450  posted:2026-03-15  due:2026-04-14  13 days past due
+        000035  Emerald Analytics (CN)  USD 500  posted:2026-05-15  credit available
 
     Action columns are the win here: ``due:`` and the days-past-due
     count tell the bookkeeper exactly which invoice is bleeding the
     most days, without forcing a separate calculation. ``(BILL)`` is
     appended to vendor-bill owners so receivables and payables don't
-    get confused at a glance.
+    get confused at a glance. ``(CN)`` marks credit notes — their
+    ``amount_due`` represents the unsettled credit balance
+    (available to apply via ``apply_credit_note`` or refund via
+    ``pay_invoice``), not money owed by the customer/vendor. The
+    "due_date" column reads as "credit available" instead of a
+    past-due count to make that semantic distinction explicit.
 
     When the due date came from the 30-day default (``no_terms`` flag),
     the days count is anchored to the assumption ("days past 30-day
@@ -186,13 +193,33 @@ def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
     lines = []
     for r in rows:
         owner = r.get("owner_name") or f"#{r['id']}"
-        if r.get("type") == "bill":
+        is_credit_note = r.get("is_credit_note", False)
+        # Owner suffix communicates the document side. Credit
+        # notes win over BILL because the credit-note semantic
+        # is more important — a "(CN)" tag tells the reader the
+        # whole amount column reads as "available credit" not
+        # "amount owed."
+        if is_credit_note:
+            owner = f"{owner} (CN)"
+        elif r.get("type") == "bill":
             owner = f"{owner} (BILL)"
         ccy = r.get("currency") or ""
         # Strip trailing zeros for compact display: "4200.00" → "4,200".
         amount_dec = Decimal(r.get("amount_due") or "0")
         amount_str = f"{int(amount_dec):,}" if amount_dec == int(amount_dec) else f"{amount_dec:,.2f}"
         posted = r.get("date_posted") or "?"
+        # Credit notes don't have a "due date" concept the way
+        # invoices/bills do — they sit as available credit until
+        # applied or refunded. Replace the due column with that
+        # semantic so a reviewer scanning the list immediately
+        # sees the difference.
+        if is_credit_note:
+            action_str = "  credit available"
+            lines.append(
+                f"{r['id']}\t{owner}\t{ccy} {amount_str}\t"
+                f"posted:{posted}{action_str}"
+            )
+            continue
         due = r.get("due_date") or "?"
         days = r.get("days_past_due")
         if days is None:
@@ -971,9 +998,16 @@ class BusinessMixin:
         Currency is shown when present so multi-currency books read
         unambiguously. Bills get the ``BILL`` tag (was already there).
         """
+        # Type tag: INV/BILL/VCHR per owner_type, plus a "(CN)"
+        # suffix when the credit-note flag is set. Compact-line
+        # consumers can grep for the tag to filter (e.g. "CN" to
+        # find every credit note in a list). The suffix preserves
+        # the owner-side info that a bare "CN" tag would hide.
         inv_type = self._OWNER_TYPE_TO_COMPACT_TAG.get(
             invoice.owner_type, "INV"
         )
+        if self._get_is_credit_note(invoice):
+            inv_type = f"{inv_type} (CN)"
         opened = _safe_invoice_date(invoice, "date_opened")
         date_str = (
             str(opened.date()) if opened else "n/a"
@@ -4868,11 +4902,18 @@ class BusinessMixin:
                 currency = (
                     inv.currency.mnemonic if inv.currency else None
                 )
+                # Credit-note row: type stays as the owner-type
+                # tag ('invoice' / 'bill'), but we add a flag so
+                # the compact formatter can distinguish. The
+                # amount-due is the unsettled credit balance —
+                # what's still available to apply or refund.
+                is_credit_note = self._get_is_credit_note(inv)
                 results.append({
                     "id": inv.id,
                     "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                    inv.owner_type, "invoice"
-                ),
+                        inv.owner_type, "invoice"
+                    ),
+                    "is_credit_note": is_credit_note,
                     "owner_name": owner_name,
                     "currency": currency,
                     "date_posted": (

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2181,6 +2181,7 @@ class BusinessMixin:
         currency: str | None = None,
         term: str | None = None,
         doc_id: str | None = None,
+        extra_slots: dict | None = None,
     ) -> dict:
         """Shared create path for customer invoice and vendor bill.
 
@@ -2192,7 +2193,8 @@ class BusinessMixin:
         with ``_verify_write``, and returns the canonical response.
 
         Args:
-            owner_type: 2 = customer invoice, 4 = vendor bill.
+            owner_type: 2 = customer invoice, 4 = vendor bill,
+                5 = employee voucher.
             owner_id: Customer ID or vendor ID (human-readable '000001').
             date_opened: ISO date; defaults to now.
             notes: Free-text notes.
@@ -2351,6 +2353,19 @@ class BusinessMixin:
                 f"{config['doc_label']} '{doc_id}'",
             )
 
+            # Apply caller-supplied slots BEFORE save so the slot
+            # writes and the row insert land in a single
+            # transaction. The credit-note feature uses this to
+            # set ``credit-note`` and ``gnc-mcp/applies-to-invoice``
+            # without opening a second write session — preserves
+            # the "one book open per write" invariant.
+            if extra_slots:
+                new_inv = book.session.query(Invoice).filter_by(
+                    guid=inv_guid,
+                ).first()
+                for key, value in extra_slots.items():
+                    new_inv[key] = value
+
             book.save()
 
             return {
@@ -2475,6 +2490,373 @@ class BusinessMixin:
             term=term,
             doc_id=voucher_id,
         )
+
+    # ── Credit-note resolution ─────────────────────────────────
+    #
+    # Credit notes share the ``invoices`` table with their non-
+    # credit twins; what distinguishes them is the ``credit-note``
+    # slot. Tools like ``add_credit_note_entry`` and
+    # ``delete_credit_note`` need to look up a document by ID,
+    # validate it IS a credit note (not a regular invoice/bill
+    # that happens to share the ID space), and report a clear
+    # error otherwise. This helper centralizes that lookup +
+    # validation.
+
+    def _resolve_credit_note(
+        self, book, credit_note_id: str, owner_type: str | None = None,
+    ):
+        """Find a credit note by ID, validating that the document
+        is in fact flagged as a credit note.
+
+        Args:
+            book: Open piecash book session.
+            credit_note_id: Human-readable ID.
+            owner_type: Optional 'customer' or 'vendor' for
+                disambiguation when the ID collides across owner
+                types. None lets ``_find_invoice`` either resolve
+                an unambiguous match or raise its collision error.
+
+        Returns:
+            piecash Invoice object (the credit-note row).
+
+        Raises:
+            ValueError: If not found, found but not a credit note,
+                or ambiguous across owner types.
+        """
+        int_ot = (
+            self._parse_owner_type(owner_type)
+            if owner_type else None
+        )
+        if int_ot == 5:
+            # Employee credit notes are deliberately excluded —
+            # the create path rejects them, but a caller could
+            # still try to use this helper with owner_type='employee'.
+            # Surface the same constraint here.
+            raise ValueError(
+                "Credit notes are not supported for employees. "
+                "Use unpost_invoice + edit on the original voucher "
+                "to amend an employee reimbursement."
+            )
+        inv = self._find_invoice(
+            book, credit_note_id, owner_type=int_ot,
+        )
+        if not inv:
+            raise ValueError(
+                f"Credit note not found: {credit_note_id}"
+            )
+        if not self._get_is_credit_note(inv):
+            # Found the ID but it's a regular invoice/bill — name
+            # the right tool to use instead so the LLM can correct
+            # course in one hop.
+            entry_tool = (
+                "add_invoice_entry"
+                if inv.owner_type == 2
+                else "add_bill_entry"
+            )
+            delete_tool = (
+                "delete_invoice"
+                if inv.owner_type == 2
+                else "delete_bill"
+            )
+            raise ValueError(
+                f"{self._doc_label_for(inv.owner_type)} "
+                f"{credit_note_id} is not a credit note. Use "
+                f"{entry_tool} / {delete_tool} for the regular "
+                f"document, or check the ID."
+            )
+        return inv
+
+    def create_credit_note(
+        self,
+        owner_id: str,
+        owner_type: str,
+        applies_to_invoice_id: str | None = None,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+        credit_note_id: str | None = None,
+    ) -> dict:
+        """Create a credit note against a customer invoice or
+        vendor bill.
+
+        A credit note is the audit-trail-preserving way to reverse
+        part or all of a posted invoice. At post time the posting
+        direction reverses: customer credit notes debit Income and
+        credit A/R (reducing what the customer owes you); vendor
+        credit notes debit A/P and credit Expense (reducing what
+        you owe the vendor).
+
+        **Linking**: when ``applies_to_invoice_id`` is given, the
+        credit note is linked to the source. Validation ensures
+        the source has the same owner_id and currency. The link is
+        stored as a custom slot (``gnc-mcp/applies-to-invoice``)
+        and surfaced in ``get_invoice`` / ``list_invoices``
+        responses. Highly recommended for audit trail; can be
+        omitted for floating credit notes the bookkeeper will
+        attach to a future invoice via ``apply_credit_note``.
+
+        **Employees deliberately excluded**: GnuCash desktop has
+        no UI for employee credit notes. Supporting them at the
+        MCP layer would create documents the desktop app couldn't
+        view or edit. For employee corrections, use
+        ``unpost_invoice`` + edit on the original voucher.
+
+        Args:
+            owner_id: Customer or vendor ID (e.g., '000001').
+            owner_type: 'customer' or 'vendor'.
+            applies_to_invoice_id: Optional source invoice/bill ID.
+                Must belong to the same owner and use the same
+                currency. Stored as a GUID slot for robustness;
+                resolved back to ``{id, type}`` for display.
+            date_opened: ISO date; defaults to today.
+            notes: Free-text notes (e.g., "Credit for out-of-scope
+                work on invoice 000028").
+            currency: ISO currency code. Defaults to the source
+                invoice's currency when ``applies_to_invoice_id``
+                is given, else the owner's currency, else the
+                book's default.
+            term: Billterm name. Rarely used for credit notes but
+                accepted for symmetry.
+            credit_note_id: Custom ID. If omitted, auto-generates
+                from ``counter_invoice`` (customer) or
+                ``counter_bill`` (vendor) — GnuCash desktop shares
+                the invoice/bill counter with credit notes rather
+                than maintaining a separate sequence.
+
+        Returns:
+            Dict with ``guid``, ``id``, ``customer_id`` /
+            ``vendor_id``, ``date_opened``, ``status='created'``,
+            ``is_credit_note=True``, and ``applies_to={id, type}``
+            when linked.
+
+        Raises:
+            ValueError: If owner_type is invalid or 'employee'; if
+                applies_to_invoice_id is given but the source
+                doesn't exist, belongs to a different owner, or
+                has a currency that conflicts with an explicit
+                ``currency`` argument.
+        """
+        int_owner_type = self._parse_owner_type(owner_type)
+        if int_owner_type == 5:
+            raise ValueError(
+                "Credit notes are not supported for employees. "
+                "GnuCash desktop has no UI for employee credit "
+                "notes; supporting them at the MCP layer would "
+                "create documents desktop users can't view or "
+                "edit. Use unpost_invoice + edit on the original "
+                "voucher to amend an employee reimbursement."
+            )
+        if int_owner_type not in (2, 4):
+            # Defensive — _parse_owner_type would only return 2,
+            # 4, or 5; this guards against a future addition.
+            raise ValueError(
+                f"Credit notes require owner_type 'customer' or "
+                f"'vendor', got {owner_type!r}."
+            )
+
+        # Always set the credit-note flag.
+        extra_slots: dict = {self._CREDIT_NOTE_SLOT_KEY: 1}
+        applies_to_dict: dict | None = None
+
+        # Validate + capture data from the source invoice if linked.
+        # This is a read-only lookup so it doesn't conflict with
+        # the create path's separate write session.
+        if applies_to_invoice_id:
+            with self.open(readonly=True) as book:
+                source = self._find_invoice(
+                    book, applies_to_invoice_id,
+                    owner_type=int_owner_type,
+                )
+                if not source:
+                    raise ValueError(
+                        f"Source "
+                        f"{self._doc_label_for(int_owner_type).lower()} "
+                        f"not found: {applies_to_invoice_id}"
+                    )
+                # Cross-owner check — credit note for customer A
+                # cannot apply to customer B's invoice.
+                source_owner = self._find_invoice_owner_by_guid(
+                    book, source.owner_type, source.owner_guid,
+                )
+                if source_owner is None:
+                    raise ValueError(
+                        f"Source {applies_to_invoice_id} has a "
+                        f"dangling owner reference — can't verify "
+                        f"it belongs to {owner_id}."
+                    )
+                if source_owner.id != owner_id:
+                    raise ValueError(
+                        f"Source "
+                        f"{self._doc_label_for(int_owner_type).lower()} "
+                        f"{applies_to_invoice_id} belongs to "
+                        f"{source_owner.id!r}, not {owner_id!r}. "
+                        f"Credit notes must apply to a document "
+                        f"from the same customer/vendor."
+                    )
+                source_currency_mnemonic = (
+                    source.currency.mnemonic
+                    if source.currency else None
+                )
+                source_guid = source.guid
+
+            # Currency rules:
+            #  - If caller passed currency, it must match source's.
+            #  - If caller omitted currency, inherit source's.
+            if currency and source_currency_mnemonic and currency != source_currency_mnemonic:
+                raise ValueError(
+                    f"Credit note currency {currency!r} doesn't "
+                    f"match source {applies_to_invoice_id}'s "
+                    f"currency {source_currency_mnemonic!r}. "
+                    f"Netting a credit against an invoice in a "
+                    f"different currency would create an FX "
+                    f"adjustment GnuCash doesn't track here."
+                )
+            if currency is None and source_currency_mnemonic:
+                currency = source_currency_mnemonic
+
+            extra_slots[self._APPLIES_TO_SLOT_KEY] = source_guid
+            applies_to_dict = {
+                "id": applies_to_invoice_id,
+                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    int_owner_type, "invoice",
+                ),
+            }
+
+        result = self._create_business_document(
+            owner_type=int_owner_type,
+            owner_id=owner_id,
+            date_opened=date_opened,
+            notes=notes,
+            currency=currency,
+            term=term,
+            doc_id=credit_note_id,
+            extra_slots=extra_slots,
+        )
+
+        # Augment the standard response with credit-note keys.
+        # The owner_id key from _create_business_document is
+        # ``customer_id`` (for owner_type=2) or ``vendor_id``
+        # (for owner_type=4) per _BUSINESS_DOC_CONFIG; we keep it.
+        result["is_credit_note"] = True
+        if applies_to_dict:
+            result["applies_to"] = applies_to_dict
+        return result
+
+    def add_credit_note_entry(
+        self,
+        credit_note_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Add a line item to a credit note.
+
+        Mirrors ``add_invoice_entry`` / ``add_bill_entry`` but
+        validates the target IS a credit note before delegating
+        to ``_add_entry``. The flag is the gate; a regular invoice
+        with the same ID gets a clear "not a credit note" error
+        naming the right tool to use instead.
+
+        The underlying entry shape is identical to a non-credit
+        document of the same owner_type: customer credit notes
+        accept INCOME accounts (the reversal reduces revenue);
+        vendor credit notes accept EXPENSE/ASSET (the reversal
+        reduces the recognized expense / capitalized inventory).
+
+        Args:
+            credit_note_id: Credit note ID (e.g., '000032').
+            account: Account path. INCOME for customer credit
+                notes, EXPENSE or ASSET for vendor credit notes.
+            description: Line item description.
+            quantity: Quantity as decimal string.
+            price: Unit price as decimal string. Positive even on
+                a credit note — the credit-note flag inverts the
+                posting direction at post time, so the entry
+                shape stays the same as a normal document.
+            owner_type: Optional 'customer' or 'vendor'. Required
+                only when the credit_note_id collides across owner
+                types (rare). Auto-detect otherwise.
+
+        Returns:
+            Dict with ``guid``, ``credit_note_id``, ``description``,
+            ``quantity``, ``price``, ``total``, ``status='created'``.
+
+        Raises:
+            ValueError: If the credit note isn't found, isn't a
+                credit note, account type is wrong for the owner
+                type, or the credit note is already posted.
+        """
+        with self.open(readonly=True) as book:
+            inv = self._resolve_credit_note(
+                book, credit_note_id, owner_type=owner_type,
+            )
+            resolved_owner_type = inv.owner_type
+
+        # Delegate to _add_entry with the resolved owner_type.
+        # The helper's allowed-account-type validation is the same
+        # for credit notes as for the corresponding regular
+        # document (the entry shape is identical; only the post-
+        # time direction differs).
+        result = self._add_entry(
+            owner_type=resolved_owner_type,
+            doc_id=credit_note_id,
+            account=account,
+            description=description,
+            quantity=quantity,
+            price=price,
+        )
+        # Surface the credit_note_id key in the response (the
+        # base helper returns invoice_id / bill_id based on
+        # owner_type config; we re-key for credit-note clarity).
+        legacy_key = (
+            "invoice_id" if resolved_owner_type == 2 else "bill_id"
+        )
+        if legacy_key in result:
+            result["credit_note_id"] = result.pop(legacy_key)
+        return result
+
+    def delete_credit_note(
+        self,
+        credit_note_id: str,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Delete an unposted credit note.
+
+        Mirrors ``delete_invoice`` / ``delete_bill`` but validates
+        the target IS a credit note before delegating to
+        ``_delete_invoice_or_bill``. Posted credit notes cannot be
+        deleted — unpost first via ``unpost_invoice``, then delete.
+
+        Args:
+            credit_note_id: Credit note ID.
+            owner_type: Optional disambiguator when the ID collides
+                across customer/vendor sides.
+
+        Returns:
+            Dict with ``id``, ``guid``, ``entries_deleted``,
+            ``type='credit_note'``, ``status='deleted'``.
+
+        Raises:
+            ValueError: If not found, not a credit note, or
+                posted.
+        """
+        with self.open(readonly=True) as book:
+            inv = self._resolve_credit_note(
+                book, credit_note_id, owner_type=owner_type,
+            )
+            resolved_owner_type = inv.owner_type
+
+        result = self._delete_invoice_or_bill(
+            credit_note_id, owner_type=resolved_owner_type,
+        )
+        # Re-key the response: base returns ``type`` of
+        # ``invoice``/``bill``; for a credit note the truth is
+        # ``credit_note`` (the slot was the differentiator).
+        result["type"] = "credit_note"
+        return result
 
     # owner_type → per-document config table for ``_add_entry``.
     # Same dispatch idiom as ``_BUSINESS_DOC_CONFIG`` for create —
@@ -2905,8 +3287,18 @@ class BusinessMixin:
             )
             owner_name = owner.name if owner else None
 
+            # Resolve applies_to for credit notes — the source
+            # link is stored as a GUID slot; we render it as the
+            # human-readable ``{id, type}`` pair. ``_invoice_to_dict``
+            # only emits the ``applies_to`` key when the credit-note
+            # flag is also set, so normal invoices/bills get the
+            # same shape they did pre-v1.3.
+            applies_to = self._resolve_applies_to(book, inv)
             result = self._invoice_to_dict(
-                inv, entries=entries, owner_name=owner_name,
+                inv,
+                entries=entries,
+                owner_name=owner_name,
+                applies_to=applies_to,
             )
             result["total"] = str(total)
             return result

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 import piecash
 
 from gnucash_mcp.book._base import (
+    _slot_value_str,
     _to_decimal,
     _verify_composite_write,
     _verify_write,
@@ -892,22 +893,37 @@ class BusinessMixin:
         return num, denom
 
     @staticmethod
-    def _invoice_to_dict(invoice, entries=None, owner_name: str | None = None) -> dict:
+    def _invoice_to_dict(
+        invoice,
+        entries=None,
+        owner_name: str | None = None,
+        applies_to: dict | None = None,
+    ) -> dict:
         """Convert a piecash Invoice to a serializable dict.
 
-        ``owner_type`` (numeric 2/4) was redundant with the
+        ``owner_type`` (numeric 2/4/5) was redundant with the
         human-readable ``type`` field and is dropped. ``is_posted``
         is derivable from ``date_posted`` (non-null = posted) and
         is dropped too. Phase 3C: ``owner_guid`` (raw 32-char hex)
         is dropped in favor of ``owner_name`` resolved by the caller
         — the same readability swap we did for entry account refs.
 
+        Credit-note keys (``is_credit_note``, ``applies_to``) are
+        emitted only when set, so normal invoices/bills/vouchers
+        get the same shape they had before v1.3. ``is_credit_note``
+        is auto-detected from the invoice's slot; ``applies_to``
+        must be resolved by the caller (the static-method shape
+        means we can't query the source invoice here, same
+        constraint as ``owner_name``).
+
         Args:
             invoice: piecash Invoice object.
-            entries: Optional list of entry dicts. If None, entries are not included.
-            owner_name: Resolved customer/vendor name. The static-method
-                shape means we can't query for it here; the caller
-                (``get_invoice``) does the lookup once and threads it.
+            entries: Optional list of entry dicts. If ``None``, entries
+                are not included.
+            owner_name: Resolved customer/vendor/employee name.
+            applies_to: For credit notes only, the ``{id, type}`` dict
+                naming the source invoice. The caller resolves this
+                via ``_resolve_applies_to(book, invoice)``.
         """
         result = {
             "guid": invoice.guid,
@@ -928,6 +944,16 @@ class BusinessMixin:
             "active": bool(invoice.active),
             "currency": invoice.currency.mnemonic if invoice.currency else None,
         }
+        # Credit-note keys conditionally included so the response
+        # shape for normal documents is byte-identical to pre-v1.3.
+        # Both keys present together when the credit-note flag is
+        # set; ``applies_to`` further conditional on whether the
+        # link is set (a credit note that floats without a source
+        # link is unusual but valid).
+        if BusinessMixin._get_is_credit_note(invoice):
+            result["is_credit_note"] = True
+            if applies_to:
+                result["applies_to"] = applies_to
         if entries is not None:
             result["entries"] = entries
         return result
@@ -2054,6 +2080,96 @@ class BusinessMixin:
         return BusinessMixin._OWNER_TYPE_TO_DOC_LABEL.get(
             owner_type, "Document"
         )
+
+    # ── Credit-note slot helpers ─────────────────────────────────
+    #
+    # GnuCash stores the credit-note flag in slots, not as a
+    # column: KVP key ``credit-note``, integer value ``1`` for
+    # credit notes, slot absent for normal documents. The flag
+    # is owner-type-agnostic — a customer invoice or vendor bill
+    # with ``credit-note=1`` is the credit-note form of that
+    # document, with reversed posting direction at post time.
+    #
+    # We add a second slot, ``gnc-mcp/applies-to-invoice``, that
+    # links a credit note back to its source document. GnuCash
+    # desktop doesn't track this linkage — its Process Payment
+    # dialog handles credit-vs-invoice netting through user
+    # selection, not stored references. The ``gnc-mcp/`` prefix
+    # signals this is an MCP-server extension (per our slot
+    # convention: bare keys for universal concepts, namespaced
+    # for tool-specific state). Stored value is the source
+    # invoice's 32-char GUID; displayed as the human-readable
+    # ``{id, type}`` pair via ``_resolve_applies_to``.
+
+    _CREDIT_NOTE_SLOT_KEY = "credit-note"
+    _APPLIES_TO_SLOT_KEY = "gnc-mcp/applies-to-invoice"
+
+    @staticmethod
+    def _get_is_credit_note(invoice) -> bool:
+        """Read the GnuCash ``credit-note`` slot. True iff value=1."""
+        try:
+            raw = invoice[BusinessMixin._CREDIT_NOTE_SLOT_KEY]
+        except KeyError:
+            return False
+        return _slot_value_str(raw) == "1"
+
+    @staticmethod
+    def _set_is_credit_note(invoice, value: bool = True) -> None:
+        """Set or clear the GnuCash ``credit-note`` slot.
+
+        Stores integer ``1`` for credit notes (GnuCash convention);
+        clearing removes the slot entirely so the absence-means-False
+        invariant holds for both desktop and MCP readers.
+        """
+        if value:
+            invoice[BusinessMixin._CREDIT_NOTE_SLOT_KEY] = 1
+        else:
+            try:
+                del invoice[BusinessMixin._CREDIT_NOTE_SLOT_KEY]
+            except KeyError:
+                pass
+
+    @staticmethod
+    def _get_applies_to_invoice_guid(invoice) -> str | None:
+        """Read the source-invoice GUID this credit note applies
+        to, if set. Returns None when no source is linked."""
+        try:
+            raw = invoice[BusinessMixin._APPLIES_TO_SLOT_KEY]
+        except KeyError:
+            return None
+        val = _slot_value_str(raw)
+        return val if val else None
+
+    @staticmethod
+    def _set_applies_to_invoice_guid(invoice, source_guid: str) -> None:
+        """Link this credit note to a source invoice by GUID. The
+        stored value is the canonical 32-char hex GUID; display
+        helpers resolve it back to the human-readable ID."""
+        invoice[BusinessMixin._APPLIES_TO_SLOT_KEY] = source_guid
+
+    @staticmethod
+    def _resolve_applies_to(book, invoice) -> dict | None:
+        """Resolve the applies-to slot to a ``{id, type}`` dict
+        suitable for display in tool responses. Returns None when:
+
+        - no source is linked (normal credit note that floats),
+        - the slot points at a GUID that doesn't exist anymore
+          (dangling reference; surface as absent rather than
+          crash the response).
+        """
+        guid = BusinessMixin._get_applies_to_invoice_guid(invoice)
+        if not guid:
+            return None
+        from piecash.business.invoice import Invoice
+        source = book.session.query(Invoice).filter_by(guid=guid).first()
+        if not source:
+            return None
+        return {
+            "id": source.id,
+            "type": BusinessMixin._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                source.owner_type, "invoice"
+            ),
+        }
 
     def _create_business_document(
         self,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2036,6 +2036,25 @@ class BusinessMixin:
         """
         return owner_type in (4, 5)
 
+    # Human-readable document label for use in error messages,
+    # status returns, and audit log entries. Title-case canonical
+    # form. Three-way (Invoice / Bill / Voucher) replaces the
+    # legacy binary ``"Bill" if is_bill else "Invoice"`` which
+    # mislabeled vouchers as bills. (Copilot PR #86 review.)
+    _OWNER_TYPE_TO_DOC_LABEL = {2: "Invoice", 4: "Bill", 5: "Voucher"}
+
+    @staticmethod
+    def _doc_label_for(owner_type: int | None) -> str:
+        """Title-case label naming the document type — used in
+        error messages and status strings. ``None`` falls back to
+        the generic ``"Document"`` since we don't know what kind
+        the caller meant; the three known types map cleanly."""
+        if owner_type is None:
+            return "Document"
+        return BusinessMixin._OWNER_TYPE_TO_DOC_LABEL.get(
+            owner_type, "Document"
+        )
+
     def _create_business_document(
         self,
         *,
@@ -2721,7 +2740,7 @@ class BusinessMixin:
         with self.open() as book:
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
             if not inv:
-                raise ValueError(f"Invoice/bill not found: {invoice_id}")
+                raise ValueError(f"Document not found: {invoice_id}")
 
             is_bill = self._is_bill_side(inv.owner_type)
 
@@ -2846,7 +2865,7 @@ class BusinessMixin:
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
             if not inv:
                 raise ValueError(
-                    f"Invoice/bill not found: {invoice_id}"
+                    f"Document not found: {invoice_id}"
                 )
 
             # Truthy check rather than ``is not None``: piecash's
@@ -2865,7 +2884,8 @@ class BusinessMixin:
             # check in ``_invoice_dependency_check``.
             if _is_invoice_posted(inv):
                 raise ValueError(
-                    f"Invoice {invoice_id} is already posted"
+                    f"{self._doc_label_for(inv.owner_type)} "
+                    f"{invoice_id} is already posted"
                 )
 
             is_bill = self._is_bill_side(inv.owner_type)
@@ -3073,16 +3093,20 @@ class BusinessMixin:
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
             if not inv:
                 raise ValueError(
-                    f"Invoice/bill not found: {invoice_id}"
+                    f"Document not found: {invoice_id}"
                 )
 
             if not _is_invoice_posted(inv):
                 raise ValueError(
-                    f"Invoice {invoice_id} is not posted"
+                    f"{self._doc_label_for(inv.owner_type)} "
+                    f"{invoice_id} is not posted"
                 )
 
             is_bill = self._is_bill_side(inv.owner_type)
-            doc_label = "Bill" if is_bill else "Invoice"
+            # Three-way label dispatch — was a binary "Bill if
+            # is_bill else Invoice" that mislabeled vouchers as
+            # bills (Copilot PR #86 review).
+            doc_label = self._doc_label_for(inv.owner_type)
 
             # Capture before-state for the audit log: the user wants
             # to see what they unposted ("was posted: 2026-04-01,
@@ -3243,12 +3267,13 @@ class BusinessMixin:
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
             if not inv:
                 raise ValueError(
-                    f"Invoice/bill not found: {invoice_id}"
+                    f"Document not found: {invoice_id}"
                 )
 
             if not _is_invoice_posted(inv):
                 raise ValueError(
-                    f"Invoice {invoice_id} is not posted — "
+                    f"{self._doc_label_for(inv.owner_type)} "
+                    f"{invoice_id} is not posted — "
                     f"post it before recording payment"
                 )
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -3468,9 +3468,19 @@ class BusinessMixin:
             # Build transaction splits
             # For customer invoice: A/R debit (positive), income credit (negative)
             # For vendor bill: A/P credit (negative), expense debit (positive)
+            # For credit notes: posting direction reverses — customer
+            # credit note credits A/R (reduces receivable) and debits
+            # Income (reverses recognized revenue); vendor credit note
+            # debits A/P (reduces payable) and credits Expense (reverses
+            # recognized expense). Expressed as XOR: a credit note flips
+            # whichever side it was on, so customer-credit-note behaves
+            # like vendor-bill posting and vice-versa. ``effective_is_bill``
+            # captures this — the rest of the math is unchanged.
+            is_credit_note = self._get_is_credit_note(inv)
+            effective_is_bill = is_bill ^ is_credit_note
             piecash_splits = []
 
-            if is_bill:
+            if effective_is_bill:
                 ar_ap_value = -grand_total
             else:
                 ar_ap_value = grand_total
@@ -3493,7 +3503,7 @@ class BusinessMixin:
                         f"Entry account not found: {acct_guid}"
                     )
 
-                if is_bill:
+                if effective_is_bill:
                     split_value = acct_total
                 else:
                     split_value = -acct_total
@@ -3548,8 +3558,17 @@ class BusinessMixin:
 
             result = {
                 "id": inv.id,
-                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                    inv.owner_type, "invoice"
+                # When the credit-note flag is set, surface
+                # ``type='credit_note'`` so the audit log
+                # decorator swaps entity_type accordingly.
+                # Otherwise the owner-type-driven label
+                # (invoice/bill/voucher) wins.
+                "type": (
+                    "credit_note"
+                    if is_credit_note
+                    else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                        inv.owner_type, "invoice"
+                    )
                 ),
                 "status": "posted",
                 "total": str(grand_total),
@@ -3626,8 +3645,12 @@ class BusinessMixin:
             )
             self._stage_audit_before({
                 "id": inv.id,
-                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                    inv.owner_type, "invoice"
+                "type": (
+                    "credit_note"
+                    if self._get_is_credit_note(inv)
+                    else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                        inv.owner_type, "invoice"
+                    )
                 ),
                 "date_posted": (
                     str(prev_post_date.date()) if prev_post_date else None
@@ -3678,6 +3701,17 @@ class BusinessMixin:
             inv.post_account = None
             book.flush()
 
+            # Capture the credit-note flag BEFORE we delete the
+            # posting transaction / lot. Post-save, slot reads on
+            # the invoice can flake with the "Multiple rows
+            # returned with uselist=False" piecash quirk when
+            # lots and transactions are being deleted in the
+            # same session. Reading the flag now and stashing it
+            # avoids the state-disturbance window.
+            is_credit_note = self._get_is_credit_note(inv)
+            inv_id_snapshot = inv.id
+            owner_type_snapshot = inv.owner_type
+
             # Delete the posting transaction (which cascades its
             # splits) and the lot (now empty after the inv.post_lot
             # = None nullified the only split-lot link).
@@ -3689,9 +3723,13 @@ class BusinessMixin:
             book.save()
 
             return {
-                "id": inv.id,
-                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                    inv.owner_type, "invoice"
+                "id": inv_id_snapshot,
+                "type": (
+                    "credit_note"
+                    if is_credit_note
+                    else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                        owner_type_snapshot, "invoice"
+                    )
                 ),
                 "status": "unposted",
             }
@@ -3927,8 +3965,18 @@ class BusinessMixin:
                     f"{pay_acct.commodity.mnemonic}."
                 )
 
-            if is_bill:
-                # Pay vendor bill: debit A/P (positive), credit bank (negative)
+            # Credit-note refund direction reverses: paying a
+            # customer credit note means SENDING cash to the
+            # customer (refund), so signs flip versus a normal
+            # customer invoice payment. Same XOR trick as
+            # post_invoice — a credit note swaps the is_bill
+            # branch.
+            is_credit_note = self._get_is_credit_note(inv)
+            effective_is_bill = is_bill ^ is_credit_note
+
+            if effective_is_bill:
+                # Pay vendor bill (or refund customer credit note):
+                # debit A/P (positive), credit bank (negative)
                 ar_ap_split = piecash.Split(
                     account=post_acct,
                     value=payment_amount,
@@ -3943,7 +3991,9 @@ class BusinessMixin:
                     memo="",
                 )
             else:
-                # Receive customer payment: credit A/R (negative), debit bank (positive)
+                # Receive customer payment (or refund-in from a
+                # vendor credit note): credit A/R (negative),
+                # debit bank (positive)
                 ar_ap_split = piecash.Split(
                     account=post_acct,
                     value=-payment_amount,
@@ -3975,10 +4025,15 @@ class BusinessMixin:
             fx_result: dict | None = None
             default_currency = self._require_default_currency(book)
             if exchange_rate is not None:
+                # FX gain/loss direction follows the effective
+                # is_bill of THIS payment — a customer credit
+                # note refund behaves like a vendor bill payment
+                # from the FX-direction perspective (cash leaving
+                # the company on the bank side).
                 fx_result = self._compute_fx_gain_loss(
                     book,
                     inv=inv,
-                    is_bill=is_bill,
+                    is_bill=effective_is_bill,
                     pay_acct=pay_acct,
                     payment_amount=payment_amount,
                     pay_quantity=pay_quantity,
@@ -4012,8 +4067,12 @@ class BusinessMixin:
 
             result = {
                 "id": inv.id,
-                "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                    inv.owner_type, "invoice"
+                "type": (
+                    "credit_note"
+                    if is_credit_note
+                    else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                        inv.owner_type, "invoice"
+                    )
                 ),
                 "status": "paid",
                 "amount_paid": str(payment_amount),
@@ -4051,6 +4110,306 @@ class BusinessMixin:
                         result["fx_notice"] = fx_result["fx_notice"]
 
         return result
+
+    def apply_credit_note(
+        self,
+        credit_note_id: str,
+        applies_to_invoice_id: str,
+        amount: str | None = None,
+        apply_date: str | None = None,
+        owner_type: str | None = None,
+    ) -> dict:
+        """Net a posted credit note against a posted invoice/bill
+        from the same owner. No cash moves — the credit balance
+        transfers between lots on the same A/R or A/P account.
+
+        This is the "Process Payment with both checked" workflow
+        from GnuCash desktop, factored into a dedicated tool for
+        LLM legibility. ``pay_invoice`` continues to handle the
+        cash-refund case (when the customer was already paid and
+        the credit note represents money owed BACK to them).
+
+        Booking shape:
+
+        - **Customer side**: two splits on the A/R account, summing
+          to zero. One debit assigned to the credit note's lot
+          (settles the negative balance there); one credit assigned
+          to the target invoice's lot (reduces what's still owed).
+        - **Vendor side**: symmetric — two splits on the A/P
+          account, credit on the credit note's lot (settles the
+          positive balance), debit on the target's lot (reduces
+          what's still owed to the vendor).
+
+        Validation:
+
+        - Both documents must be posted (nothing to net otherwise).
+        - Same owner (customer A's credit note can't net B's bill).
+        - Same currency (cross-currency netting would create FX
+          adjustments outside GnuCash's tracking).
+        - Same A/R or A/P post account.
+        - Target must be a regular invoice/bill (not another credit
+          note — credits don't net against credits).
+        - ``amount`` (if supplied) must not exceed the lesser of
+          the two remaining balances.
+
+        Args:
+            credit_note_id: The credit note to apply (must be
+                posted).
+            applies_to_invoice_id: The target invoice/bill to net
+                against (must be posted, same owner, same currency).
+            amount: Amount to apply, as a decimal string in the
+                document currency. Defaults to ``min(credit_note_
+                remaining, target_remaining)`` — apply as much as
+                possible.
+            apply_date: ISO date for the netting transaction.
+                Defaults to today.
+            owner_type: Optional disambiguator for ID collisions.
+
+        Returns:
+            Dict with ``credit_note_id``, ``applies_to_invoice_id``,
+            ``amount_applied``, ``credit_note_remaining``,
+            ``target_remaining``, ``transaction_guid``,
+            ``apply_date``, ``status='applied'``.
+
+        Raises:
+            ValueError: For any of the validation failures above,
+                or if ``amount`` rounds to zero in the target
+                commodity.
+        """
+        from datetime import datetime as _dt
+        # piecash Transaction.post_date wants a ``date`` object, not
+        # a ``datetime`` — passing a datetime raises GncValidationError.
+        parsed_date = (
+            _dt.strptime(apply_date, "%Y-%m-%d").date()
+            if apply_date else _dt.now().date()
+        )
+
+        with self.open(readonly=False) as book:
+            # Resolve the credit note (validates it IS a credit note).
+            cn = self._resolve_credit_note(
+                book, credit_note_id, owner_type=owner_type,
+            )
+            # Resolve the target — use the credit note's owner_type
+            # to disambiguate (they must match anyway).
+            target = self._find_invoice(
+                book, applies_to_invoice_id,
+                owner_type=cn.owner_type,
+            )
+            if not target:
+                raise ValueError(
+                    f"Target {self._doc_label_for(cn.owner_type).lower()} "
+                    f"not found: {applies_to_invoice_id}"
+                )
+
+            # Target must NOT be a credit note itself — netting
+            # credits against credits is semantically meaningless.
+            if self._get_is_credit_note(target):
+                raise ValueError(
+                    f"Target {applies_to_invoice_id} is itself a "
+                    f"credit note. Apply credit notes to regular "
+                    f"invoices/bills, not to each other."
+                )
+
+            # Both must be posted (no lots to net otherwise).
+            if not _is_invoice_posted(cn):
+                raise ValueError(
+                    f"Credit note {credit_note_id} is not posted "
+                    f"— post it before applying."
+                )
+            if not _is_invoice_posted(target):
+                raise ValueError(
+                    f"Target {applies_to_invoice_id} is not "
+                    f"posted — post it before applying credits."
+                )
+
+            # Same owner check.
+            if cn.owner_guid != target.owner_guid:
+                cn_owner = self._find_invoice_owner_by_guid(
+                    book, cn.owner_type, cn.owner_guid,
+                )
+                target_owner = self._find_invoice_owner_by_guid(
+                    book, target.owner_type, target.owner_guid,
+                )
+                raise ValueError(
+                    f"Credit note belongs to "
+                    f"{cn_owner.id if cn_owner else '?'!r} but "
+                    f"target belongs to "
+                    f"{target_owner.id if target_owner else '?'!r}. "
+                    f"Credit notes can only net against documents "
+                    f"from the same customer/vendor."
+                )
+
+            # Same currency check.
+            if cn.currency_guid != target.currency_guid:
+                raise ValueError(
+                    f"Credit note currency "
+                    f"{cn.currency.mnemonic!r} doesn't match "
+                    f"target currency {target.currency.mnemonic!r}. "
+                    f"Cross-currency netting would create an FX "
+                    f"adjustment outside GnuCash's tracking."
+                )
+
+            # Same A/R or A/P account.
+            if cn.post_acc_guid != target.post_acc_guid:
+                raise ValueError(
+                    f"Credit note posted to "
+                    f"{cn.post_account.fullname!r} but target "
+                    f"posted to {target.post_account.fullname!r}. "
+                    f"Both must use the same A/R or A/P account "
+                    f"to net."
+                )
+
+            post_acct = cn.post_account
+
+            # Resolve lots by GUID — same pattern as pay_invoice.
+            cn_lot = next(
+                (l for l in post_acct.lots if l.guid == cn.post_lot_guid),
+                None,
+            )
+            target_lot = next(
+                (l for l in post_acct.lots if l.guid == target.post_lot_guid),
+                None,
+            )
+            if cn_lot is None or target_lot is None:
+                raise ValueError(
+                    f"Could not resolve lots for credit note "
+                    f"or target — book may be inconsistent."
+                )
+
+            # Lot balances. Customer-side: target_lot is positive
+            # (receivable), cn_lot is negative (credit). Vendor
+            # side: signs reversed. Either way, ``abs()`` gives
+            # the available amount on each side.
+            cn_remaining = abs(self._calculate_lot_balance(cn_lot))
+            target_remaining = abs(
+                self._calculate_lot_balance(target_lot)
+            )
+
+            if cn_remaining == 0:
+                raise ValueError(
+                    f"Credit note {credit_note_id} has no "
+                    f"remaining balance to apply (already fully "
+                    f"netted or refunded)."
+                )
+            if target_remaining == 0:
+                raise ValueError(
+                    f"Target {applies_to_invoice_id} has no "
+                    f"remaining balance — nothing to apply credit "
+                    f"against."
+                )
+
+            max_apply = min(cn_remaining, target_remaining)
+            if amount is None:
+                apply_amount = max_apply
+            else:
+                apply_amount = _to_decimal(amount)
+                if apply_amount <= 0:
+                    raise ValueError(
+                        f"Apply amount must be positive, got "
+                        f"{apply_amount}."
+                    )
+                if apply_amount > max_apply:
+                    raise ValueError(
+                        f"Apply amount {apply_amount} exceeds the "
+                        f"smaller of credit-note remaining "
+                        f"({cn_remaining}) and target remaining "
+                        f"({target_remaining}). Use {max_apply} "
+                        f"or less."
+                    )
+
+            # Build the netting transaction:
+            #   Customer side: cn_lot gets +apply_amount (settles
+            #     credit toward zero from negative); target_lot
+            #     gets -apply_amount (reduces receivable).
+            #   Vendor side: cn_lot gets -apply_amount; target_lot
+            #     gets +apply_amount. Symmetric.
+            is_bill_side = self._is_bill_side(cn.owner_type)
+            if is_bill_side:
+                cn_split_value = -apply_amount
+                target_split_value = apply_amount
+            else:
+                cn_split_value = apply_amount
+                target_split_value = -apply_amount
+
+            # Quantize to the post-account's commodity.
+            quantum = _commodity_quantum(post_acct.commodity)
+            cn_split_value = cn_split_value.quantize(quantum)
+            target_split_value = target_split_value.quantize(quantum)
+
+            txn_desc = (
+                f"Credit applied: {credit_note_id} → "
+                f"{applies_to_invoice_id}"
+            )
+            cn_split = piecash.Split(
+                account=post_acct,
+                value=cn_split_value,
+                quantity=cn_split_value,
+                memo=f"Net against {applies_to_invoice_id}",
+                action="Payment",
+            )
+            target_split = piecash.Split(
+                account=post_acct,
+                value=target_split_value,
+                quantity=target_split_value,
+                memo=f"Credit from {credit_note_id}",
+                action="Payment",
+            )
+
+            txn = piecash.Transaction(
+                currency=post_acct.commodity,
+                description=txn_desc,
+                post_date=parsed_date,
+                num="",
+                splits=[cn_split, target_split],
+            )
+
+            # Assign splits to the respective lots — this is what
+            # tells GnuCash the lots are being settled.
+            cn_split.lot = cn_lot
+            target_split.lot = target_lot
+
+            book.flush()
+
+            # Mark txn as a payment-type transaction (GnuCash UI
+            # convention) so desktop knows to render it under
+            # the lot's payment activity.
+            txn["trans-txn-type"] = "P"
+
+            # Close lots that reached zero. A fully-settled credit
+            # note (apply == cn_remaining) closes its lot. A
+            # fully-settled target (apply == target_remaining)
+            # closes its lot. Either or both can close.
+            new_cn_remaining = abs(
+                self._calculate_lot_balance(cn_lot)
+            )
+            new_target_remaining = abs(
+                self._calculate_lot_balance(target_lot)
+            )
+            if new_cn_remaining == 0:
+                cn_lot.is_closed = -1
+            if new_target_remaining == 0:
+                target_lot.is_closed = -1
+
+            book.save()
+
+            # Quantize all amounts to the post-account's commodity
+            # so the response shape stays consistent regardless
+            # of whether the lot-balance Decimals carried extra
+            # precision. "$100.00" not "$100".
+            return {
+                "credit_note_id": credit_note_id,
+                "applies_to_invoice_id": applies_to_invoice_id,
+                "amount_applied": str(apply_amount.quantize(quantum)),
+                "credit_note_remaining": str(
+                    new_cn_remaining.quantize(quantum)
+                ),
+                "target_remaining": str(
+                    new_target_remaining.quantize(quantum)
+                ),
+                "transaction_guid": txn.guid,
+                "apply_date": str(parsed_date),
+                "status": "applied",
+            }
 
     # ── Delete paths ──────────────────────────────────────────────
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1000,11 +1000,25 @@ def _fmt_credit_note_apply(entry: dict) -> list[str]:
             f"against: {target_id}"
         ),
     ]
-    if cn_remaining and cn_remaining != "0":
+    # ``apply_credit_note`` returns quantized strings like
+    # "0.00", not "0", so a string-equality check against "0"
+    # would print "remaining: 0.00" lines on fully-settled
+    # documents. Decimal comparison handles every quantize
+    # shape ("0", "0.00", "0.0000") uniformly.
+    # (Copilot PR #87 review.)
+    from decimal import Decimal as _D, InvalidOperation as _IO
+    def _is_zero(s: str) -> bool:
+        if not s:
+            return True
+        try:
+            return _D(s) == 0
+        except _IO:
+            return False
+    if not _is_zero(cn_remaining):
         lines.append(
             f"{_INDENT}credit note remaining: {cn_remaining}"
         )
-    if target_remaining and target_remaining != "0":
+    if not _is_zero(target_remaining):
         lines.append(
             f"{_INDENT}target remaining: {target_remaining}"
         )

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -935,19 +935,69 @@ def _fmt_voucher_delete(entry: dict) -> list[str]:
     return lines
 
 
+# ── Credit-note formatters ───────────────────────────────────
+# Credit notes can be customer- or vendor-sided (owner_type 2 or
+# 4); the credit-note flag is the differentiator. The formatters
+# surface the side in the audit line because a reviewer scanning
+# the log shouldn't have to cross-reference the source ID to
+# know which kind of credit note was issued. ``applies_to`` is
+# shown when the link is set.
+
+
+def _fmt_credit_note_create(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    cn_id = after.get("id", "")
+    owner_type = params.get("owner_type", "")
+    # owner_id key is owner-type-dependent: customer credit notes
+    # surface customer_id; vendor credit notes surface vendor_id.
+    # Pull whichever the after-state carries.
+    owner_id = (
+        after.get("customer_id")
+        or after.get("vendor_id")
+        or params.get("owner_id", "")
+    )
+    lines = [f"{time_part}  CREATE CREDIT NOTE  id:{cn_id}"]
+    detail = f"{_INDENT}{owner_type}: {owner_id}"
+    applies_to = after.get("applies_to")
+    if applies_to:
+        detail += f"  applies to: {applies_to.get('id', '')}"
+    lines.append(detail)
+    return lines
+
+
+def _fmt_credit_note_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state")
+
+    lines = [
+        f"{time_part}  DELETE CREDIT NOTE  "
+        f"id:{params.get('credit_note_id', '')}"
+    ]
+    if after:
+        entries = after.get("entries_deleted", 0)
+        if entries:
+            lines.append(f"{_INDENT}entries removed: {entries}")
+    return lines
+
+
 def _fmt_entry_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
     after = entry.get("after_state") or {}
     desc = after.get("description", params.get("description", ""))
     total = after.get("total", "")
-    # Entry can belong to an invoice / bill / voucher — the params
-    # carry whichever ID key the tool wrapper used. First-match
-    # wins; all three are mutually exclusive in practice.
+    # Entry can belong to an invoice / bill / voucher / credit
+    # note — the params carry whichever ID key the tool wrapper
+    # used. First-match wins; all four are mutually exclusive in
+    # practice.
     inv_id = (
         params.get("invoice_id", "")
         or params.get("bill_id", "")
         or params.get("voucher_id", "")
+        or params.get("credit_note_id", "")
     )
     return [
         f"{time_part}  CREATE ENTRY",
@@ -1095,6 +1145,12 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("voucher", "POST"): _fmt_voucher_post,
     ("voucher", "UNPOST"): _fmt_voucher_unpost,
     ("voucher", "PAY"): _fmt_voucher_pay,
+    # Credit-note CREATE / DELETE land here; POST / UNPOST /
+    # PAY / APPLY are added in the lifecycle commit alongside
+    # the polymorphic-entity-type-swap handler that recognizes
+    # type='credit_note' in tool responses.
+    ("credit_note", "CREATE"): _fmt_credit_note_create,
+    ("credit_note", "DELETE"): _fmt_credit_note_delete,
     ("entry", "CREATE"): _fmt_entry_create,
     ("price", "DELETE"): _fmt_price_delete,
     ("budget", "UPDATE"): _fmt_budget_update,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -944,6 +944,73 @@ def _fmt_voucher_delete(entry: dict) -> list[str]:
 # shown when the link is set.
 
 
+def _fmt_credit_note_post(entry: dict) -> list[str]:
+    """Credit note POST — same shape as invoice POST but
+    explicitly labeled. The posting direction was reversed at
+    the book layer; the audit log just reports what happened."""
+    lines = _fmt_invoice_post(entry)
+    if lines:
+        lines[0] = lines[0].replace(
+            "POST INVOICE", "POST CREDIT NOTE",
+        )
+    return lines
+
+
+def _fmt_credit_note_unpost(entry: dict) -> list[str]:
+    lines = _fmt_invoice_unpost(entry)
+    if lines:
+        lines[0] = lines[0].replace(
+            "UNPOST INVOICE", "UNPOST CREDIT NOTE",
+        )
+    return lines
+
+
+def _fmt_credit_note_pay(entry: dict) -> list[str]:
+    """Credit note PAY — for credit notes, ``pay_invoice`` is
+    the cash-refund path (the bookkeeper sent cash to a customer
+    or received it from a vendor, depending on side). The
+    audit-log label calls it out so a reviewer doesn't mistake
+    a refund for a normal payment."""
+    lines = _fmt_invoice_pay(entry)
+    if lines:
+        lines[0] = lines[0].replace(
+            "PAY INVOICE", "REFUND CREDIT NOTE",
+        )
+    return lines
+
+
+def _fmt_credit_note_apply(entry: dict) -> list[str]:
+    """Credit note APPLY — the netting transaction that
+    settles a credit note against an outstanding invoice/bill
+    from the same owner. No cash moves; the credit balance just
+    transfers between lots on the same A/R or A/P account.
+    """
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    cn_id = params.get("credit_note_id", "")
+    target_id = params.get("applies_to_invoice_id", "")
+    amount = after.get("amount_applied", "")
+    cn_remaining = after.get("credit_note_remaining", "")
+    target_remaining = after.get("target_remaining", "")
+    lines = [
+        f"{time_part}  APPLY CREDIT NOTE  id:{cn_id}",
+        (
+            f"{_INDENT}applied: {amount}  "
+            f"against: {target_id}"
+        ),
+    ]
+    if cn_remaining and cn_remaining != "0":
+        lines.append(
+            f"{_INDENT}credit note remaining: {cn_remaining}"
+        )
+    if target_remaining and target_remaining != "0":
+        lines.append(
+            f"{_INDENT}target remaining: {target_remaining}"
+        )
+    return lines
+
+
 def _fmt_credit_note_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -1145,12 +1212,19 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("voucher", "POST"): _fmt_voucher_post,
     ("voucher", "UNPOST"): _fmt_voucher_unpost,
     ("voucher", "PAY"): _fmt_voucher_pay,
-    # Credit-note CREATE / DELETE land here; POST / UNPOST /
-    # PAY / APPLY are added in the lifecycle commit alongside
-    # the polymorphic-entity-type-swap handler that recognizes
-    # type='credit_note' in tool responses.
+    # Credit-note CREATE / DELETE for the create-side surface;
+    # POST / UNPOST / PAY are reached via the polymorphic
+    # entity_type swap (the lifecycle tools register as
+    # ``entity_type="invoice"`` and the audit-decorator's
+    # polymorphism handler rewrites it when the response type
+    # is "credit_note"). APPLY is the netting tool added
+    # alongside this commit.
     ("credit_note", "CREATE"): _fmt_credit_note_create,
     ("credit_note", "DELETE"): _fmt_credit_note_delete,
+    ("credit_note", "POST"): _fmt_credit_note_post,
+    ("credit_note", "UNPOST"): _fmt_credit_note_unpost,
+    ("credit_note", "PAY"): _fmt_credit_note_pay,
+    ("credit_note", "APPLY"): _fmt_credit_note_apply,
     ("entry", "CREATE"): _fmt_entry_create,
     ("price", "DELETE"): _fmt_price_delete,
     ("budget", "UPDATE"): _fmt_budget_update,
@@ -1511,18 +1585,23 @@ def audit_log(
                     else:
                         entry["result"] = "success"
                         if classification == "write":
-                            # Invoice/bill/voucher polymorphism:
-                            # post_invoice / unpost_invoice /
-                            # pay_invoice all carry
+                            # Invoice/bill/voucher/credit_note
+                            # polymorphism: post_invoice /
+                            # unpost_invoice / pay_invoice all carry
                             # entity_type="invoice" on the decorator
-                            # but accept any of the three kinds.
+                            # but accept any of the four kinds.
                             # The response's ``type`` field is the
                             # truth — swap entity_type to match so
                             # the audit log doesn't mis-categorize.
+                            # Credit notes can be customer- or
+                            # vendor-sided; the type field is just
+                            # "credit_note" regardless of owner_type
+                            # (the formatter pulls the owner side
+                            # from the response payload).
                             if (
                                 entity_type == "invoice"
                                 and result_data.get("type")
-                                in {"bill", "voucher"}
+                                in {"bill", "voucher", "credit_note"}
                             ):
                                 entry["entity_type"] = (
                                     result_data["type"]

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -315,6 +315,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "create_credit_note",
         "add_credit_note_entry",
         "delete_credit_note",
+        "apply_credit_note",
         "create_billterm",
         "list_billterms",
         "vendor_spending_report",
@@ -669,7 +670,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (94 tools).
+                       for every module (95 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -306,6 +306,15 @@ TOOL_MODULES: dict[str, list[str]] = {
         "create_voucher",
         "add_voucher_entry",
         "delete_voucher",
+        # Credit notes (v1.3). Customer and vendor only —
+        # employees deliberately excluded (no GnuCash desktop
+        # equivalent). Lifecycle (post / unpost / pay / apply)
+        # flows through the polymorphic invoice tools in
+        # freelancer, detecting the credit-note slot to reverse
+        # posting direction.
+        "create_credit_note",
+        "add_credit_note_entry",
+        "delete_credit_note",
         "create_billterm",
         "list_billterms",
         "vendor_spending_report",
@@ -660,7 +669,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (91 tools).
+                       for every module (94 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -240,6 +240,20 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
             "the server with --modules=...,Business or omit "
             "owner_type to operate on customer invoices only."
         )
+    # Only None and 'customer' fall through to "customer" coercion.
+    # Anything else (typos like 'venddor', unknown future types) is
+    # rejected here so the LLM gets a clear validation error instead
+    # of a silent coercion that masks the typo as "search customer
+    # invoices, find nothing, return not-found." Pre-fix: 'venddor'
+    # → coerced to 'customer' → book-layer lookup against customer
+    # invoices → "invoice not found", with no indication the input
+    # was misspelled. (Copilot review on PR #86.)
+    if owner_type is not None and owner_type != "customer":
+        raise ValueError(
+            f"Invalid owner_type {owner_type!r}. Must be 'customer' "
+            f"(or omit). 'vendor' and 'employee' require the "
+            f"Business module."
+        )
     return "customer"
 
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -660,6 +660,54 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="apply", entity_type="credit_note")
+    def apply_credit_note(
+        credit_note_id: str,
+        applies_to_invoice_id: str,
+        amount: str | None = None,
+        apply_date: str | None = None,
+        owner_type: str | None = None,
+    ) -> str:
+        """Net a posted credit note against a posted invoice or
+        bill from the same owner. No cash moves — the credit
+        balance transfers between lots on the same A/R or A/P
+        account.
+
+        This is the most common credit-note settlement path: the
+        bookkeeper issues a credit note against an overcharge,
+        then nets it against the next invoice from that customer
+        (or applies it to an outstanding bill on the vendor side).
+        Use ``pay_invoice`` instead when the credit note will be
+        settled by sending or receiving cash.
+
+        Args:
+            credit_note_id: The credit note to apply (must be
+                posted).
+            applies_to_invoice_id: The target invoice/bill (must
+                be posted, same owner, same currency, same A/R
+                or A/P post account).
+            amount: Decimal-string amount to apply, in the
+                document currency. Defaults to ``min(credit_note_
+                remaining, target_remaining)`` — apply as much
+                as possible.
+            apply_date: ISO date for the netting transaction.
+                Defaults to today.
+            owner_type: Optional 'customer' or 'vendor'
+                disambiguator for ID collisions.
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.apply_credit_note(
+            credit_note_id=credit_note_id,
+            applies_to_invoice_id=applies_to_invoice_id,
+            amount=amount,
+            apply_date=apply_date,
+            owner_type=owner_type,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="credit_note")
     def delete_credit_note(
         credit_note_id: str,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -555,6 +555,137 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="credit_note")
+    def create_credit_note(
+        owner_id: str,
+        owner_type: str,
+        applies_to_invoice_id: str | None = None,
+        date_opened: str | None = None,
+        notes: str = "",
+        currency: str | None = None,
+        term: str | None = None,
+        credit_note_id: str | None = None,
+    ) -> str:
+        """Create a credit note against a customer invoice or
+        vendor bill.
+
+        A credit note reverses part or all of a posted invoice
+        while preserving the original posting in the audit trail.
+        At post time, posting direction reverses: customer credit
+        notes debit Income / credit A/R (reducing receivables);
+        vendor credit notes debit A/P / credit Expense (reducing
+        payables). Settled either by refund (``pay_invoice``) or
+        by netting against an outstanding invoice
+        (``apply_credit_note``).
+
+        Use ``add_credit_note_entry`` to add line items, then
+        ``post_invoice`` to post.
+
+        Args:
+            owner_id: Customer or vendor ID (e.g., "000001").
+            owner_type: "customer" or "vendor". Employees are not
+                supported (GnuCash desktop has no UI for employee
+                credit notes; use unpost_invoice + edit on the
+                voucher to amend an employee reimbursement).
+            applies_to_invoice_id: Optional source invoice / bill
+                ID. Must belong to the same owner and use the
+                same currency. Highly recommended for audit
+                trail. Can be omitted for floating credit notes
+                that will be applied later.
+            date_opened: ISO date (YYYY-MM-DD). Defaults to today.
+            notes: Free-text notes (e.g., reason for the credit).
+            currency: ISO currency code. Inherited from source
+                invoice when applies_to_invoice_id is given;
+                otherwise from owner's currency or book default.
+            term: Billterm name. Rarely used for credit notes.
+            credit_note_id: Custom ID. Auto-generated from the
+                shared invoice/bill counter when omitted.
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.create_credit_note(
+            owner_id=owner_id,
+            owner_type=owner_type,
+            applies_to_invoice_id=applies_to_invoice_id,
+            date_opened=date_opened,
+            notes=notes,
+            currency=currency,
+            term=term,
+            credit_note_id=credit_note_id,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="entry")
+    def add_credit_note_entry(
+        credit_note_id: str,
+        account: str,
+        description: str,
+        quantity: str,
+        price: str,
+        owner_type: str | None = None,
+    ) -> str:
+        """Add a line item to a credit note.
+
+        Mirrors ``add_invoice_entry`` / ``add_bill_entry`` but
+        validates the target is in fact a credit note (the slot
+        flag is the gate). Account type rules match the
+        non-credit twin: INCOME for customer credit notes,
+        EXPENSE/ASSET for vendor credit notes. Prices stay
+        positive — the credit-note flag inverts posting direction
+        at post time, not at entry-add time.
+
+        Args:
+            credit_note_id: Credit note ID (e.g., "000032").
+            account: Account path appropriate for the owner type
+                (INCOME for customer, EXPENSE/ASSET for vendor).
+            description: Line item description.
+            quantity: Quantity as decimal string.
+            price: Unit price as decimal string.
+            owner_type: Optional "customer" or "vendor"
+                disambiguator for ID collisions. Usually omitted.
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.add_credit_note_entry(
+            credit_note_id=credit_note_id,
+            account=account,
+            description=description,
+            quantity=quantity,
+            price=price,
+            owner_type=owner_type,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="delete", entity_type="credit_note")
+    def delete_credit_note(
+        credit_note_id: str,
+        owner_type: str | None = None,
+    ) -> str:
+        """Delete an unposted credit note.
+
+        Validates the target is a credit note before deletion.
+        Posted credit notes cannot be deleted — unpost first via
+        ``unpost_invoice``, then delete.
+
+        Args:
+            credit_note_id: Credit note ID.
+            owner_type: Optional "customer" or "vendor"
+                disambiguator for ID collisions.
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.delete_credit_note(
+            credit_note_id=credit_note_id,
+            owner_type=owner_type,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="read")
     def list_invoices(
         owner_type: str | None = None,

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2495,6 +2495,161 @@ class TestApplyCreditNote:
             )
 
 
+class TestCreditNoteDisplayPolish:
+    """Display rendering for credit notes: list_invoices,
+    get_outstanding_invoices, and the dashboard's A/R / A/P
+    netting. Tests pin the surface a reviewer would scan to
+    understand which documents are credit notes at a glance.
+    """
+
+    def test_list_invoices_compact_marks_credit_notes(
+        self, business_book,
+    ):
+        """Credit notes get a ``(CN)`` suffix on the type tag in
+        compact output. Customer credit notes render as ``INV
+        (CN)``; vendor as ``BILL (CN)``. Tab-separated, so the
+        suffix is easy to grep for or split on."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_vendor(name="Office Depot")
+        gb.create_invoice(customer_id="000001")  # plain INV
+        gb.create_bill(vendor_id="000001")  # plain BILL
+        gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.create_credit_note(
+            owner_id="000001", owner_type="vendor",
+        )
+        out = gb.list_invoices()  # compact default
+        # Both credit notes show the (CN) suffix on the tag column.
+        assert "INV (CN)" in out
+        assert "BILL (CN)" in out
+        # Plain invoice/bill still render with bare tags.
+        # Look for the bare tag NOT followed by " (CN)" — a single
+        # tab-after-tag is the canonical separator.
+        assert "\tINV\t" in out  # plain customer invoice
+        assert "\tBILL\t" in out  # plain vendor bill
+
+    def test_get_outstanding_invoices_marks_credit_notes(
+        self, business_book,
+    ):
+        """Outstanding credit notes appear with a ``(CN)`` suffix
+        on the owner column AND a "credit available" annotation
+        in the due-date column — distinguishing them from
+        invoices that read as "X days past due"."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # Post a regular invoice (creates one outstanding row)
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Post a credit note (also outstanding — unapplied credit)
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="dispute", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        out = gb.get_outstanding_invoices()  # compact default
+        # Both rows present.
+        assert "000001" in out
+        assert cn["id"] in out
+        # Credit note has the (CN) marker and the "credit
+        # available" action column.
+        assert "(CN)" in out
+        assert "credit available" in out
+        # The "past due" wording does NOT appear for the credit
+        # note row (it should only appear for the regular invoice
+        # if its due date is past; with default test date, the
+        # invoice probably has a due-in or past-due reading —
+        # either way the credit note shouldn't carry that text).
+        # Pull the CN's line specifically and check.
+        cn_line = [
+            ln for ln in out.split("\n") if cn["id"] in ln
+        ][0]
+        assert "past due" not in cn_line
+        assert "credit available" in cn_line
+
+    def test_get_outstanding_verbose_carries_is_credit_note(
+        self, business_book,
+    ):
+        """Verbose output exposes the is_credit_note flag in the
+        dict shape — important for LLMs that filter / branch on
+        credit-note state programmatically."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        rows = gb.get_outstanding_invoices(compact=False)
+        cn_row = next(r for r in rows if r["id"] == cn["id"])
+        assert cn_row["is_credit_note"] is True
+
+    def test_dashboard_ar_nets_credit_notes_against_invoices(
+        self, business_book,
+    ):
+        """The headline regression — get_book_summary's
+        Receivables total uses the raw A/R balance, which already
+        nets credit notes against invoices because the post
+        directions reverse. Invoice $500 + credit note $100 →
+        A/R should read $400 (not $500 + $100 = $600, and not
+        $500). Locking this so a future refactor that misroutes
+        credit-note posting math gets caught.
+        """
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # Invoice $500 posted.
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Credit note $100 posted (reduces what customer owes).
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="dispute", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # A/R balance should net to $400 — the raw split sum.
+        ar_balance = gb.get_balance("Assets:Accounts Receivable")
+        assert ar_balance == Decimal("400.00")
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2094,6 +2094,407 @@ class TestDeleteCreditNote:
             gb.delete_credit_note(credit_note_id="000001")
 
 
+class TestCreditNotePosting:
+    """Tests for the posting-direction reversal on credit notes.
+
+    Customer credit notes credit A/R (reduce receivable) and
+    debit Income (reverse revenue) — opposite of a normal
+    customer invoice. Vendor credit notes debit A/P (reduce
+    payable) and credit Expense (reverse expense). The XOR
+    trick (effective_is_bill = is_bill ^ is_credit_note) is
+    the implementation; these tests lock the math from the
+    outside.
+    """
+
+    def _setup_customer_credit_note(
+        self, gb, amount="100.00",
+    ) -> str:
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="Out-of-scope work credit",
+            quantity="1", price=amount,
+        )
+        return cn["id"]
+
+    def _setup_vendor_credit_note(
+        self, gb, amount="100.00",
+    ) -> str:
+        gb.create_vendor(name="Office Depot")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="vendor",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Expenses:Office Supplies",
+            description="Defective product",
+            quantity="1", price=amount,
+        )
+        return cn["id"]
+
+    def test_customer_credit_note_post_reverses_ar(self, business_book):
+        """Posting a customer credit note CREDITS A/R (negative
+        movement) — reducing what the customer owes. Compare to
+        a normal customer invoice which DEBITS A/R (positive)."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._setup_customer_credit_note(gb)
+        ar_before = gb.get_balance("Assets:Accounts Receivable")
+        result = gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        assert result["status"] == "posted"
+        assert result["type"] == "credit_note"
+        ar_after = gb.get_balance("Assets:Accounts Receivable")
+        # A/R went DOWN (became more negative or less positive)
+        # by the credit note amount — opposite of an invoice post.
+        assert ar_after - ar_before == Decimal("-100.00")
+        # Income reversed: Income:Sales decreased by 100.
+        # Income natural balance in piecash is negative (credit-
+        # normal), so a debit to Income MAKES the signed balance
+        # LESS NEGATIVE (closer to zero) — net +100 in signed terms.
+        income_balance = gb.get_balance("Income:Sales")
+        # Was 0, now +100 (the debit pushed credit-normal toward 0
+        # and past, into positive signed-balance territory).
+        assert income_balance == Decimal("100.00")
+
+    def test_vendor_credit_note_post_reverses_ap(self, business_book):
+        """Posting a vendor credit note DEBITS A/P (reduces what
+        we owe the vendor) — opposite of a vendor bill which
+        CREDITS A/P (creates payable)."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._setup_vendor_credit_note(gb)
+        ap_before = gb.get_balance("Liabilities:Accounts Payable")
+        result = gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        assert result["status"] == "posted"
+        assert result["type"] == "credit_note"
+        ap_after = gb.get_balance("Liabilities:Accounts Payable")
+        # A/P went UP (less negative, or positive) — reducing
+        # the liability from the company's perspective.
+        assert ap_after - ap_before == Decimal("100.00")
+
+    def test_credit_note_unpost_reverses_post(self, business_book):
+        """Unposting a credit note removes the netting and
+        returns A/R / A/P to its pre-post state. Just like
+        unposting an invoice — the transaction is removed."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._setup_customer_credit_note(gb)
+        ar_before_post = gb.get_balance("Assets:Accounts Receivable")
+        gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        result = gb.unpost_invoice(
+            invoice_id=cn_id, owner_type="customer",
+        )
+        assert result["status"] == "unposted"
+        assert result["type"] == "credit_note"
+        ar_after_unpost = gb.get_balance("Assets:Accounts Receivable")
+        assert ar_after_unpost == ar_before_post
+
+    def test_pay_customer_credit_note_refunds_cash(self, business_book):
+        """``pay_invoice`` on a customer credit note SENDS cash
+        to the customer (refund). Checking goes DOWN, A/R returns
+        from credit balance back toward zero (positive movement)."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._setup_customer_credit_note(gb)
+        gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        checking_before = gb.get_balance("Assets:Checking")
+        ar_before = gb.get_balance("Assets:Accounts Receivable")
+        result = gb.pay_invoice(
+            invoice_id=cn_id,
+            payment_account="Assets:Checking",
+            amount="100.00",
+            owner_type="customer",
+        )
+        assert result["status"] == "paid"
+        assert result["type"] == "credit_note"
+        # Cash left the company (refund).
+        assert gb.get_balance("Assets:Checking") - checking_before == Decimal("-100.00")
+        # A/R movement REVERSED the post: credit went DOWN $100
+        # post, then went UP $100 on refund (net to zero).
+        assert gb.get_balance("Assets:Accounts Receivable") - ar_before == Decimal("100.00")
+
+    def test_pay_vendor_credit_note_receives_cash(self, business_book):
+        """``pay_invoice`` on a vendor credit note RECEIVES cash
+        from the vendor (vendor sent us a refund check). Checking
+        UP, A/P down."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._setup_vendor_credit_note(gb)
+        gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        checking_before = gb.get_balance("Assets:Checking")
+        ap_before = gb.get_balance("Liabilities:Accounts Payable")
+        gb.pay_invoice(
+            invoice_id=cn_id,
+            payment_account="Assets:Checking",
+            amount="100.00",
+            owner_type="vendor",
+        )
+        # Cash arrived.
+        assert gb.get_balance("Assets:Checking") - checking_before == Decimal("100.00")
+        # A/P movement reversed the post.
+        assert gb.get_balance("Liabilities:Accounts Payable") - ap_before == Decimal("-100.00")
+
+
+class TestApplyCreditNote:
+    """Tests for apply_credit_note — the netting tool.
+
+    The headline cases: a posted credit note nets against a
+    posted invoice from the same customer/vendor. Both lots
+    reduce by the applied amount; no cash moves. Validation
+    rejects cross-owner, cross-currency, cross-account, and
+    over-apply attempts.
+    """
+
+    def _setup_pair(
+        self, gb, source_amount="500.00", credit_amount="100.00",
+    ):
+        """Post an invoice and a credit note from the same
+        customer. Returns (invoice_id, credit_note_id)."""
+        gb.create_customer(name="Acme Co")
+        # Source invoice: $500 owed by Acme
+        src = gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id=src["id"],
+            account="Income:Sales",
+            description="Services", quantity="1", price=source_amount,
+        )
+        gb.post_invoice(
+            invoice_id=src["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Credit note: $100 reduction
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id=src["id"],
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="Disputed line",
+            quantity="1", price=credit_amount,
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        return src["id"], cn["id"]
+
+    def test_apply_full_credit_against_larger_invoice(self, business_book):
+        """Credit $100 against $500 invoice: credit fully
+        consumed, invoice's remaining drops to $400, A/R net
+        movement is zero (the credit was already booked at post
+        time; apply just transfers between lots)."""
+        gb = GnuCashBook(str(business_book))
+        src_id, cn_id = self._setup_pair(gb)
+        ar_before = gb.get_balance("Assets:Accounts Receivable")
+        result = gb.apply_credit_note(
+            credit_note_id=cn_id,
+            applies_to_invoice_id=src_id,
+        )
+        assert result["status"] == "applied"
+        assert result["amount_applied"] == "100.00"
+        # Credit note fully settled, invoice has $400 left.
+        assert Decimal(result["credit_note_remaining"]) == Decimal("0")
+        assert Decimal(result["target_remaining"]) == Decimal("400")
+        # A/R net movement: zero. The apply is a lot-rearrangement,
+        # not a balance change. (Net effect: A/R was 500 - 100 =
+        # 400 after both posts; after apply, still 400.)
+        ar_after = gb.get_balance("Assets:Accounts Receivable")
+        assert ar_after == ar_before
+
+    def test_apply_partial_amount(self, business_book):
+        """Explicit amount, smaller than credit_note_remaining,
+        partially applies and leaves both lots open."""
+        gb = GnuCashBook(str(business_book))
+        src_id, cn_id = self._setup_pair(gb)
+        result = gb.apply_credit_note(
+            credit_note_id=cn_id,
+            applies_to_invoice_id=src_id,
+            amount="40.00",
+        )
+        assert result["amount_applied"] == "40.00"
+        assert Decimal(result["credit_note_remaining"]) == Decimal("60")
+        assert Decimal(result["target_remaining"]) == Decimal("460")
+
+    def test_apply_default_amount_is_min_of_remaining(self, business_book):
+        """When amount is omitted, the apply defaults to
+        min(credit_note_remaining, target_remaining)."""
+        gb = GnuCashBook(str(business_book))
+        # Make the credit LARGER than the invoice so the target
+        # is the limiting side.
+        src_id, cn_id = self._setup_pair(
+            gb, source_amount="50.00", credit_amount="200.00",
+        )
+        result = gb.apply_credit_note(
+            credit_note_id=cn_id,
+            applies_to_invoice_id=src_id,
+        )
+        # min(200, 50) = 50 applied; invoice fully cleared,
+        # credit note has $150 remaining.
+        assert result["amount_applied"] == "50.00"
+        assert Decimal(result["target_remaining"]) == Decimal("0")
+        assert Decimal(result["credit_note_remaining"]) == Decimal("150")
+
+    def test_apply_over_max_rejected(self, business_book):
+        """Applying more than the lesser-remaining is rejected
+        with both balances named in the error."""
+        gb = GnuCashBook(str(business_book))
+        src_id, cn_id = self._setup_pair(gb)
+        with pytest.raises(ValueError, match="exceeds the smaller of"):
+            gb.apply_credit_note(
+                credit_note_id=cn_id,
+                applies_to_invoice_id=src_id,
+                amount="200.00",
+            )
+
+    def test_apply_to_unposted_target_rejected(self, business_book):
+        """Target must be posted (no lot to settle otherwise)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # Source invoice unposted
+        src = gb.create_invoice(customer_id="000001")
+        # Credit note posted
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(ValueError, match="not posted"):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=src["id"],
+            )
+
+    def test_apply_unposted_credit_note_rejected(self, business_book):
+        """Credit note must be posted too."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        src = gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id=src["id"],
+            account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=src["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Credit note unposted
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        with pytest.raises(ValueError, match="Credit note.*not posted"):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=src["id"],
+            )
+
+    def test_apply_to_credit_note_rejected(self, business_book):
+        """Target can't itself be a credit note — credits don't
+        net against credits."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn1 = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn1["id"], account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id=cn1["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn2 = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn2["id"], account="Income:Sales",
+            description="x", quantity="1", price="30",
+        )
+        gb.post_invoice(
+            invoice_id=cn2["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(
+            ValueError, match="itself a credit note",
+        ):
+            gb.apply_credit_note(
+                credit_note_id=cn1["id"],
+                applies_to_invoice_id=cn2["id"],
+            )
+
+    def test_apply_cross_owner_rejected(self, business_book):
+        """Credit notes can only net against documents from the
+        same customer/vendor."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_customer(name="Beta Inc")
+        # Beta's invoice
+        beta_inv = gb.create_invoice(customer_id="000002")
+        gb.add_invoice_entry(
+            invoice_id=beta_inv["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=beta_inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Acme's credit note — different owner
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(
+            ValueError, match="same customer/vendor",
+        ):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=beta_inv["id"],
+            )
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2495,6 +2495,171 @@ class TestApplyCreditNote:
             )
 
 
+class TestCreditNotePr87ReviewFollowups:
+    """Tests for the five Copilot PR #87 review findings.
+
+    Each test exercises one validation gap or formatting bug
+    Copilot flagged. They live in their own class so the
+    follow-up boundary is visible in test output and traceable
+    back to the review.
+    """
+
+    def test_resolve_credit_note_suggests_voucher_tool_for_voucher(
+        self, business_book,
+    ):
+        """Comment 1: ``_resolve_credit_note`` error message
+        should suggest ``add_voucher_entry`` / ``delete_voucher``
+        when the found document is a voucher (owner_type=5),
+        not ``add_bill_entry`` / ``delete_bill`` (the legacy
+        binary-dispatch bug)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria")
+        # Create a voucher with the same ID space as customer
+        # invoices — owner_type=5 row, not flagged as credit note.
+        gb.create_voucher(employee_id="000001")
+        # Now try to use add_credit_note_entry on the voucher's
+        # ID. _resolve_credit_note finds it, sees it's NOT a
+        # credit note, and emits the suggestion message.
+        with pytest.raises(
+            ValueError, match="add_voucher_entry / delete_voucher",
+        ):
+            gb.add_credit_note_entry(
+                credit_note_id="000001",
+                account="Expenses:Office Supplies",
+                description="x", quantity="1", price="50",
+            )
+
+    def test_create_credit_note_rejects_credit_note_source(
+        self, business_book,
+    ):
+        """Comment 5: linking a credit note to another credit
+        note is semantically meaningless and would mis-label
+        ``applies_to.type``. Reject with a clear message."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # First credit note (standalone, no source link)
+        cn1 = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        # Try to create a second credit note pointing at the first
+        with pytest.raises(
+            ValueError, match="itself a credit note",
+        ):
+            gb.create_credit_note(
+                owner_id="000001", owner_type="customer",
+                applies_to_invoice_id=cn1["id"],
+            )
+
+    def test_apply_credit_note_rejects_cross_currency_post_account(
+        self, business_book,
+    ):
+        """Comment 2: cross-currency apply isn't supported —
+        when the document currency differs from the post
+        account's commodity, the netting transaction can't
+        cleanly use a single amount. Reject with a clear
+        message that points at the per-currency A/R convention
+        as the fix.
+
+        Setup uses raw piecash to engineer the cross-currency
+        post state directly (EUR/USD price via piecash.Price,
+        EUR customer + EUR credit note posted to USD A/R).
+        The full posting flow validates the cross-currency
+        guard fires at apply time, not at post."""
+        import piecash
+        from datetime import date as date_cls
+        gb = GnuCashBook(str(business_book))
+        # Add EUR + EUR/USD price via raw piecash (same pattern
+        # the multi_currency tests use in test_book.py).
+        with gb.open(readonly=False) as bk:
+            eur = piecash.Commodity(
+                namespace="CURRENCY", mnemonic="EUR",
+                fullname="Euro", fraction=100,
+            )
+            bk.session.add(eur)
+            bk.flush()
+            usd = bk.default_currency
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date_cls(2026, 5, 24),
+                value="1.10",
+                type="last",
+            ))
+            bk.save()
+        gb.create_customer(name="Berlin GmbH", currency="EUR")
+        # Source invoice in EUR posted to USD A/R (cross-currency)
+        src = gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id=src["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=src["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id=src["id"],
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(
+            ValueError, match="Cross-currency apply not supported",
+        ):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=src["id"],
+            )
+
+    def test_apply_quantize_to_zero_rejected(self, business_book):
+        """Comment 3: a sub-quantum apply amount (e.g. "0.001"
+        on a USD account with 0.01 quantum) would round to zero
+        and produce a no-op netting transaction reported as
+        success. Guard rejects with the quantum named so the
+        caller knows the minimum."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # Set up a posted invoice + credit note pair
+        src = gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id=src["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=src["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id=src["id"],
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(
+            ValueError, match="quantizes to zero",
+        ):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=src["id"],
+                amount="0.001",
+            )
+
+
 class TestCreditNoteDisplayPolish:
     """Display rendering for credit notes: list_invoices,
     get_outstanding_invoices, and the dashboard's A/R / A/P

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1799,6 +1799,301 @@ class TestInvoiceToDictCreditNoteKeys:
             assert "applies_to" not in result
 
 
+class TestCreateCreditNote:
+    """Tests for create_credit_note — the user-facing entry
+    point. Validates owner_type gating, applies_to source
+    matching, currency inheritance and currency conflict
+    rejection, and the credit-note flag / applies_to keys in
+    the response.
+    """
+
+    def test_customer_credit_note_basic(self, business_book):
+        """Standalone credit note — no applies_to, customer
+        side. Response surfaces is_credit_note=True and the
+        customer_id key from the underlying create path."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        result = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        assert result["status"] == "created"
+        assert result["customer_id"] == "000001"
+        assert result["is_credit_note"] is True
+        assert "applies_to" not in result
+        # Round-trip via get_invoice confirms the slot was set.
+        full = gb.get_invoice(result["id"], owner_type="customer")
+        assert full["is_credit_note"] is True
+        assert full["type"] == "invoice"  # owner-type-driven; flag is separate
+
+    def test_vendor_credit_note_basic(self, business_book):
+        """Symmetric — vendor side credit note. Response keys
+        use vendor_id."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.create_credit_note(
+            owner_id="000001", owner_type="vendor",
+        )
+        assert result["status"] == "created"
+        assert result["vendor_id"] == "000001"
+        assert result["is_credit_note"] is True
+
+    def test_employee_owner_type_rejected(self, business_book):
+        """Employees explicitly excluded — no GnuCash desktop UI
+        for employee credit notes."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria")
+        with pytest.raises(ValueError, match="not supported for employees"):
+            gb.create_credit_note(
+                owner_id="000001", owner_type="employee",
+            )
+
+    def test_invalid_owner_type_rejected(self, business_book):
+        """Typos / unknown owner types rejected via the standard
+        _parse_owner_type path."""
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Invalid owner_type"):
+            gb.create_credit_note(
+                owner_id="000001", owner_type="custmer",
+            )
+
+    def test_applies_to_link_resolved_in_response(self, business_book):
+        """When applies_to_invoice_id is given and valid, the
+        response includes applies_to={id, type} dict."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        source = gb.create_invoice(customer_id="000001")
+        result = gb.create_credit_note(
+            owner_id="000001",
+            owner_type="customer",
+            applies_to_invoice_id=source["id"],
+        )
+        assert result["applies_to"] == {
+            "id": source["id"], "type": "invoice",
+        }
+        # The link also round-trips through get_invoice.
+        full = gb.get_invoice(result["id"], owner_type="customer")
+        assert full["applies_to"]["id"] == source["id"]
+
+    def test_applies_to_source_not_found(self, business_book):
+        """Source ID that doesn't exist is rejected with a clear
+        error rather than silently creating an orphan link."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        with pytest.raises(ValueError, match="Source.*not found"):
+            gb.create_credit_note(
+                owner_id="000001",
+                owner_type="customer",
+                applies_to_invoice_id="NOPE",
+            )
+
+    def test_applies_to_cross_owner_rejected(self, business_book):
+        """A credit note for customer A pointing at customer B's
+        invoice is wrong bookkeeping — reject with the
+        mismatched IDs named in the error."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_customer(name="Beta Inc")
+        # Acme is 000001; Beta is 000002.
+        beta_invoice = gb.create_invoice(customer_id="000002")
+        with pytest.raises(
+            ValueError, match="belongs to.*not.*000001",
+        ):
+            gb.create_credit_note(
+                owner_id="000001",
+                owner_type="customer",
+                applies_to_invoice_id=beta_invoice["id"],
+            )
+
+    def test_currency_inherited_from_source(self, business_book):
+        """When applies_to is given and currency is omitted, the
+        credit note adopts the source's currency. Important for
+        multi-currency books where issuing a credit note in the
+        wrong currency would create FX confusion."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        # Add EUR to the test book and create a EUR customer.
+        with gb.open(readonly=False) as bk:
+            bk.session.add(
+                piecash.factories.create_currency_from_ISO("EUR")
+            )
+            bk.save()
+        gb.create_customer(name="Berlin GmbH", currency="EUR")
+        source = gb.create_invoice(customer_id="000001")
+        # No explicit currency; should inherit EUR from source.
+        cn = gb.create_credit_note(
+            owner_id="000001",
+            owner_type="customer",
+            applies_to_invoice_id=source["id"],
+        )
+        full = gb.get_invoice(cn["id"], owner_type="customer")
+        assert full["currency"] == "EUR"
+
+    def test_currency_mismatch_rejected(self, business_book):
+        """Explicit currency conflicting with source's is rejected
+        — netting across currencies would create FX adjustments
+        outside GnuCash's tracking."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as bk:
+            bk.session.add(
+                piecash.factories.create_currency_from_ISO("EUR")
+            )
+            bk.save()
+        gb.create_customer(name="Berlin GmbH", currency="EUR")
+        source = gb.create_invoice(customer_id="000001")
+        with pytest.raises(
+            ValueError, match="doesn't match source.*currency",
+        ):
+            gb.create_credit_note(
+                owner_id="000001",
+                owner_type="customer",
+                applies_to_invoice_id=source["id"],
+                currency="USD",
+            )
+
+    def test_custom_credit_note_id_accepted(self, business_book):
+        """Custom IDs (e.g. 'CN-2026-001') override the
+        auto-counter, same as invoices/bills."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        result = gb.create_credit_note(
+            owner_id="000001",
+            owner_type="customer",
+            credit_note_id="CN-2026-001",
+        )
+        assert result["id"] == "CN-2026-001"
+
+
+class TestAddCreditNoteEntry:
+    """Tests for add_credit_note_entry — validates the target
+    is a credit note before delegating to _add_entry. Account
+    type rules mirror the host owner_type."""
+
+    def test_customer_credit_note_accepts_income_entry(self, business_book):
+        """Customer credit note entry → INCOME account
+        (mirrors regular customer invoice)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        result = gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="Out-of-scope work credit",
+            quantity="1", price="500.00",
+        )
+        assert result["status"] == "created"
+        assert result["credit_note_id"] == cn["id"]
+        assert result["total"] == "500.00"
+
+    def test_vendor_credit_note_accepts_expense_entry(self, business_book):
+        """Vendor credit note entry → EXPENSE account (mirrors
+        regular vendor bill)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="vendor",
+        )
+        result = gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Expenses:Office Supplies",
+            description="Defective product return",
+            quantity="1", price="42.00",
+        )
+        assert result["status"] == "created"
+        assert result["credit_note_id"] == cn["id"]
+
+    def test_non_credit_note_rejected_with_helpful_message(self, business_book):
+        """If the caller passes a regular invoice's ID to
+        add_credit_note_entry, fail loud and name the correct
+        tool to use instead. Pre-fix this would silently add
+        an entry to the wrong document type."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")  # regular invoice
+        with pytest.raises(
+            ValueError, match="not a credit note.*add_invoice_entry",
+        ):
+            gb.add_credit_note_entry(
+                credit_note_id="000001",
+                account="Income:Sales",
+                description="Wrong tool",
+                quantity="1", price="100",
+            )
+
+    def test_credit_note_not_found(self, business_book):
+        """Missing ID → 'Credit note not found' (clearer than
+        the generic invoice error)."""
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Credit note not found"):
+            gb.add_credit_note_entry(
+                credit_note_id="NOPE",
+                account="Income:Sales",
+                description="x", quantity="1", price="1",
+            )
+
+    def test_wrong_account_type_rejected(self, business_book):
+        """Account-type validation flows through to _add_entry;
+        EXPENSE on a customer credit note rejected just as on a
+        customer invoice."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        with pytest.raises(ValueError, match="must be INCOME"):
+            gb.add_credit_note_entry(
+                credit_note_id=cn["id"],
+                account="Expenses:Office Supplies",
+                description="Wrong direction",
+                quantity="1", price="100",
+            )
+
+
+class TestDeleteCreditNote:
+    """Tests for delete_credit_note — validates the target is
+    a credit note, blocks deletion of posted credit notes,
+    cleans up entries."""
+
+    def test_delete_unposted_credit_note(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        result = gb.delete_credit_note(credit_note_id=cn["id"])
+        assert result["status"] == "deleted"
+        # type re-keyed to credit_note (base would say 'invoice')
+        assert result["type"] == "credit_note"
+
+    def test_delete_with_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="x", quantity="1", price="100",
+        )
+        result = gb.delete_credit_note(credit_note_id=cn["id"])
+        assert result["status"] == "deleted"
+        assert result["entries_deleted"] == 1
+
+    def test_non_credit_note_rejected(self, business_book):
+        """A regular invoice cannot be deleted via this tool —
+        the validation gate fails loud and names the right tool."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(
+            ValueError, match="not a credit note.*delete_invoice",
+        ):
+            gb.delete_credit_note(credit_note_id="000001")
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1525,6 +1525,280 @@ class TestVoucherLifecycle:
         assert gb.get_balance("Assets:Checking") == Decimal("9950.00")
 
 
+class TestCreditNoteSlotHelpers:
+    """Tests for the credit-note slot infrastructure
+    (``_get_is_credit_note`` / ``_set_is_credit_note`` /
+    ``_get_applies_to_invoice_guid`` /
+    ``_set_applies_to_invoice_guid`` / ``_resolve_applies_to``).
+
+    These are the foundation: every higher-level credit-note tool
+    in subsequent commits relies on them. Lock the contract so
+    the abstraction can't drift silently — particularly the
+    "value=1 / absent=false" convention and the dangling-reference
+    handling on resolve.
+    """
+
+    def _new_invoice(self, gb):
+        """Make a customer + invoice quickly. Returns the invoice
+        ORM object inside a fresh writable session — caller owns
+        the ``with gb.open()`` block."""
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+
+    def test_get_is_credit_note_false_for_unflagged(self, business_book):
+        """A freshly-created invoice has no credit-note slot;
+        the helper returns False (not None, not raise)."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._get_is_credit_note(inv) is False
+
+    def test_set_and_read_is_credit_note(self, business_book):
+        """Round-trip: set True, save, re-open, read back True."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, True)
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._get_is_credit_note(inv) is True
+
+    def test_set_false_clears_slot(self, business_book):
+        """``_set_is_credit_note(False)`` removes the slot entirely
+        (not stores ``0``). Important: the "absent-means-False"
+        convention is what GnuCash desktop reads — storing 0 would
+        be a non-standard state."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, True)
+            book.save()
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, False)
+            book.save()
+        # Slot should be gone — re-read returns False AND the
+        # underlying access raises KeyError on direct lookup.
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._get_is_credit_note(inv) is False
+            with pytest.raises(KeyError):
+                inv[BusinessMixin._CREDIT_NOTE_SLOT_KEY]
+
+    def test_set_false_on_unflagged_is_idempotent(self, business_book):
+        """Clearing a slot that was never set must not raise.
+        Defensive — the higher-level ``delete_credit_note`` path
+        could conceivably hit this case after partial state."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            # Should not raise.
+            BusinessMixin._set_is_credit_note(inv, False)
+
+    def test_applies_to_guid_returns_none_when_unset(self, business_book):
+        """A fresh credit note (no link to source) returns None
+        from the GUID accessor, not KeyError."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._get_applies_to_invoice_guid(inv) is None
+
+    def test_set_and_read_applies_to_guid(self, business_book):
+        """Round-trip: store a 32-char GUID, read back the same
+        string. The namespaced slot key (``gnc-mcp/applies-to-
+        invoice``) uses ``/`` which creates a sub-slot in GnuCash's
+        KVP store — verifying the round-trip confirms the
+        sub-slot path doesn't lose data."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        source_guid = "0" * 32  # Real shape, but invalid as a lookup
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_applies_to_invoice_guid(inv, source_guid)
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._get_applies_to_invoice_guid(inv) == source_guid
+
+    def test_resolve_applies_to_returns_id_and_type(self, business_book):
+        """When the link points at a real invoice, resolve returns
+        the human-readable ``{id, type}`` pair."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        # Source invoice (the one being credited)
+        source = gb.create_invoice(customer_id="000001")
+        # Credit note (links back to source)
+        credit = gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            cn = book.session.query(Invoice).filter_by(
+                id=credit["id"],
+            ).first()
+            BusinessMixin._set_is_credit_note(cn, True)
+            BusinessMixin._set_applies_to_invoice_guid(cn, source["guid"])
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            cn = book.session.query(Invoice).filter_by(
+                id=credit["id"],
+            ).first()
+            resolved = BusinessMixin._resolve_applies_to(book, cn)
+            assert resolved == {"id": source["id"], "type": "invoice"}
+
+    def test_resolve_applies_to_returns_none_for_dangling_reference(
+        self, business_book,
+    ):
+        """When the linked source GUID doesn't exist (e.g. the
+        source was deleted after the credit note was created),
+        resolve returns None rather than crashing the response.
+        Dangling references shouldn't break ``get_invoice``."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_applies_to_invoice_guid(
+                inv, "deadbeef" * 4,  # 32 chars, won't match any row
+            )
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._resolve_applies_to(book, inv) is None
+
+    def test_resolve_applies_to_returns_none_when_no_link(
+        self, business_book,
+    ):
+        """When the credit-note flag is set but no source link is
+        stored, resolve returns None (a credit note that floats
+        without explicit source is valid — the bookkeeper might
+        attach it via Process Payment netting later)."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        self._new_invoice(gb)
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, True)
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert BusinessMixin._resolve_applies_to(book, inv) is None
+
+
+class TestInvoiceToDictCreditNoteKeys:
+    """The response-shape contract: credit-note keys appear only
+    when the credit-note flag is set on the invoice.
+
+    Normal invoices/bills/vouchers must produce byte-identical
+    output to pre-v1.3 — verified by inspecting the absence of
+    the new keys on unflagged docs. Flagged docs get
+    ``is_credit_note: True``, and ``applies_to: {...}`` when the
+    caller threaded a resolved dict.
+    """
+
+    def test_normal_invoice_omits_credit_note_keys(self, business_book):
+        """Pre-v1.3 contract — a normal invoice produces a dict
+        without ``is_credit_note`` or ``applies_to`` keys."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            result = BusinessMixin._invoice_to_dict(inv)
+            assert "is_credit_note" not in result
+            assert "applies_to" not in result
+
+    def test_credit_note_flag_included_when_set(self, business_book):
+        """``is_credit_note: True`` appears when the slot is set."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, True)
+            book.save()
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            result = BusinessMixin._invoice_to_dict(inv)
+            assert result["is_credit_note"] is True
+            # applies_to absent when caller didn't pass it.
+            assert "applies_to" not in result
+
+    def test_applies_to_threaded_when_flag_and_kwarg_both_set(
+        self, business_book,
+    ):
+        """When both the credit-note flag AND the caller-resolved
+        applies_to are present, both keys appear in the dict."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            BusinessMixin._set_is_credit_note(inv, True)
+            book.save()
+        applies_to = {"id": "000028", "type": "invoice"}
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            result = BusinessMixin._invoice_to_dict(
+                inv, applies_to=applies_to,
+            )
+            assert result["is_credit_note"] is True
+            assert result["applies_to"] == applies_to
+
+    def test_applies_to_dropped_when_flag_absent(self, business_book):
+        """Defensive — even if a caller mistakenly passes
+        ``applies_to`` for a non-credit-note invoice, the dict
+        shouldn't include it. The credit-note flag is the gate;
+        no flag means no credit-note keys at all."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")
+        applies_to = {"id": "000028", "type": "invoice"}
+        with gb.open(readonly=True) as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            result = BusinessMixin._invoice_to_dict(
+                inv, applies_to=applies_to,
+            )
+            assert "is_credit_note" not in result
+            assert "applies_to" not in result
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,11 +80,12 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 91 — 88
-        post-module-restructure + 3 voucher tools added in v1.3
-        (create_voucher, add_voucher_entry, delete_voucher)."""
+        """Total tools across all sub-modules should be 94 —
+        88 post-module-restructure + 3 voucher tools + 3 credit-
+        note tools (create_credit_note, add_credit_note_entry,
+        delete_credit_note) added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 91
+        assert total == 94
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -228,9 +229,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 91 tools (88 +3 vouchers)."""
+        """--modules=all should keep all 94 tools (88 + 3 vouchers + 3 credit notes)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 91
+        assert len(self._tool_names()) == 94
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -262,12 +263,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 91
+        assert len(self._tool_names()) == 94
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 91 tools."""
+        """'all' mixed with other modules should keep all 94 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 91
+        assert len(self._tool_names()) == 94
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -228,7 +228,7 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 87 tools."""
+        """--modules=all should keep all 91 tools (88 +3 vouchers)."""
         _apply_module_filter("all")
         assert len(self._tool_names()) == 91
 
@@ -265,7 +265,7 @@ class TestApplyModuleFilter:
         assert len(self._tool_names()) == 91
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 87 tools."""
+        """'all' mixed with other modules should keep all 91 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
         assert len(self._tool_names()) == 91
 
@@ -555,3 +555,35 @@ class TestOwnerTypeGating:
         _LOADED_MODULES.update({"core", "freelancer"})
         with pytest.raises(ValueError, match="requires the Business module"):
             _gate_owner_type("vendor")
+
+    def test_business_absent_rejects_explicit_employee(self):
+        """Symmetric with the vendor rejection — employee gating
+        was added with vouchers (v1.3) and needs the same
+        guardrail. Without business, owner_type='employee' raises
+        with the Business-module-required message. (Copilot PR
+        #86 review found this coverage gap.)"""
+        import pytest
+        from gnucash_mcp.server import _LOADED_MODULES
+        from gnucash_mcp.tools._helpers import _gate_owner_type
+
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update({"core", "freelancer"})
+        with pytest.raises(ValueError, match="requires the Business module"):
+            _gate_owner_type("employee")
+
+    def test_business_absent_rejects_typo(self):
+        """Without business, a typo like 'venddor' must fail fast
+        — pre-fix the gate silently coerced unknown strings to
+        'customer', masking the typo behind a confusing "invoice
+        not found" downstream error. The gate now rejects anything
+        outside {None, 'customer'} (or the two business-gated
+        names which raise their own messages). (Copilot PR #86
+        review.)"""
+        import pytest
+        from gnucash_mcp.server import _LOADED_MODULES
+        from gnucash_mcp.tools._helpers import _gate_owner_type
+
+        _LOADED_MODULES.clear()
+        _LOADED_MODULES.update({"core", "freelancer"})
+        with pytest.raises(ValueError, match="Invalid owner_type"):
+            _gate_owner_type("venddor")

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,12 +80,12 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 94 —
-        88 post-module-restructure + 3 voucher tools + 3 credit-
+        """Total tools across all sub-modules should be 95 —
+        88 post-module-restructure + 3 voucher tools + 4 credit-
         note tools (create_credit_note, add_credit_note_entry,
-        delete_credit_note) added in v1.3."""
+        delete_credit_note, apply_credit_note) added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 94
+        assert total == 95
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -229,9 +229,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 94 tools (88 + 3 vouchers + 3 credit notes)."""
+        """--modules=all should keep all 95 tools (88 + 3 vouchers + 4 credit notes)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 94
+        assert len(self._tool_names()) == 95
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -263,12 +263,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 94
+        assert len(self._tool_names()) == 95
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 94 tools."""
+        """'all' mixed with other modules should keep all 95 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 94
+        assert len(self._tool_names()) == 95
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

Second of four Stage 3 headline features. Adds customer and
vendor credit notes — the audit-trail-preserving way to reverse
part or all of a posted invoice without rewriting history. The
posting direction reverses at post time (XOR over is_bill +
is_credit_note); a new ``apply_credit_note`` tool nets posted
credit notes against posted invoices/bills from the same owner
without moving cash.

**Five commits, themed:**

1. **Copilot PR #86 follow-up fixes** (commit 0, ``306852e``) —
   the six actionable findings from Copilot's post-merge review:
   ``_gate_owner_type`` fails fast on typos instead of silently
   coercing; new test for ``_gate_owner_type('employee')``
   rejection; two stale "all 87 tools" docstrings refreshed; a
   ``_doc_label_for(owner_type)`` helper replaces the binary
   "Bill if is_bill else Invoice" pattern that mislabeled
   vouchers as bills; "Invoice/bill not found" → "Document not
   found" before the lookup tells us which type.
2. **Slot infrastructure + conventions** (``37b4aab``) — slot
   helpers for ``credit-note`` (GnuCash native) and ``gnc-mcp/
   applies-to-invoice`` (our namespaced linkage); ``_slot_value_
   str`` hoisted to ``_base.py`` so business and admin both pull
   from the shared utility; ``_invoice_to_dict`` extended to
   surface ``is_credit_note`` and ``applies_to`` keys when set;
   CLAUDE.md documents the bare-vs-namespaced slot key principle
3. **Create / add entry / delete** (``d3c5d39``) — three new
   tools (``create_credit_note``, ``add_credit_note_entry``,
   ``delete_credit_note``) with explicit ``is-a-credit-note``
   validation. Employee credit notes deliberately excluded
   (GnuCash desktop has no UI for them — supporting them at
   the MCP layer would create documents desktop users can't
   view). Source linking validates customer/vendor + currency
   match against the source invoice.
4. **Posting reversal + apply netting** (``2a8a6b9``) — XOR
   sign flip in ``post_invoice`` / ``pay_invoice`` so customer
   credit notes post like vendor bills and vice versa. New
   ``apply_credit_note`` tool books a two-split netting
   transaction on the shared A/R or A/P account (no cash
   moves) — GnuCash desktop's "Process Payment with both
   checked" workflow factored into a dedicated LLM-facing tool.
   Audit log polymorphism handler swaps entity_type for
   credit-note responses.
5. **Display polish** (``3650771``) — ``(CN)`` tags in
   ``list_invoices`` / ``get_outstanding_invoices``; "credit
   available" replaces "X days past due" in the action column
   for credit notes; ``is_credit_note`` surfaces in verbose
   output. Dashboard A/R / A/P totals already netted credit
   notes correctly (raw balance arithmetic does the right
   thing); locked with a regression test.

**Tool count:** 95 (was 91; +4 credit-note tools).

## Test plan

- [x] 1,191 unit tests pass (was 1,143 pre-branch; +48 new
  across TestCreditNoteSlotHelpers (9),
  TestInvoiceToDictCreditNoteKeys (4), TestCreateCreditNote (9),
  TestAddCreditNoteEntry (5), TestDeleteCreditNote (3),
  TestCreditNotePosting (5), TestApplyCreditNote (8),
  TestCreditNoteDisplayPolish (4), plus +1 ownertype gating
  test for the Copilot follow-up)
- [x] All existing 240 business tests still pass (XOR sign
  flip preserves customer/vendor invoice/bill behavior)
- [x] Live demo against Alex Chen-Morales: issue a credit
  note against an existing invoice, apply it, verify A/R
  nets to the expected figure
- [x] Bookkeeper review (deferred — Steve will run separately)