### PR TITLE
feat(business): jobs — project-level grouping over invoices/bills (Stage 3 #3)

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -293,9 +293,15 @@ class BusinessMixin:
         pair. Picks the right table to query based on owner_type.
 
         ``invoices.owner_guid`` is a generic FK — the row points at
-        the customer/vendor/employee table depending on
-        ``owner_type``. Centralizing the picker keeps the three-way
+        the customer/vendor/employee/job table depending on
+        ``owner_type``. Centralizing the picker keeps the four-way
         dispatch out of every callsite that needs the owner's name.
+
+        For owner_type=3 (Job), the helper chases through the Job
+        to return the underlying customer/vendor — that's the
+        counterparty a bookkeeper cares about. Callers that need
+        the Job itself (e.g. to surface ``job: {id, name}``)
+        should query Job directly via ``_find_job_by_guid``.
         """
         if owner_type == 2:
             return BusinessMixin._find_customer_by_guid(book, guid)
@@ -303,6 +309,13 @@ class BusinessMixin:
             return BusinessMixin._find_vendor_by_guid(book, guid)
         if owner_type == 5:
             return BusinessMixin._find_employee_by_guid(book, guid)
+        if owner_type == 3:
+            job = BusinessMixin._find_job_by_guid(book, guid)
+            if job is None:
+                return None
+            return BusinessMixin._find_invoice_owner_by_guid(
+                book, job.owner_type, job.owner_guid,
+            )
         return None
 
     # Path for the auto-created realized-FX-gain/loss income account.
@@ -989,6 +1002,7 @@ class BusinessMixin:
         entries=None,
         owner_name: str | None = None,
         applies_to: dict | None = None,
+        job: dict | None = None,
     ) -> dict:
         """Convert a piecash Invoice to a serializable dict.
 
@@ -1001,27 +1015,55 @@ class BusinessMixin:
 
         Credit-note keys (``is_credit_note``, ``applies_to``) are
         emitted only when set, so normal invoices/bills/vouchers
-        get the same shape they had before v1.3. ``is_credit_note``
-        is auto-detected from the invoice's slot; ``applies_to``
-        must be resolved by the caller (the static-method shape
-        means we can't query the source invoice here, same
-        constraint as ``owner_name``).
+        get the same shape they had before v1.3.
+
+        Job linkage (``job`` field) is emitted only when the
+        invoice is grouped under a Job (owner_type=3). The
+        ``type`` field stays semantic (invoice/bill) — for
+        job-attached invoices we look through the Job to its
+        underlying customer/vendor to decide whether this is a
+        customer invoice or vendor bill. From the bookkeeper's
+        perspective, "Berlin Digital's invoice under the API
+        Rewrite job" is still an invoice; the job is grouping
+        metadata.
 
         Args:
             invoice: piecash Invoice object.
             entries: Optional list of entry dicts. If ``None``, entries
                 are not included.
             owner_name: Resolved customer/vendor/employee name.
+                For job-attached invoices, this is the underlying
+                customer/vendor name (the job's owner), resolved
+                by the caller through ``_find_invoice_owner_by_guid``
+                which chases owner_type=3 through to the real owner.
             applies_to: For credit notes only, the ``{id, type}`` dict
-                naming the source invoice. The caller resolves this
-                via ``_resolve_applies_to(book, invoice)``.
+                naming the source invoice.
+            job: For job-attached invoices only, the ``{id, name}``
+                dict naming the grouping job. Caller resolves via
+                ``_find_job_by_guid(book, invoice.owner_guid)``
+                when ``invoice.owner_type == 3``.
         """
+        # Type resolution: owner_type 2/4/5 maps directly. For
+        # owner_type=3 (Job), the semantic type follows the job's
+        # underlying owner — customer-job → "invoice", vendor-job
+        # → "bill". The ``job`` kwarg carries that resolution from
+        # the caller (we can't query the session from a staticmethod).
+        if invoice.owner_type == 3 and job is not None:
+            # The job dict carries 'owner_type' as a string —
+            # 'customer' or 'vendor' — from the caller's lookup.
+            type_field = (
+                "invoice" if job.get("owner_type") == "customer"
+                else "bill"
+            )
+        else:
+            type_field = BusinessMixin._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                invoice.owner_type, "invoice",
+            )
+
         result = {
             "guid": invoice.guid,
             "id": invoice.id,
-            "type": BusinessMixin._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                invoice.owner_type, "invoice"
-            ),
+            "type": type_field,
             "owner_name": owner_name,
             "date_opened": (
                 str(_safe_invoice_date(invoice, "date_opened").date())
@@ -1045,6 +1087,12 @@ class BusinessMixin:
             result["is_credit_note"] = True
             if applies_to:
                 result["applies_to"] = applies_to
+        # Job link present iff caller threaded a job dict. The
+        # ``id`` and ``name`` are the surface a bookkeeper wants;
+        # ``owner_type`` lives on the parent caller's
+        # ``_job_to_dict`` output if they need it.
+        if job is not None:
+            result["job"] = {"id": job["id"], "name": job["name"]}
         if entries is not None:
             result["entries"] = entries
         return result
@@ -2280,6 +2328,7 @@ class BusinessMixin:
         term: str | None = None,
         doc_id: str | None = None,
         extra_slots: dict | None = None,
+        job_id: str | None = None,
     ) -> dict:
         """Shared create path for customer invoice and vendor bill.
 
@@ -2327,6 +2376,54 @@ class BusinessMixin:
                 raise ValueError(
                     f"{config['owner_label']} not found: {owner_id}"
                 )
+
+            # Job linkage: when ``job_id`` is given, the invoice
+            # is grouped under a Job. The job must (a) exist,
+            # (b) belong to the same customer/vendor the caller
+            # named, and (c) match the owner_type (customer-
+            # invoice → customer-job; vendor-bill → vendor-job).
+            # On success, we override the insert's owner_type to
+            # 3 (Job) and owner_guid to job.guid — GnuCash's
+            # polymorphic owner_guid encoding. The customer/
+            # vendor relationship is preserved indirectly: the
+            # Job row itself carries the underlying owner.
+            job_obj = None
+            if job_id:
+                if owner_type == 5:
+                    raise ValueError(
+                        "Employee vouchers cannot be grouped under "
+                        "a job — piecash's job model is "
+                        "customer/vendor only."
+                    )
+                job_obj = self._find_job(book, job_id)
+                if not job_obj:
+                    raise ValueError(f"Job not found: {job_id}")
+                if job_obj.owner_type != owner_type:
+                    expected = (
+                        "customer" if owner_type == 2 else "vendor"
+                    )
+                    got = (
+                        "customer" if job_obj.owner_type == 2
+                        else "vendor"
+                    )
+                    raise ValueError(
+                        f"Job {job_id!r} is a {got} job; this "
+                        f"is a {expected} document. Customer "
+                        f"invoices can only be grouped under "
+                        f"customer jobs, vendor bills under "
+                        f"vendor jobs."
+                    )
+                if job_obj.owner_guid != owner.guid:
+                    job_owner = self._find_invoice_owner_by_guid(
+                        book, job_obj.owner_type, job_obj.owner_guid,
+                    )
+                    raise ValueError(
+                        f"Job {job_id!r} belongs to "
+                        f"{(job_owner.id if job_owner else '?')!r}, "
+                        f"not {owner_id!r}. The job and the "
+                        f"document must reference the same "
+                        f"customer/vendor."
+                    )
 
             if currency:
                 currency_obj = None
@@ -2433,8 +2530,14 @@ class BusinessMixin:
                     notes=notes,
                     active=1,
                     currency=currency_guid,
-                    owner_type=owner_type,
-                    owner_guid=owner.guid,
+                    # When linked to a job, the invoice's
+                    # polymorphic owner pointer routes to the
+                    # Job row (owner_type=3) — the job carries
+                    # the underlying customer/vendor reference.
+                    owner_type=3 if job_obj else owner_type,
+                    owner_guid=(
+                        job_obj.guid if job_obj else owner.guid
+                    ),
                     terms=term_guid,
                     billing_id="",
                     post_txn=None,
@@ -2482,6 +2585,7 @@ class BusinessMixin:
         currency: str | None = None,
         term: str | None = None,
         invoice_id: str | None = None,
+        job_id: str | None = None,
     ) -> dict:
         """Create a customer invoice.
 
@@ -2496,9 +2600,19 @@ class BusinessMixin:
             term: Billterm name (e.g., 'Net 30'). Optional.
             invoice_id: Custom invoice number. If omitted, auto-generates
                 from the book's invoice counter.
+            job_id: Optional Job ID to group this invoice under.
+                The job must belong to the same customer and be
+                a customer-job (created with owner_type='customer').
+                When set, the invoice's owner_type becomes 3 (Job)
+                with owner_guid pointing at the Job, per GnuCash's
+                polymorphic owner encoding; the customer
+                relationship is preserved indirectly through the
+                Job row.
 
         Returns:
-            Dict with guid, id, customer_id, status.
+            Dict with guid, id, customer_id, status (plus a
+            ``job: {id, name}`` field surfaces in ``get_invoice``
+            responses when linked).
         """
         return self._create_business_document(
             owner_type=2,
@@ -2508,6 +2622,7 @@ class BusinessMixin:
             currency=currency,
             term=term,
             doc_id=invoice_id,
+            job_id=job_id,
         )
 
     def create_bill(
@@ -2518,6 +2633,7 @@ class BusinessMixin:
         currency: str | None = None,
         term: str | None = None,
         bill_id: str | None = None,
+        job_id: str | None = None,
     ) -> dict:
         """Create a vendor bill.
 
@@ -2532,6 +2648,10 @@ class BusinessMixin:
             term: Billterm name (e.g., 'Net 30'). Optional.
             bill_id: Custom bill number. If omitted, auto-generates
                 from the book's bill counter.
+            job_id: Optional Job ID to group this bill under. The
+                job must belong to the same vendor and be a
+                vendor-job. Same polymorphic routing as
+                ``create_invoice``'s ``job_id``.
 
         Returns:
             Dict with guid, id, vendor_id, status.
@@ -2544,6 +2664,7 @@ class BusinessMixin:
             currency=currency,
             term=term,
             doc_id=bill_id,
+            job_id=job_id,
         )
 
     def create_voucher(
@@ -3263,6 +3384,7 @@ class BusinessMixin:
         status: str | None = None,
         compact: bool = True,
         limit: int | None = None,
+        job_id: str | None = None,
     ) -> list[dict] | str:
         """List invoices and/or bills.
 
@@ -3273,6 +3395,13 @@ class BusinessMixin:
             limit: Maximum invoices to return. Defaults to 50, capped at
                    250 server-side. Pre-fix this method dumped every
                    invoice in the book regardless of caller intent.
+            job_id: Filter to invoices grouped under a specific job
+                — useful for the per-engagement listing pattern
+                (e.g., "what invoices are part of the API Rewrite
+                project?"). Job-attached invoices have
+                ``owner_type=3`` with ``owner_guid`` pointing at
+                the job; this filter resolves the job and matches
+                against its GUID.
 
         Returns:
             Compact string (with optional truncation notice) or list of
@@ -3284,7 +3413,32 @@ class BusinessMixin:
         with self.open() as book:
             query = book.session.query(Invoice)
 
-            if ot is not None:
+            # job_id filter trumps owner_type for the SQL query —
+            # job-attached invoices have owner_type=3 regardless
+            # of whether the underlying counterparty is customer
+            # or vendor. We rewrite the filter to "owner_guid =
+            # <job.guid>" and skip the owner_type filter (or
+            # cross-check it against the job's underlying type
+            # if the caller passed both).
+            if job_id:
+                job = self._find_job(book, job_id)
+                if not job:
+                    raise ValueError(f"Job not found: {job_id}")
+                if ot is not None and ot != job.owner_type:
+                    expected = (
+                        "customer" if job.owner_type == 2 else "vendor"
+                    )
+                    raise ValueError(
+                        f"Job {job_id!r} is a {expected} job; "
+                        f"owner_type={owner_type!r} doesn't match. "
+                        f"Drop the owner_type filter or pass a "
+                        f"matching job_id."
+                    )
+                query = query.filter(
+                    Invoice.owner_type == 3,
+                    Invoice.owner_guid == job.guid,
+                )
+            elif ot is not None:
                 query = query.filter(Invoice.owner_type == ot)
 
             invoices = query.order_by(Invoice.date_opened.desc()).all()
@@ -3316,9 +3470,22 @@ class BusinessMixin:
                     o = self._find_invoice_owner_by_guid(
                         book, i.owner_type, i.owner_guid,
                     )
+                    # Job linkage threads through to the response
+                    # so the verbose listing shows ``job: {id,
+                    # name}`` on grouped invoices — important for
+                    # LLMs / dashboards filtering by job.
+                    j_dict = None
+                    if i.owner_type == 3:
+                        j_obj = self._find_job_by_guid(
+                            book, i.owner_guid,
+                        )
+                        if j_obj is not None:
+                            j_dict = self._job_to_dict(j_obj)
                     results.append(
                         self._invoice_to_dict(
-                            i, owner_name=o.name if o else None,
+                            i,
+                            owner_name=o.name if o else None,
+                            job=j_dict,
                         )
                     )
                 # Envelope shape matches ``get_unreconciled_splits`` and
@@ -3414,11 +3581,25 @@ class BusinessMixin:
             # flag is also set, so normal invoices/bills get the
             # same shape they did pre-v1.3.
             applies_to = self._resolve_applies_to(book, inv)
+            # Resolve job linkage for job-attached invoices
+            # (owner_type=3 means owner_guid points at a Job).
+            # _invoice_to_dict uses the dict to compute the
+            # type field (invoice vs bill based on the job's
+            # underlying owner) AND to emit the surface
+            # ``job: {id, name}`` field.
+            job_dict = None
+            if inv.owner_type == 3:
+                job_obj = self._find_job_by_guid(
+                    book, inv.owner_guid,
+                )
+                if job_obj is not None:
+                    job_dict = self._job_to_dict(job_obj)
             result = self._invoice_to_dict(
                 inv,
                 entries=entries,
                 owner_name=owner_name,
                 applies_to=applies_to,
+                job=job_dict,
             )
             result["total"] = str(total)
             return result

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -203,6 +203,12 @@ def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
             owner = f"{owner} (CN)"
         elif r.get("type") == "bill":
             owner = f"{owner} (BILL)"
+        # Job annotation — appended after any (CN)/(BILL) tag
+        # so a row that's BOTH (e.g. a vendor credit note on a
+        # vendor job) reads as ``Vendor (BILL) (job:JOB-001)``.
+        job_id = r.get("job_id")
+        if job_id:
+            owner = f"{owner} (job:{job_id})"
         ccy = r.get("currency") or ""
         # Strip trailing zeros for compact display: "4200.00" → "4,200".
         amount_dec = Decimal(r.get("amount_due") or "0")
@@ -1148,8 +1154,15 @@ class BusinessMixin:
         # consumers can grep for the tag to filter (e.g. "CN" to
         # find every credit note in a list). The suffix preserves
         # the owner-side info that a bare "CN" tag would hide.
+        # For job-attached invoices (owner_type=3), the tag
+        # follows the underlying side (INV/BILL via the job's
+        # owner_type) rather than a generic "JOB" tag — what
+        # matters for filtering is "is this a customer invoice
+        # or a vendor bill", with the job link a separate
+        # annotation appended via the owner column.
+        effective_ot = self._effective_owner_type(book, invoice)
         inv_type = self._OWNER_TYPE_TO_COMPACT_TAG.get(
-            invoice.owner_type, "INV"
+            effective_ot, "INV"
         )
         if self._get_is_credit_note(invoice):
             inv_type = f"{inv_type} (CN)"
@@ -1159,13 +1172,25 @@ class BusinessMixin:
         )
         status = "posted" if _is_invoice_posted(invoice) else "open"
 
-        # Owner lookup — customers/vendors/employees share the
-        # same ``owner_guid`` namespace shape across three tables.
-        # ``_find_invoice_owner_by_guid`` dispatches on owner_type.
+        # Owner lookup — customers/vendors/employees/jobs share
+        # the same ``owner_guid`` namespace shape across four
+        # tables. ``_find_invoice_owner_by_guid`` dispatches on
+        # owner_type and chases owner_type=3 through the Job to
+        # the underlying customer/vendor.
         owner = self._find_invoice_owner_by_guid(
             book, invoice.owner_type, invoice.owner_guid,
         )
         owner_name = owner.name if owner else "?"
+
+        # Job annotation: append ``(job:XXXXXX)`` to the owner
+        # column so a bookkeeper scanning a long invoice list
+        # can immediately see which project each row belongs to.
+        # Using the job's ID (not name) keeps the column narrow
+        # — the name surfaces in ``get_job(job_id)`` if needed.
+        if invoice.owner_type == 3:
+            job = self._find_job_by_guid(book, invoice.owner_guid)
+            if job is not None:
+                owner_name = f"{owner_name} (job:{job.id})"
 
         # Total: sum of (quantity * price) across entries. Falls back
         # to "?" when entries can't be loaded — keeps the row legible
@@ -5688,11 +5713,25 @@ class BusinessMixin:
                 # the compact formatter can distinguish. The
                 # amount-due is the unsettled credit balance —
                 # what's still available to apply or refund.
+                # For job-attached docs (owner_type=3), the
+                # semantic type comes from the effective
+                # owner_type (chases through the Job to the
+                # underlying customer/vendor); we also surface
+                # a job_id so the formatter can annotate the
+                # row.
                 is_credit_note = self._get_is_credit_note(inv)
+                effective_ot = self._effective_owner_type(
+                    book, inv,
+                )
+                job_id_field = None
+                if inv.owner_type == 3:
+                    j = self._find_job_by_guid(book, inv.owner_guid)
+                    if j is not None:
+                        job_id_field = j.id
                 results.append({
                     "id": inv.id,
                     "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                        inv.owner_type, "invoice"
+                        effective_ot, "invoice"
                     ),
                     "is_credit_note": is_credit_note,
                     "owner_name": owner_name,
@@ -5708,6 +5747,7 @@ class BusinessMixin:
                     "original_amount": str(grand_total),
                     "amount_paid": str(amount_paid),
                     "amount_due": str(abs(balance)),
+                    "job_id": job_id_field,
                 })
 
             # Sort: most overdue first (largest days_past_due), so the

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -204,8 +204,13 @@ def _format_outstanding_invoices_compact(rows: list[dict]) -> str:
         elif r.get("type") == "bill":
             owner = f"{owner} (BILL)"
         # Job annotation — appended after any (CN)/(BILL) tag
-        # so a row that's BOTH (e.g. a vendor credit note on a
-        # vendor job) reads as ``Vendor (BILL) (job:JOB-001)``.
+        # so a row that's both a credit note AND job-attached
+        # reads as ``Customer (CN) (job:JOB-001)``, or a plain
+        # vendor bill in a job as ``Vendor (BILL) (job:JOB-001)``.
+        # ``(CN)`` and ``(BILL)`` are mutually exclusive per the
+        # if/elif above — credit notes are flagged via (CN)
+        # regardless of side. (Copilot PR #88 review caught the
+        # original comment showing them together.)
         job_id = r.get("job_id")
         if job_id:
             owner = f"{owner} (job:{job_id})"
@@ -1160,7 +1165,14 @@ class BusinessMixin:
         # matters for filtering is "is this a customer invoice
         # or a vendor bill", with the job link a separate
         # annotation appended via the owner column.
-        effective_ot = self._effective_owner_type(book, invoice)
+        #
+        # Single Job lookup via ``_resolve_owner_type_and_job``
+        # — both the type tag and the job annotation come from
+        # the same Job row. (Copilot PR #88 review flagged the
+        # original two-call pattern as redundant.)
+        effective_ot, job = self._resolve_owner_type_and_job(
+            book, invoice,
+        )
         inv_type = self._OWNER_TYPE_TO_COMPACT_TAG.get(
             effective_ot, "INV"
         )
@@ -1187,10 +1199,8 @@ class BusinessMixin:
         # can immediately see which project each row belongs to.
         # Using the job's ID (not name) keeps the column narrow
         # — the name surfaces in ``get_job(job_id)`` if needed.
-        if invoice.owner_type == 3:
-            job = self._find_job_by_guid(book, invoice.owner_guid)
-            if job is not None:
-                owner_name = f"{owner_name} (job:{job.id})"
+        if job is not None:
+            owner_name = f"{owner_name} (job:{job.id})"
 
         # Total: sum of (quantity * price) across entries. Falls back
         # to "?" when entries can't be loaded — keeps the row legible
@@ -2284,6 +2294,11 @@ class BusinessMixin:
         raw owner_type if the job lookup fails (dangling
         owner_guid). Same defensive shape as
         ``_find_invoice_owner_by_guid``.
+
+        For callers that also need the Job itself (e.g. to
+        surface a (job:JOB-X) annotation), use
+        ``_resolve_owner_type_and_job`` instead — single Job
+        query, both outputs.
         """
         if invoice.owner_type != 3:
             return invoice.owner_type
@@ -2291,6 +2306,31 @@ class BusinessMixin:
         if job is None:
             return invoice.owner_type
         return job.owner_type
+
+    @staticmethod
+    def _resolve_owner_type_and_job(book, invoice):
+        """Single-query variant of ``_effective_owner_type``
+        that also returns the Job object when one is linked.
+
+        Returns ``(effective_owner_type, job_or_none)``. For
+        direct documents (owner_type 2/4/5) the Job is None.
+        For job-attached docs (owner_type=3), both are derived
+        from a single Job lookup — avoids the redundant query
+        pattern Copilot flagged on PR #88 where callsites in
+        ``_invoice_to_compact_line`` and
+        ``get_outstanding_invoices`` were doing
+        ``_effective_owner_type`` AND ``_find_job_by_guid``
+        side-by-side (each chasing the same Job row).
+
+        Defensive fallback to (raw_owner_type, None) on dangling
+        owner_guid — same shape as the original helper.
+        """
+        if invoice.owner_type != 3:
+            return invoice.owner_type, None
+        job = BusinessMixin._find_job_by_guid(book, invoice.owner_guid)
+        if job is None:
+            return invoice.owner_type, None
+        return job.owner_type, job
 
     # Human-readable document label for use in error messages,
     # status returns, and audit log entries. Title-case canonical
@@ -3281,13 +3321,11 @@ class BusinessMixin:
             # so reaching here with the wrong side means a true
             # caller mistake (customer-id passed to
             # add_bill_entry, e.g.).
-            effective_owner_type = inv.owner_type
-            if inv.owner_type == 3:
-                job_for_inv = self._find_job_by_guid(
-                    book, inv.owner_guid,
-                )
-                if job_for_inv is not None:
-                    effective_owner_type = job_for_inv.owner_type
+            # Centralize via _effective_owner_type — Copilot PR
+            # #88 flagged this as duplicate logic with the helper.
+            effective_owner_type = self._effective_owner_type(
+                book, inv,
+            )
             if effective_owner_type != owner_type:
                 raise ValueError(
                     f"'{doc_id}' is a {cfg['twin_label']}, not a "
@@ -3564,20 +3602,33 @@ class BusinessMixin:
                 # Verbose path: resolve owner per invoice so each dict
                 # carries the readable name. ``owner_guid`` was dropped
                 # from the dict shape in Phase 3C.
+                #
+                # Job preload — avoids the N+1 query pattern Copilot
+                # flagged on PR #88. Single query for every Job
+                # referenced by job-attached invoices in the result
+                # set, indexed by GUID, then in-memory lookup per
+                # row. With 100 job-attached invoices spanning 5
+                # jobs, this is 1 query instead of 100.
+                from piecash.business.invoice import Job
+                job_attached_guids = [
+                    i.owner_guid for i in invoices
+                    if i.owner_type == 3 and i.owner_guid
+                ]
+                jobs_by_guid: dict = {}
+                if job_attached_guids:
+                    for j in book.session.query(Job).filter(
+                        Job.guid.in_(set(job_attached_guids))
+                    ).all():
+                        jobs_by_guid[j.guid] = j
+
                 results = []
                 for i in invoices:
                     o = self._find_invoice_owner_by_guid(
                         book, i.owner_type, i.owner_guid,
                     )
-                    # Job linkage threads through to the response
-                    # so the verbose listing shows ``job: {id,
-                    # name}`` on grouped invoices — important for
-                    # LLMs / dashboards filtering by job.
                     j_dict = None
                     if i.owner_type == 3:
-                        j_obj = self._find_job_by_guid(
-                            book, i.owner_guid,
-                        )
+                        j_obj = jobs_by_guid.get(i.owner_guid)
                         if j_obj is not None:
                             j_dict = self._job_to_dict(j_obj)
                     results.append(
@@ -5679,19 +5730,21 @@ class BusinessMixin:
 
                 amount_paid = grand_total - abs(balance)
 
-                owner_name = None
-                if is_bill:
-                    v = self._find_vendor_by_guid(
-                        book, inv.owner_guid
-                    )
-                    if v:
-                        owner_name = v.name
-                else:
-                    c = self._find_customer_by_guid(
-                        book, inv.owner_guid
-                    )
-                    if c:
-                        owner_name = c.name
+                # Owner lookup via the polymorphic dispatcher —
+                # routes customer/vendor/employee/job (chasing
+                # owner_type=3 through the Job to the underlying
+                # counterparty). Pre-fix this used the direct
+                # customer/vendor finders keyed off ``is_bill``,
+                # which returned None for job-attached invoices
+                # because inv.owner_guid points at a Job, not a
+                # customer/vendor row. Bookkeeper didn't probe
+                # this path; Copilot caught the related redundant-
+                # query pattern below and the bug surfaced
+                # during the refactor.
+                owner = self._find_invoice_owner_by_guid(
+                    book, inv.owner_type, inv.owner_guid,
+                )
+                owner_name = owner.name if owner else None
 
                 posted_dt = _safe_invoice_date(inv, "date_posted")
                 # Resolve the due date through the same three-step
@@ -5719,15 +5772,18 @@ class BusinessMixin:
                 # underlying customer/vendor); we also surface
                 # a job_id so the formatter can annotate the
                 # row.
+                #
+                # Single Job query via _resolve_owner_type_and_job
+                # — Copilot PR #88 review caught the original
+                # ``_effective_owner_type`` + ``_find_job_by_guid``
+                # side-by-side as redundant.
                 is_credit_note = self._get_is_credit_note(inv)
-                effective_ot = self._effective_owner_type(
-                    book, inv,
+                effective_ot, job_for_inv = (
+                    self._resolve_owner_type_and_job(book, inv)
                 )
-                job_id_field = None
-                if inv.owner_type == 3:
-                    j = self._find_job_by_guid(book, inv.owner_guid)
-                    if j is not None:
-                        job_id_field = j.id
+                job_id_field = (
+                    job_for_inv.id if job_for_inv else None
+                )
                 results.append({
                     "id": inv.id,
                     "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -653,6 +653,26 @@ class BusinessMixin:
         return book.session.query(Employee).filter_by(id=employee_id).first()
 
     @staticmethod
+    def _find_job(book, job_id: str):
+        """Find a job by its human-readable ID (e.g., '000001').
+
+        Indexed lookup. Returns None if no job has the given ID.
+        Unlike invoices, job IDs are unambiguous across owner
+        types — a single ``counter_job`` advances regardless of
+        whether the job is for a customer or vendor.
+        """
+        from piecash.business.invoice import Job
+        return book.session.query(Job).filter_by(id=job_id).first()
+
+    @staticmethod
+    def _find_job_by_guid(book, guid: str):
+        """Find a job by GUID. Used to resolve invoice→job links
+        where the invoice's ``owner_guid`` (with owner_type=3)
+        points at the job."""
+        from piecash.business.invoice import Job
+        return book.session.query(Job).filter_by(guid=guid).first()
+
+    @staticmethod
     def _parse_owner_type(owner_type: str | None) -> int | None:
         """Map an owner_type string to its piecash integer code.
 
@@ -876,6 +896,50 @@ class BusinessMixin:
     def _employee_to_compact_line(employee) -> str:
         """One-line compact: 'id  name  currency'."""
         return f"{employee.id}\t{employee.name}\t{employee.currency.mnemonic}"
+
+    @staticmethod
+    def _job_to_dict(job, owner_name: str | None = None) -> dict:
+        """Convert a piecash Job to a serializable dict.
+
+        The job's ``owner_type`` is stored as the underlying
+        customer (2) or vendor (4) — we surface that as a
+        human-readable ``owner_type`` string for symmetry with
+        every other tool's owner-typed response. ``owner_name``
+        is resolved by the caller (static-method shape can't
+        query the session)."""
+        return {
+            "guid": job.guid,
+            "id": job.id,
+            "name": job.name,
+            "reference": job.reference or "",
+            "active": bool(job.active),
+            # Map back to the human label — Customer/Vendor only
+            # since piecash's PersonType is {Vendor:4, Customer:2}.
+            "owner_type": (
+                "customer" if job.owner_type == 2 else "vendor"
+            ),
+            "owner_name": owner_name,
+        }
+
+    @staticmethod
+    def _job_to_compact_line(job, owner_name: str | None = None) -> str:
+        """One-line compact: ``id  name  CUSTOMER/VENDOR  owner_name``.
+
+        The owner tag (CUSTOMER / VENDOR) is the differentiator
+        a bookkeeper would scan for — customer jobs and vendor
+        jobs serve different purposes (revenue-side vs cost-side).
+        Active/inactive isn't shown — list_jobs filters by
+        active_only at the call site, so a row appearing in the
+        list is implicitly active unless include_inactive was set.
+        """
+        owner_tag = (
+            "CUSTOMER" if job.owner_type == 2 else "VENDOR"
+        )
+        owner_str = owner_name or "?"
+        ref_part = f"  ref:{job.reference}" if job.reference else ""
+        return (
+            f"{job.id}\t{job.name}\t{owner_tag}\t{owner_str}{ref_part}"
+        )
 
     @staticmethod
     def _billterm_to_dict(bt) -> dict:
@@ -4840,6 +4904,401 @@ class BusinessMixin:
             find_entity_method="_find_employee",
             # Employees own nothing in 1.3.0 — no dependency check.
         )
+
+    # ── Job CRUD ─────────────────────────────────────────────────
+    #
+    # Jobs are a customer/vendor-level grouping over invoices or
+    # bills. Three things make them simpler than the other
+    # business entities we've built:
+    #
+    # 1. The ``piecash.Job(name, owner, reference, active)``
+    #    constructor is OPEN — unlike Invoice / Customer / Vendor
+    #    / Employee, which we wrestled into raw SQL inserts. We
+    #    use the ORM directly here.
+    # 2. The constructor auto-assigns the 6-digit ID via
+    #    ``on_book_add`` calling ``_assign_id`` (advances
+    #    ``counter_job``). No manual counter handling.
+    # 3. Jobs have no posted state — only ``active`` (1) /
+    #    ``inactive`` (0). No post / unpost / pay tools. The
+    #    financial lifecycle remains on the linked invoices.
+    #
+    # Employee jobs are deliberately not supported — piecash's
+    # ``PersonType`` map only has ``Customer: 2`` and
+    # ``Vendor: 4``; passing an Employee to ``Job()`` would
+    # raise ``KeyError``. Same desktop-parity principle as
+    # credit notes (no GnuCash UI for them).
+
+    def create_job(
+        self,
+        owner_id: str,
+        owner_type: str,
+        name: str,
+        reference: str = "",
+    ) -> dict:
+        """Create a job for a customer or vendor.
+
+        A job groups invoices (or bills) from one counterparty
+        under a project-level container. The financial lifecycle
+        stays on the invoices; the job is organizational only —
+        no posted state, no posting math, just ``active``/
+        ``inactive``.
+
+        Args:
+            owner_id: Customer or vendor ID (e.g., '000001').
+            owner_type: 'customer' or 'vendor'. Employees are not
+                supported (piecash's PersonType has no Employee
+                entry; GnuCash desktop has no Employee Job UI).
+            name: Human-readable job name (e.g., 'API Rewrite').
+            reference: Optional reference string (PO number, etc.).
+
+        Returns:
+            Dict with guid, id, name, reference, active,
+            owner_type, status='created'.
+
+        Raises:
+            ValueError: If owner_type is invalid, 'employee', or
+                the named owner doesn't exist.
+        """
+        from piecash.business.invoice import Job
+
+        int_owner_type = self._parse_owner_type(owner_type)
+        if int_owner_type == 5:
+            raise ValueError(
+                "Jobs are not supported for employees. GnuCash "
+                "desktop has no UI for employee jobs (piecash's "
+                "PersonType map has only Customer and Vendor), "
+                "so creating one here would produce a document "
+                "desktop users can't view or edit. Job-track "
+                "employee work via vouchers' notes field instead."
+            )
+        if int_owner_type not in (2, 4):
+            raise ValueError(
+                f"Jobs require owner_type 'customer' or 'vendor', "
+                f"got {owner_type!r}."
+            )
+
+        find_owner = (
+            self._find_customer
+            if int_owner_type == 2
+            else self._find_vendor
+        )
+        with self.open(readonly=False) as book:
+            owner = find_owner(book, owner_id)
+            if not owner:
+                label = (
+                    "Customer" if int_owner_type == 2 else "Vendor"
+                )
+                raise ValueError(f"{label} not found: {owner_id}")
+
+            # The Job constructor handles owner_type, owner_guid,
+            # and (on book.add) the auto-id assignment. The
+            # ``if owner.book:`` branch in piecash's __init__ adds
+            # the job to the book automatically, so we don't need
+            # a separate ``book.session.add(job)``.
+            job = Job(
+                name=name,
+                owner=owner,
+                reference=reference,
+                active=1,
+            )
+
+            book.save()
+
+            # Verify the row landed (consistency with the rest of
+            # the business module's "every write is verified"
+            # invariant).
+            from gnucash_mcp.book._base import _verify_write
+            _verify_write(
+                book.session, Job.__table__, job.guid,
+                f"Job '{name}'",
+            )
+
+            return {
+                "guid": job.guid,
+                "id": job.id,
+                "name": name,
+                "reference": reference,
+                "active": True,
+                "owner_type": owner_type,
+                "status": "created",
+            }
+
+    def list_jobs(
+        self,
+        owner_type: str | None = None,
+        owner_id: str | None = None,
+        active_only: bool = True,
+        compact: bool = True,
+    ) -> list[dict] | str:
+        """List jobs, optionally filtered by owner_type and/or
+        owner_id.
+
+        Args:
+            owner_type: Filter by 'customer' or 'vendor'. Omit
+                for all.
+            owner_id: Filter by specific customer or vendor ID
+                (requires owner_type to disambiguate the lookup;
+                rejected otherwise to avoid ambiguous cross-
+                sequence ID matches).
+            active_only: If True (default), exclude inactive jobs.
+            compact: If True (default), return tab-separated
+                one-line-per-job string; otherwise a list of
+                dicts.
+
+        Returns:
+            Compact string or list of dicts depending on
+            ``compact``.
+        """
+        from piecash.business.invoice import Job
+
+        int_owner_type = (
+            self._parse_owner_type(owner_type) if owner_type else None
+        )
+        if int_owner_type == 5:
+            # Symmetric with create_job — surface the constraint
+            # at the filter boundary too rather than silently
+            # returning an empty list.
+            raise ValueError(
+                "Jobs are not supported for employees; "
+                "owner_type='employee' has no jobs to list."
+            )
+
+        if owner_id and not owner_type:
+            raise ValueError(
+                "owner_id requires owner_type to be set — "
+                "customer and vendor IDs share a sequence space, "
+                "so disambiguation is required."
+            )
+
+        with self.open() as book:
+            query = book.session.query(Job)
+            if int_owner_type is not None:
+                query = query.filter(Job.owner_type == int_owner_type)
+            if active_only:
+                query = query.filter(Job.active == 1)
+            if owner_id:
+                find_owner = (
+                    self._find_customer
+                    if int_owner_type == 2
+                    else self._find_vendor
+                )
+                owner = find_owner(book, owner_id)
+                if not owner:
+                    label = (
+                        "Customer" if int_owner_type == 2
+                        else "Vendor"
+                    )
+                    raise ValueError(
+                        f"{label} not found: {owner_id}"
+                    )
+                query = query.filter(Job.owner_guid == owner.guid)
+
+            jobs = sorted(query.all(), key=lambda j: j.id)
+
+            if compact:
+                lines = []
+                for job in jobs:
+                    owner = self._find_invoice_owner_by_guid(
+                        book, job.owner_type, job.owner_guid,
+                    )
+                    lines.append(
+                        self._job_to_compact_line(
+                            job, owner_name=(
+                                owner.name if owner else None
+                            ),
+                        )
+                    )
+                return "\n".join(lines)
+
+            results = []
+            for job in jobs:
+                owner = self._find_invoice_owner_by_guid(
+                    book, job.owner_type, job.owner_guid,
+                )
+                results.append(
+                    self._job_to_dict(
+                        job,
+                        owner_name=owner.name if owner else None,
+                    )
+                )
+            return results
+
+    def get_job(self, job_id: str) -> dict:
+        """Get a job's details by ID.
+
+        Returns:
+            Dict with guid, id, name, reference, active,
+            owner_type, owner_name, plus a ``linked_invoices``
+            summary (count + IDs) so the caller can see what's
+            attached without a separate ``list_invoices`` call.
+
+        Raises:
+            ValueError: If job not found.
+        """
+        from piecash.business.invoice import Invoice, Job
+        with self.open() as book:
+            job = self._find_job(book, job_id)
+            if not job:
+                raise ValueError(f"Job not found: {job_id}")
+            owner = self._find_invoice_owner_by_guid(
+                book, job.owner_type, job.owner_guid,
+            )
+            result = self._job_to_dict(
+                job, owner_name=owner.name if owner else None,
+            )
+            # Linked invoices: owner_type=3 + owner_guid=job.guid
+            # is the polymorphic linkage. Sort by ID for stable
+            # output.
+            linked = book.session.query(Invoice).filter(
+                Invoice.owner_type == 3,
+                Invoice.owner_guid == job.guid,
+            ).order_by(Invoice.id).all()
+            result["linked_invoices"] = {
+                "count": len(linked),
+                "ids": [inv.id for inv in linked],
+            }
+            return result
+
+    def update_job(
+        self,
+        job_id: str,
+        name: str | None = None,
+        reference: str | None = None,
+        active: bool | None = None,
+    ) -> dict:
+        """Update a job's name, reference, or active state.
+
+        Any subset of fields can be passed; unspecified fields
+        are left unchanged. Returns a diff-style response
+        (changed fields only) following the same convention as
+        ``update_account`` / ``update_transaction``.
+
+        Args:
+            job_id: Job ID.
+            name: New name (optional).
+            reference: New reference (optional).
+            active: New active flag (optional).
+
+        Returns:
+            Dict with id, guid, status='updated', plus only the
+            fields that changed.
+
+        Raises:
+            ValueError: If job not found or no fields supplied.
+        """
+        if name is None and reference is None and active is None:
+            raise ValueError(
+                "update_job requires at least one of name, "
+                "reference, or active."
+            )
+        with self.open(readonly=False) as book:
+            job = self._find_job(book, job_id)
+            if not job:
+                raise ValueError(f"Job not found: {job_id}")
+            # Capture before-state for audit log staging.
+            before = {
+                "id": job.id,
+                "name": job.name,
+                "reference": job.reference or "",
+                "active": bool(job.active),
+            }
+            self._stage_audit_before(before)
+
+            changed = {}
+            if name is not None and name != job.name:
+                job.name = name
+                changed["name"] = name
+            if reference is not None and reference != (job.reference or ""):
+                job.reference = reference
+                changed["reference"] = reference
+            if active is not None and bool(job.active) != active:
+                job.active = 1 if active else 0
+                changed["active"] = active
+
+            book.save()
+
+            return {
+                "id": job.id,
+                "guid": job.guid,
+                "status": "updated",
+                **changed,
+            }
+
+    def delete_job(self, job_id: str, force: bool = False) -> dict:
+        """Delete a job.
+
+        Refuses by default when invoices/bills are linked to the
+        job — data-loss prevention. ``force=True`` re-parents
+        every linked invoice back to its underlying customer/
+        vendor (reverses the indirection by rewriting
+        owner_type/owner_guid) before deleting the job row,
+        preserving invoice history.
+
+        Args:
+            job_id: Job ID.
+            force: If True, re-parent linked invoices instead of
+                refusing. Default False.
+
+        Returns:
+            Dict with id, guid, name, reparented_count (0 unless
+            force was used), status='deleted'.
+
+        Raises:
+            ValueError: If job not found, or linked invoices
+                exist and ``force`` is False.
+        """
+        from piecash.business.invoice import Invoice, Job
+        with self.open(readonly=False) as book:
+            job = self._find_job(book, job_id)
+            if not job:
+                raise ValueError(f"Job not found: {job_id}")
+            job_name = job.name
+            job_guid = job.guid
+            underlying_owner_type = job.owner_type
+            underlying_owner_guid = job.owner_guid
+
+            linked = book.session.query(Invoice).filter(
+                Invoice.owner_type == 3,
+                Invoice.owner_guid == job.guid,
+            ).all()
+
+            reparented_count = 0
+            if linked:
+                if not force:
+                    raise ValueError(
+                        f"Job '{job_id}' has {len(linked)} linked "
+                        f"invoice(s)/bill(s). Pass force=True to "
+                        f"re-parent them back to the underlying "
+                        f"customer/vendor before deleting the "
+                        f"job, or unlink/delete the documents "
+                        f"first."
+                    )
+                # Re-parent: rewrite owner_type/owner_guid on
+                # each linked invoice to point at the customer
+                # or vendor the job was for. This preserves the
+                # invoice history while removing the
+                # intermediate Job row.
+                for inv in linked:
+                    inv.owner_type = underlying_owner_type
+                    inv.owner_guid = underlying_owner_guid
+                    reparented_count += 1
+
+            book.session.delete(job)
+            book.save()
+
+            from gnucash_mcp.book._base import _verify_delete
+            _verify_delete(
+                book.session, Job.__table__, {"guid": job_guid},
+                f"Job '{job_id}'",
+            )
+
+            return {
+                "id": job_id,
+                "guid": job_guid,
+                "name": job_name,
+                "reparented_count": reparented_count,
+                "status": "deleted",
+            }
 
     # ── Reporting ────────────────────────────────────────────────
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -780,6 +780,39 @@ class BusinessMixin:
 
         query = book.session.query(Invoice).filter(Invoice.id == invoice_id)
         if owner_type is not None:
+            # Job-attached invoices have owner_type=3 internally
+            # — the owner_guid points at a Job, which in turn
+            # points at the customer or vendor. From the
+            # bookkeeper's perspective, those invoices are still
+            # customer/vendor invoices (just grouped). So an
+            # owner_type=2 lookup must match BOTH direct
+            # customer invoices (owner_type=2) AND job-attached
+            # invoices whose job has owner_type=2.
+            #
+            # Pre-fix: ``add_invoice_entry`` /
+            # ``delete_invoice`` / etc. all filter by
+            # owner_type=2 and would have failed with "Invoice
+            # not found" on any invoice attached to a job. Fix:
+            # build a subquery of job GUIDs matching the
+            # requested owner_type and OR it in.
+            #
+            # Employee (owner_type=5) is exempt — piecash's job
+            # model is customer/vendor only, so vouchers can't
+            # be job-attached. The lookup degrades to the
+            # original direct-match filter.
+            from sqlalchemy import and_, or_
+            from piecash.business.invoice import Job
+            if owner_type in (2, 4):
+                job_guid_sq = book.session.query(Job.guid).filter(
+                    Job.owner_type == owner_type
+                ).subquery()
+                return query.filter(or_(
+                    Invoice.owner_type == owner_type,
+                    and_(
+                        Invoice.owner_type == 3,
+                        Invoice.owner_guid.in_(job_guid_sq),
+                    ),
+                )).first()
             return query.filter(Invoice.owner_type == owner_type).first()
 
         # owner_type=None: caller didn't disambiguate. Pull all
@@ -1420,7 +1453,7 @@ class BusinessMixin:
         """
         from sqlalchemy import text
 
-        is_bill = self._is_bill_side(inv.owner_type)
+        is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
         if is_bill:
             rows = book.session.execute(
                 text("SELECT * FROM entries WHERE bill = :guid"),
@@ -2205,8 +2238,34 @@ class BusinessMixin:
         column group (``b_*``), same allowed account types. The
         legacy code used ``inv.owner_type == 4`` to mean this; the
         rename to ``_is_bill_side`` captures the truth.
+
+        For job-attached invoices (owner_type=3), pass the job's
+        owner_type instead — see ``_effective_owner_type``.
         """
         return owner_type in (4, 5)
+
+    @staticmethod
+    def _effective_owner_type(book, invoice) -> int:
+        """Resolve a document's "semantic" owner_type.
+
+        Direct customer invoices / vendor bills / vouchers
+        return their owner_type unchanged (2/4/5). Job-attached
+        invoices (owner_type=3) chase through the Job to its
+        underlying owner_type (2 or 4) — that's the side every
+        side-aware check (posting direction, account-type
+        validation, label dispatch) actually cares about.
+
+        Returns the underlying owner_type, falling back to the
+        raw owner_type if the job lookup fails (dangling
+        owner_guid). Same defensive shape as
+        ``_find_invoice_owner_by_guid``.
+        """
+        if invoice.owner_type != 3:
+            return invoice.owner_type
+        job = BusinessMixin._find_job_by_guid(book, invoice.owner_guid)
+        if job is None:
+            return invoice.owner_type
+        return job.owner_type
 
     # Human-readable document label for use in error messages,
     # status returns, and audit log entries. Title-case canonical
@@ -3189,7 +3248,22 @@ class BusinessMixin:
                 raise ValueError(
                     f"{cfg['label']} not found: {doc_id}"
                 )
-            if inv.owner_type != owner_type:
+            # Side-check: the invoice's "effective" owner_type
+            # is owner_type directly when 2/4/5; for owner_type=3
+            # (job-attached) it's the underlying job's
+            # owner_type. ``_find_invoice`` already filters by
+            # both direct and job-attached for owner_type 2/4,
+            # so reaching here with the wrong side means a true
+            # caller mistake (customer-id passed to
+            # add_bill_entry, e.g.).
+            effective_owner_type = inv.owner_type
+            if inv.owner_type == 3:
+                job_for_inv = self._find_job_by_guid(
+                    book, inv.owner_guid,
+                )
+                if job_for_inv is not None:
+                    effective_owner_type = job_for_inv.owner_type
+            if effective_owner_type != owner_type:
                 raise ValueError(
                     f"'{doc_id}' is a {cfg['twin_label']}, not a "
                     f"{cfg['label'].lower()}. Use "
@@ -3527,7 +3601,7 @@ class BusinessMixin:
             if not inv:
                 raise ValueError(f"Document not found: {invoice_id}")
 
-            is_bill = self._is_bill_side(inv.owner_type)
+            is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
 
             # Get entries via raw SQL since ORM relationship doesn't
             # work for vendor bills (bill column is VARCHAR, not FK)
@@ -3697,7 +3771,7 @@ class BusinessMixin:
                     f"{invoice_id} is already posted"
                 )
 
-            is_bill = self._is_bill_side(inv.owner_type)
+            is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
 
             post_acct = self._resolve_account(book, post_account)
             if not post_acct:
@@ -3930,7 +4004,7 @@ class BusinessMixin:
                     f"{invoice_id} is not posted"
                 )
 
-            is_bill = self._is_bill_side(inv.owner_type)
+            is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
             # Three-way label dispatch — was a binary "Bill if
             # is_bill else Invoice" that mislabeled vouchers as
             # bills (Copilot PR #86 review).
@@ -4124,7 +4198,7 @@ class BusinessMixin:
                     f"post it before recording payment"
                 )
 
-            is_bill = self._is_bill_side(inv.owner_type)
+            is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
 
             pay_acct = self._resolve_account(book, payment_account)
             if not pay_acct:
@@ -5550,7 +5624,7 @@ class BusinessMixin:
 
             results = []
             for inv in invoices:
-                is_bill = self._is_bill_side(inv.owner_type)
+                is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
 
                 post_acc_guid = inv.post_acc_guid
                 post_acct = book.session.query(
@@ -5645,6 +5719,163 @@ class BusinessMixin:
             if compact:
                 return _format_outstanding_invoices_compact(results)
             return results
+
+    def get_job_report(self, job_id: str) -> dict:
+        """Per-job summary: billed / paid / outstanding totals
+        across all linked invoices, plus the per-invoice
+        breakdown.
+
+        **Currency handling**: a job's linked invoices CAN span
+        multiple currencies (a project that bills mostly in EUR
+        but had one USD reimbursement on the same engagement),
+        so totals are returned as a dict keyed by currency
+        rather than a single scalar. Single-currency jobs render
+        as a one-key dict — the shape is consistent regardless
+        of cardinality, which is friendlier for LLMs that would
+        otherwise have to branch on whether ``totals_by_currency``
+        is flat or keyed.
+
+        **Posted vs unposted**: both are included. Posted
+        invoices contribute to ``billed`` / ``paid`` /
+        ``outstanding`` via their lot balance. Unposted (draft)
+        invoices contribute the entry-computed face value as
+        ``billed`` and ``outstanding``, with ``paid=0`` — a
+        bookkeeper looking at a job's pipeline wants drafts in
+        the picture too, not just what's been formalized.
+
+        Args:
+            job_id: Job ID.
+
+        Returns:
+            Dict with:
+
+            - ``job_id``, ``job_name``, ``owner_type``,
+              ``owner_name`` — job identity context
+            - ``linked_invoices_count`` — total invoices linked
+            - ``posted_count``, ``open_count`` — status breakdown
+            - ``totals_by_currency`` — ``{ccy: {billed, paid,
+              outstanding}}`` per currency present in the
+              linked invoices
+            - ``invoices`` — per-invoice list of ``{id, status,
+              currency, billed, paid, outstanding, date_opened,
+              date_posted}``
+
+        Raises:
+            ValueError: If job not found.
+        """
+        from piecash.business.invoice import Invoice
+        with self.open() as book:
+            job = self._find_job(book, job_id)
+            if not job:
+                raise ValueError(f"Job not found: {job_id}")
+            owner = self._find_invoice_owner_by_guid(
+                book, job.owner_type, job.owner_guid,
+            )
+            owner_name = owner.name if owner else None
+            owner_type = (
+                "customer" if job.owner_type == 2 else "vendor"
+            )
+
+            # Linked invoices: polymorphic owner pointer where
+            # owner_type=3 and owner_guid=job.guid. Indexed query.
+            invoices = book.session.query(Invoice).filter(
+                Invoice.owner_type == 3,
+                Invoice.owner_guid == job.guid,
+            ).order_by(Invoice.date_opened).all()
+
+            totals_by_currency: dict[str, dict[str, Decimal]] = {}
+            invoice_rows = []
+            posted_count = 0
+            open_count = 0
+
+            for inv in invoices:
+                ccy = inv.currency.mnemonic if inv.currency else "?"
+                # Face value: sum of (qty * price) across entries.
+                # Falls back to 0 on entry-load failure rather
+                # than aborting the whole report — matches the
+                # _invoice_to_compact_line defensive shape.
+                try:
+                    _, _, billed = (
+                        self._get_invoice_entries_and_total(book, inv)
+                    )
+                except (ValueError, AttributeError):
+                    billed = Decimal("0")
+
+                if _is_invoice_posted(inv):
+                    posted_count += 1
+                    # Posted: paid = billed - outstanding (from
+                    # the lot balance). The lot balance is the
+                    # unsettled amount, so abs(balance) =
+                    # outstanding.
+                    post_acct_guid = inv.post_acc_guid
+                    post_acct = book.session.query(
+                        piecash.Account
+                    ).filter_by(guid=post_acct_guid).first()
+                    lot_obj = None
+                    if post_acct:
+                        for lot in post_acct.lots:
+                            if lot.guid == inv.post_lot_guid:
+                                lot_obj = lot
+                                break
+                    if lot_obj:
+                        outstanding = abs(
+                            self._calculate_lot_balance(lot_obj)
+                        )
+                        paid = billed - outstanding
+                    else:
+                        # Defensive: lot not found despite
+                        # posted state — treat as fully owed
+                        # rather than crashing the report.
+                        outstanding = billed
+                        paid = Decimal("0")
+                    status = "posted"
+                else:
+                    open_count += 1
+                    paid = Decimal("0")
+                    outstanding = billed
+                    status = "open"
+
+                posted_dt = _safe_invoice_date(inv, "date_posted")
+                opened_dt = _safe_invoice_date(inv, "date_opened")
+                invoice_rows.append({
+                    "id": inv.id,
+                    "status": status,
+                    "currency": ccy,
+                    "billed": str(billed),
+                    "paid": str(paid),
+                    "outstanding": str(outstanding),
+                    "date_opened": (
+                        str(opened_dt.date()) if opened_dt else None
+                    ),
+                    "date_posted": (
+                        str(posted_dt.date()) if posted_dt else None
+                    ),
+                })
+
+                bucket = totals_by_currency.setdefault(ccy, {
+                    "billed": Decimal("0"),
+                    "paid": Decimal("0"),
+                    "outstanding": Decimal("0"),
+                })
+                bucket["billed"] += billed
+                bucket["paid"] += paid
+                bucket["outstanding"] += outstanding
+
+            # Stringify Decimal totals for JSON-friendly output.
+            return {
+                "job_id": job.id,
+                "job_name": job.name,
+                "owner_type": owner_type,
+                "owner_name": owner_name,
+                "linked_invoices_count": len(invoices),
+                "posted_count": posted_count,
+                "open_count": open_count,
+                "totals_by_currency": {
+                    ccy: {k: str(v) for k, v in bucket.items()}
+                    for ccy, bucket in totals_by_currency.items()
+                },
+                "invoices": invoice_rows,
+            }
 
     def vendor_spending_report(
         self,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -718,6 +718,74 @@ def _fmt_employee_delete(entry: dict) -> list[str]:
     return _fmt_person_delete(entry, "employee", "employee_id")
 
 
+# ── Job formatters ───────────────────────────────────────────
+# Jobs aren't business-persons (no currency/address fields), so
+# they get their own formatters rather than going through
+# _fmt_person_*. Owner_type and owner_id surface so a reviewer
+# scanning the audit log can immediately see which counterparty
+# the job belongs to without a separate lookup.
+
+
+def _fmt_job_create(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    job_id = after.get("id", "")
+    name = after.get("name", params.get("name", ""))
+    owner_type = (
+        after.get("owner_type") or params.get("owner_type", "")
+    )
+    owner_id = params.get("owner_id", "")
+    ref = after.get("reference") or params.get("reference", "")
+    lines = [
+        f"{time_part}  CREATE JOB  id:{job_id}",
+        f'{_INDENT}name: "{name}"  {owner_type}: {owner_id}',
+    ]
+    if ref:
+        lines.append(f"{_INDENT}reference: {ref}")
+    return lines
+
+
+def _fmt_job_update(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    after = entry.get("after_state") or {}
+    job_id = params.get("job_id", "")
+    lines = [f"{time_part}  UPDATE JOB  id:{job_id}"]
+    # Show only the fields that changed (the book method returns
+    # only changed keys in after_state — anything missing means
+    # unchanged, anything present means new value).
+    for key in ("name", "reference", "active"):
+        if key in after:
+            old_val = before.get(key, "?")
+            new_val = after[key]
+            lines.append(
+                f"{_INDENT}{key}: {old_val!r} → {new_val!r}"
+            )
+    return lines
+
+
+def _fmt_job_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    job_id = params.get("job_id", "")
+    name = after.get("name", "")
+    reparented = after.get("reparented_count", 0)
+    lines = [f"{time_part}  DELETE JOB  id:{job_id}"]
+    if name:
+        lines.append(f'{_INDENT}name: "{name}"')
+    if reparented:
+        # force=True re-parented invoices to the underlying
+        # customer/vendor — call that out so a reviewer sees the
+        # invoice owners changed as a side effect of the delete.
+        lines.append(
+            f"{_INDENT}reparented invoices: {reparented}"
+        )
+    return lines
+
+
 def _fmt_billterm_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -1210,6 +1278,9 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("employee", "CREATE"): _fmt_employee_create,
     ("employee", "UPDATE"): _fmt_employee_update,
     ("employee", "DELETE"): _fmt_employee_delete,
+    ("job", "CREATE"): _fmt_job_create,
+    ("job", "UPDATE"): _fmt_job_update,
+    ("job", "DELETE"): _fmt_job_delete,
     ("billterm", "CREATE"): _fmt_billterm_create,
     ("invoice", "CREATE"): _fmt_invoice_create,
     ("invoice", "DELETE"): _fmt_invoice_delete,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -316,6 +316,16 @@ TOOL_MODULES: dict[str, list[str]] = {
         "add_credit_note_entry",
         "delete_credit_note",
         "apply_credit_note",
+        # Jobs (v1.3). Project-level grouping over invoices/bills
+        # for a single customer or vendor. No posted state — only
+        # active/inactive. Linked invoices route through the
+        # polymorphic owner_type=3 dispatch (see create_invoice's
+        # job_id parameter).
+        "create_job",
+        "list_jobs",
+        "get_job",
+        "update_job",
+        "delete_job",
         "create_billterm",
         "list_billterms",
         "vendor_spending_report",
@@ -670,7 +680,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (95 tools).
+                       for every module (100 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -326,6 +326,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_job",
         "update_job",
         "delete_job",
+        "get_job_report",
         "create_billterm",
         "list_billterms",
         "vendor_spending_report",
@@ -680,7 +681,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (100 tools).
+                       for every module (101 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1127,6 +1127,29 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="read")
+    def get_job_report(job_id: str) -> str:
+        """Per-job summary: billed / paid / outstanding totals
+        across all linked invoices, plus the per-invoice
+        breakdown.
+
+        Totals are returned as ``totals_by_currency`` (a dict
+        keyed by ISO currency code) so the same shape works
+        whether the job's invoices share a currency or span
+        multiple. Both posted and unposted (draft) invoices are
+        included — drafts contribute their face value as
+        ``billed`` + ``outstanding`` with ``paid=0``, so the
+        report shows the full pipeline.
+
+        Args:
+            job_id: Job ID (e.g., "000001").
+        """
+        book = get_book()
+        result = book.get_job_report(job_id=job_id)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="job")
     def delete_job(job_id: str, force: bool = False) -> str:
         """Delete a job.

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1076,7 +1076,14 @@ def register(mcp, get_book) -> None:
             active_only=active_only,
             compact=not verbose,
         )
-        return _json(result) if verbose else result
+        # Match the other list_* tools' verbose pattern
+        # (json.dumps indent=2 preserves empty strings; _json
+        # strips them, which Copilot flagged as a shape
+        # divergence on PR #88).
+        if verbose:
+            import json
+            return json.dumps(result, indent=2)
+        return result
 
     @mcp.tool()
     @safe_tool

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -355,6 +355,7 @@ def register(mcp, get_book) -> None:
         currency: str | None = None,
         term: str | None = None,
         invoice_id: str | None = None,
+        job_id: str | None = None,
     ) -> str:
         """Create a customer invoice.
 
@@ -368,12 +369,18 @@ def register(mcp, get_book) -> None:
             term: Billterm name (e.g., "Net 30"). Optional.
             invoice_id: Custom invoice number (e.g., "INV-2026-001"). If omitted,
                 auto-generates from the book's invoice counter.
+            job_id: Optional Job ID. When set, groups the invoice
+                under the named job. The job must belong to the
+                same customer and be a customer-job (created
+                with owner_type='customer'). Use ``create_job``
+                first to define the job, then attach invoices
+                to it via this parameter.
         """
         book = get_book()
         result = book.create_invoice(
             customer_id=customer_id, date_opened=date_opened,
             notes=notes, currency=currency, term=term,
-            invoice_id=invoice_id,
+            invoice_id=invoice_id, job_id=job_id,
         )
         return _json(result)
 
@@ -387,6 +394,7 @@ def register(mcp, get_book) -> None:
         currency: str | None = None,
         term: str | None = None,
         bill_id: str | None = None,
+        job_id: str | None = None,
     ) -> str:
         """Create a vendor bill.
 
@@ -400,12 +408,15 @@ def register(mcp, get_book) -> None:
             term: Billterm name (e.g., "Net 30"). Optional.
             bill_id: Custom bill number (e.g., "BILL-2026-001"). If omitted,
                 auto-generates from the book's bill counter.
+            job_id: Optional Job ID. When set, groups the bill
+                under the named job. The job must belong to the
+                same vendor and be a vendor-job.
         """
         book = get_book()
         result = book.create_bill(
             vendor_id=vendor_id, date_opened=date_opened,
             notes=notes, currency=currency, term=term,
-            bill_id=bill_id,
+            bill_id=bill_id, job_id=job_id,
         )
         return _json(result)
 
@@ -740,6 +751,7 @@ def register(mcp, get_book) -> None:
         status: str | None = None,
         verbose: bool = False,
         limit: int = 50,
+        job_id: str | None = None,
     ) -> str:
         """List invoices and/or vendor bills.
 
@@ -754,6 +766,9 @@ def register(mcp, get_book) -> None:
             limit: Maximum invoices to return. Defaults to 50, capped
                    at 250. Compact output appends a truncation notice
                    when results are clipped.
+            job_id: Filter to invoices grouped under a specific
+                job — useful for the "what's part of this
+                engagement?" listing pattern.
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -762,6 +777,7 @@ def register(mcp, get_book) -> None:
             status=status,
             compact=not verbose,
             limit=limit,
+            job_id=job_id,
         )
         if verbose:
             return json.dumps(result, indent=2)

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -988,6 +988,149 @@ def register(mcp, get_book) -> None:
         result = book.delete_employee(employee_id=employee_id)
         return _json(result)
 
+    # ── Job CRUD tools ───────────────────────────────────────
+    #
+    # Jobs are project-level grouping over invoices/bills for a
+    # single customer or vendor. The financial lifecycle stays
+    # on the linked invoices; the job itself only has
+    # ``active``/``inactive`` state. See create_invoice and
+    # create_bill (v1.3) for how to link a new invoice to a job.
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="job")
+    def create_job(
+        owner_id: str,
+        owner_type: str,
+        name: str,
+        reference: str = "",
+    ) -> str:
+        """Create a job for a customer or vendor.
+
+        A job groups invoices (or bills) from one counterparty
+        under a project-level container. Useful when a single
+        customer has multiple distinct engagements (e.g., 'API
+        Rewrite' and 'Q3 Maintenance') that should be reported
+        on separately even though invoices flow to the same A/R.
+
+        Args:
+            owner_id: Customer or vendor ID (e.g., "000001").
+            owner_type: "customer" or "vendor". Employees are
+                not supported (no GnuCash desktop UI for
+                employee jobs).
+            name: Human-readable job name (e.g., "API Rewrite").
+            reference: Optional reference string (PO number,
+                project code).
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.create_job(
+            owner_id=owner_id,
+            owner_type=owner_type,
+            name=name,
+            reference=reference,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="read")
+    def list_jobs(
+        owner_type: str | None = None,
+        owner_id: str | None = None,
+        active_only: bool = True,
+        verbose: bool = False,
+    ) -> str:
+        """List jobs, optionally filtered.
+
+        Args:
+            owner_type: Filter by "customer" or "vendor". Omit
+                for all.
+            owner_id: Filter by specific customer or vendor ID
+                (requires owner_type).
+            active_only: If True (default), exclude inactive jobs.
+            verbose: If True, return full JSON dicts; otherwise
+                compact tab-separated rows.
+        """
+        owner_type = _gate_owner_type(owner_type)
+        book = get_book()
+        result = book.list_jobs(
+            owner_type=owner_type,
+            owner_id=owner_id,
+            active_only=active_only,
+            compact=not verbose,
+        )
+        return _json(result) if verbose else result
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="read")
+    def get_job(job_id: str) -> str:
+        """Get a job's details by ID.
+
+        Returns name, owner, active state, plus a count + IDs
+        list of every invoice/bill linked to the job.
+
+        Args:
+            job_id: Job ID (e.g., "000001").
+        """
+        book = get_book()
+        result = book.get_job(job_id=job_id)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="update", entity_type="job")
+    def update_job(
+        job_id: str,
+        name: str | None = None,
+        reference: str | None = None,
+        active: bool | None = None,
+    ) -> str:
+        """Update a job's name, reference, or active state.
+
+        Any subset of fields can be passed; unspecified fields
+        are left unchanged. Returns a diff-style response.
+
+        Args:
+            job_id: Job ID.
+            name: New name (optional).
+            reference: New reference (optional).
+            active: New active flag — pass False to deactivate a
+                completed job without deleting it (preserves
+                history).
+        """
+        book = get_book()
+        result = book.update_job(
+            job_id=job_id,
+            name=name,
+            reference=reference,
+            active=active,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="delete", entity_type="job")
+    def delete_job(job_id: str, force: bool = False) -> str:
+        """Delete a job.
+
+        Refuses by default when invoices/bills are linked to the
+        job (data-loss prevention). ``force=True`` re-parents
+        every linked invoice back to its underlying customer or
+        vendor before deleting the job row, preserving invoice
+        history. Use ``update_job(active=False)`` instead if you
+        want to keep the job in place but mark the project done.
+
+        Args:
+            job_id: Job ID.
+            force: If True, re-parent linked invoices instead of
+                refusing. Default False.
+        """
+        book = get_book()
+        result = book.delete_job(job_id=job_id, force=force)
+        return _json(result)
+
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -870,6 +870,136 @@ class TestGetJobReport:
         assert Decimal(usd["outstanding"]) == Decimal("150")
 
 
+class TestJobDisplayPolish:
+    """Tests for the (job:JOB-X) annotation in list_invoices and
+    get_outstanding_invoices compact output. Job-attached
+    invoices should be visibly distinguished from direct
+    customer invoices / vendor bills in any compact-list view.
+    """
+
+    def test_list_invoices_compact_shows_job_annotation(
+        self, business_book,
+    ):
+        """A job-attached customer invoice renders with both
+        the INV tag (semantic side, resolved via the job's
+        underlying owner_type) and a (job:JOB-X) suffix on the
+        owner column."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite",
+        )
+        gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        out = gb.list_invoices()  # compact default
+        # Semantic tag is INV (customer-side), not generic
+        assert "\tINV\t" in out
+        # Owner column carries the job annotation
+        assert f"(job:{job['id']})" in out
+
+    def test_list_invoices_vendor_bill_in_job(self, business_book):
+        """Symmetric: vendor bill attached to vendor job renders
+        BILL tag + (job:JOB-X) annotation."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        job = gb.create_job(
+            owner_id="000001", owner_type="vendor", name="Supplies",
+        )
+        gb.create_bill(vendor_id="000001", job_id=job["id"])
+        out = gb.list_invoices()
+        assert "\tBILL\t" in out
+        assert f"(job:{job['id']})" in out
+
+    def test_non_job_invoice_no_annotation(self, business_book):
+        """Pre-v1.3 contract — direct customer invoices (no job)
+        produce compact output without a job annotation."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")  # no job_id
+        out = gb.list_invoices()
+        assert "(job:" not in out
+
+    def test_get_outstanding_shows_job_annotation(self, business_book):
+        """get_outstanding_invoices compact output annotates
+        job-attached docs with (job:JOB-X) on the owner
+        column."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        out = gb.get_outstanding_invoices()  # compact default
+        assert f"(job:{job['id']})" in out
+
+    def test_get_outstanding_credit_note_in_job(self, business_book):
+        """A credit note attached to a job carries BOTH the (CN)
+        tag AND the (job:JOB-X) annotation — order: owner →
+        (CN) → (job:X)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        # Create + post a source invoice first so the credit
+        # note has something to link to
+        src = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=src["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=src["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id=src["id"],
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        # Note: credit notes themselves aren't job-linked
+        # here — only the source invoice is. The credit
+        # note's compact line should NOT show a job
+        # annotation (it's not attached to a job).
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        out = gb.get_outstanding_invoices()
+        # The source invoice line carries the job annotation
+        src_line = next(
+            ln for ln in out.split("\n") if ln.startswith(src["id"])
+        )
+        assert f"(job:{job['id']})" in src_line
+        # The credit note line carries (CN) but not (job:...)
+        cn_line = next(
+            ln for ln in out.split("\n") if ln.startswith(cn["id"])
+        )
+        assert "(CN)" in cn_line
+        assert "(job:" not in cn_line
+
+
 class TestInvoiceJobLinkage:
     """Tests for the job_id parameter on create_invoice /
     create_bill, plus the cascading effects on _invoice_to_dict

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -672,6 +672,204 @@ class TestDeleteJob:
             gb.delete_job(job_id="999999")
 
 
+class TestInvoiceJobLinkage:
+    """Tests for the job_id parameter on create_invoice /
+    create_bill, plus the cascading effects on _invoice_to_dict
+    (type field computation, job field surfacing) and
+    list_invoices (job_id filter).
+    """
+
+    def test_create_invoice_with_job_id(self, business_book):
+        """Invoice attached to a job: owner_type=3 internally,
+        but the response surface still reports type='invoice'
+        (semantic) and adds job: {id, name}."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001",
+            job_id=job["id"],
+        )
+        # get_invoice surfaces both the semantic type and the
+        # job link.
+        fetched = gb.get_invoice(
+            inv["id"], owner_type=None,
+        )
+        # owner_type=3 internally; type stays 'invoice' from the
+        # semantic resolution through the job's underlying owner.
+        assert fetched["type"] == "invoice"
+        assert fetched["owner_name"] == "Acme Co"
+        assert fetched["job"] == {
+            "id": job["id"], "name": "API Rewrite",
+        }
+
+    def test_create_bill_with_job_id(self, business_book):
+        """Symmetric for vendor side: bill attached to a vendor
+        job. type='bill' resolved through the job."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        job = gb.create_job(
+            owner_id="000001", owner_type="vendor",
+            name="Q3 supply contract",
+        )
+        bill = gb.create_bill(
+            vendor_id="000001",
+            job_id=job["id"],
+        )
+        fetched = gb.get_invoice(bill["id"])
+        assert fetched["type"] == "bill"
+        assert fetched["owner_name"] == "Office Depot"
+        assert fetched["job"]["id"] == job["id"]
+
+    def test_job_id_cross_customer_rejected(self, business_book):
+        """Job belonging to customer A cannot be used on an
+        invoice for customer B."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_customer(name="Beta Inc")
+        # Acme is 000001; Beta is 000002.
+        acme_job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        with pytest.raises(
+            ValueError, match="belongs to.*not",
+        ):
+            gb.create_invoice(
+                customer_id="000002",
+                job_id=acme_job["id"],
+            )
+
+    def test_customer_invoice_with_vendor_job_rejected(
+        self, business_book,
+    ):
+        """A customer invoice can't link to a vendor job and
+        vice-versa — owner_type must match."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_vendor(name="Office Depot")
+        # Vendor job
+        v_job = gb.create_job(
+            owner_id="000001", owner_type="vendor", name="X",
+        )
+        with pytest.raises(
+            ValueError, match="is a vendor job; this is a customer",
+        ):
+            gb.create_invoice(
+                customer_id="000001",
+                job_id=v_job["id"],
+            )
+
+    def test_job_id_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        with pytest.raises(ValueError, match="Job not found"):
+            gb.create_invoice(
+                customer_id="000001",
+                job_id="999999",
+            )
+
+    def test_normal_invoice_omits_job_key(self, business_book):
+        """Invoices NOT attached to a job omit the 'job' field
+        entirely — same shape as pre-v1.3 for non-job docs."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")  # no job
+        fetched = gb.get_invoice("000001")
+        assert "job" not in fetched
+
+    def test_list_invoices_filtered_by_job(self, business_book):
+        """list_invoices(job_id=...) returns only invoices linked
+        to that job."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job_a = gb.create_job(
+            owner_id="000001", owner_type="customer", name="A",
+        )
+        job_b = gb.create_job(
+            owner_id="000001", owner_type="customer", name="B",
+        )
+        # 2 invoices on job A, 1 on job B, 1 standalone
+        gb.create_invoice(customer_id="000001", job_id=job_a["id"])
+        gb.create_invoice(customer_id="000001", job_id=job_a["id"])
+        gb.create_invoice(customer_id="000001", job_id=job_b["id"])
+        gb.create_invoice(customer_id="000001")  # standalone
+
+        result_a = gb.list_invoices(
+            job_id=job_a["id"], compact=False,
+        )
+        # ``invoices`` is the envelope key set by list_invoices
+        assert len(result_a["invoices"]) == 2
+        result_b = gb.list_invoices(
+            job_id=job_b["id"], compact=False,
+        )
+        assert len(result_b["invoices"]) == 1
+        # All invoices (no job filter) shows all 4
+        result_all = gb.list_invoices(compact=False)
+        assert len(result_all["invoices"]) == 4
+
+    def test_list_invoices_job_id_with_mismatched_owner_type(
+        self, business_book,
+    ):
+        """If caller passes both job_id and owner_type, they
+        must agree — vendor-job + owner_type=customer rejected."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        v_job = gb.create_job(
+            owner_id="000001", owner_type="vendor", name="X",
+        )
+        with pytest.raises(
+            ValueError, match="vendor job.*doesn't match",
+        ):
+            gb.list_invoices(
+                job_id=v_job["id"],
+                owner_type="customer",
+            )
+
+    def test_get_job_includes_linked_invoices(self, business_book):
+        """After Commit-1 returned count=0 / ids=[] for empty
+        jobs, Commit-2 actually links invoices — verify
+        get_job's linked_invoices list now populates."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        gb.create_invoice(customer_id="000001", job_id=job["id"])
+        gb.create_invoice(customer_id="000001", job_id=job["id"])
+        result = gb.get_job(job_id=job["id"])
+        assert result["linked_invoices"]["count"] == 2
+        assert len(result["linked_invoices"]["ids"]) == 2
+
+    def test_voucher_with_job_id_rejected(self, business_book):
+        """Vouchers can't be grouped under jobs — piecash's
+        job model is customer/vendor only. Surfaces at the
+        _create_business_document level when job_id is set
+        alongside owner_type=5."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_employee(name="Maria")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        with pytest.raises(
+            ValueError, match="Employee vouchers cannot be grouped",
+        ):
+            # We call _create_business_document directly because
+            # create_voucher doesn't have a job_id parameter at
+            # the public surface — verifies the inner guard
+            # catches anyone who reaches the helper via a
+            # future path.
+            gb._create_business_document(
+                owner_type=5,
+                owner_id="000001",
+                doc_id=None,
+                job_id=job["id"],
+            )
+
+
 class TestUpdateCustomer:
     """Tests for ``update_customer``.
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -347,6 +347,331 @@ class TestDeleteEmployee:
             gb.delete_employee(employee_id="999999")
 
 
+class TestCreateJob:
+    """Tests for create_job.
+
+    Job is the third v1.3 business surface (after vouchers and
+    credit notes). Unlike those, the piecash Job constructor
+    is OPEN, so the create path uses the ORM directly. Owner
+    is restricted to customer/vendor (piecash's PersonType map
+    has no Employee entry; create_job rejects 'employee' with
+    a clear message).
+    """
+
+    def test_create_customer_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        result = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite",
+        )
+        assert result["status"] == "created"
+        assert result["name"] == "API Rewrite"
+        assert result["owner_type"] == "customer"
+        assert result["active"] is True
+        # counter_job advances independently from invoice/bill
+        assert result["id"] == "000001"
+        assert len(result["guid"]) == 32
+
+    def test_create_vendor_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        result = gb.create_job(
+            owner_id="000001", owner_type="vendor",
+            name="Q3 supply contract",
+        )
+        assert result["owner_type"] == "vendor"
+        assert result["name"] == "Q3 supply contract"
+
+    def test_create_job_with_reference(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        result = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="Kitchen renovation",
+            reference="PO-2026-042",
+        )
+        assert result["reference"] == "PO-2026-042"
+
+    def test_employee_owner_rejected(self, business_book):
+        """Employees are deliberately unsupported — piecash's
+        PersonType has no Employee entry (would KeyError at
+        the constructor), and GnuCash desktop has no UI."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Maria")
+        with pytest.raises(
+            ValueError, match="not supported for employees",
+        ):
+            gb.create_job(
+                owner_id="000001", owner_type="employee",
+                name="x",
+            )
+
+    def test_invalid_owner_type_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Invalid owner_type"):
+            gb.create_job(
+                owner_id="000001", owner_type="custmer", name="x",
+            )
+
+    def test_owner_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Customer not found"):
+            gb.create_job(
+                owner_id="999999", owner_type="customer", name="x",
+            )
+
+    def test_job_counter_independent_from_invoice_counter(
+        self, business_book,
+    ):
+        """The book's counter_job advances independently from
+        counter_invoice and counter_bill — creating an invoice
+        first shouldn't bump the job sequence."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_invoice(customer_id="000001")  # invoice 000001
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="x",
+        )
+        # Job counter starts at 0; first auto-id is 000001 even
+        # though an invoice with the same ID exists.
+        assert job["id"] == "000001"
+
+
+class TestListJobs:
+    """Tests for list_jobs filtering and output shape."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        result = gb.list_jobs()
+        assert result == ""
+
+    def test_compact_default(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        result = gb.list_jobs()
+        # Compact format: tab-separated with CUSTOMER tag
+        assert "000001" in result
+        assert "CUSTOMER" in result
+        assert "Acme Co" in result
+
+    def test_verbose_returns_dicts(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        result = gb.list_jobs(compact=False)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "X"
+        assert result[0]["owner_type"] == "customer"
+        assert result[0]["owner_name"] == "Acme Co"
+
+    def test_filter_by_owner_type(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_vendor(name="Office Depot")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="Cust",
+        )
+        gb.create_job(
+            owner_id="000001", owner_type="vendor", name="Vend",
+        )
+        cust = gb.list_jobs(owner_type="customer", compact=False)
+        assert len(cust) == 1
+        assert cust[0]["name"] == "Cust"
+        vend = gb.list_jobs(owner_type="vendor", compact=False)
+        assert len(vend) == 1
+        assert vend[0]["name"] == "Vend"
+
+    def test_filter_by_owner_id_requires_owner_type(
+        self, business_book,
+    ):
+        """owner_id without owner_type is rejected — customer
+        and vendor IDs share a sequence space, so the lookup
+        would be ambiguous."""
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(
+            ValueError, match="owner_id requires owner_type",
+        ):
+            gb.list_jobs(owner_id="000001")
+
+    def test_active_only_default(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        active = gb.create_job(
+            owner_id="000001", owner_type="customer", name="Active",
+        )
+        inactive = gb.create_job(
+            owner_id="000001", owner_type="customer", name="Done",
+        )
+        # Deactivate the second
+        gb.update_job(job_id=inactive["id"], active=False)
+        # Default lists only active
+        result = gb.list_jobs(compact=False)
+        assert len(result) == 1
+        assert result[0]["id"] == active["id"]
+        # include_inactive surfaces both
+        result_all = gb.list_jobs(active_only=False, compact=False)
+        assert len(result_all) == 2
+
+
+class TestGetJob:
+    """Tests for get_job — details + linked-invoices summary."""
+
+    def test_get_job_basic(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite", reference="PO-001",
+        )
+        result = gb.get_job(job_id=job["id"])
+        assert result["name"] == "API Rewrite"
+        assert result["reference"] == "PO-001"
+        assert result["owner_type"] == "customer"
+        assert result["owner_name"] == "Acme Co"
+        # No linked invoices yet
+        assert result["linked_invoices"]["count"] == 0
+        assert result["linked_invoices"]["ids"] == []
+
+    def test_get_nonexistent_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Job not found"):
+            gb.get_job(job_id="999999")
+
+
+class TestUpdateJob:
+    """Tests for update_job — diff-style response, partial
+    updates, rejection of empty calls."""
+
+    def test_update_name(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="Old",
+        )
+        result = gb.update_job(job_id="000001", name="New")
+        assert result["status"] == "updated"
+        assert result["name"] == "New"
+        # Reference + active not in diff response (unchanged)
+        assert "reference" not in result
+        assert "active" not in result
+
+    def test_update_active(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        result = gb.update_job(job_id="000001", active=False)
+        assert result["active"] is False
+        # Confirm via get_job
+        fetched = gb.get_job(job_id="000001")
+        assert fetched["active"] is False
+
+    def test_no_fields_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        with pytest.raises(
+            ValueError, match="at least one of",
+        ):
+            gb.update_job(job_id="000001")
+
+    def test_update_nonexistent_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Job not found"):
+            gb.update_job(job_id="999999", name="x")
+
+
+class TestDeleteJob:
+    """Tests for delete_job — including the force-reparent path
+    that re-routes linked invoices back to the underlying
+    customer/vendor before deleting the job row."""
+
+    def test_delete_unlinked_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        result = gb.delete_job(job_id="000001")
+        assert result["status"] == "deleted"
+        assert result["reparented_count"] == 0
+
+    def test_delete_with_linked_invoices_refused(
+        self, business_book,
+    ):
+        """Default: refuse to delete a job with linked invoices.
+        Names how many are linked + suggests force=True or
+        unlinking the documents first."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        # Manually link an invoice to the job (commit 2 will
+        # add the job_id parameter; for this test we set
+        # owner_type/owner_guid directly).
+        gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice, Job
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            job = book.session.query(Job).filter_by(id="000001").first()
+            inv.owner_type = 3
+            inv.owner_guid = job.guid
+            book.save()
+        with pytest.raises(
+            ValueError, match="has 1 linked",
+        ):
+            gb.delete_job(job_id="000001")
+
+    def test_delete_with_force_reparents_invoices(
+        self, business_book,
+    ):
+        """force=True re-parents linked invoices back to the
+        underlying customer (owner_type 3→2 with owner_guid
+        flipped from job to customer) before deleting. Invoice
+        history is preserved; only the intermediate Job row
+        disappears."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        gb.create_invoice(customer_id="000001")
+        with gb.open(readonly=False) as book:
+            from piecash.business.invoice import Invoice, Job
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            job = book.session.query(Job).filter_by(id="000001").first()
+            customer_guid = job.owner_guid  # Acme's GUID
+            inv.owner_type = 3
+            inv.owner_guid = job.guid
+            book.save()
+        result = gb.delete_job(job_id="000001", force=True)
+        assert result["status"] == "deleted"
+        assert result["reparented_count"] == 1
+        # Re-fetch invoice — should be back to owner_type=2,
+        # owner_guid=customer.
+        with gb.open() as book:
+            from piecash.business.invoice import Invoice
+            inv = book.session.query(Invoice).filter_by(id="000001").first()
+            assert inv.owner_type == 2
+            assert inv.owner_guid == customer_guid
+
+    def test_delete_nonexistent_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Job not found"):
+            gb.delete_job(job_id="999999")
+
+
 class TestUpdateCustomer:
     """Tests for ``update_customer``.
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1000,6 +1000,123 @@ class TestJobDisplayPolish:
         assert "(job:" not in cn_line
 
 
+class TestJobPr88ReviewFollowups:
+    """Tests for the Copilot PR #88 review follow-ups.
+
+    The headline regression test is for a bug Copilot's
+    redundant-query findings indirectly surfaced: pre-fix,
+    ``get_outstanding_invoices`` resolved owner_name via direct
+    customer/vendor lookups keyed off ``is_bill``, which
+    returned None for job-attached invoices because
+    inv.owner_guid points at a Job (not a customer/vendor row).
+    The bookkeeper didn't probe this exact path; the bug came
+    out during the refactor to ``_resolve_owner_type_and_job``.
+    """
+
+    def test_get_outstanding_resolves_job_attached_owner_name(
+        self, business_book,
+    ):
+        """A posted job-attached invoice should appear in
+        get_outstanding_invoices with the correct owner_name
+        (the underlying customer/vendor), not None.
+
+        Pre-fix: get_outstanding called _find_customer_by_guid
+        / _find_vendor_by_guid directly with inv.owner_guid,
+        which is a Job GUID for owner_type=3 rows — the
+        customer/vendor table lookups returned nothing.
+        """
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="API Rewrite",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        outstanding = gb.get_outstanding_invoices(compact=False)
+        row = next(r for r in outstanding if r["id"] == inv["id"])
+        # The bug: pre-fix, owner_name was None on job-attached
+        # posted invoices.
+        assert row["owner_name"] == "Acme Co"
+        # And the job_id surfaces correctly (verbose response
+        # shape; commit 4 introduced this field).
+        assert row["job_id"] == job["id"]
+
+    def test_list_jobs_verbose_uses_indented_json(self, business_book):
+        """list_jobs verbose output should match other list_*
+        tools' shape (json.dumps with indent=2, preserves empty
+        strings) rather than using _json (minified, strips
+        empties). Copilot caught the divergence on PR #88."""
+        from gnucash_mcp.tools._helpers import safe_tool
+        # Test through the tool wrapper layer rather than the
+        # book method — the inconsistency was at the wrapper
+        # boundary.
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="X", reference="",  # empty ref to test strip behavior
+        )
+        # Direct book method returns the list shape unchanged.
+        rows = gb.list_jobs(compact=False)
+        assert len(rows) == 1
+        # Empty reference SHOULD survive the verbose JSON path
+        # — the bug was that _json stripped it. We verify the
+        # book-method dict has it as empty string (matching
+        # other list_* methods' behavior).
+        assert rows[0]["reference"] == ""
+
+    def test_effective_owner_type_and_job_single_query(
+        self, business_book,
+    ):
+        """_resolve_owner_type_and_job returns both the
+        effective owner_type AND the Job (when present) from
+        the same query — replaces the side-by-side
+        _effective_owner_type + _find_job_by_guid pattern
+        Copilot flagged."""
+        from gnucash_mcp.book.business import BusinessMixin
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        with gb.open() as book:
+            from piecash.business.invoice import Invoice
+            inv_obj = book.session.query(Invoice).filter_by(
+                id=inv["id"],
+            ).first()
+            # Job-attached: returns (job's owner_type, job obj)
+            eff_ot, j = BusinessMixin._resolve_owner_type_and_job(
+                book, inv_obj,
+            )
+            assert eff_ot == 2  # customer
+            assert j is not None
+            assert j.id == job["id"]
+            # Direct invoice (no job): returns (own owner_type, None)
+            gb.create_invoice(customer_id="000001")
+            direct_inv = book.session.query(Invoice).filter_by(
+                id="000002",
+            ).first()
+            eff_ot2, j2 = BusinessMixin._resolve_owner_type_and_job(
+                book, direct_inv,
+            )
+            assert eff_ot2 == 2
+            assert j2 is None
+
+
 class TestInvoiceJobLinkage:
     """Tests for the job_id parameter on create_invoice /
     create_bill, plus the cascading effects on _invoice_to_dict

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -672,6 +672,204 @@ class TestDeleteJob:
             gb.delete_job(job_id="999999")
 
 
+class TestGetJobReport:
+    """Tests for get_job_report.
+
+    Per-job summary aggregating billed/paid/outstanding across
+    every linked invoice. Multi-currency support via
+    ``totals_by_currency``. Posted invoices contribute lot-
+    based amounts; unposted (draft) invoices contribute face
+    value with paid=0 so the report shows the pipeline.
+    """
+
+    def _setup_customer_with_posted_invoice(
+        self, gb, customer_name="Acme Co",
+        amount="500.00", post=True,
+    ):
+        """Helper to create customer + invoice + entry +
+        optionally post. Returns (job_id, invoice_id).
+        """
+        gb.create_customer(name=customer_name)
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv["id"],
+            account="Income:Sales",
+            description="Work",
+            quantity="1", price=amount,
+        )
+        if post:
+            gb.post_invoice(
+                invoice_id=inv["id"],
+                post_account="Assets:Accounts Receivable",
+                owner_type="customer",
+            )
+        return job["id"], inv["id"]
+
+    def test_job_not_found(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Job not found"):
+            gb.get_job_report(job_id="999999")
+
+    def test_empty_job_report(self, business_book):
+        """A job with no linked invoices reports zero counts and
+        an empty totals_by_currency dict — not an error."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="X",
+        )
+        result = gb.get_job_report(job_id=job["id"])
+        assert result["linked_invoices_count"] == 0
+        assert result["posted_count"] == 0
+        assert result["open_count"] == 0
+        assert result["totals_by_currency"] == {}
+        assert result["invoices"] == []
+
+    def test_single_posted_invoice(self, business_book):
+        """Posted invoice with no payments: billed=500,
+        paid=0, outstanding=500."""
+        gb = GnuCashBook(str(business_book))
+        job_id, _ = self._setup_customer_with_posted_invoice(gb)
+        result = gb.get_job_report(job_id=job_id)
+        assert result["linked_invoices_count"] == 1
+        assert result["posted_count"] == 1
+        assert result["open_count"] == 0
+        usd_totals = result["totals_by_currency"]["USD"]
+        assert Decimal(usd_totals["billed"]) == Decimal("500")
+        assert Decimal(usd_totals["paid"]) == Decimal("0")
+        assert Decimal(usd_totals["outstanding"]) == Decimal("500")
+        # Per-invoice row
+        assert len(result["invoices"]) == 1
+        assert result["invoices"][0]["status"] == "posted"
+
+    def test_partial_payment(self, business_book):
+        """After paying $200 against a $500 invoice: paid=200,
+        outstanding=300."""
+        gb = GnuCashBook(str(business_book))
+        job_id, inv_id = self._setup_customer_with_posted_invoice(gb)
+        gb.pay_invoice(
+            invoice_id=inv_id,
+            payment_account="Assets:Checking",
+            amount="200.00",
+            owner_type="customer",
+        )
+        result = gb.get_job_report(job_id=job_id)
+        usd = result["totals_by_currency"]["USD"]
+        assert Decimal(usd["paid"]) == Decimal("200")
+        assert Decimal(usd["outstanding"]) == Decimal("300")
+
+    def test_unposted_invoice_included(self, business_book):
+        """Drafts (unposted) contribute face value as billed +
+        outstanding, paid=0. Shows the pipeline alongside the
+        posted obligations."""
+        gb = GnuCashBook(str(business_book))
+        # Create posted invoice for $500
+        job_id, _ = self._setup_customer_with_posted_invoice(gb)
+        # Create draft invoice for $300 on same job
+        draft = gb.create_invoice(
+            customer_id="000001", job_id=job_id,
+        )
+        gb.add_invoice_entry(
+            invoice_id=draft["id"],
+            account="Income:Sales",
+            description="Future work",
+            quantity="1", price="300.00",
+        )
+        result = gb.get_job_report(job_id=job_id)
+        assert result["posted_count"] == 1
+        assert result["open_count"] == 1
+        usd = result["totals_by_currency"]["USD"]
+        # Total billed: 500 (posted) + 300 (draft) = 800
+        assert Decimal(usd["billed"]) == Decimal("800")
+        # Total outstanding: 500 (posted, unpaid) + 300 (draft) = 800
+        assert Decimal(usd["outstanding"]) == Decimal("800")
+
+    def test_multi_currency_totals(self, business_book):
+        """Mixed-currency job: totals_by_currency has one entry
+        per currency seen."""
+        import piecash
+        from datetime import date as date_cls
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as bk:
+            eur = piecash.Commodity(
+                namespace="CURRENCY", mnemonic="EUR",
+                fullname="Euro", fraction=100,
+            )
+            bk.session.add(eur)
+            bk.flush()
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=bk.default_currency,
+                date=date_cls(2026, 5, 24),
+                value="1.10", type="last",
+            ))
+            bk.save()
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer", name="Project",
+        )
+        # USD invoice
+        inv_usd = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv_usd["id"], account="Income:Sales",
+            description="USD work", quantity="1", price="500",
+        )
+        # EUR invoice
+        inv_eur = gb.create_invoice(
+            customer_id="000001", job_id=job["id"], currency="EUR",
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv_eur["id"], account="Income:Sales",
+            description="EUR work", quantity="1", price="400",
+        )
+        result = gb.get_job_report(job_id=job["id"])
+        assert result["linked_invoices_count"] == 2
+        assert "USD" in result["totals_by_currency"]
+        assert "EUR" in result["totals_by_currency"]
+        assert (
+            Decimal(result["totals_by_currency"]["USD"]["billed"])
+            == Decimal("500")
+        )
+        assert (
+            Decimal(result["totals_by_currency"]["EUR"]["billed"])
+            == Decimal("400")
+        )
+
+    def test_vendor_job_report(self, business_book):
+        """Vendor jobs work symmetrically — bills posted to A/P
+        report the same shape, owner_type='vendor'."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        job = gb.create_job(
+            owner_id="000001", owner_type="vendor", name="Supply",
+        )
+        bill = gb.create_bill(
+            vendor_id="000001", job_id=job["id"],
+        )
+        gb.add_bill_entry(
+            bill_id=bill["id"],
+            account="Expenses:Office Supplies",
+            description="Paper", quantity="1", price="150.00",
+        )
+        gb.post_invoice(
+            invoice_id=bill["id"],
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        result = gb.get_job_report(job_id=job["id"])
+        assert result["owner_type"] == "vendor"
+        assert result["owner_name"] == "Office Depot"
+        usd = result["totals_by_currency"]["USD"]
+        assert Decimal(usd["billed"]) == Decimal("150")
+        assert Decimal(usd["outstanding"]) == Decimal("150")
+
+
 class TestInvoiceJobLinkage:
     """Tests for the job_id parameter on create_invoice /
     create_bill, plus the cascading effects on _invoice_to_dict

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,13 +80,12 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 100 —
+        """Total tools across all sub-modules should be 101 —
         88 post-module-restructure + 3 voucher tools +
-        4 credit-note tools + 5 job tools (create_job,
-        list_jobs, get_job, update_job, delete_job) added
-        in v1.3."""
+        4 credit-note tools + 5 job CRUD tools +
+        1 get_job_report added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 100
+        assert total == 101
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -230,9 +229,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 100 tools (88 + 3 vouchers + 4 credit notes + 5 jobs)."""
+        """--modules=all should keep all 101 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 100
+        assert len(self._tool_names()) == 101
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -264,12 +263,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 100
+        assert len(self._tool_names()) == 101
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 100 tools."""
+        """'all' mixed with other modules should keep all 101 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 100
+        assert len(self._tool_names()) == 101
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,12 +80,13 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 95 —
-        88 post-module-restructure + 3 voucher tools + 4 credit-
-        note tools (create_credit_note, add_credit_note_entry,
-        delete_credit_note, apply_credit_note) added in v1.3."""
+        """Total tools across all sub-modules should be 100 —
+        88 post-module-restructure + 3 voucher tools +
+        4 credit-note tools + 5 job tools (create_job,
+        list_jobs, get_job, update_job, delete_job) added
+        in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 95
+        assert total == 100
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -229,9 +230,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 95 tools (88 + 3 vouchers + 4 credit notes)."""
+        """--modules=all should keep all 100 tools (88 + 3 vouchers + 4 credit notes + 5 jobs)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 95
+        assert len(self._tool_names()) == 100
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -263,12 +264,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 95
+        assert len(self._tool_names()) == 100
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 95 tools."""
+        """'all' mixed with other modules should keep all 100 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 95
+        assert len(self._tool_names()) == 100
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

Third of four Stage 3 headline features. Adds GnuCash's Job
concept — a customer/vendor-level grouping over invoices or
bills that lets a bookkeeper report on a single engagement
('API Rewrite', 'Q3 Maintenance', 'Kitchen renovation')
separately from the customer/vendor's overall A/R.

Six new tools and one extended-parameter pair, in four themed
commits:

1. **Job CRUD** (\`d06f2ea\`) — \`create_job\`, \`list_jobs\`,
   \`get_job\`, \`update_job\`, \`delete_job\`. Uses piecash's
   ORM-native Job constructor (open, unlike Invoice's). Owner
   restricted to customer/vendor — piecash's PersonType map
   has no Employee entry, and GnuCash desktop has no
   employee-job UI (same desktop-parity principle as credit
   notes). delete_job refuses by default when invoices are
   linked; \`force=True\` re-parents linked invoices back to
   the underlying customer/vendor before deleting (preserves
   invoice history).

2. **job_id on create_invoice / create_bill** (\`553ac64\`) —
   the linkage parameter. Validates the job belongs to the
   same customer/vendor with matching owner_type
   (customer-job + customer-invoice; vendor-job + vendor-bill).
   The actual INSERT overrides owner_type=3 and owner_guid=
   job.guid (GnuCash's polymorphic owner encoding).
   \`_find_invoice_owner_by_guid\` extended to chase owner_type=3
   through the Job to the underlying customer/vendor — one
   chokepoint fix that propagates transparently to every
   existing caller. \`get_invoice\` surfaces \`job: {id, name}\`
   on linked invoices. \`list_invoices\` gains a \`job_id\`
   filter.

3. **get_job_report + lifecycle plumbing** (\`8dc3133\`) — per-job
   billed/paid/outstanding summary across all linked invoices,
   with multi-currency support via \`totals_by_currency\`
   (always a dict, even for single-currency jobs, for shape
   consistency). The bigger work was the lifecycle plumbing:
   pre-fix, every \`add_invoice_entry\` / \`post_invoice\` /
   \`pay_invoice\` against a job-attached invoice failed with
   "Invoice not found" because the strict owner_type filter
   excluded owner_type=3 rows. A new \`_effective_owner_type\`
   helper chases the Job to the underlying type; \`_find_invoice\`
   uses a Job-subquery OR to match both direct and
   job-attached rows; \`_add_entry\`'s side-check and six
   \`is_bill\` callsites in post/unpost/pay all swap to the
   effective owner_type. Lifecycle now threads through
   transparently.

4. **Display polish** (\`549491c\`) — \`(job:JOB-X)\` annotation
   on the owner column of \`list_invoices\` and
   \`get_outstanding_invoices\` compact output. A row that's
   both a credit note AND job-attached reads as
   \`Owner (CN) (job:JOB-X)\` — the existing (CN) tag composes
   with the new annotation. Verbose output also surfaces a
   top-level \`job_id\` field for programmatic filtering.

**Tool count:** 101 (was 95; +5 CRUD + 1 report).

## Test plan

- [x] 1,240 unit tests pass (was 1,195 pre-branch; +45 new
  across TestCreateJob (7), TestListJobs (6), TestGetJob (2),
  TestUpdateJob (4), TestDeleteJob (4), TestGetJobReport (7),
  TestInvoiceJobLinkage (10), TestJobDisplayPolish (5))
- [x] All existing 329 business tests still pass (the
  \`_find_invoice\` SQL extension and \`_effective_owner_type\`
  refactor preserve direct-invoice behavior)
- [x] Live demo against Alex Chen-Morales (create a job for
  Berlin Digital, link an invoice, get_job_report, verify
  display annotations)
- [x] Bookkeeper review
- [x] Copilot review + resolve threads with \`scripts/resolve_pr_threads.py\`