### PR TITLE
feat(business): sales-tax tables (Stage 3 #4, v1.3 final feature)

### DIFF
--- a/specs/TAXTABLES_SPEC.md
+++ b/specs/TAXTABLES_SPEC.md
@@ -1,0 +1,601 @@
+# Taxtables Specification
+## GnuCash MCP Server v1.3 — Stage 3 Final Feature
+
+**Author:** Claude (Opus 4.7, post-compaction successor)
+**Date:** 2026-05-26
+**Status:** Draft for review
+**Prerequisites:**
+- Business module foundation (customers/vendors/employees, invoices/bills/vouchers, credit notes, jobs — all shipped in v1.3)
+- Multi-currency support (FX gain/loss on cross-currency payment — shipped v1.2.1)
+- Cross-currency exchange-rate lookup (`_find_exchange_rate`, `_qty_for_split` — shipped)
+
+---
+
+## Executive Summary
+
+Taxtables complete the v1.3 business module by adding sales-tax support to invoice/bill/voucher/credit-note line items. The bookkeeper defines named tax tables (GST 5%, GST+PST composite, Eco-Fee $5 flat) and tags individual line entries with the table that applies. Posting splits the line value into pre-tax revenue/expense and one or more tax-account amounts, producing a tax-collected liability or input-tax-credit asset that can be remitted to the tax authority on schedule.
+
+This is the heavyweight piece of v1.3. The data model is small, the entry-level wire-up is small, but the posting math has four behavioral quadrants and the line-to-splits relationship grows from 1:1 to 1:N where N is the number of entries in the applied taxtable. Implementation expectation: **~1500-2000 LOC across 5-7 commits**.
+
+The polymorphism inheritance from the existing business plumbing means invoices, bills, vouchers, and credit notes all gain tax support from a single seam — `_get_invoice_entries_and_total` — without per-document-type special-casing.
+
+---
+
+## Background: How GnuCash Models Tax
+
+A **Taxtable** is a named composite of one or more **TaxtableEntry** rows. Each entry routes a portion of tax to a specific GL account.
+
+```python
+# Single-rate taxtable (e.g., California sales tax)
+ca_sales = Taxtable(name="CA Sales Tax 7.25%", entries=[
+    TaxtableEntry(
+        type="percentage",
+        amount=Decimal("7.25"),
+        account=tax_payable_ca,
+    ),
+])
+
+# Multi-rate composite (e.g., GST 5% + PST 7% in BC, Canada)
+bc_gst_pst = Taxtable(name="BC GST+PST", entries=[
+    TaxtableEntry(type="percentage", amount=Decimal("5.00"),
+                  account=gst_payable),
+    TaxtableEntry(type="percentage", amount=Decimal("7.00"),
+                  account=pst_payable),
+])
+
+# Flat-value entry (e.g., environmental handling fee)
+eco_fee = Taxtable(name="Eco-Fee $5", entries=[
+    TaxtableEntry(type="value", amount=Decimal("5.00"),
+                  account=eco_fee_payable),
+])
+
+# Mixed composite (sales tax + flat environmental fee)
+ca_with_eco = Taxtable(name="CA Sales + Eco", entries=[
+    TaxtableEntry(type="percentage", amount=Decimal("7.25"),
+                  account=tax_payable_ca),
+    TaxtableEntry(type="value", amount=Decimal("5.00"),
+                  account=eco_fee_payable),
+])
+```
+
+**The 1:N relationship is the structural fact that shapes everything downstream.** One invoice line tagged with a multi-entry taxtable produces N+1 splits on the posting transaction (one revenue/expense split + N tax splits). The existing posting code at `business.py:3948-3969` assumes 1:1 (one entry → one account total → one split); the math seam must aggregate across taxtable entries before that loop runs.
+
+### Per-entry tax flags
+
+The `entries` table already carries the tax wire-up columns; they are hardcoded `0/None` today at `business.py:3391-3396`:
+
+| Column | Meaning |
+|---|---|
+| `i_taxable` / `b_taxable` | Boolean: is this entry subject to tax? |
+| `i_taxincluded` / `b_taxincluded` | Boolean: is the entry value tax-inclusive (gross) or tax-exclusive (pre-tax)? |
+| `i_taxtable` / `b_taxtable` | GUID reference to the Taxtable to apply |
+
+The `i_*` / `b_*` doubling is the same invoice-side / bill-side pattern already used for prices and accounts. Vouchers (owner_type=5) share the `b_*` group with bills per `_ENTRY_CONFIG`.
+
+### Per-entity defaults
+
+`Customer` and `Vendor` carry default-taxtable and tax-included columns plus a per-entity override gate:
+
+| Customer column | Vendor column | Meaning |
+|---|---|---|
+| `taxtable` (GUID) | `tax_table` (GUID) | Default taxtable for new entries |
+| `tax_included` | `tax_inc` | Default tax-included flag |
+| `tax_override` | `tax_override` | When 1, the entity default applies to new entries; when 0, no default (each entry must specify) |
+
+`Employee` has no analog (employee vouchers don't typically carry sales tax; expense receipts are recorded as-paid).
+
+**Inheritance cascade** (matching GnuCash desktop behavior):
+1. If entry creation specifies `taxtable` explicitly → use it
+2. Else if entity's `tax_override = 1` AND entity has a default → use entity default
+3. Else → no tax (`taxable=0`)
+
+For v1.3 MVP, we **defer the entity-default cascade**. Every entry that wants tax must specify it explicitly. The override flag and inheritance are recommended for a follow-on PR — the math seam is already structured to handle inherited taxtables identically to explicit ones, so the deferral is cheap to reverse.
+
+---
+
+## The Math: Four Quadrants
+
+For each entry row with `(quantity, price, taxable, tax_included, taxtable)`:
+
+### Quadrant 1: `taxable = 0` (no tax)
+
+```
+pretax       = Q × P
+tax_total    = 0
+tax_by_acct  = {}
+gross        = Q × P
+ar_contribution = gross
+```
+
+Identical to today's behavior. This is the no-op case the existing math already handles.
+
+### Quadrant 2: `taxable = 1, tax_included = 0` (tax added on top)
+
+The line price represents the pre-tax amount; tax is added.
+
+```
+pretax = Q × P
+for each entry e in taxtable:
+    if e.type == "percentage":
+        tax_e = (pretax × e.amount / 100).quantize(quantum)
+    else:  # e.type == "value"
+        tax_e = e.amount.quantize(quantum)
+    tax_by_acct[e.account] += tax_e
+tax_total = Σ tax_e
+gross     = pretax + tax_total
+ar_contribution = gross
+```
+
+### Quadrant 3: `taxable = 1, tax_included = 1`, percentage-only taxtable
+
+The line price represents the gross (tax-inclusive) amount; pre-tax is extracted.
+
+```
+total_rate = Σ entry.amount for entries where type == "percentage"  # as fraction
+gross      = Q × P
+pretax     = (gross / (1 + total_rate/100)).quantize(quantum)
+for each entry e in taxtable:
+    tax_e = (pretax × e.amount / 100).quantize(quantum)
+    tax_by_acct[e.account] += tax_e
+tax_total = Σ tax_e
+# Rounding adjustment: enforce gross = pretax + tax_total exactly
+residual = gross - pretax - tax_total
+if residual != 0:
+    # Apply residual to largest-rate entry to keep error in the
+    # dominant tax authority's bucket rather than smearing.
+    apply residual to tax_by_acct[largest_rate_entry.account]
+ar_contribution = gross
+```
+
+### Quadrant 4: `taxable = 1, tax_included = 1`, mixed value+percentage taxtable
+
+The tax-inclusive value contains both flat-value tax and percentage tax. Algebra:
+
+```
+gross  = pretax + Σ value_entries + pretax × (Σ rate%) / 100
+gross  = pretax × (1 + Σ rate%/100) + Σ value_entries
+pretax = (gross - Σ value_entries) / (1 + Σ rate%/100)
+```
+
+So:
+
+```
+sum_values   = Σ e.amount for entries where type == "value"
+sum_rates    = Σ e.amount for entries where type == "percentage"  # as fraction (5.0 not 0.05)
+gross        = Q × P
+pretax       = ((gross - sum_values) / (1 + sum_rates/100)).quantize(quantum)
+for each entry e in taxtable:
+    if e.type == "value":
+        tax_e = e.amount.quantize(quantum)
+    else:  # percentage
+        tax_e = (pretax × e.amount / 100).quantize(quantum)
+    tax_by_acct[e.account] += tax_e
+tax_total = Σ tax_e
+# Same residual-to-largest-rate adjustment as Quadrant 3
+ar_contribution = gross
+```
+
+### Rounding policy
+
+- Each tax-component value is `.quantize(currency_quantum)` independently. This matches GnuCash desktop and keeps per-line tax components individually auditable.
+- The Quadrant 3/4 residual adjustment ensures `gross == pretax + Σ tax` *exactly* at the line level, even when independent rounding would have produced a sub-cent gap. Applied to the largest-rate percentage entry by convention.
+- Aggregation across lines uses already-rounded per-line values. The grand total is the sum of per-line gross amounts.
+
+### Why per-line rounding (not document-level)
+
+Two reasonable choices exist:
+1. **Per-line**: round each line's tax independently. Each line is self-consistent. Cross-line accumulation may differ from `total_gross / (1+rate)` by a few cents on long invoices.
+2. **Document-level**: compute total gross, derive total tax at the end. Document totals are crisp but per-line tax breakdowns are approximations.
+
+GnuCash desktop uses **per-line**. The bookkeeper expects each line to balance to its own gross. Aggregate fuzz is acceptable; line-level fuzz is not.
+
+---
+
+## The Seam: `_get_invoice_entries_and_total`
+
+The function at `business.py:1482-1531` is THE place the math lives. Current shape:
+
+```python
+def _get_invoice_entries_and_total(self, book, inv):
+    # Returns: (rows, {account_guid: Decimal}, grand_total)
+```
+
+New shape:
+
+```python
+def _get_invoice_entries_and_total(self, book, inv):
+    # Returns:
+    #   (rows,
+    #    acct_totals,        # {account_guid: Decimal} — revenue/expense
+    #                        # AND tax-payable accounts together
+    #    grand_total,        # gross customer-facing total (incl. tax)
+    #    tax_breakdown,      # optional: {taxtable_guid: {account_guid:
+    #                        #   Decimal}} for display surfaces that
+    #                        #   want per-tax-table summarization
+    #    subtotal)           # sum of per-line pretax amounts
+```
+
+**Downstream callers** at `business.py:1209, 3865, 5726, 5895, 6077`:
+- `_invoice_to_compact_line` (1209): uses `grand_total` only — unchanged
+- `post_invoice` (3865): uses `acct_totals` and `grand_total` — works unchanged because tax accounts are folded into `acct_totals`
+- `get_outstanding_invoices` (5726): uses `grand_total` only — unchanged
+- `_collect_warnings` reconciliation path (5895): uses `grand_total` only — unchanged
+- `get_job_report` (6077): uses `grand_total` only — unchanged
+
+**The compact rendering surfaces auto-work** because they consume `grand_total`, which absorbs tax transparently. Only the verbose `get_invoice` path needs new fields via `_entry_to_dict`.
+
+### Posting math, mechanically unchanged
+
+The loop at `business.py:3948-3969` walks `acct_totals.items()` and emits one split per account. Because tax-payable accounts now appear in that same dict, **the loop is byte-identical**. The XOR sign-flip for credit notes (`effective_is_bill = is_bill ^ is_credit_note`) flips both revenue/expense splits AND tax splits in unison — which is correct for refund accounting (a customer credit note for $108 gross reduces A/R by $108, debits Revenue $100, debits GST Payable $8).
+
+### Cross-currency × tax
+
+Tax-payable accounts conventionally live in the book's default currency, while the invoice may be foreign-currency. The existing `_qty_for_split(acct, value_in_invoice_ccy)` helper at `business.py:3893-3917` already converts at `book.prices` for the post date. **No new infrastructure** — the tax-account split routes through the same converter as the A/R split.
+
+**Sharp edge worth a test**: an EUR invoice with USD-denominated GST Payable will book the tax-component at the EUR/USD rate on post date. If the rate moves before remittance, an FX gain/loss on the tax-payable balance arises — recognized at remittance time via the existing `pay_invoice` FX path, but only if the bookkeeper structures remittance as a payment-style transaction. The taxtable feature itself doesn't introduce new FX recognition; it inherits the existing machinery.
+
+---
+
+## Entry-Level Wire-Up
+
+`_add_entry` at `business.py:3287` gains three optional kwargs:
+
+```python
+def _add_entry(
+    self,
+    *,
+    owner_type: int,
+    doc_id: str,
+    account: str,
+    description: str,
+    quantity: str,
+    price: str,
+    taxtable: str | None = None,        # NEW — taxtable name
+    tax_included: bool = False,         # NEW — gross/net flag
+    # taxable derived: taxable = (taxtable is not None)
+) -> dict:
+```
+
+Routing into the values dict:
+
+```python
+taxable_int = 1 if taxtable else 0
+taxincluded_int = 1 if tax_included else 0
+taxtable_guid = self._find_taxtable(book, taxtable).guid if taxtable else None
+
+if is_bill_side:
+    values["b_taxable"] = taxable_int
+    values["b_taxincluded"] = taxincluded_int
+    values["b_taxtable"] = taxtable_guid
+else:
+    values["i_taxable"] = taxable_int
+    values["i_taxincluded"] = taxincluded_int
+    values["i_taxtable"] = taxtable_guid
+```
+
+Validation:
+- `tax_included=True` requires `taxtable` to be set (no-op otherwise; treat as user error and raise)
+- `taxtable` name must resolve to an existing Taxtable; raise `ValueError("Taxtable not found: {name}")` otherwise
+- Taxtable refcount increments on entry creation, decrements on entry deletion (the bookkeeping discipline GnuCash desktop enforces)
+
+The four `add_*_entry` tool wrappers (`add_invoice_entry`, `add_bill_entry`, `add_voucher_entry`, `add_credit_note_entry`) each grow two optional schema params — `taxtable` and `tax_included`. Owner-type polymorphism rides for free.
+
+---
+
+## Display Surfaces
+
+### `_entry_to_dict` (the only surface that genuinely changes)
+
+Current shape:
+
+```python
+{"guid", "date", "description", "quantity", "price", "total", "account"}
+```
+
+New shape (only when entry is taxable):
+
+```python
+{
+    "guid", "date", "description",
+    "quantity", "price",
+    "subtotal": "100.00",        # pretax (Q × P when tax-exclusive,
+                                 # extracted when tax-inclusive)
+    "tax": "8.25",               # total tax for this line
+    "tax_breakdown": {           # per-payable-account tax
+        "Liabilities:GST Payable": "5.00",
+        "Liabilities:PST Payable": "7.00",
+    },
+    "total": "108.25",           # gross (subtotal + tax)
+    "taxtable": "CA Sales Tax 7.25%",
+    "tax_included": false,
+    "account": "Income:Sales"
+}
+```
+
+For non-taxable entries, the response is byte-identical to today's shape (no `tax`/`taxtable` keys). This preserves the "absent = empty" project convention and keeps non-tax workflows unchanged.
+
+**Semantic decision: `total` is gross.** This matches the bookkeeper's mental model (what the customer paid / the vendor invoiced) and matches the downstream `grand_total`. The internal field `quantity * price` is the storage value but not the rendered total.
+
+### Other surfaces
+
+- `_invoice_to_compact_line`: no change (consumes `grand_total`)
+- `_invoice_to_dict`: optionally adds a top-level `tax_summary` block when any entry is taxable:
+
+  ```python
+  "tax_summary": {
+      "subtotal": "500.00",
+      "tax_total": "41.25",
+      "by_taxtable": {
+          "CA Sales Tax 7.25%": "36.25",
+          "Eco-Fee $5": "5.00",
+      },
+      "by_account": {
+          "Liabilities:GST Payable": "...",
+          ...
+      },
+      "total": "541.25"
+  }
+  ```
+
+  Conditional emission preserves shape for tax-free invoices.
+
+- `get_outstanding_invoices`: optionally adds `tax_total` per row when the invoice has tax. Useful for sales-tax remittance workflows. Compact format unchanged.
+
+- `get_job_report`: no change (totals_by_currency aggregates grand_total).
+
+---
+
+## Tool Surface
+
+### New tools (5)
+
+```
+create_taxtable(name, entries=[{type, amount, account}, ...])
+list_taxtables(compact=True)
+get_taxtable(name)
+update_taxtable(name, *, new_name=None, entries=None, force=False)
+delete_taxtable(name)
+```
+
+**No `description` field.** The piecash `Taxtable` schema has no
+`description` column; the taxtable's name (e.g., "BC GST+PST",
+"CA Sales 7.25%") carries the human-readable label.
+
+**`entries` parameter shape**:
+```python
+entries = [
+    {"type": "percentage", "amount": "5.00", "account": "Liabilities:GST Payable"},
+    {"type": "percentage", "amount": "7.00", "account": "Liabilities:PST Payable"},
+]
+```
+
+**Refcount discipline**:
+- `update_taxtable` with new `entries` while `refcount > 0` is a destructive operation on already-posted invoice math — refuse unless `force=True`, and even with force, posted-invoice transactions are NOT recomputed (they retain their original splits; only future entries see the new rates).
+- `delete_taxtable` requires `refcount == 0`. Returns clear error listing the entries that reference it.
+
+**Validation**:
+- Entry accounts must be LIABILITY (for sales/output tax) or ASSET (for input tax credits / VAT receivable). Reject EQUITY/INCOME/EXPENSE.
+- Percentage amounts must be `0 < amount < 100` (a 100%+ tax rate is almost certainly user error). Reject with clear message.
+- Value amounts must be `> 0`.
+
+### Modified tools (5)
+
+```
+add_invoice_entry       — gains taxtable, tax_included
+add_bill_entry          — gains taxtable, tax_included
+add_voucher_entry       — gains taxtable, tax_included
+add_credit_note_entry   — gains taxtable, tax_included
+get_invoice             — return shape grows with tax_summary block (conditional)
+```
+
+### Out of scope for v1.3
+
+- `set_customer_taxtable` / `set_vendor_taxtable` — fold into `update_customer` / `update_vendor` if pursued. Recommend deferring entirely.
+- `tax_override` flag on customer/vendor — defer with the cascade.
+- Generic `tax_remittance` workflow (compute output tax − input tax for a period, build a remittance transaction) — significant feature on its own; flag as a v1.4 candidate.
+
+**Final tool count after taxtables: 106** (101 + 5 new). Modified tools don't grow the count.
+
+---
+
+## Audit Log Dispatch
+
+Add entries to the dispatch table in `logging_config.py`:
+
+| (entity_type, operation) | Formatter |
+|---|---|
+| `("taxtable", "CREATE")` | name, description, entry count, entry list (`type rate% → account` lines) |
+| `("taxtable", "UPDATE")` | name, before/after diff on changed fields; entry-list diff when entries changed |
+| `("taxtable", "DELETE")` | name + refcount-at-delete (must be 0) |
+
+The `_fmt_entry_create` formatter (for `add_*_entry`) extends to recognize the new `taxtable`/`tax_included` fields and render them on the audit line when present.
+
+---
+
+## Refcount Discipline
+
+GnuCash maintains a refcount on Taxtable to track how many entries reference it. The bookkeeping model is:
+
+- `create_taxtable` → refcount = 0
+- `add_*_entry` with taxtable → increment refcount on the referenced taxtable
+- Entry deletion → decrement refcount on the referenced taxtable
+- `update_taxtable` while refcount > 0 → warn; require `force=True` (and never recompute posted invoices)
+- `delete_taxtable` while refcount > 0 → refuse with clear error
+
+**Implementation note**: piecash exposes `Taxtable.refcount` as a column. We manage the counter ourselves on entry create/delete because piecash doesn't auto-maintain it.
+
+**Edge case**: voiding an invoice does not decrement refcount because the entries are not deleted (void preserves splits with zero values for audit-trail purposes). This means a voided invoice still pins its taxtable. Document this in the `delete_taxtable` error message.
+
+---
+
+## Testing Strategy
+
+### Unit tests (~400-500 LOC)
+
+`tests/test_business.py` gains test classes:
+
+1. **`TestTaxtableCRUD`** — create, list (compact + verbose), get, update, delete; refcount tracking; validation rejection (bad rates, wrong account types, missing accounts); duplicate-name handling.
+2. **`TestTaxtableMath`** — the four quadrants, each with single-entry and multi-entry taxtables. Tax-inclusive + tax-exclusive. Mixed value+percentage. Rounding residual policy (verify the largest-rate entry absorbs sub-cent error).
+3. **`TestTaxtableEntryWireup`** — add_invoice_entry / add_bill_entry / add_voucher_entry / add_credit_note_entry each with taxtable + tax_included; verify i_*/b_* routing.
+4. **`TestTaxtablePosting`** — full post_invoice round-trip with taxable entries; verify split count, split sign-direction per quadrant; verify A/R split equals sum of revenue + tax splits.
+5. **`TestTaxtableCreditNoteReversal`** — credit note with tax reverses all splits including tax via the existing XOR.
+6. **`TestTaxtableCrossCurrency`** — EUR invoice with USD GST Payable; verify FX conversion on tax-component split; verify the rate matches `_qty_for_split`'s output.
+7. **`TestTaxtableDisplay`** — `_entry_to_dict` shape (taxable vs non-taxable); `_invoice_to_dict` tax_summary block conditional emission.
+8. **`TestTaxtableLifecycle`** — refcount discipline; delete-while-in-use rejection; update-while-in-use warning; voided-invoice-pins-taxtable case.
+
+Expected total: 80-120 new tests. Brings tests to ~1,330+.
+
+### Integration / synthetic-book
+
+Add **Phase 14** to `scripts/synthetic_book/` covering tax-aware lines:
+- Customer invoice with CA Sales Tax 7.25%, tax-exclusive
+- Customer invoice with BC GST+PST composite, tax-inclusive
+- Vendor bill (B2B input tax credit) with VAT 19%
+- Credit note refunding a tax-inclusive line
+- EUR-billed line with USD GST Payable (cross-currency tax)
+- Multi-rate composite with `value`+`percentage` mix (eco-fee + sales tax)
+
+Phase 14 backs up to `.pre-phase14.gnucash` before running so the fix-cycle pattern from prior synthetic-book work continues to hold.
+
+### Bookkeeper review checklist
+
+The bookkeeper review loop runs after each commit lands. Specifically probe:
+- Multi-rate composite invoice (GST+PST) — does each tax line route to the correct payable?
+- Tax-inclusive line — does the rendered subtotal match what the bookkeeper would compute by hand?
+- Sub-cent residual — does `gross == subtotal + tax` exactly?
+- Credit-note with tax — does it correctly *reduce* tax-payable (not increase)?
+- Cross-currency tax — does the FX rate applied to the tax split match the rate applied to the A/R split?
+- `get_invoice` verbose output on a non-taxable invoice — byte-identical to pre-taxtable shape?
+
+---
+
+## Commit Plan
+
+Six commits on a single feature branch `feat/taxtables`, target `develop`. Each commit ships independently testable; the math seam (Commit 3) is the structural turn that the rest builds on.
+
+### Commit 1: Taxtable + TaxtableEntry CRUD
+
+- `book/business.py`: `_taxtable_to_dict`, `_find_taxtable`, `create_taxtable`, `list_taxtables`, `get_taxtable`, `update_taxtable`, `delete_taxtable`
+- `tools/business.py`: tool wrappers + schema
+- `server.py`: `TOOL_MODULES["business"]` additions
+- `logging_config.py`: dispatch table entries + formatters
+- Tests: `TestTaxtableCRUD` (~25 tests)
+
+No posting math; safe foundation. Refcount management present but inert (no entries reference taxtables yet).
+
+### Commit 2: Per-quadrant tax math helper (pure function, isolated)
+
+- `book/business.py`: `_compute_entry_tax(row, taxtable)` returns `{pretax, tax_total, tax_by_acct, gross}`. Pure function — takes row + resolved taxtable, returns the per-line breakdown. No book mutation.
+- Tests: `TestTaxtableMath` (~30 tests covering all four quadrants + rounding residual + value/percentage mixes)
+
+Quarantines the math from the seam. Reviewable in isolation.
+
+### Commit 3: `_get_invoice_entries_and_total` extension + posting
+
+- `book/business.py`: enrich `_get_invoice_entries_and_total` to aggregate tax-component splits into `acct_totals`; add `subtotal` and `tax_breakdown` return fields.
+- `post_invoice`: zero structural changes — verify by snapshot diff.
+- Tests: `TestTaxtablePosting`, `TestTaxtableCreditNoteReversal` (~25 tests)
+
+This commit is the real work. Bookkeeper review loop runs after this commit lands.
+
+### Commit 4: Entry-level wire-up + tool params
+
+- `book/business.py`: `_add_entry` extension; the four `add_*_entry` wrappers grow `taxtable` + `tax_included` kwargs.
+- `tools/business.py`: schema growth on four tools.
+- Refcount increment/decrement on entry create/delete.
+- Tests: `TestTaxtableEntryWireup`, `TestTaxtableLifecycle` (~20 tests)
+
+### Commit 5: Display ripple
+
+- `book/business.py`: `_entry_to_dict` extension (taxable conditional fields); `_invoice_to_dict` optional `tax_summary` block.
+- Tests: `TestTaxtableDisplay` (~12 tests)
+
+After this commit, `get_invoice` on a tax-aware invoice surfaces the full breakdown to the bookkeeper.
+
+### Commit 6: Cross-currency tax verification + synthetic-book Phase 14
+
+- Tests: `TestTaxtableCrossCurrency` (~8 tests)
+- `scripts/synthetic_book/phase_14.py`: tax scenarios on Alex Chen-Morales
+- Manual bookkeeper review loop on the rebuilt book
+
+### Optional Commit 7: Audit-log polish + Copilot review followups
+
+Once PR opens, address Copilot review findings. Likely small (label drift, redundant queries, missing chokepoints). Resolve via `scripts/resolve_pr_threads.py` per the established procedure.
+
+---
+
+## Out of Scope
+
+Items considered and declined for v1.3. Each gets a one-line note here so future Claudes don't re-litigate.
+
+- **Customer/Vendor default-taxtable inheritance** — recommend deferring. The math seam is structured to accept any taxtable identically whether from explicit override or cascaded default, so a follow-on PR adds ~80 LOC without touching the math.
+- **Sales-tax remittance workflow** — significant feature (period-based aggregation, output-minus-input-credit math, remittance transaction generation). Flag as v1.4 candidate.
+- **Editing taxtables already in use** — accepted but with `force=True` guard. Posted invoices retain their original splits; the new entries see the new rates. Document loudly in update_taxtable error/warning.
+- **Per-document tax_summary on `get_outstanding_invoices`** — minor convenience, defer until bookkeeper asks for it. The grand_total already includes tax.
+- **Tax_override flag on customer/vendor** — deferred with the cascade.
+- **Recomputing tax on already-posted invoices** — never. Posted = immutable as far as tax math goes. Audit-trail principle.
+
+---
+
+## Open Questions (Pre-Implementation Review)
+
+Questions where the design could go either way. Resolve before Commit 1 starts.
+
+1. **Should `tax_included=True` without a taxtable raise, or silently default to `False`?**
+   - Raise (current spec): user error caught loudly.
+   - Silent: forgiving; "if you didn't say what tax, you couldn't have meant to include it."
+   - Recommended: raise.
+
+2. **Should `update_taxtable` with new entries automatically refresh `Taxtable.refcount`?**
+   - The piecash `refcount` semantics aren't fully documented. May want to verify by inspection of a desktop-edited book before deciding.
+
+3. **Should multi-currency taxtables (taxtable entries in different commodities) be permitted?**
+   - I.e., GST Payable in CAD and an Eco-Fee Payable in USD on the same taxtable.
+   - Recommended: REJECT at `create_taxtable` validation. Taxtables route to one commodity; the invoice currency converts to that commodity for all entries. Mixed-commodity taxtables don't have a clean rendering.
+
+4. **Round-trip closure for taxtables** — by the project's `TestShortGuidRoundTripClosure` contract, every short-form output must be acceptable as input. Taxtables are referenced by name (not GUID) in tool input. Should `create_taxtable` return a short GUID too?
+   - Recommended: yes. Even though name is the primary handle, return both `{name, guid}` for symmetry with other entities.
+
+5. **Should `_get_invoice_entries_and_total` return shape be a NamedTuple/dataclass instead of a 5-tuple?**
+   - Five-element tuple gets unwieldy and prone to caller mis-ordering.
+   - Recommended: use a small dataclass `_InvoiceTotals(rows, acct_totals, grand_total, subtotal, tax_breakdown)`. The internal callers can destructure.
+
+---
+
+## Risk Register
+
+Items where the implementation could surprise us. None are blockers; all are watch-fors.
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Sub-cent rounding errors propagate to A/R imbalance | Medium | Residual-to-largest-rate adjustment per line; integration test sums values to zero |
+| piecash refcount semantics differ from spec | Medium | Verify by inspecting a desktop-edited book before Commit 1 |
+| Cross-currency tax with no rate-on-file | Low | Existing `_qty_for_split` raises clear error; tax path inherits it |
+| Voided invoice still pins taxtable | Low (documented) | Mentioned in `delete_taxtable` error message |
+| Composite taxtables (GST+PST) reveal a bug in the existing `acct_totals` dedup | Low | Test explicitly: two distinct payable accounts on one line must produce two splits |
+
+---
+
+## Working Notes
+
+Notes for the implementer (whether that's me-tomorrow or a successor):
+
+- **The seam is `_get_invoice_entries_and_total`.** Resist the urge to split tax math into a separate top-level function. Keeping it inside the existing aggregator means downstream callers don't need to know there's tax — they just see a richer `acct_totals` dict and the same `grand_total`.
+- **Don't add a "tax" dispatch to `_BUSINESS_DOC_CONFIG` or `_ENTRY_CONFIG`.** Tax is orthogonal to doc-type and entry-type. The polymorphism inheritance is one of the gifts of the existing architecture; honoring it means tax code lives in *fewer* places, not more.
+- **The Quadrant 3/4 residual policy is the only place rounding is non-obvious.** Don't try to be clever. Apply the residual to the largest-rate percentage entry. Test that decision explicitly.
+- **`book.flush()` mid-transaction-build is forbidden** per the existing piecash gotcha. Tax-component splits and revenue/expense splits ride the same `book.save()` at the end of `post_invoice`. Don't break that.
+- **Verify `Taxtable.refcount` is integer-coerced** before increment/decrement. piecash's column type is `BIGINT`; SQLAlchemy returns int but null is possible on never-referenced rows.
+
+---
+
+## What's Different From Predecessor Analysis
+
+This spec was written after a fresh code-driven blast-radius analysis (post-compaction session, 2026-05-26). The predecessor's pre-compaction note (CLAUDE.local.md, same date) sketched the work but underweighted a few items:
+
+- **Display ripple is smaller than predecessor thought** — 3 of 4 surfaces consume `grand_total` and auto-work; only `_entry_to_dict` genuinely needs new fields.
+- **Polymorphism is a savings, not a cost** — the existing owner_type / credit-note / job-linkage machinery handles tax through XOR sign-flip and the unified `_qty_for_split` without per-doc-type special-casing.
+- **Multi-entry-per-taxtable was ambiguous** in the predecessor's prose. This spec formalizes it: one entry × N taxtable entries = up to N tax splits per line. The Quadrant 4 algebra (mixed value+percentage) only emerges when this is explicit.
+- **Customer/Vendor `tax_override` flag** is a separate gate from the default taxtable. Predecessor said "default-taxtable" but didn't note the explicit override mechanism. Specced for deferral but documented for the follow-on PR.
+- **Cross-currency × tax** wasn't surfaced as a sharp edge by the predecessor. The existing FX machinery covers it but the interaction between tax-payable commodity and invoice currency is non-obvious enough to deserve a test.
+
+Net: the spec sizes the work at ~1500-2000 LOC across 5-7 commits, down from the predecessor's 2500-3500 — primarily because the polymorphism inheritance is free and the display ripple narrower than feared.

--- a/specs/archive/PRODUCTION_FINDINGS_1_3.md
+++ b/specs/archive/PRODUCTION_FINDINGS_1_3.md
@@ -1,0 +1,106 @@
+# Production Findings — v1.3 cycle
+
+**Source:** Live accounting sessions, April–May 2026
+**Status:** Archived — all items shipped
+**Original home:** `specs/NEXT_STEPS_1_3.md` (retired, see archive
+                   convention)
+
+The bookkeeper review loop (live MCP usage against Alex Chen-Morales
+and Lin Wei test books) surfaced three concrete UX findings during
+the April–May 2026 production sessions. All three shipped in v1.3
+Stages 2–3. This file preserves the original framing as written
+contemporaneously so future contributors have the production
+context if they ever want to trace back from a shipped feature to
+the underlying user signal.
+
+---
+
+## `reconcile_account` bulk mode
+
+**Original problem statement:**
+Every reconciliation today requires two tool calls and a large token
+payload. The LLM calls `get_unreconciled_splits` to get GUIDs, then
+passes the entire GUID array back to `reconcile_account`. For a
+checking account with 108 unreconciled splits, the GUID array alone
+costs ~300 tokens — just echoing the server's own data back to it.
+
+In production accounting (April–May 2026 session), every
+reconciliation was all-or-nothing: reconcile every unreconciled
+split against the statement balance. The partial-selection
+capability was never used.
+
+**Original plan:**
+Add `reconcile_all=True` parameter to `reconcile_account`. When set,
+the server internally fetches all unreconciled splits, sums them
+against the existing reconciled balance, and verifies the total
+matches `statement_balance`. If it ties, reconcile all splits in one
+operation. If it doesn't, reject with the discrepancy amount so the
+LLM knows what's missing.
+
+Keep the existing `split_guids` parameter for partial reconciliation
+— it's the right design when statement and book disagree and the
+LLM needs to select a subset. But for the common case (OFX import →
+book everything → reconcile all), one call instead of two, 300 fewer
+tokens, zero risk of GUID copy errors.
+
+Optional enhancement: `through_date` parameter that reconciles all
+splits on or before a given date. Useful when the book has
+post-statement transactions that shouldn't be included.
+
+**Shipped:** v1.3 Stage 2 (PR #80, `feat/v1.3-stage-2`).
+
+---
+
+## `reconcile_account` does not accept account shortcuts
+
+**Original problem statement:**
+`reconcile_account` rejects `%xxxxxxx` account shortcuts in the
+`account` parameter, requiring the full account path. Every other
+tool that accepts an account name resolves shortcuts correctly. This
+was flagged three times during the April–May 2026 production
+session.
+
+**Original plan:**
+Wire the `_resolve_account_shortcut` helper into `reconcile_account`'s
+account parameter handling, same as every other tool.
+
+**Shipped:** Folded into the v1.3 short-GUID rollout (PR #53,
+`feat/short-account-guids`) which threaded `_resolve_account`
+support through every account-accepting tool, `reconcile_account`
+included.
+
+---
+
+## `employee` owner_type validation on business tools
+
+**Original problem statement:**
+`unpost_invoice(id="000001", owner_type="employee")` silently
+ignores the invalid owner_type, falls through to the unfiltered
+lookup, and returns a confusing disambiguation error between
+customer invoice and vendor bill. The LLM gets redirected to valid
+options ("customer" or "vendor") but the error message doesn't
+mention that "employee" was invalid input.
+
+**Original plan:**
+Validate `owner_type` against `["customer", "vendor"]` (or
+`["customer", "vendor", "employee"]` once expense vouchers exist) at
+the entry point of `unpost_invoice`, `post_invoice`, `pay_invoice`,
+and any other tool that accepts it. Reject with:
+`"Invalid owner_type 'employee'. Must be 'customer' or 'vendor'."`
+
+**Shipped:** v1.3 Stage 3 vouchers (PR #86, `feat/vouchers`) made
+`employee` a valid owner_type. The accompanying
+`_gate_owner_type` helper in `tools/_helpers.py` enforces
+validation at every business-tool entry point and rejects typos
+with a clear message naming the valid options.
+
+---
+
+## Why archive instead of just deleting
+
+These findings are kept because they represent a working pattern
+that the project has come to rely on: bookkeeper review loop
+generates real production signal, which becomes the dominant input
+to the backlog. Preserving the original framing — even after the
+work shipped — documents the loop's value so future contributors
+can see what the signal actually looks like.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2454,6 +2454,173 @@ class BusinessMixin:
 
         return resolved
 
+    @staticmethod
+    def _compute_entry_tax(
+        quantity: Decimal,
+        price: Decimal,
+        taxable: bool,
+        tax_included: bool,
+        taxtable_entries: list[dict],
+        quantum: Decimal,
+    ) -> dict:
+        """Per-line tax math. Pure function; no book access.
+
+        Caller resolves the taxtable to a list of
+        ``{type, amount, account_guid}`` dicts before invoking
+        (``type`` is ``'value'`` or ``'percentage'``; ``amount``
+        is ``Decimal``; ``account_guid`` is the FK to wherever the
+        tax component routes).
+
+        Four quadrants of behavior:
+
+        1. ``taxable=False``: no tax. ``pretax = Q × P``,
+           ``tax_total = 0``, ``tax_by_acct = {}``, ``gross = Q × P``.
+
+        2. ``taxable=True, tax_included=False`` (tax-exclusive):
+           Line value IS pre-tax; tax adds on top. For each entry,
+           percentage entries contribute ``pretax × rate / 100``,
+           value entries contribute their flat amount. Each is
+           quantized independently per the per-line rounding policy
+           (auditable line-by-line, matches GnuCash desktop).
+
+        3. ``taxable=True, tax_included=True``, all-percentage
+           taxtable: Line value is gross. Pretax extracted via
+           ``pretax = gross / (1 + Σ rate / 100)``. Per-entry tax
+           computed from extracted pretax.
+
+        4. ``taxable=True, tax_included=True``, mixed value +
+           percentage: Pretax extracted via
+           ``pretax = (gross − Σ value) / (1 + Σ rate / 100)``.
+           Value entries contribute their flat amount unchanged;
+           percentage entries contribute ``pretax × rate / 100``.
+
+        **Rounding residual policy** (Quadrants 3/4): after
+        independent per-entry quantization, ``gross == pretax +
+        Σ tax`` may differ by at most one quantum. The residual is
+        applied to the largest-rate percentage entry (or the first
+        value entry as fallback for all-value tax-inclusive — an
+        edge case that's algebraically degenerate but harmless).
+        Done this way to keep the dominant tax authority's bucket
+        carrying the rounding noise rather than smearing it across
+        all entries.
+
+        Args:
+            quantity, price: line-item quantity and unit price as
+                ``Decimal``.
+            taxable: whether this line has a taxtable applied.
+            tax_included: whether ``Q × P`` represents gross
+                (tax-inclusive) or pre-tax (tax-exclusive).
+            taxtable_entries: resolved taxtable entries as dicts
+                with ``type``, ``amount`` (``Decimal``), and
+                ``account_guid`` keys.
+            quantum: smallest representable unit of the currency
+                (typically ``Decimal('0.01')``; derived from
+                ``_commodity_quantum`` on the invoice currency).
+
+        Returns:
+            ``{pretax, tax_total, tax_by_acct, gross}`` — all
+            ``Decimal`` values; ``tax_by_acct`` is
+            ``{account_guid: Decimal}`` with one entry per distinct
+            payable account (composite taxtables routing to the
+            same account collapse to one entry by sum).
+        """
+        line_value = quantity * price
+
+        if not taxable or not taxtable_entries:
+            # Quadrant 1, or defensive no-entries fallback (the
+            # caller should have validated; behave as no-tax).
+            qv = line_value.quantize(quantum)
+            return {
+                "pretax": qv,
+                "tax_total": Decimal(0),
+                "tax_by_acct": {},
+                "gross": qv,
+            }
+
+        sum_values = sum(
+            (
+                e["amount"]
+                for e in taxtable_entries
+                if e["type"] == "value"
+            ),
+            Decimal(0),
+        )
+        sum_rates = sum(
+            (
+                e["amount"]
+                for e in taxtable_entries
+                if e["type"] == "percentage"
+            ),
+            Decimal(0),
+        )
+        rate_factor = sum_rates / Decimal(100)
+
+        if tax_included:
+            # Quadrants 3/4: extract pretax from gross.
+            gross = line_value.quantize(quantum)
+            if rate_factor == 0:
+                # All-value tax-inclusive: pretax = gross − values.
+                pretax = (gross - sum_values).quantize(quantum)
+            else:
+                pretax = (
+                    (gross - sum_values)
+                    / (Decimal(1) + rate_factor)
+                ).quantize(quantum)
+        else:
+            # Quadrant 2: line value IS pretax.
+            pretax = line_value.quantize(quantum)
+            gross = None  # computed after tax_total
+
+        tax_by_acct: dict[str, Decimal] = {}
+        for e in taxtable_entries:
+            acct_guid = e["account_guid"]
+            if e["type"] == "percentage":
+                tax_e = (
+                    pretax * e["amount"] / Decimal(100)
+                ).quantize(quantum)
+            else:
+                tax_e = e["amount"].quantize(quantum)
+            tax_by_acct[acct_guid] = (
+                tax_by_acct.get(acct_guid, Decimal(0)) + tax_e
+            )
+
+        tax_total = sum(tax_by_acct.values(), Decimal(0))
+
+        if tax_included:
+            # Residual adjustment: enforce gross = pretax + tax_total
+            # exactly. The residual is at most ±1 quantum from the
+            # independent per-entry rounding.
+            residual = gross - pretax - tax_total
+            if residual != 0:
+                # Find largest-rate percentage entry; fall back to
+                # first value entry if no percentage entries exist.
+                target_acct = None
+                largest_rate = Decimal(0)
+                for e in taxtable_entries:
+                    if (
+                        e["type"] == "percentage"
+                        and e["amount"] > largest_rate
+                    ):
+                        largest_rate = e["amount"]
+                        target_acct = e["account_guid"]
+                if target_acct is None:
+                    target_acct = (
+                        taxtable_entries[0]["account_guid"]
+                    )
+                tax_by_acct[target_acct] = (
+                    tax_by_acct[target_acct] + residual
+                )
+                tax_total = tax_total + residual
+        else:
+            gross = pretax + tax_total
+
+        return {
+            "pretax": pretax,
+            "tax_total": tax_total,
+            "tax_by_acct": tax_by_acct,
+            "gross": gross,
+        }
+
     def create_taxtable(
         self,
         name: str,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1289,9 +1289,9 @@ class BusinessMixin:
         # to "?" when entries can't be loaded — keeps the row legible
         # even on data-corruption edge cases.
         try:
-            _, _, grand_total = self._get_invoice_entries_and_total(
+            grand_total = self._get_invoice_entries_and_total(
                 book, invoice,
-            )
+            )["grand_total"]
             ccy = (
                 invoice.currency.mnemonic
                 if invoice.currency else ""
@@ -1563,13 +1563,40 @@ class BusinessMixin:
         return posted + timedelta(days=30), True
 
     def _get_invoice_entries_and_total(self, book, inv):
-        """Query entries for an invoice/bill and compute total.
+        """Query entries for an invoice/bill and compute totals,
+        absorbing per-line tax math.
+
+        For each entry, looks up its taxtable (when ``i_taxable``
+        or ``b_taxable`` is set) and invokes ``_compute_entry_tax``
+        to derive pretax / tax / gross + per-tax-account splits.
+        Aggregates revenue/expense AND tax-payable account amounts
+        into a single ``acct_totals`` dict so the downstream
+        ``post_invoice`` loop emits one split per account without
+        knowing about tax specifically.
 
         Returns:
-            Tuple of (entries_list, per_account_totals_dict, grand_total).
-            per_account_totals maps account_guid -> Decimal total.
+            Dict with keys:
+
+            - ``rows``: raw SQL rows from the entries table
+              (unchanged interface; callers don't read them
+              directly).
+            - ``acct_totals``: ``{account_guid: Decimal}`` covering
+              revenue/expense accounts AND tax-payable accounts
+              together. Used by ``post_invoice`` to emit splits.
+            - ``grand_total``: ``Decimal`` — gross customer-facing
+              total (sum of per-line gross). Includes tax for
+              tax-bearing entries.
+            - ``subtotal``: ``Decimal`` — sum of per-line pretax
+              amounts.
+            - ``tax_breakdown``: ``{account_guid: Decimal}`` — the
+              tax-only portion, available separately for display
+              surfaces that want to render a tax summary.
+
+        Raises:
+            ValueError: when the invoice has no entries.
         """
         from sqlalchemy import text
+        from piecash.business.tax import Taxtable
 
         is_bill = self._is_bill_side(self._effective_owner_type(book, inv))
         if is_bill:
@@ -1588,8 +1615,43 @@ class BusinessMixin:
                 f"Cannot post: invoice {inv.id} has no entries"
             )
 
+        # Taxtable resolution is cached so an invoice with many
+        # lines sharing the same taxtable hits SQL once per
+        # distinct taxtable, not once per line.
+        taxtable_cache: dict[str, list[dict]] = {}
+
+        def _resolve_taxtable_entries(taxtable_guid):
+            if not taxtable_guid:
+                return []
+            if taxtable_guid in taxtable_cache:
+                return taxtable_cache[taxtable_guid]
+            tt = book.session.query(Taxtable).filter_by(
+                guid=taxtable_guid,
+            ).first()
+            if not tt:
+                # Defensive: ``i_taxtable``/``b_taxtable`` points at
+                # a missing row. Entry creation validates this; if
+                # we land here the book is mid-corruption — treat
+                # as no-tax rather than crash the math seam.
+                taxtable_cache[taxtable_guid] = []
+                return []
+            resolved = [
+                {
+                    "type": e.type,
+                    "amount": e.amount,
+                    "account_guid": e.account_guid,
+                }
+                for e in tt.entries
+            ]
+            taxtable_cache[taxtable_guid] = resolved
+            return resolved
+
+        quantum = _commodity_quantum(inv.currency)
         acct_totals: dict[str, Decimal] = {}
+        tax_breakdown: dict[str, Decimal] = {}
         grand_total = Decimal(0)
+        subtotal = Decimal(0)
+
         for row in rows:
             q_num = row.quantity_num or 0
             q_denom = row.quantity_denom or 1
@@ -1599,19 +1661,60 @@ class BusinessMixin:
                 p_num = row.b_price_num or 0
                 p_denom = row.b_price_denom or 1
                 acct_guid = row.b_acct
+                taxable = bool(row.b_taxable)
+                tax_included = bool(row.b_taxincluded)
+                taxtable_guid = row.b_taxtable
             else:
                 p_num = row.i_price_num or 0
                 p_denom = row.i_price_denom or 1
                 acct_guid = row.i_acct
+                taxable = bool(row.i_taxable)
+                tax_included = bool(row.i_taxincluded)
+                taxtable_guid = row.i_taxtable
 
             price = Decimal(p_num) / Decimal(p_denom)
-            entry_total = quantity * price
-            grand_total += entry_total
-            acct_totals[acct_guid] = acct_totals.get(
-                acct_guid, Decimal(0)
-            ) + entry_total
+            taxtable_entries = _resolve_taxtable_entries(taxtable_guid)
 
-        return rows, acct_totals, grand_total
+            tax_result = self._compute_entry_tax(
+                quantity=quantity,
+                price=price,
+                taxable=taxable,
+                tax_included=tax_included,
+                taxtable_entries=taxtable_entries,
+                quantum=quantum,
+            )
+
+            # Revenue/expense account gets the pretax portion.
+            acct_totals[acct_guid] = (
+                acct_totals.get(acct_guid, Decimal(0))
+                + tax_result["pretax"]
+            )
+            # Tax-payable accounts get their per-entry components.
+            # Composite taxtables that route to the same account
+            # already collapse inside _compute_entry_tax; we just
+            # fold the result into the global acct_totals here.
+            for tax_acct, tax_amount in (
+                tax_result["tax_by_acct"].items()
+            ):
+                acct_totals[tax_acct] = (
+                    acct_totals.get(tax_acct, Decimal(0))
+                    + tax_amount
+                )
+                tax_breakdown[tax_acct] = (
+                    tax_breakdown.get(tax_acct, Decimal(0))
+                    + tax_amount
+                )
+
+            grand_total += tax_result["gross"]
+            subtotal += tax_result["pretax"]
+
+        return {
+            "rows": rows,
+            "acct_totals": acct_totals,
+            "grand_total": grand_total,
+            "subtotal": subtotal,
+            "tax_breakdown": tax_breakdown,
+        }
 
     # ── Customer / Vendor / Billterm CRUD ─────────────────────────
 
@@ -4668,9 +4771,9 @@ class BusinessMixin:
                     f"got {post_acct.type}"
                 )
 
-            _, acct_totals, grand_total = (
-                self._get_invoice_entries_and_total(book, inv)
-            )
+            totals = self._get_invoice_entries_and_total(book, inv)
+            acct_totals = totals["acct_totals"]
+            grand_total = totals["grand_total"]
 
             lot = Lot(
                 title=f"Invoice {inv.id}",
@@ -6529,9 +6632,9 @@ class BusinessMixin:
                     continue
 
                 try:
-                    _, _, grand_total = (
-                        self._get_invoice_entries_and_total(book, inv)
-                    )
+                    grand_total = self._get_invoice_entries_and_total(
+                        book, inv,
+                    )["grand_total"]
                 except ValueError:
                     grand_total = abs(balance)
 
@@ -6698,9 +6801,9 @@ class BusinessMixin:
                 # than aborting the whole report — matches the
                 # _invoice_to_compact_line defensive shape.
                 try:
-                    _, _, billed = (
-                        self._get_invoice_entries_and_total(book, inv)
-                    )
+                    billed = self._get_invoice_entries_and_total(
+                        book, inv,
+                    )["grand_total"]
                 except (ValueError, AttributeError):
                     billed = Decimal("0")
 
@@ -6880,11 +6983,9 @@ class BusinessMixin:
                             break
 
                 try:
-                    _, _, total = (
-                        self._get_invoice_entries_and_total(
-                            book, bill
-                        )
-                    )
+                    total = self._get_invoice_entries_and_total(
+                        book, bill,
+                    )["grand_total"]
                 except ValueError:
                     # Empty/corrupted entries — fall back to the
                     # lot balance (computed above). Pre-fix this

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -4744,12 +4744,28 @@ class BusinessMixin:
             for a in book.accounts:
                 account_paths[a.guid] = a.fullname
 
-            # Build taxtable_guid → name map for entries that
-            # reference taxtables. One query, like account_paths.
-            from piecash.business.tax import Taxtable
+            # Build taxtable_guid → name map only for taxtables
+            # actually referenced by this invoice's entries — skip
+            # the query entirely when no entries are tax-bearing,
+            # and otherwise filter to just the needed GUIDs. Saves
+            # an O(N-taxtables-in-book) scan on every get_invoice
+            # call against a large book. Same preload pattern as
+            # the Job lookup in list_invoices.
+            if is_bill:
+                needed_tt_guids = {
+                    r.b_taxtable for r in rows if r.b_taxtable
+                }
+            else:
+                needed_tt_guids = {
+                    r.i_taxtable for r in rows if r.i_taxtable
+                }
             taxtable_names: dict[str, str] = {}
-            for tt in book.session.query(Taxtable).all():
-                taxtable_names[tt.guid] = tt.name
+            if needed_tt_guids:
+                from piecash.business.tax import Taxtable
+                for tt in book.session.query(Taxtable).filter(
+                    Taxtable.guid.in_(needed_tt_guids),
+                ).all():
+                    taxtable_names[tt.guid] = tt.name
 
             entries = [
                 self._entry_to_dict(

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -4026,6 +4026,8 @@ class BusinessMixin:
         quantity: str,
         price: str,
         owner_type: str | None = None,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> dict:
         """Add a line item to a credit note.
 
@@ -4082,6 +4084,8 @@ class BusinessMixin:
             description=description,
             quantity=quantity,
             price=price,
+            taxtable=taxtable,
+            tax_included=tax_included,
         )
         # Surface the credit_note_id key in the response (the
         # base helper returns invoice_id / bill_id based on
@@ -4192,6 +4196,8 @@ class BusinessMixin:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> dict:
         """Shared implementation behind ``add_invoice_entry`` and
         ``add_bill_entry``. The two methods were 90% duplicated
@@ -4201,9 +4207,34 @@ class BusinessMixin:
         helper takes ``owner_type`` (2=customer invoice, 4=vendor
         bill), looks up the per-doc config in ``_ENTRY_CONFIG``,
         and writes the entry.
+
+        **Taxtable wire-up (commit 4 of the v1.3 taxtable arc):**
+
+        When ``taxtable`` is given, the entry is marked taxable and
+        the resolved taxtable's GUID is written to ``i_taxtable``
+        or ``b_taxtable`` (side-dependent). ``tax_included`` flags
+        whether the line price represents pre-tax (False, default)
+        or gross (True) — the posting math in
+        ``_get_invoice_entries_and_total`` uses this to decide
+        whether to extract pretax from gross or add tax on top.
+
+        ``tax_included=True`` without ``taxtable`` raises — silently
+        treating it as no-op would drop the caller's signal that
+        they thought they were enabling tax.
+
+        The taxtable's stored ``refcount`` column is incremented
+        post-insert to keep GnuCash desktop's bookkeeping in sync
+        (our own lifecycle checks use SQL-computed counts, but the
+        desktop UI reads the stored value).
         """
         import uuid
         from piecash.business.invoice import Entry
+
+        if tax_included and not taxtable:
+            raise ValueError(
+                "tax_included=True requires a taxtable. Specify "
+                "which taxtable applies, or omit tax_included."
+            )
 
         cfg = self._ENTRY_CONFIG[owner_type]
         # Both vendor bills (4) and employee expense vouchers (5)
@@ -4263,18 +4294,42 @@ class BusinessMixin:
             p_num, p_denom = self._decimal_to_num_denom(unit_price)
             entry_guid = uuid.uuid4().hex
 
+            # Resolve the taxtable upfront so a missing-taxtable
+            # error fires before any write. The resolved Taxtable
+            # is also captured so we can bump its refcount after
+            # the INSERT succeeds.
+            tt_obj = None
+            if taxtable:
+                tt_obj = self._find_taxtable(book, taxtable)
+                if not tt_obj:
+                    raise ValueError(
+                        f"Taxtable not found: {taxtable!r}"
+                    )
+
+            taxable_int = 1 if taxtable else 0
+            taxincl_int = 1 if tax_included else 0
+            tt_guid = tt_obj.guid if tt_obj else None
+
             # The Entries table has parallel ``i_*`` (invoice side)
             # and ``b_*`` (bill side) column groups. Exactly one
             # group carries values for any given entry; the other
             # is zeroed/NULL. Voucher entries (owner_type=5) share
             # the ``b_*`` / ``bill`` group with vendor bills — see
             # ``is_bill_side`` above.
+            #
+            # Tax fields land on the same side as the price/account
+            # — invoice-side entries write ``i_taxtable``, bill-side
+            # write ``b_taxtable``. The other side stays zeroed.
             if is_bill_side:
                 values = dict(
                     i_acct=None, i_price_num=0, i_price_denom=1,
                     invoice=None,
                     b_acct=acct.guid, b_price_num=p_num,
                     b_price_denom=p_denom, bill=inv.guid,
+                    i_taxable=0, i_taxincluded=0, i_taxtable=None,
+                    b_taxable=taxable_int,
+                    b_taxincluded=taxincl_int,
+                    b_taxtable=tt_guid,
                 )
             else:
                 values = dict(
@@ -4282,6 +4337,10 @@ class BusinessMixin:
                     i_price_denom=p_denom, invoice=inv.guid,
                     b_acct=None, b_price_num=0, b_price_denom=1,
                     bill=None,
+                    i_taxable=taxable_int,
+                    i_taxincluded=taxincl_int,
+                    i_taxtable=tt_guid,
+                    b_taxable=0, b_taxincluded=0, b_taxtable=None,
                 )
 
             book.session.execute(
@@ -4298,12 +4357,6 @@ class BusinessMixin:
                     i_discount_denom=1,
                     i_disc_type="",
                     i_disc_how="",
-                    i_taxable=0,
-                    i_taxincluded=0,
-                    i_taxtable=None,
-                    b_taxable=0,
-                    b_taxincluded=0,
-                    b_taxtable=None,
                     b_paytype=0,
                     billable=0,
                     billto_type=0,
@@ -4317,6 +4370,14 @@ class BusinessMixin:
                 f"{cfg['label']} entry '{description}' on "
                 f"{cfg['label'].lower()} {doc_id}",
             )
+
+            # Refcount maintenance: GnuCash desktop reads
+            # Taxtable.refcount to know whether a taxtable is in
+            # use. Our own lifecycle checks use the SQL-computed
+            # count (authoritative), but we keep the stored value
+            # in sync so desktop interop stays clean.
+            if tt_obj is not None:
+                tt_obj.refcount = (tt_obj.refcount or 0) + 1
 
             book.save()
 
@@ -4338,6 +4399,8 @@ class BusinessMixin:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> dict:
         """Add a line item entry to a customer invoice.
 
@@ -4358,6 +4421,8 @@ class BusinessMixin:
             description=description,
             quantity=quantity,
             price=price,
+            taxtable=taxtable,
+            tax_included=tax_included,
         )
 
     def add_bill_entry(
@@ -4367,6 +4432,8 @@ class BusinessMixin:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> dict:
         """Add a line item entry to a vendor bill.
 
@@ -4376,6 +4443,12 @@ class BusinessMixin:
             description: Line item description.
             quantity: Quantity as string (e.g., '1', '2.5').
             price: Unit price as string (e.g., '50.00').
+            taxtable: Optional taxtable name. When given, the entry
+                contributes tax components per the taxtable's entries
+                at posting time.
+            tax_included: If True, ``price`` is treated as gross
+                (tax-inclusive); pretax extracted. If False (default),
+                ``price`` is pre-tax and tax adds on top.
 
         Returns:
             Dict with guid, bill_id, total, status.
@@ -4387,6 +4460,8 @@ class BusinessMixin:
             description=description,
             quantity=quantity,
             price=price,
+            taxtable=taxtable,
+            tax_included=tax_included,
         )
 
     def add_voucher_entry(
@@ -4396,6 +4471,8 @@ class BusinessMixin:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> dict:
         """Add a line item entry to an employee expense voucher.
 
@@ -4412,6 +4489,10 @@ class BusinessMixin:
             description: Line item description.
             quantity: Quantity as string (e.g., '1').
             price: Unit price as string (e.g., '42.50').
+            taxtable: Optional taxtable name. Same semantics as
+                ``add_bill_entry``.
+            tax_included: If True, ``price`` is gross; pretax
+                extracted at posting.
 
         Returns:
             Dict with guid, voucher_id, total, status.
@@ -4423,6 +4504,8 @@ class BusinessMixin:
             description=description,
             quantity=quantity,
             price=price,
+            taxtable=taxtable,
+            tax_included=tax_included,
         )
 
     def list_invoices(
@@ -5915,6 +5998,38 @@ class BusinessMixin:
                 .where(entry_fk_col == inv_guid)
             ).scalar()
             if entry_count:
+                # Refcount maintenance: before deleting tax-bearing
+                # entries, tally per-taxtable counts and decrement
+                # the stored ``Taxtable.refcount`` so desktop interop
+                # stays clean. Both ``i_taxtable`` and ``b_taxtable``
+                # columns are checked — the side depends on
+                # owner_type, but a defensive UNION covers any
+                # legacy data oddities. SQL-computed counts in our
+                # own logic are unaffected by this step (they query
+                # the entries table fresh).
+                from sqlalchemy import text
+                tax_refs = book.session.execute(
+                    text(
+                        "SELECT taxtable_guid, COUNT(*) AS n FROM ("
+                        "  SELECT i_taxtable AS taxtable_guid FROM entries "
+                        f"  WHERE {entry_fk} = :guid AND i_taxtable IS NOT NULL "
+                        "  UNION ALL "
+                        "  SELECT b_taxtable AS taxtable_guid FROM entries "
+                        f"  WHERE {entry_fk} = :guid AND b_taxtable IS NOT NULL "
+                        ") AS refs GROUP BY taxtable_guid"
+                    ),
+                    {"guid": inv_guid},
+                ).fetchall()
+                for ref in tax_refs:
+                    book.session.execute(
+                        text(
+                            "UPDATE taxtables "
+                            "SET refcount = MAX(0, refcount - :n) "
+                            "WHERE guid = :guid"
+                        ),
+                        {"n": ref.n, "guid": ref.taxtable_guid},
+                    )
+
                 book.session.execute(
                     Entry.__table__.delete().where(entry_fk_col == inv_guid)
                 )

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1130,6 +1130,7 @@ class BusinessMixin:
         owner_name: str | None = None,
         applies_to: dict | None = None,
         job: dict | None = None,
+        tax_summary: dict | None = None,
     ) -> dict:
         """Convert a piecash Invoice to a serializable dict.
 
@@ -1222,6 +1223,11 @@ class BusinessMixin:
             result["job"] = {"id": job["id"], "name": job["name"]}
         if entries is not None:
             result["entries"] = entries
+        # Tax summary conditional on the invoice having any
+        # tax-bearing lines. Non-tax invoices keep their pre-v1.3
+        # response shape byte-identical.
+        if tax_summary is not None:
+            result["tax_summary"] = tax_summary
         return result
 
     def _invoice_to_compact_line(self, book, invoice) -> str:
@@ -1321,6 +1327,7 @@ class BusinessMixin:
         entry_row,
         is_bill: bool = False,
         account_paths: dict | None = None,
+        taxtable_names: dict | None = None,
     ) -> dict:
         """Convert an entry row (from raw SQL) to a serializable dict.
 
@@ -1333,6 +1340,11 @@ class BusinessMixin:
                 builds this map once per invoice and passes it through;
                 this keeps the static-method shape while letting the
                 response be readable to humans/LLMs.
+            taxtable_names: Optional ``{taxtable_guid: name}`` map for
+                resolving the entry's applied taxtable to its readable
+                name. Tax fields (taxable, tax_included, taxtable) are
+                emitted only when the entry is taxable — non-tax
+                entries keep their pre-v1.3 shape exactly.
         """
         q_num = entry_row.quantity_num or 0
         q_denom = entry_row.quantity_denom or 1
@@ -1342,10 +1354,16 @@ class BusinessMixin:
             p_num = entry_row.b_price_num or 0
             p_denom = entry_row.b_price_denom or 1
             acct_guid = entry_row.b_acct
+            taxable = bool(entry_row.b_taxable)
+            tax_included = bool(entry_row.b_taxincluded)
+            taxtable_guid = entry_row.b_taxtable
         else:
             p_num = entry_row.i_price_num or 0
             p_denom = entry_row.i_price_denom or 1
             acct_guid = entry_row.i_acct
+            taxable = bool(entry_row.i_taxable)
+            tax_included = bool(entry_row.i_taxincluded)
+            taxtable_guid = entry_row.i_taxtable
 
         price = Decimal(p_num) / Decimal(p_denom)
         total = quantity * price
@@ -1375,6 +1393,20 @@ class BusinessMixin:
             )
         else:
             result["account_guid"] = acct_guid or ""
+
+        # Tax fields conditional on taxable=1 — non-tax entries
+        # keep their byte-identical pre-v1.3 shape so existing
+        # consumers see no diff.
+        if taxable:
+            result["taxable"] = True
+            result["tax_included"] = tax_included
+            if taxtable_guid:
+                if taxtable_names is not None:
+                    result["taxtable"] = taxtable_names.get(
+                        taxtable_guid, taxtable_guid,
+                    )
+                else:
+                    result["taxtable_guid"] = taxtable_guid
         return result
 
     @staticmethod
@@ -1591,6 +1623,11 @@ class BusinessMixin:
             - ``tax_breakdown``: ``{account_guid: Decimal}`` — the
               tax-only portion, available separately for display
               surfaces that want to render a tax summary.
+            - ``tax_by_taxtable``: ``{taxtable_guid: Decimal}`` —
+              tax aggregated by the taxtable that produced it,
+              for surfaces that want to render a "Tax — GST 5%:
+              $15, BC GST+PST: $7" rollup. A taxtable with zero
+              tax-bearing lines on this invoice does not appear.
 
         Raises:
             ValueError: when the invoice has no entries.
@@ -1649,6 +1686,7 @@ class BusinessMixin:
         quantum = _commodity_quantum(inv.currency)
         acct_totals: dict[str, Decimal] = {}
         tax_breakdown: dict[str, Decimal] = {}
+        tax_by_taxtable: dict[str, Decimal] = {}
         grand_total = Decimal(0)
         subtotal = Decimal(0)
 
@@ -1705,6 +1743,16 @@ class BusinessMixin:
                     + tax_amount
                 )
 
+            # Per-taxtable rollup: when this line was tax-bearing,
+            # attribute its total tax to the source taxtable so
+            # display surfaces can render "GST 5%: $15, BC GST+PST:
+            # $7" without re-deriving from row data.
+            if taxtable_guid and tax_result["tax_total"] != 0:
+                tax_by_taxtable[taxtable_guid] = (
+                    tax_by_taxtable.get(taxtable_guid, Decimal(0))
+                    + tax_result["tax_total"]
+                )
+
             grand_total += tax_result["gross"]
             subtotal += tax_result["pretax"]
 
@@ -1714,6 +1762,7 @@ class BusinessMixin:
             "grand_total": grand_total,
             "subtotal": subtotal,
             "tax_breakdown": tax_breakdown,
+            "tax_by_taxtable": tax_by_taxtable,
         }
 
     # ── Customer / Vendor / Billterm CRUD ─────────────────────────
@@ -4695,17 +4744,63 @@ class BusinessMixin:
             for a in book.accounts:
                 account_paths[a.guid] = a.fullname
 
+            # Build taxtable_guid → name map for entries that
+            # reference taxtables. One query, like account_paths.
+            from piecash.business.tax import Taxtable
+            taxtable_names: dict[str, str] = {}
+            for tt in book.session.query(Taxtable).all():
+                taxtable_names[tt.guid] = tt.name
+
             entries = [
                 self._entry_to_dict(
-                    r, is_bill=is_bill, account_paths=account_paths,
+                    r,
+                    is_bill=is_bill,
+                    account_paths=account_paths,
+                    taxtable_names=taxtable_names,
                 )
                 for r in rows
             ]
 
-            total = sum(
-                Decimal(e["quantity"]) * Decimal(e["price"])
-                for e in entries
-            )
+            # Tax summary: compute via the seam so the math
+            # matches what posting would produce. Empty entries
+            # raises ValueError on the seam — guarded by the
+            # outer rows check. If no entries are tax-bearing,
+            # tax_summary stays None and the response shape
+            # matches pre-v1.3 byte-for-byte.
+            tax_summary = None
+            if rows:
+                totals = self._get_invoice_entries_and_total(
+                    book, inv,
+                )
+                if totals["tax_breakdown"]:
+                    tax_summary = {
+                        "subtotal": str(totals["subtotal"]),
+                        "tax_total": str(
+                            sum(
+                                totals["tax_breakdown"].values(),
+                                Decimal(0),
+                            )
+                        ),
+                        "by_taxtable": {
+                            taxtable_names.get(g, g): str(v)
+                            for g, v in totals[
+                                "tax_by_taxtable"
+                            ].items()
+                        },
+                        "by_account": {
+                            account_paths.get(g, g): str(v)
+                            for g, v in totals[
+                                "tax_breakdown"
+                            ].items()
+                        },
+                        "total": str(totals["grand_total"]),
+                    }
+                # Customer-facing total uses the seam's
+                # grand_total (gross). Non-tax invoices fold to
+                # the same Q×P sum they had pre-v1.3.
+                total = totals["grand_total"]
+            else:
+                total = Decimal(0)
 
             # Three-way owner lookup — vouchers route to employees,
             # bills to vendors, invoices to customers. Pre-fix this
@@ -4743,6 +4838,7 @@ class BusinessMixin:
                 owner_name=owner_name,
                 applies_to=applies_to,
                 job=job_dict,
+                tax_summary=tax_summary,
             )
             result["total"] = str(total)
             return result

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -689,6 +689,27 @@ class BusinessMixin:
         return book.session.query(Job).filter_by(id=job_id).first()
 
     @staticmethod
+    def _find_taxtable(book, name: str):
+        """Find a Taxtable by exact name.
+
+        Taxtables are keyed by name across the book — there is no
+        per-jurisdiction or per-entity namespace. A book has at most
+        one taxtable named "GST 5%" and lookups are O(log n) via the
+        unique-name index. Returns None if not found; callers raise.
+        """
+        from piecash.business.tax import Taxtable
+        return book.session.query(Taxtable).filter_by(name=name).first()
+
+    @staticmethod
+    def _find_taxtable_by_guid(book, guid: str):
+        """Find a Taxtable by full GUID. Caller passes a 32-char hex
+        string (resolved via :meth:`_resolve_guid` upstream when the
+        input was a short prefix). Returns None if not found.
+        """
+        from piecash.business.tax import Taxtable
+        return book.session.query(Taxtable).filter_by(guid=guid).first()
+
+    @staticmethod
     def _find_job_by_guid(book, guid: str):
         """Find a job by GUID. Used to resolve invoice→job links
         where the invoice's ``owner_guid`` (with owner_type=3)
@@ -1009,6 +1030,68 @@ class BusinessMixin:
             "due_days": bt.duedays,
             "discount_days": bt.discountdays if bt.discountdays else 0,
             "discount": str(bt.discount) if bt.discount else "0",
+        }
+
+    @staticmethod
+    def _taxtable_entry_to_dict(
+        tte,
+        account_paths: dict | None = None,
+    ) -> dict:
+        """Serialize a TaxtableEntry to a dict.
+
+        Args:
+            tte: piecash TaxtableEntry object.
+            account_paths: Optional ``{account_guid: fullname}`` map.
+                When present, the entry's ``account`` field is the
+                resolved path (readable); otherwise the raw GUID
+                appears as ``account_guid``. Same pattern as
+                ``_entry_to_dict``.
+        """
+        result = {
+            "id": tte.id,
+            "type": tte.type,
+            "amount": str(tte.amount),
+        }
+        if account_paths is not None:
+            result["account"] = account_paths.get(
+                tte.account_guid, tte.account_guid,
+            )
+        else:
+            result["account_guid"] = tte.account_guid
+        return result
+
+    @staticmethod
+    def _taxtable_to_dict(
+        tt,
+        account_paths: dict | None = None,
+        refcount: int | None = None,
+    ) -> dict:
+        """Serialize a Taxtable to a dict.
+
+        Args:
+            tt: piecash Taxtable object.
+            account_paths: Optional ``{account_guid: fullname}`` map
+                covering every entry's account. Pre-built by the
+                caller (one query rather than N).
+            refcount: Optional computed-from-SQL refcount. The
+                stored ``Taxtable.refcount`` column tracks GnuCash
+                desktop's bookkeeping; the SQL-computed value is
+                authoritative for lifecycle checks. When given,
+                replaces the stored value in the response.
+        """
+        entries = [
+            BusinessMixin._taxtable_entry_to_dict(
+                e, account_paths=account_paths,
+            )
+            for e in tt.entries
+        ]
+        return {
+            "guid": tt.guid,
+            "name": tt.name,
+            "refcount": (
+                refcount if refcount is not None else tt.refcount
+            ),
+            "entries": entries,
         }
 
     @staticmethod
@@ -2206,6 +2289,563 @@ class BusinessMixin:
                 return "\n".join(lines)
             else:
                 return [self._billterm_to_dict(t) for t in terms]
+
+    # ── Taxtable CRUD ─────────────────────────────────────────────
+    #
+    # Taxtables route sales-tax math on invoice/bill/voucher/credit-
+    # note line entries. A taxtable holds one or more
+    # ``TaxtableEntry`` rows; each entry contributes either a
+    # percentage rate (5.00 means 5%) or a flat value (5.00 means a
+    # fixed $5 surcharge) routed to a specific GL account.
+    #
+    # A multi-entry taxtable (e.g., GST 5% + PST 7%) produces N tax
+    # splits per line at posting time, one per entry to its own
+    # account — see commit 3's posting math. This commit is pure
+    # data CRUD; the wire-up into entries (commit 4) and into
+    # ``_get_invoice_entries_and_total`` (commit 3) happens later.
+    #
+    # **Refcount discipline.** GnuCash desktop maintains
+    # ``Taxtable.refcount`` as the number of entries referencing the
+    # taxtable. piecash does not auto-maintain it; we manage it
+    # manually on entry create/delete in commit 4. For lifecycle
+    # checks here (delete guard, update warning), we use
+    # ``_compute_taxtable_refcount`` — an indexed SQL count over the
+    # ``entries`` table, authoritative regardless of the stored
+    # ``refcount`` column. Voided invoices still pin their taxtables
+    # because their entry rows persist for audit trail.
+
+    @staticmethod
+    def _compute_taxtable_refcount(book, taxtable_guid: str) -> int:
+        """Count Entry rows referencing this taxtable via
+        ``i_taxtable`` or ``b_taxtable``. Authoritative for delete
+        guards and update warnings — independent of the stored
+        ``Taxtable.refcount`` column which is maintained for desktop
+        interop but not used for our own logic.
+        """
+        from sqlalchemy import text
+        row = book.session.execute(
+            text(
+                "SELECT COUNT(*) FROM entries "
+                "WHERE i_taxtable = :guid OR b_taxtable = :guid"
+            ),
+            {"guid": taxtable_guid},
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    @staticmethod
+    def _taxtable_entry_summary(e) -> str:
+        """One-token compact summary of a taxtable entry.
+
+        ``5%→GST Payable`` for percentage entries, ``$5→Eco Fee``
+        for flat-value. The arrow makes the routing direction
+        visually unmistakable.
+        """
+        acct_name = e.account.name if e.account else "?"
+        if e.type == "percentage":
+            return f"{e.amount}%→{acct_name}"
+        return f"${e.amount}→{acct_name}"
+
+    def _validate_taxtable_entries(
+        self, book, entries: list[dict],
+    ) -> list[dict]:
+        """Validate a list of taxtable-entry dicts and resolve their
+        accounts. Returns piecash-ready ``{type, amount, account}``
+        records.
+
+        Validations:
+          - non-empty list
+          - each entry has ``type`` in ``{"value", "percentage"}``
+          - amount parses to ``Decimal`` and is > 0
+          - percentage amount < 100 (rates expressed as percent,
+            not fraction; >=100% is almost certainly user error)
+          - account resolves and has type ASSET or LIABILITY
+            (sales-tax payable / input-tax-credit receivable —
+            anything else would book tax into the wrong section)
+          - all entries reference accounts in the same commodity
+            (multi-commodity taxtables are rejected per spec; one
+            taxtable per jurisdiction/commodity is the supported
+            model)
+
+        Args:
+            book: open piecash book session.
+            entries: list of ``{type, amount, account}`` dicts as
+                they arrive from the MCP tool layer.
+
+        Returns:
+            List of resolved records with ``amount`` as ``Decimal``
+            and ``account`` as the piecash ``Account`` object.
+
+        Raises:
+            ValueError on any validation failure, with the entry
+            index in the message so the caller can pinpoint which
+            entry was the problem.
+        """
+        if not entries:
+            raise ValueError(
+                "Taxtable must have at least one entry"
+            )
+
+        resolved: list[dict] = []
+        commodities_seen: set[str] = set()
+
+        for i, e in enumerate(entries):
+            type_val = e.get("type")
+            if type_val not in ("value", "percentage"):
+                raise ValueError(
+                    f"Entry {i}: type must be 'value' or "
+                    f"'percentage', got {type_val!r}"
+                )
+
+            try:
+                amount = _to_decimal(str(e.get("amount", "")))
+            except Exception:
+                raise ValueError(
+                    f"Entry {i}: amount {e.get('amount')!r} not a "
+                    f"valid decimal"
+                )
+            if amount <= 0:
+                raise ValueError(
+                    f"Entry {i}: amount must be > 0, got {amount}"
+                )
+            if (
+                type_val == "percentage"
+                and amount >= Decimal("100")
+            ):
+                raise ValueError(
+                    f"Entry {i}: percentage rate {amount} >= 100 "
+                    f"is almost certainly user error. Rates are "
+                    f"expressed as a percentage (5.0 for 5%, not "
+                    f"0.05). If you genuinely want a rate this "
+                    f"large, file an issue."
+                )
+
+            account_ref = e.get("account")
+            if not account_ref:
+                raise ValueError(f"Entry {i}: account is required")
+            acct = self._resolve_account(book, account_ref)
+            if not acct:
+                raise ValueError(
+                    f"Entry {i}: account not found: {account_ref!r}"
+                )
+            if acct.type not in ("ASSET", "LIABILITY"):
+                raise ValueError(
+                    f"Entry {i}: account {acct.fullname!r} has type "
+                    f"{acct.type!r}; taxtable entries must reference "
+                    f"ASSET (input-tax-credit receivable) or "
+                    f"LIABILITY (output sales-tax payable) accounts. "
+                    f"Got something else — verify the account "
+                    f"hierarchy."
+                )
+            commodities_seen.add(acct.commodity.guid)
+            resolved.append({
+                "type": type_val,
+                "amount": amount,
+                "account": acct,
+            })
+
+        if len(commodities_seen) > 1:
+            raise ValueError(
+                f"Taxtable entries must all reference accounts in "
+                f"the same commodity; got accounts in "
+                f"{len(commodities_seen)} different commodities. "
+                f"Multi-currency taxtables are rejected — split "
+                f"into one taxtable per jurisdiction/commodity."
+            )
+
+        return resolved
+
+    def create_taxtable(
+        self,
+        name: str,
+        entries: list[dict],
+    ) -> dict:
+        """Create a new tax table.
+
+        A taxtable holds one or more entries. Each entry contributes
+        either a percentage rate (``type='percentage'``,
+        ``amount=5.00`` means 5%) or a flat value
+        (``type='value'``, ``amount=5.00`` means a fixed $5
+        surcharge) routed to a specific ASSET or LIABILITY account.
+
+        Multi-entry taxtables (e.g., GST 5% + PST 7%) are
+        supported. At posting time each entry produces its own
+        split to its own account. All entries on a single taxtable
+        must reference accounts in the same commodity.
+
+        Args:
+            name: Taxtable name. Must be unique within the book.
+            entries: List of ``{type, amount, account}`` dicts.
+                ``type`` is ``'value'`` or ``'percentage'``.
+                ``amount`` is a positive Decimal as string;
+                percentages are expressed as the rate (``5.00`` =
+                5%, not ``0.05``). ``account`` is a path,
+                ``%short-guid``, or full GUID; must resolve to an
+                ASSET or LIABILITY account.
+
+        Returns:
+            ``{guid, name, entry_count, entries, status='created'}``.
+
+        Raises:
+            ValueError: duplicate name; empty entries; invalid
+                type/amount/account; wrong account type;
+                multi-currency entry mix.
+        """
+        from piecash.business.tax import Taxtable, TaxtableEntry
+
+        with self.open(readonly=False) as book:
+            existing = self._find_taxtable(book, name)
+            if existing:
+                raise ValueError(
+                    f"Taxtable {name!r} already exists "
+                    f"(guid={existing.guid[:8]})"
+                )
+
+            resolved = self._validate_taxtable_entries(book, entries)
+
+            tt = Taxtable(
+                name=name,
+                entries=[
+                    TaxtableEntry(
+                        type=r["type"],
+                        amount=r["amount"],
+                        account=r["account"],
+                    )
+                    for r in resolved
+                ],
+            )
+            book.session.add(tt)
+            book.flush()
+
+            # Capture before-close to avoid DetachedInstanceError
+            # on attribute access after ``book.save()`` exits the
+            # session.
+            tt_guid = tt.guid
+            tt_name = tt.name
+            account_paths = {
+                r["account"].guid: r["account"].fullname
+                for r in resolved
+            }
+            entry_dicts = [
+                self._taxtable_entry_to_dict(
+                    e, account_paths=account_paths,
+                )
+                for e in tt.entries
+            ]
+
+            book.save()
+
+            return {
+                "guid": tt_guid,
+                "name": tt_name,
+                "entry_count": len(entry_dicts),
+                "entries": entry_dicts,
+                "status": "created",
+            }
+
+    def list_taxtables(
+        self, compact: bool = True,
+    ) -> list[dict] | str:
+        """List all tax tables.
+
+        Args:
+            compact: When True (default), return a newline-separated
+                string with one line per taxtable. Each line is
+                ``name<TAB>N entry/entries: summary`` where the
+                summary is a comma-separated rendering of each
+                entry (e.g., ``5%→GST Payable, 7%→PST Payable``).
+                When False, return a list of full dicts including
+                resolved account paths and computed refcount.
+
+        Returns:
+            Compact string or verbose list, as documented above.
+            Empty taxtable list returns empty string / empty list.
+        """
+        from piecash.business.tax import Taxtable
+
+        with self.open() as book:
+            tables = book.session.query(Taxtable).order_by(
+                Taxtable.name,
+            ).all()
+
+            if compact:
+                lines = []
+                for tt in tables:
+                    summary = ", ".join(
+                        self._taxtable_entry_summary(e)
+                        for e in tt.entries
+                    )
+                    n = len(tt.entries)
+                    suffix = "entry" if n == 1 else "entries"
+                    lines.append(
+                        f"{tt.name}\t{n} {suffix}: {summary}"
+                    )
+                return "\n".join(lines)
+
+            return [
+                self._taxtable_to_dict(
+                    tt,
+                    account_paths={
+                        e.account_guid: e.account.fullname
+                        for e in tt.entries
+                    },
+                    refcount=self._compute_taxtable_refcount(
+                        book, tt.guid,
+                    ),
+                )
+                for tt in tables
+            ]
+
+    def get_taxtable(self, name: str) -> dict:
+        """Full details for a tax table.
+
+        Args:
+            name: Taxtable name.
+
+        Returns:
+            ``{guid, name, refcount, entries: [...]}`` with resolved
+            account paths on each entry. ``refcount`` is the
+            SQL-computed count of Entry rows referencing this
+            taxtable.
+
+        Raises:
+            ValueError: taxtable not found.
+        """
+        with self.open() as book:
+            tt = self._find_taxtable(book, name)
+            if not tt:
+                raise ValueError(f"Taxtable not found: {name!r}")
+            return self._taxtable_to_dict(
+                tt,
+                account_paths={
+                    e.account_guid: e.account.fullname
+                    for e in tt.entries
+                },
+                refcount=self._compute_taxtable_refcount(
+                    book, tt.guid,
+                ),
+            )
+
+    def update_taxtable(
+        self,
+        name: str,
+        new_name: str | None = None,
+        entries: list[dict] | None = None,
+        force: bool = False,
+    ) -> dict:
+        """Update a tax table's name and/or entries.
+
+        Diff-style response: only changed fields are returned.
+
+        **Entry replacement on an in-use taxtable** is destructive
+        to FUTURE entries' tax math (existing posted invoices
+        retain their splits — splits are stored, not derived). When
+        the SQL-computed refcount > 0 and ``entries`` is given,
+        ``force=True`` is required. The check uses the SQL refcount
+        not the stored ``refcount`` column, so voided invoices that
+        still pin the taxtable are honored.
+
+        Args:
+            name: Current taxtable name.
+            new_name: New name (optional). Rejected if it collides
+                with another taxtable.
+            entries: Replacement entry list (optional). Validated
+                with the same rules as ``create_taxtable``.
+                Old entries are deleted via the relation's
+                ``delete-orphan`` cascade.
+            force: Required to replace entries when refcount > 0.
+                Has no effect on name-only updates.
+
+        Returns:
+            ``{guid, name, status, changed}`` where ``changed``
+            lists only the fields that actually changed.
+
+        Raises:
+            ValueError: taxtable not found; no fields supplied;
+                new_name collision; entry validation failure;
+                in-use taxtable without ``force=True``.
+        """
+        if new_name is None and entries is None:
+            raise ValueError(
+                "update_taxtable requires at least one of "
+                "new_name or entries."
+            )
+
+        from piecash.business.tax import TaxtableEntry
+
+        with self.open(readonly=False) as book:
+            tt = self._find_taxtable(book, name)
+            if not tt:
+                raise ValueError(f"Taxtable not found: {name!r}")
+            tt_guid = tt.guid
+
+            # Capture before-state for the audit log (entries
+            # snapshot serialized eagerly so detach doesn't bite
+            # the formatter at write time).
+            before_entries = [
+                self._taxtable_entry_to_dict(
+                    e,
+                    account_paths={
+                        e.account_guid: e.account.fullname,
+                    },
+                )
+                for e in tt.entries
+            ]
+            self._stage_audit_before({
+                "name": tt.name,
+                "entries": before_entries,
+            })
+
+            changed: dict = {}
+
+            if new_name is not None and new_name != tt.name:
+                collision = self._find_taxtable(book, new_name)
+                if collision and collision.guid != tt.guid:
+                    raise ValueError(
+                        f"Taxtable {new_name!r} already exists "
+                        f"(guid={collision.guid[:8]})"
+                    )
+                changed["name"] = {
+                    "before": tt.name, "after": new_name,
+                }
+                tt.name = new_name
+
+            if entries is not None:
+                refcount = self._compute_taxtable_refcount(
+                    book, tt_guid,
+                )
+                if refcount > 0 and not force:
+                    raise ValueError(
+                        f"Taxtable {name!r} is referenced by "
+                        f"{refcount} entries. Replacing its "
+                        f"entries changes the tax math for "
+                        f"FUTURE entries on those documents — "
+                        f"existing posted invoices retain their "
+                        f"original splits. Pass ``force=True`` "
+                        f"to proceed."
+                    )
+                resolved = self._validate_taxtable_entries(
+                    book, entries,
+                )
+                # Replacing via slice assignment relies on the
+                # entries relation's ``cascade="all, delete-orphan"``
+                # to remove the displaced rows. The new TaxtableEntry
+                # objects auto-register with the taxtable via the
+                # back_populates relation; no explicit session.add()
+                # needed.
+                tt.entries[:] = [
+                    TaxtableEntry(
+                        type=r["type"],
+                        amount=r["amount"],
+                        account=r["account"],
+                    )
+                    for r in resolved
+                ]
+                # Flush so the new entries' ``account_guid`` FK and
+                # autoincrement ``id`` columns are populated before
+                # we serialize the after-state. Pre-flush,
+                # ``e.account_guid`` is None on the new entries and
+                # ``_taxtable_entry_to_dict`` would drop the resolved
+                # ``account`` path. Matches the explicit flush in
+                # ``create_taxtable``.
+                book.flush()
+                after_entries = [
+                    self._taxtable_entry_to_dict(
+                        e,
+                        account_paths={
+                            r["account"].guid: r["account"].fullname
+                            for r in resolved
+                        },
+                    )
+                    for e in tt.entries
+                ]
+                changed["entries"] = {
+                    "before": before_entries,
+                    "after": after_entries,
+                }
+
+            book.save()
+
+            if not changed:
+                return {
+                    "guid": tt_guid,
+                    "name": name,
+                    "status": "unchanged",
+                }
+
+            return {
+                "guid": tt_guid,
+                "name": new_name if new_name else name,
+                "status": "updated",
+                "changed": changed,
+            }
+
+    def delete_taxtable(self, name: str) -> dict:
+        """Delete a tax table.
+
+        Refuses when the SQL-computed refcount is > 0 — see the
+        Refcount Discipline note in the section header. Voided
+        invoices still pin their taxtables. The entries-relation
+        ``cascade="all, delete-orphan"`` cleans up child
+        TaxtableEntry rows automatically.
+
+        Args:
+            name: Taxtable name.
+
+        Returns:
+            ``{guid, name, status='deleted'}``.
+
+        Raises:
+            ValueError: taxtable not found, or refcount > 0 with a
+                clear message naming the count.
+        """
+        from piecash.business.tax import Taxtable
+
+        with self.open(readonly=False) as book:
+            tt = self._find_taxtable(book, name)
+            if not tt:
+                raise ValueError(f"Taxtable not found: {name!r}")
+            tt_guid = tt.guid
+
+            refcount = self._compute_taxtable_refcount(book, tt_guid)
+            if refcount > 0:
+                raise ValueError(
+                    f"Cannot delete taxtable {name!r}: {refcount} "
+                    f"entries reference it. Remove or re-assign "
+                    f"those entries first. (Note: voided invoices "
+                    f"still pin their taxtables — voided entry "
+                    f"rows persist for audit-trail purposes.)"
+                )
+
+            # Capture serializable snapshot for the audit log
+            # before delete (entries are detached after save).
+            self._stage_audit_before({
+                "name": name,
+                "entries": [
+                    self._taxtable_entry_to_dict(
+                        e,
+                        account_paths={
+                            e.account_guid: e.account.fullname,
+                        },
+                    )
+                    for e in tt.entries
+                ],
+            })
+
+            book.session.delete(tt)
+            book.save()
+
+            from gnucash_mcp.book._base import _verify_delete
+            _verify_delete(
+                book.session, Taxtable.__table__,
+                {"guid": tt_guid},
+                f"Taxtable {name!r}",
+            )
+
+            return {
+                "guid": tt_guid,
+                "name": name,
+                "status": "deleted",
+            }
 
     # ── Invoice / Bill creation, posting, payment ─────────────────
     #

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -798,6 +798,87 @@ def _fmt_billterm_create(entry: dict) -> list[str]:
     ]
 
 
+def _fmt_taxtable_entry_line(e: dict) -> str:
+    """Render one taxtable entry as ``5%→GST Payable`` or
+    ``$5→Eco Fee Payable``. Mirrors the runtime
+    ``_taxtable_entry_summary`` so audit-log rows look identical
+    to what list_taxtables prints."""
+    type_val = e.get("type", "")
+    amount = e.get("amount", "")
+    # account_paths-resolved (preferred) → "account"; falls back
+    # to "account_guid" for entries serialized without the path
+    # map (shouldn't happen via our book methods, but defensive).
+    acct = e.get("account") or e.get("account_guid", "?")
+    if type_val == "percentage":
+        return f"{amount}%→{acct}"
+    return f"${amount}→{acct}"
+
+
+def _fmt_taxtable_create(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    name = after.get("name", params.get("name", ""))
+    entries = after.get("entries") or params.get("entries") or []
+    lines = [
+        f"{time_part}  CREATE TAXTABLE",
+        f'{_INDENT}name: "{name}"  entries: {len(entries)}',
+    ]
+    for e in entries:
+        lines.append(f"{_INDENT}  {_fmt_taxtable_entry_line(e)}")
+    return lines
+
+
+def _fmt_taxtable_update(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    name = params.get("name", "")
+    lines = [f'{time_part}  UPDATE TAXTABLE  name: "{name}"']
+    changed = after.get("changed") or {}
+    if "name" in changed:
+        old = changed["name"].get("before", "?")
+        new = changed["name"].get("after", "?")
+        lines.append(f"{_INDENT}name: {old!r} → {new!r}")
+    if "entries" in changed:
+        before_entries = changed["entries"].get("before") or []
+        after_entries = changed["entries"].get("after") or []
+        lines.append(
+            f"{_INDENT}entries: {len(before_entries)} → "
+            f"{len(after_entries)}"
+        )
+        # Show the before/after detail; this is the audit
+        # rationale for keeping the diff in the response.
+        if before_entries:
+            lines.append(f"{_INDENT}  before:")
+            for e in before_entries:
+                lines.append(
+                    f"{_INDENT}    {_fmt_taxtable_entry_line(e)}"
+                )
+        if after_entries:
+            lines.append(f"{_INDENT}  after:")
+            for e in after_entries:
+                lines.append(
+                    f"{_INDENT}    {_fmt_taxtable_entry_line(e)}"
+                )
+    return lines
+
+
+def _fmt_taxtable_delete(entry: dict) -> list[str]:
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    name = params.get("name", "")
+    entries = before.get("entries") or []
+    lines = [
+        f'{time_part}  DELETE TAXTABLE  name: "{name}"',
+        f"{_INDENT}removed entries: {len(entries)}",
+    ]
+    for e in entries:
+        lines.append(f"{_INDENT}  {_fmt_taxtable_entry_line(e)}")
+    return lines
+
+
 def _fmt_invoice_create(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     params = entry.get("params") or {}
@@ -1282,6 +1363,9 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("job", "UPDATE"): _fmt_job_update,
     ("job", "DELETE"): _fmt_job_delete,
     ("billterm", "CREATE"): _fmt_billterm_create,
+    ("taxtable", "CREATE"): _fmt_taxtable_create,
+    ("taxtable", "UPDATE"): _fmt_taxtable_update,
+    ("taxtable", "DELETE"): _fmt_taxtable_delete,
     ("invoice", "CREATE"): _fmt_invoice_create,
     ("invoice", "DELETE"): _fmt_invoice_delete,
     ("invoice", "POST"): _fmt_invoice_post,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -802,13 +802,29 @@ def _fmt_taxtable_entry_line(e: dict) -> str:
     """Render one taxtable entry as ``5%→GST Payable`` or
     ``$5→Eco Fee Payable``. Mirrors the runtime
     ``_taxtable_entry_summary`` so audit-log rows look identical
-    to what list_taxtables prints."""
+    to what ``list_taxtables`` prints — leaf account name, no
+    parent path prefix.
+
+    Per CLAUDE.md the audit log canonicalizes account *parameter*
+    references to fullnames (so a ``%shortguid`` input renders as
+    ``Income:Sales``). This renderer is for taxtable-entry
+    *structure* (metadata about the taxtable itself, not a user
+    parameter), so the leaf-name convention matches the user's
+    mental model from ``list_taxtables`` and keeps audit lines
+    scannable.
+    """
     type_val = e.get("type", "")
     amount = e.get("amount", "")
     # account_paths-resolved (preferred) → "account"; falls back
     # to "account_guid" for entries serialized without the path
     # map (shouldn't happen via our book methods, but defensive).
     acct = e.get("account") or e.get("account_guid", "?")
+    # Trim to leaf name to match _taxtable_entry_summary's
+    # ``e.account.name`` output. A path "Liabilities:GST Payable"
+    # becomes "GST Payable"; a bare leaf or raw GUID passes
+    # through unchanged.
+    if ":" in acct:
+        acct = acct.rsplit(":", 1)[-1]
     if type_val == "percentage":
         return f"{amount}%→{acct}"
     return f"${amount}→{acct}"

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -270,6 +270,15 @@ TOOL_MODULES: dict[str, list[str]] = {
     # invoicing is the dominant use case; runtime owner_type gating
     # (see _gate_owner_type in tools/_helpers.py) rejects vendor-side
     # use when business isn't loaded.
+    #
+    # Taxtables live in freelancer because customer-facing sales
+    # tax (Canadian GST, UK VAT, US state sales tax on services)
+    # is a primary freelancer concern — a solo consultant
+    # collecting tax on invoices needs the CRUD surface without
+    # also pulling in vendor management. The polymorphic
+    # add_*_entry tools share the taxtable parameter; runtime
+    # use on a vendor bill or voucher reads the same taxtable
+    # registry whether ``business`` is loaded or not.
     "freelancer": [
         "create_customer",
         "list_customers",
@@ -285,6 +294,11 @@ TOOL_MODULES: dict[str, list[str]] = {
         "pay_invoice",
         "delete_invoice",
         "get_outstanding_invoices",
+        "create_taxtable",
+        "list_taxtables",
+        "get_taxtable",
+        "update_taxtable",
+        "delete_taxtable",
     ],
     "business": [
         "create_vendor",
@@ -329,11 +343,6 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_job_report",
         "create_billterm",
         "list_billterms",
-        "create_taxtable",
-        "list_taxtables",
-        "get_taxtable",
-        "update_taxtable",
-        "delete_taxtable",
         "vendor_spending_report",
     ],
 }
@@ -719,9 +728,12 @@ Options:
                          portfolio    Commodities + prices —
                                       the multi-currency primitive.
                          investor     Tax-lot management.
-                         freelancer   Customer invoicing.
-                         business     Vendor + employee management +
-                                      vendor bills (additive to
+                         freelancer   Customer invoicing + sales-tax
+                                      configuration (taxtables for
+                                      GST / VAT / US state sales tax).
+                         business     Vendor + employee management,
+                                      vendor bills, jobs, credit
+                                      notes, billterms (additive to
                                       freelancer for full business
                                       workflow).
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -329,6 +329,11 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_job_report",
         "create_billterm",
         "list_billterms",
+        "create_taxtable",
+        "list_taxtables",
+        "get_taxtable",
+        "update_taxtable",
+        "delete_taxtable",
         "vendor_spending_report",
     ],
 }
@@ -681,7 +686,7 @@ Usage: gnucash-mcp [OPTIONS]
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core (26 tools, always-on). Use "all"
-                       for every module (101 tools).
+                       for every module (106 tools).
 
                        Modules (role-aligned, flat partition; pick
                        what fits your workflow):

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -347,6 +347,142 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
+    @audit_log(classification="write", operation="create", entity_type="taxtable")
+    def create_taxtable(
+        name: str,
+        entries: list[dict],
+    ) -> str:
+        """Create a new sales-tax table.
+
+        A taxtable holds one or more entries. Each entry contributes
+        either a percentage rate or a flat-value surcharge routed to
+        a specific GL account (ASSET for input-tax credit, LIABILITY
+        for output sales tax payable). Multi-entry composites (e.g.,
+        GST 5% + PST 7%) produce multiple tax splits per line at
+        posting time.
+
+        Args:
+            name: Taxtable name, unique within the book
+                (e.g., "CA Sales 7.25%", "BC GST+PST").
+            entries: List of {type, amount, account} dicts.
+                ``type``: "value" or "percentage".
+                ``amount``: positive decimal as string. Percentages
+                are the rate ("5.00" = 5%, not "0.05").
+                ``account``: account path, %short-guid, or full GUID.
+                Must be ASSET or LIABILITY type. All entries on a
+                single taxtable must reference accounts in the same
+                commodity.
+
+        Example:
+            create_taxtable(
+                name="BC GST+PST",
+                entries=[
+                    {"type": "percentage", "amount": "5.00",
+                     "account": "Liabilities:GST Payable"},
+                    {"type": "percentage", "amount": "7.00",
+                     "account": "Liabilities:PST Payable"},
+                ],
+            )
+        """
+        book = get_book()
+        result = book.create_taxtable(name=name, entries=entries)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="read")
+    def list_taxtables(
+        verbose: bool = False,
+    ) -> str:
+        """List all sales-tax tables.
+
+        Compact format (default): one line per taxtable with name,
+        entry count, and per-entry rate→account routing. Verbose:
+        full JSON with resolved account paths and refcount.
+
+        Args:
+            verbose: If true, return full JSON for each taxtable.
+        """
+        book = get_book()
+        result = book.list_taxtables(compact=not verbose)
+        if verbose:
+            return json.dumps(result, indent=2)
+        return result
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="read")
+    def get_taxtable(name: str) -> str:
+        """Get full details for one sales-tax table.
+
+        Returns guid, name, refcount (count of Entry rows
+        referencing it — voided invoices still count), and the
+        resolved entry list with account paths.
+
+        Args:
+            name: Taxtable name.
+        """
+        book = get_book()
+        result = book.get_taxtable(name=name)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="update", entity_type="taxtable")
+    def update_taxtable(
+        name: str,
+        new_name: str | None = None,
+        entries: list[dict] | None = None,
+        force: bool = False,
+    ) -> str:
+        """Update a sales-tax table's name and/or entries.
+
+        Diff-style response: only changed fields are returned.
+
+        **Entry replacement on a taxtable that's already in use** is
+        destructive to FUTURE entries' tax math. Existing posted
+        invoices retain their original splits (splits are stored,
+        not derived), but new entries on any document will use the
+        replacement entries' rates. When refcount > 0 and
+        ``entries`` is given, ``force=True`` is required to proceed.
+
+        Args:
+            name: Current taxtable name.
+            new_name: New name (optional).
+            entries: Replacement entry list (optional). Same shape
+                and validation as ``create_taxtable``.
+            force: Required to replace entries when the taxtable
+                is already referenced by document entries.
+        """
+        book = get_book()
+        result = book.update_taxtable(
+            name=name,
+            new_name=new_name,
+            entries=entries,
+            force=force,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="write", operation="delete", entity_type="taxtable")
+    def delete_taxtable(name: str) -> str:
+        """Delete a sales-tax table.
+
+        Refuses when any Entry row references the taxtable (computed
+        via SQL on the entries table). Voided invoices still pin
+        their taxtables — voided entry rows persist for audit-trail
+        purposes. Remove or re-assign referencing entries first.
+
+        Args:
+            name: Taxtable name.
+        """
+        book = get_book()
+        result = book.delete_taxtable(name=name)
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
     @audit_log(classification="write", operation="create", entity_type="invoice")
     def create_invoice(
         customer_id: str,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -565,6 +565,8 @@ def register(mcp, get_book) -> None:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> str:
         """Add a line item to a customer invoice.
 
@@ -577,11 +579,19 @@ def register(mcp, get_book) -> None:
             description: Line item description.
             quantity: Quantity as decimal string (e.g., "1", "2.5").
             price: Unit price as decimal string (e.g., "100.00").
+            taxtable: Optional taxtable name. When given, the line
+                contributes tax components per the taxtable's entries
+                at posting time. Multi-entry taxtables (e.g., GST+PST)
+                produce one tax split per entry.
+            tax_included: If true, ``price`` is the gross (tax-included)
+                value; pretax extracted at posting. If false (default),
+                ``price`` is pre-tax and tax adds on top.
         """
         book = get_book()
         result = book.add_invoice_entry(
             invoice_id=invoice_id, account=account,
             description=description, quantity=quantity, price=price,
+            taxtable=taxtable, tax_included=tax_included,
         )
         return _json(result)
 
@@ -594,6 +604,8 @@ def register(mcp, get_book) -> None:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> str:
         """Add a line item to a vendor bill.
 
@@ -606,11 +618,18 @@ def register(mcp, get_book) -> None:
             description: Line item description.
             quantity: Quantity as decimal string (e.g., "1", "2.5").
             price: Unit price as decimal string (e.g., "50.00").
+            taxtable: Optional taxtable name. For vendor bills, the
+                tax component typically routes to an ASSET account
+                (input-tax credit receivable) per the taxtable's
+                entries.
+            tax_included: If true, ``price`` is gross; pretax extracted
+                at posting. If false (default), tax adds on top.
         """
         book = get_book()
         result = book.add_bill_entry(
             bill_id=bill_id, account=account,
             description=description, quantity=quantity, price=price,
+            taxtable=taxtable, tax_included=tax_included,
         )
         return _json(result)
 
@@ -661,6 +680,8 @@ def register(mcp, get_book) -> None:
         description: str,
         quantity: str,
         price: str,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> str:
         """Add a line item to an employee expense voucher.
 
@@ -675,11 +696,16 @@ def register(mcp, get_book) -> None:
             description: Line item description.
             quantity: Quantity as decimal string (e.g., "1").
             price: Unit price as decimal string (e.g., "42.50").
+            taxtable: Optional taxtable name. Same semantics as
+                ``add_bill_entry``.
+            tax_included: If true, ``price`` is gross; pretax extracted
+                at posting.
         """
         book = get_book()
         result = book.add_voucher_entry(
             voucher_id=voucher_id, account=account,
             description=description, quantity=quantity, price=price,
+            taxtable=taxtable, tax_included=tax_included,
         )
         return _json(result)
 
@@ -772,6 +798,8 @@ def register(mcp, get_book) -> None:
         quantity: str,
         price: str,
         owner_type: str | None = None,
+        taxtable: str | None = None,
+        tax_included: bool = False,
     ) -> str:
         """Add a line item to a credit note.
 
@@ -792,6 +820,13 @@ def register(mcp, get_book) -> None:
             price: Unit price as decimal string.
             owner_type: Optional "customer" or "vendor"
                 disambiguator for ID collisions. Usually omitted.
+            taxtable: Optional taxtable name. Same semantics as
+                ``add_invoice_entry``; the credit-note flag inverts
+                tax-split direction at posting time so a refunded
+                tax-inclusive sale produces a debit to the tax-payable
+                account.
+            tax_included: If true, ``price`` is gross; pretax
+                extracted at posting.
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -802,6 +837,8 @@ def register(mcp, get_book) -> None:
             quantity=quantity,
             price=price,
             owner_type=owner_type,
+            taxtable=taxtable,
+            tax_included=tax_included,
         )
         return _json(result)
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1710,6 +1710,626 @@ class TestListBillterms:
         assert result[0]["description"] == "Standard terms"
 
 
+def _add_tax_accounts(gb):
+    """Helper: add two LIABILITY tax-payable accounts to the
+    business book fixture so taxtable tests have somewhere to
+    route tax components. Returns the paths for reuse in test
+    assertions."""
+    gb.create_account(
+        name="GST Payable",
+        account_type="LIABILITY",
+        parent="Liabilities",
+    )
+    gb.create_account(
+        name="PST Payable",
+        account_type="LIABILITY",
+        parent="Liabilities",
+    )
+    return (
+        "Liabilities:GST Payable",
+        "Liabilities:PST Payable",
+    )
+
+
+class TestCreateTaxtable:
+    """Tests for create_taxtable."""
+
+    def test_single_entry_percentage(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        result = gb.create_taxtable(
+            name="GST 5%",
+            entries=[
+                {"type": "percentage", "amount": "5.00",
+                 "account": gst},
+            ],
+        )
+        assert result["status"] == "created"
+        assert result["name"] == "GST 5%"
+        assert result["entry_count"] == 1
+        assert len(result["guid"]) == 32
+        assert result["entries"][0]["type"] == "percentage"
+        assert result["entries"][0]["amount"] == "5"
+        assert result["entries"][0]["account"] == gst
+
+    def test_multi_entry_composite(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        result = gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5.00",
+                 "account": gst},
+                {"type": "percentage", "amount": "7.00",
+                 "account": pst},
+            ],
+        )
+        assert result["entry_count"] == 2
+        accounts = {e["account"] for e in result["entries"]}
+        assert accounts == {gst, pst}
+
+    def test_flat_value_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        result = gb.create_taxtable(
+            name="Eco Fee $5",
+            entries=[
+                {"type": "value", "amount": "5.00", "account": gst},
+            ],
+        )
+        assert result["entries"][0]["type"] == "value"
+        assert result["entries"][0]["amount"] == "5"
+
+    def test_mixed_value_and_percentage(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        result = gb.create_taxtable(
+            name="Sales+Eco",
+            entries=[
+                {"type": "percentage", "amount": "7.25",
+                 "account": gst},
+                {"type": "value", "amount": "5.00", "account": pst},
+            ],
+        )
+        types = {e["type"] for e in result["entries"]}
+        assert types == {"percentage", "value"}
+
+    def test_account_via_short_guid(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst_path, _ = _add_tax_accounts(gb)
+        # Find the short-guid prefix from list_accounts output.
+        listing = gb.list_accounts()
+        gst_row = next(
+            line for line in listing.splitlines()
+            if "GST Payable" in line
+        )
+        short_guid = gst_row.split("\t")[0]
+        assert short_guid.startswith("%")
+        result = gb.create_taxtable(
+            name="GST via short",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": short_guid},
+            ],
+        )
+        # Resolved to the path in the response.
+        assert result["entries"][0]["account"] == gst_path
+
+    def test_duplicate_name_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        with pytest.raises(ValueError, match="already exists"):
+            gb.create_taxtable(
+                name="GST 5%",
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": gst}],
+            )
+
+    def test_empty_entries_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        _add_tax_accounts(gb)
+        with pytest.raises(ValueError, match="at least one entry"):
+            gb.create_taxtable(name="Empty", entries=[])
+
+    def test_bad_type_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        with pytest.raises(ValueError, match="type must be"):
+            gb.create_taxtable(
+                name="Bad",
+                entries=[{"type": "flat", "amount": "5",
+                          "account": gst}],
+            )
+
+    def test_zero_amount_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        with pytest.raises(ValueError, match="amount must be > 0"):
+            gb.create_taxtable(
+                name="Zero",
+                entries=[{"type": "percentage", "amount": "0",
+                          "account": gst}],
+            )
+
+    def test_negative_amount_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        with pytest.raises(ValueError, match="amount must be > 0"):
+            gb.create_taxtable(
+                name="Neg",
+                entries=[{"type": "percentage", "amount": "-5",
+                          "account": gst}],
+            )
+
+    def test_high_percentage_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        # 100%+ rate almost certainly indicates the user expressed
+        # the rate as a fraction (0.05) and we're seeing 5.0 — but
+        # also 100% itself is a likely user error.
+        with pytest.raises(ValueError, match="user error"):
+            gb.create_taxtable(
+                name="Too high",
+                entries=[{"type": "percentage", "amount": "150",
+                          "account": gst}],
+            )
+
+    def test_missing_account_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        _add_tax_accounts(gb)
+        with pytest.raises(ValueError, match="account not found"):
+            gb.create_taxtable(
+                name="Bad acct",
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": "Liabilities:Does Not Exist"}],
+            )
+
+    def test_wrong_account_type_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        _add_tax_accounts(gb)
+        # Income accounts are valid existing accounts but the wrong
+        # type for tax routing.
+        with pytest.raises(ValueError, match="ASSET.*LIABILITY"):
+            gb.create_taxtable(
+                name="Wrong type",
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": "Income:Sales"}],
+            )
+
+    def test_multi_currency_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        _add_tax_accounts(gb)
+        # Add a EUR-denominated liability account and pair it with
+        # a USD one to trigger the multi-commodity guard.
+        gb.create_account(
+            name="EU VAT Payable",
+            account_type="LIABILITY",
+            parent="Liabilities",
+            commodity="EUR",
+        )
+        with pytest.raises(ValueError, match="different commodit"):
+            gb.create_taxtable(
+                name="Mixed currency",
+                entries=[
+                    {"type": "percentage", "amount": "5",
+                     "account": "Liabilities:GST Payable"},
+                    {"type": "percentage", "amount": "19",
+                     "account": "Liabilities:EU VAT Payable"},
+                ],
+            )
+
+    def test_initial_refcount_zero(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 0
+
+
+class TestListTaxtables:
+    """Tests for list_taxtables."""
+
+    def test_empty_list(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        assert gb.list_taxtables() == ""
+        assert gb.list_taxtables(compact=False) == []
+
+    def test_compact_single_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        result = gb.list_taxtables()
+        assert "GST 5%" in result
+        assert "1 entry" in result
+        # Summary token has the arrow renderer.
+        assert "5%→GST Payable" in result
+
+    def test_compact_multi_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        result = gb.list_taxtables()
+        assert "2 entries" in result
+        assert "5%→GST Payable" in result
+        assert "7%→PST Payable" in result
+
+    def test_verbose_includes_refcount(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        result = gb.list_taxtables(compact=False)
+        assert len(result) == 1
+        assert result[0]["name"] == "GST 5%"
+        assert result[0]["refcount"] == 0
+        assert result[0]["entries"][0]["account"] == gst
+
+    def test_sorted_by_name(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        for nm in ["Zeta", "Alpha", "Mu"]:
+            gb.create_taxtable(
+                name=nm,
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": gst}],
+            )
+        result = gb.list_taxtables(compact=False)
+        assert [t["name"] for t in result] == ["Alpha", "Mu", "Zeta"]
+
+
+class TestGetTaxtable:
+    """Tests for get_taxtable."""
+
+    def test_basic_lookup(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        tt = gb.get_taxtable("BC GST+PST")
+        assert tt["name"] == "BC GST+PST"
+        assert len(tt["entries"]) == 2
+        assert tt["refcount"] == 0
+        # Account paths resolved on each entry.
+        accounts = {e["account"] for e in tt["entries"]}
+        assert accounts == {gst, pst}
+
+    def test_not_found_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.get_taxtable("Nonexistent")
+
+
+class TestUpdateTaxtable:
+    """Tests for update_taxtable."""
+
+    def test_no_fields_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        with pytest.raises(ValueError, match="at least one"):
+            gb.update_taxtable(name="GST 5%")
+
+    def test_rename(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        result = gb.update_taxtable(
+            name="GST 5%", new_name="Federal GST",
+        )
+        assert result["status"] == "updated"
+        assert result["name"] == "Federal GST"
+        assert "name" in result["changed"]
+        # Confirm rename via lookup under the new name.
+        tt = gb.get_taxtable("Federal GST")
+        assert tt["name"] == "Federal GST"
+
+    def test_rename_collision_rejected(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        for nm in ["GST 5%", "PST 7%"]:
+            gb.create_taxtable(
+                name=nm,
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": gst}],
+            )
+        with pytest.raises(ValueError, match="already exists"):
+            gb.update_taxtable(name="GST 5%", new_name="PST 7%")
+
+    def test_replace_entries(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        result = gb.update_taxtable(
+            name="GST 5%",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        assert result["status"] == "updated"
+        assert "entries" in result["changed"]
+        # ``after`` entries must carry the resolved account path
+        # — pre-flush, the FK is None and the path would silently
+        # drop. Regression guard for the bookkeeper-found bug
+        # on Commit 1 live test.
+        after = result["changed"]["entries"]["after"]
+        assert len(after) == 2
+        assert {e["account"] for e in after} == {gst, pst}
+        # Verify via re-read.
+        tt = gb.get_taxtable("GST 5%")
+        assert len(tt["entries"]) == 2
+
+    def test_replace_entries_in_use_without_force_rejected(
+        self, business_book,
+    ):
+        """Direct SQL insert simulates an in-use refcount > 0
+        without needing Commit 4's wire-up."""
+        from sqlalchemy import text
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        tt = gb.get_taxtable("GST 5%")
+        # Insert a phantom Entry row referencing the taxtable so
+        # the refcount-computer reports > 0.
+        with gb.open(readonly=False) as book:
+            book.session.execute(
+                text(
+                    "INSERT INTO entries "
+                    "(guid, date, date_entered, description, action, "
+                    "notes, quantity_num, quantity_denom, "
+                    "i_acct, i_price_num, i_price_denom, "
+                    "i_discount_num, i_discount_denom, "
+                    "i_disc_type, i_disc_how, "
+                    "i_taxable, i_taxincluded, i_taxtable, "
+                    "b_acct, b_price_num, b_price_denom, "
+                    "b_taxable, b_taxincluded, b_taxtable, "
+                    "b_paytype, billable, billto_type, "
+                    "billto_guid, order_guid, invoice, bill) "
+                    "VALUES "
+                    "(:guid, :now, :now, '', '', '', "
+                    "1, 1, NULL, 0, 1, 0, 1, '', '', "
+                    "1, 0, :ttg, NULL, 0, 1, 0, 0, NULL, "
+                    "0, 0, 0, NULL, NULL, NULL, NULL)"
+                ),
+                {
+                    "guid": "deadbeef" * 4,
+                    "now": "2026-01-01 00:00:00",
+                    "ttg": tt["guid"],
+                },
+            )
+            book.save()
+        with pytest.raises(ValueError, match="force=True"):
+            gb.update_taxtable(
+                name="GST 5%",
+                entries=[{"type": "percentage", "amount": "10",
+                          "account": gst}],
+            )
+
+    def test_replace_entries_in_use_with_force(self, business_book):
+        from sqlalchemy import text
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        tt = gb.get_taxtable("GST 5%")
+        with gb.open(readonly=False) as book:
+            book.session.execute(
+                text(
+                    "INSERT INTO entries "
+                    "(guid, date, date_entered, description, action, "
+                    "notes, quantity_num, quantity_denom, "
+                    "i_acct, i_price_num, i_price_denom, "
+                    "i_discount_num, i_discount_denom, "
+                    "i_disc_type, i_disc_how, "
+                    "i_taxable, i_taxincluded, i_taxtable, "
+                    "b_acct, b_price_num, b_price_denom, "
+                    "b_taxable, b_taxincluded, b_taxtable, "
+                    "b_paytype, billable, billto_type, "
+                    "billto_guid, order_guid, invoice, bill) "
+                    "VALUES "
+                    "(:guid, :now, :now, '', '', '', "
+                    "1, 1, NULL, 0, 1, 0, 1, '', '', "
+                    "1, 0, :ttg, NULL, 0, 1, 0, 0, NULL, "
+                    "0, 0, 0, NULL, NULL, NULL, NULL)"
+                ),
+                {
+                    "guid": "deadbeef" * 4,
+                    "now": "2026-01-01 00:00:00",
+                    "ttg": tt["guid"],
+                },
+            )
+            book.save()
+        result = gb.update_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "10",
+                      "account": gst}],
+            force=True,
+        )
+        assert result["status"] == "updated"
+
+
+class TestDeleteTaxtable:
+    """Tests for delete_taxtable."""
+
+    def test_delete_unused(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        result = gb.delete_taxtable("GST 5%")
+        assert result["status"] == "deleted"
+        assert result["name"] == "GST 5%"
+        # Confirm gone.
+        with pytest.raises(ValueError, match="not found"):
+            gb.get_taxtable("GST 5%")
+
+    def test_not_found_raises(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="not found"):
+            gb.delete_taxtable("Nonexistent")
+
+    def test_in_use_rejected(self, business_book):
+        from sqlalchemy import text
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        tt = gb.get_taxtable("GST 5%")
+        with gb.open(readonly=False) as book:
+            book.session.execute(
+                text(
+                    "INSERT INTO entries "
+                    "(guid, date, date_entered, description, action, "
+                    "notes, quantity_num, quantity_denom, "
+                    "i_acct, i_price_num, i_price_denom, "
+                    "i_discount_num, i_discount_denom, "
+                    "i_disc_type, i_disc_how, "
+                    "i_taxable, i_taxincluded, i_taxtable, "
+                    "b_acct, b_price_num, b_price_denom, "
+                    "b_taxable, b_taxincluded, b_taxtable, "
+                    "b_paytype, billable, billto_type, "
+                    "billto_guid, order_guid, invoice, bill) "
+                    "VALUES "
+                    "(:guid, :now, :now, '', '', '', "
+                    "1, 1, NULL, 0, 1, 0, 1, '', '', "
+                    "1, 0, :ttg, NULL, 0, 1, 0, 0, NULL, "
+                    "0, 0, 0, NULL, NULL, NULL, NULL)"
+                ),
+                {
+                    "guid": "deadbeef" * 4,
+                    "now": "2026-01-01 00:00:00",
+                    "ttg": tt["guid"],
+                },
+            )
+            book.save()
+        with pytest.raises(ValueError, match="1 entries reference"):
+            gb.delete_taxtable("GST 5%")
+
+
+class TestTaxtableRefcount:
+    """Direct tests for the SQL-computed refcount helper."""
+
+    def test_refcount_zero_for_unused(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        with gb.open() as book:
+            tt = gb._find_taxtable(book, "GST 5%")
+            assert gb._compute_taxtable_refcount(book, tt.guid) == 0
+
+    def test_refcount_counts_b_taxtable_too(self, business_book):
+        """The refcount SQL must OR ``i_taxtable`` and
+        ``b_taxtable`` — vendor bills route through the b_*
+        columns and their refs must count."""
+        from sqlalchemy import text
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        tt = gb.get_taxtable("GST 5%")
+        # Insert one i_taxtable row and one b_taxtable row.
+        with gb.open(readonly=False) as book:
+            for tag, payload in (
+                ("i", {"i_tt": tt["guid"], "b_tt": None}),
+                ("b", {"i_tt": None, "b_tt": tt["guid"]}),
+            ):
+                book.session.execute(
+                    text(
+                        "INSERT INTO entries "
+                        "(guid, date, date_entered, description, "
+                        "action, notes, quantity_num, quantity_denom, "
+                        "i_acct, i_price_num, i_price_denom, "
+                        "i_discount_num, i_discount_denom, "
+                        "i_disc_type, i_disc_how, "
+                        "i_taxable, i_taxincluded, i_taxtable, "
+                        "b_acct, b_price_num, b_price_denom, "
+                        "b_taxable, b_taxincluded, b_taxtable, "
+                        "b_paytype, billable, billto_type, "
+                        "billto_guid, order_guid, invoice, bill) "
+                        "VALUES (:guid, :now, :now, '', '', '', "
+                        "1, 1, NULL, 0, 1, 0, 1, '', '', "
+                        "1, 0, :i_tt, NULL, 0, 1, 0, 0, :b_tt, "
+                        "0, 0, 0, NULL, NULL, NULL, NULL)"
+                    ),
+                    {
+                        "guid": tag * 32,
+                        "now": "2026-01-01 00:00:00",
+                        **payload,
+                    },
+                )
+            book.save()
+        with gb.open() as book:
+            tt_obj = gb._find_taxtable(book, "GST 5%")
+            assert gb._compute_taxtable_refcount(
+                book, tt_obj.guid,
+            ) == 2
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2330,6 +2330,335 @@ class TestTaxtableRefcount:
             ) == 2
 
 
+class TestTaxtableMath:
+    """Tests for ``_compute_entry_tax`` — the per-quadrant tax
+    math helper. Pure function, no book fixture required."""
+
+    # The helper is a staticmethod on BusinessMixin; we reach
+    # through GnuCashBook (which mixes it in).
+    from gnucash_mcp.book import GnuCashBook as _GB
+    _fn = staticmethod(_GB._compute_entry_tax)
+
+    USD_QUANTUM = Decimal("0.01")
+    JPY_QUANTUM = Decimal("1")
+
+    GST_GUID = "g" * 32
+    PST_GUID = "p" * 32
+    ECO_GUID = "e" * 32
+
+    def _gst_5(self):
+        return {"type": "percentage", "amount": Decimal("5"),
+                "account_guid": self.GST_GUID}
+
+    def _pst_7(self):
+        return {"type": "percentage", "amount": Decimal("7"),
+                "account_guid": self.PST_GUID}
+
+    def _eco_5(self):
+        return {"type": "value", "amount": Decimal("5"),
+                "account_guid": self.ECO_GUID}
+
+    # ── Quadrant 1: no tax ────────────────────────────────────
+
+    def test_q1_not_taxable(self):
+        r = self._fn(
+            quantity=Decimal("2"), price=Decimal("100"),
+            taxable=False, tax_included=False,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("200.00")
+        assert r["tax_total"] == Decimal(0)
+        assert r["tax_by_acct"] == {}
+        assert r["gross"] == Decimal("200.00")
+
+    def test_q1_empty_taxtable_treated_as_not_taxable(self):
+        # Defensive: taxable=True but no entries. Caller should
+        # have validated; behave as no-tax.
+        r = self._fn(
+            quantity=Decimal("2"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("200.00")
+        assert r["tax_total"] == Decimal(0)
+        assert r["gross"] == Decimal("200.00")
+
+    # ── Quadrant 2: tax-exclusive (tax added on top) ───────────
+
+    def test_q2_single_percentage(self):
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["tax_by_acct"] == {self.GST_GUID: Decimal("5.00")}
+        assert r["gross"] == Decimal("105.00")
+
+    def test_q2_multi_percentage_composite(self):
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._gst_5(), self._pst_7()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("12.00")
+        assert r["tax_by_acct"] == {
+            self.GST_GUID: Decimal("5.00"),
+            self.PST_GUID: Decimal("7.00"),
+        }
+        assert r["gross"] == Decimal("112.00")
+
+    def test_q2_flat_value(self):
+        r = self._fn(
+            quantity=Decimal("3"), price=Decimal("20"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._eco_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        # Flat $5 on a $60 line: gross = 65.
+        assert r["pretax"] == Decimal("60.00")
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["gross"] == Decimal("65.00")
+
+    def test_q2_mixed_value_and_percentage(self):
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._gst_5(), self._eco_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        # Pretax 100, GST 5%, Eco $5 → gross 110.
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("10.00")
+        assert r["tax_by_acct"] == {
+            self.GST_GUID: Decimal("5.00"),
+            self.ECO_GUID: Decimal("5.00"),
+        }
+        assert r["gross"] == Decimal("110.00")
+
+    def test_q2_composite_same_account_collapses(self):
+        # Two percentage entries pointing to the same account
+        # should sum into one tax_by_acct entry.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[
+                {"type": "percentage", "amount": Decimal("3"),
+                 "account_guid": self.GST_GUID},
+                {"type": "percentage", "amount": Decimal("2"),
+                 "account_guid": self.GST_GUID},
+            ],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["tax_by_acct"] == {self.GST_GUID: Decimal("5.00")}
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["gross"] == Decimal("105.00")
+
+    # ── Quadrant 3: tax-inclusive, percentage-only ─────────────
+
+    def test_q3_single_percentage_clean(self):
+        # Gross $105 includes 5% GST → pretax = 105/1.05 = 100.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("105"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["gross"] == Decimal("105.00")
+        # And the residual identity must hold exactly.
+        assert r["pretax"] + r["tax_total"] == r["gross"]
+
+    def test_q3_composite_clean(self):
+        # Gross $112 with GST 5% + PST 7% → pretax = 112/1.12 = 100.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("112"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._gst_5(), self._pst_7()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_by_acct"] == {
+            self.GST_GUID: Decimal("5.00"),
+            self.PST_GUID: Decimal("7.00"),
+        }
+        assert r["gross"] == Decimal("112.00")
+        assert r["pretax"] + r["tax_total"] == r["gross"]
+
+    def test_q3_residual_to_largest_rate(self):
+        # Gross $100 with GST 5% + PST 7% has no clean integer
+        # pretax. pretax = 100 / 1.12 = 89.2857... → 89.29.
+        # Per-entry independent rounding: 89.29 * 0.05 = 4.4645
+        # → 4.46, 89.29 * 0.07 = 6.2503 → 6.25.
+        # Sum: 4.46 + 6.25 = 10.71. Residual:
+        # 100.00 - 89.29 - 10.71 = 0.00 → no adjustment needed
+        # in this case. Let's pick numbers that DO show residual.
+        # Gross $100.07 with GST 5%: pretax = 100.07/1.05
+        # = 95.30476... → 95.30. tax = 95.30*0.05 = 4.765 → 4.77
+        # (with banker's; 4.765 → 4.76 because 6 is even).
+        # 95.30 + 4.76 = 100.06; residual = 100.07 - 100.06 = 0.01.
+        # Residual goes to the largest-rate (only) entry.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("100.07"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        # The residual identity is the contract — the math may
+        # round either way under banker's, but the identity
+        # MUST hold.
+        assert r["pretax"] + r["tax_total"] == r["gross"]
+        # And the gross is preserved exactly.
+        assert r["gross"] == Decimal("100.07")
+
+    def test_q3_residual_routes_to_largest_percentage(self):
+        # Construct a case where the residual is non-zero and
+        # verify the per-account allocation puts the residual on
+        # the largest-rate entry. Pick numbers that produce a
+        # one-cent residual under banker's rounding.
+        # Gross $10.05 with GST 5% + PST 7%:
+        # pretax = 10.05 / 1.12 = 8.973214... → 8.97
+        # GST: 8.97 * 0.05 = 0.4485 → 0.45 (banker's: 5 even)
+        # PST: 8.97 * 0.07 = 0.6279 → 0.63
+        # Sum tax: 1.08. pretax + tax = 10.05 → no residual.
+        # Try gross $10.06:
+        # pretax = 10.06 / 1.12 = 8.982142... → 8.98
+        # GST: 8.98 * 0.05 = 0.449 → 0.45
+        # PST: 8.98 * 0.07 = 0.6286 → 0.63
+        # Sum: 1.08; pretax + tax = 10.06 → no residual.
+        # Try gross $10.13:
+        # pretax = 10.13 / 1.12 = 9.04464... → 9.04
+        # GST: 9.04 * 0.05 = 0.452 → 0.45
+        # PST: 9.04 * 0.07 = 0.6328 → 0.63
+        # Sum: 1.08; pretax + tax = 10.12 → residual 0.01.
+        # → PST is largest rate, gets the +0.01.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("10.13"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._gst_5(), self._pst_7()],
+            quantum=self.USD_QUANTUM,
+        )
+        # Contract: identity holds, residual targets PST (the
+        # 7% entry, which has the higher rate).
+        assert r["pretax"] + r["tax_total"] == r["gross"]
+        assert r["gross"] == Decimal("10.13")
+        # PST tax should be slightly more than the "clean"
+        # per-entry calculation; GST should be the clean amount.
+        gst = r["tax_by_acct"][self.GST_GUID]
+        pst = r["tax_by_acct"][self.PST_GUID]
+        # GST gets the clean 5% (4.5 mils → 0.45 under banker's,
+        # though either rounding direction is acceptable).
+        # PST absorbs the residual.
+        assert gst == Decimal("0.45")
+        # PST is "0.63 + residual", testing that the residual
+        # landed there: PST > pretax * 0.07 quantized.
+        pretax = r["pretax"]
+        pst_clean = (pretax * Decimal("7") / Decimal("100")).quantize(
+            self.USD_QUANTUM
+        )
+        assert pst >= pst_clean
+
+    # ── Quadrant 4: tax-inclusive, mixed value + percentage ────
+
+    def test_q4_mixed_clean(self):
+        # Gross $110 with GST 5% (percentage) + Eco $5 (value).
+        # Algebra: pretax = (110 - 5) / 1.05 = 105 / 1.05 = 100.
+        # GST: 100 * 0.05 = 5.00. Eco: 5.00.
+        # Sum tax: 10.00. pretax + tax = 110 ✓
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("110"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._gst_5(), self._eco_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_by_acct"] == {
+            self.GST_GUID: Decimal("5.00"),
+            self.ECO_GUID: Decimal("5.00"),
+        }
+        assert r["gross"] == Decimal("110.00")
+        assert r["pretax"] + r["tax_total"] == r["gross"]
+
+    def test_q4_all_value_collapses_to_subtraction(self):
+        # Tax-inclusive all-value: pretax = gross − Σ value.
+        # No rate to extract, no residual.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("105"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[self._eco_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["gross"] == Decimal("105.00")
+
+    # ── Different commodity quanta ─────────────────────────────
+
+    def test_jpy_no_decimals(self):
+        # JPY's quantum is 1 (no sub-yen). Tax math should round
+        # to integer amounts.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("1000"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[
+                {"type": "percentage", "amount": Decimal("10"),
+                 "account_guid": self.GST_GUID},
+            ],
+            quantum=self.JPY_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("1000")
+        assert r["tax_total"] == Decimal("100")
+        assert r["gross"] == Decimal("1100")
+
+    def test_jpy_tax_inclusive_rounds_correctly(self):
+        # ¥1100 with 10% included → pretax = 1100/1.1 = 1000.
+        r = self._fn(
+            quantity=Decimal("1"), price=Decimal("1100"),
+            taxable=True, tax_included=True,
+            taxtable_entries=[
+                {"type": "percentage", "amount": Decimal("10"),
+                 "account_guid": self.GST_GUID},
+            ],
+            quantum=self.JPY_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("1000")
+        assert r["tax_total"] == Decimal("100")
+        assert r["gross"] == Decimal("1100")
+
+    # ── Quantity × price edge cases ────────────────────────────
+
+    def test_zero_quantity(self):
+        r = self._fn(
+            quantity=Decimal("0"), price=Decimal("100"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        assert r["pretax"] == Decimal("0.00")
+        assert r["tax_total"] == Decimal("0.00")
+        assert r["gross"] == Decimal("0.00")
+
+    def test_fractional_quantity(self):
+        # 2.5 hours @ $40/hr taxable at 5%.
+        r = self._fn(
+            quantity=Decimal("2.5"), price=Decimal("40"),
+            taxable=True, tax_included=False,
+            taxtable_entries=[self._gst_5()],
+            quantum=self.USD_QUANTUM,
+        )
+        # pretax = 100, tax = 5, gross = 105.
+        assert r["pretax"] == Decimal("100.00")
+        assert r["tax_total"] == Decimal("5.00")
+        assert r["gross"] == Decimal("105.00")
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2980,6 +2980,310 @@ class TestTaxtableCreditNoteReversal:
         ) == Decimal(0)
 
 
+class TestTaxtableEntryWireup:
+    """Commit 4: add_*_entry tools accept taxtable + tax_included
+    kwargs. End-to-end create-entry-with-tax → post → see splits
+    without needing the raw-SQL ``_set_entry_tax`` shim."""
+
+    def _setup(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        return gb, gst, pst
+
+    def test_invoice_entry_with_taxtable(self, business_book):
+        gb, gst, _ = self._setup(business_book)
+        result = gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        assert result["status"] == "created"
+        # Refcount incremented from 0 to 1.
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 1
+
+    def test_invoice_entry_no_taxtable_unchanged(self, business_book):
+        """Backward compat: omitting taxtable leaves tax fields zeroed
+        and refcount untouched."""
+        gb, _, _ = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="No-tax",
+            quantity="1",
+            price="100",
+        )
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 0
+
+    def test_tax_included_requires_taxtable(self, business_book):
+        gb, _, _ = self._setup(business_book)
+        with pytest.raises(ValueError, match="tax_included.*requires"):
+            gb.add_invoice_entry(
+                invoice_id="000001",
+                account="Income:Sales",
+                description="No taxtable",
+                quantity="1",
+                price="100",
+                tax_included=True,
+            )
+
+    def test_unknown_taxtable_rejected(self, business_book):
+        gb, _, _ = self._setup(business_book)
+        with pytest.raises(ValueError, match="Taxtable not found"):
+            gb.add_invoice_entry(
+                invoice_id="000001",
+                account="Income:Sales",
+                description="Bad taxtable",
+                quantity="1",
+                price="100",
+                taxtable="Nonexistent",
+            )
+
+    def test_end_to_end_post_with_added_tax(self, business_book):
+        """Full integration: create entry with tax via the tool,
+        post, verify the posting transaction has correct splits."""
+        gb, gst, pst = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100",
+            taxtable="BC GST+PST",
+        )
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert Decimal(result["total"]) == Decimal("112.00")
+        txn = gb.get_transaction(result["transaction_guid"])
+        splits = {s["account"]: Decimal(s["value"]) for s in txn["splits"]}
+        assert splits["Assets:Accounts Receivable"] == Decimal("112.00")
+        assert splits["Income:Sales"] == Decimal("-100.00")
+        assert splits["Liabilities:GST Payable"] == Decimal("-5.00")
+        assert splits["Liabilities:PST Payable"] == Decimal("-7.00")
+
+    def test_bill_entry_with_taxtable_routes_b_side(
+        self, business_book,
+    ):
+        """Vendor bills must write to b_taxtable (not i_taxtable)."""
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50",
+            taxtable="GST 5%",
+        )
+        # Refcount incremented (no matter which side).
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 1
+        # Direct SQL verification that the routing is b_*, not i_*.
+        from sqlalchemy import text
+        with gb.open() as book:
+            row = book.session.execute(
+                text(
+                    "SELECT i_taxtable, b_taxtable FROM entries "
+                    "ORDER BY date DESC LIMIT 1"
+                )
+            ).fetchone()
+            assert row.i_taxtable is None
+            assert row.b_taxtable is not None
+
+    def test_voucher_entry_with_taxtable_routes_b_side(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_employee(name="Jane Smith")
+        gb.create_voucher(employee_id="000001")
+        gb.add_voucher_entry(
+            voucher_id="000001",
+            account="Expenses:Office Supplies",
+            description="Pens",
+            quantity="1",
+            price="20",
+            taxtable="GST 5%",
+        )
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 1
+
+    def test_credit_note_entry_with_taxtable(self, business_book):
+        gb, gst, _ = self._setup(business_book)
+        gb.create_credit_note(
+            owner_type="customer", owner_id="000001",
+        )
+        # Find the credit note's ID.
+        envelope = gb.list_invoices(
+            compact=False, owner_type="customer",
+        )
+        cn = next(d for d in envelope["invoices"]
+                  if d.get("is_credit_note"))
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"],
+            account="Income:Sales",
+            description="Refund",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 1
+
+
+class TestTaxtableLifecycle:
+    """Refcount lifecycle: maintained on entry add/delete,
+    enforced as guards on update/delete of the taxtable itself."""
+
+    def test_refcount_increments_per_entry(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="A",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="B",
+            quantity="2",
+            price="50",
+            taxtable="GST 5%",
+        )
+        tt = gb.get_taxtable("GST 5%")
+        assert tt["refcount"] == 2
+
+    def test_refcount_decrements_on_invoice_delete(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="A",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="B",
+            quantity="1",
+            price="50",
+            taxtable="GST 5%",
+        )
+        assert gb.get_taxtable("GST 5%")["refcount"] == 2
+        gb.delete_invoice(invoice_id="000001")
+        # Both refs gone after the invoice's entries are deleted.
+        assert gb.get_taxtable("GST 5%")["refcount"] == 0
+
+    def test_delete_in_use_taxtable_rejected_via_real_entries(
+        self, business_book,
+    ):
+        """The Commit-1 ``delete_taxtable`` guard now sees real
+        entries (not just simulated SQL inserts). End-to-end."""
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="A",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        with pytest.raises(ValueError, match="1 entries reference"):
+            gb.delete_taxtable("GST 5%")
+
+    def test_update_in_use_rejected_via_real_entries(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="A",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        with pytest.raises(ValueError, match="force=True"):
+            gb.update_taxtable(
+                name="GST 5%",
+                entries=[{"type": "percentage", "amount": "10",
+                          "account": gst}],
+            )
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3284,6 +3284,202 @@ class TestTaxtableLifecycle:
             )
 
 
+class TestTaxtableDisplay:
+    """Commit 5: per-entry tax tags + document-level tax_summary
+    block. Conditional emission keeps non-tax responses
+    byte-identical to pre-taxtable shape."""
+
+    def _setup(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        return gb, gst, pst
+
+    def test_non_tax_invoice_unchanged_shape(self, business_book):
+        """Backward-compat: an invoice with no tax-bearing entries
+        returns no tax_summary key and entries lack tax fields."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Plain",
+            quantity="1",
+            price="100",
+        )
+        inv = gb.get_invoice("000001")
+        assert "tax_summary" not in inv
+        assert inv["entries"][0].keys() == {
+            "guid", "date", "description",
+            "quantity", "price", "total", "account",
+        }
+
+    def test_taxable_entry_carries_tax_fields(self, business_book):
+        gb, _, _ = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        inv = gb.get_invoice("000001")
+        e = inv["entries"][0]
+        assert e["taxable"] is True
+        assert e["tax_included"] is False
+        assert e["taxtable"] == "GST 5%"
+
+    def test_tax_included_flag_surfaces(self, business_book):
+        gb, _, _ = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Gross",
+            quantity="1",
+            price="105",
+            taxtable="GST 5%",
+            tax_included=True,
+        )
+        inv = gb.get_invoice("000001")
+        e = inv["entries"][0]
+        assert e["tax_included"] is True
+
+    def test_tax_summary_block_emitted(self, business_book):
+        """Single-entry invoice with tax produces a complete
+        tax_summary with all five fields populated."""
+        gb, gst, _ = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        inv = gb.get_invoice("000001")
+        ts = inv["tax_summary"]
+        assert ts["subtotal"] == "100.00"
+        assert ts["tax_total"] == "5.00"
+        assert ts["total"] == "105.00"
+        assert ts["by_taxtable"] == {"GST 5%": "5.00"}
+        assert ts["by_account"] == {
+            "Liabilities:GST Payable": "5.00"
+        }
+        # Customer-facing total uses the gross figure.
+        assert inv["total"] == "105.00"
+
+    def test_tax_summary_composite_by_taxtable(self, business_book):
+        """Multi-line invoice spanning two taxtables: by_taxtable
+        rolls up each taxtable's contribution; by_account splits
+        across the underlying payable accounts."""
+        gb, gst, pst = self._setup(business_book)
+        # Line A: $100 GST 5% → $5 tax → GST Payable
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="A",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        # Line B: $200 BC GST+PST → $10 GST + $14 PST → both
+        # accounts
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="B",
+            quantity="1",
+            price="200",
+            taxtable="BC GST+PST",
+        )
+        inv = gb.get_invoice("000001")
+        ts = inv["tax_summary"]
+        assert ts["subtotal"] == "300.00"
+        assert ts["tax_total"] == "29.00"
+        assert ts["total"] == "329.00"
+        # Per-taxtable rollup:
+        assert ts["by_taxtable"] == {
+            "GST 5%": "5.00",
+            "BC GST+PST": "24.00",  # 10 + 14
+        }
+        # Per-account: GST Payable collects from both taxtables.
+        assert ts["by_account"] == {
+            "Liabilities:GST Payable": "15.00",  # 5 + 10
+            "Liabilities:PST Payable": "14.00",
+        }
+
+    def test_mixed_invoice_only_tax_lines_in_summary(
+        self, business_book,
+    ):
+        """An invoice with some tax-bearing and some non-tax lines
+        still produces a tax_summary; non-tax lines simply
+        contribute to subtotal/total but not to tax_total."""
+        gb, _, _ = self._setup(business_book)
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="No tax",
+            quantity="1",
+            price="50",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Taxed",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        inv = gb.get_invoice("000001")
+        ts = inv["tax_summary"]
+        # Subtotal is sum of per-line pretax = 50 + 100 = 150.
+        assert ts["subtotal"] == "150.00"
+        # Tax_total only from the taxed line.
+        assert ts["tax_total"] == "5.00"
+        assert ts["total"] == "155.00"
+
+    def test_bill_taxable_entry_displays(self, business_book):
+        """Vendor bill displays b_taxable correctly (not i_taxable)."""
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50",
+            taxtable="GST 5%",
+        )
+        inv = gb.get_invoice("000001", owner_type="vendor")
+        e = inv["entries"][0]
+        assert e["taxable"] is True
+        assert e["taxtable"] == "GST 5%"
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -2659,6 +2659,327 @@ class TestTaxtableMath:
         assert r["gross"] == Decimal("105.00")
 
 
+def _set_entry_tax(
+    gb, invoice_id, taxtable_name,
+    tax_included=False, is_bill=False,
+):
+    """Raw-SQL helper to flip i_taxable/b_taxable + assign a
+    taxtable on every entry of an invoice/bill. Pre-Commit-4
+    workaround so posting tests can exercise tax math without
+    the entry-creation wire-up.
+    """
+    from sqlalchemy import text
+    with gb.open(readonly=False) as book:
+        tt = gb._find_taxtable(book, taxtable_name)
+        col = "bill" if is_bill else "invoice"
+        rows = book.session.execute(
+            text(
+                f"SELECT e.guid AS entry_guid FROM entries e "
+                f"JOIN invoices i ON i.guid = e.{col} "
+                f"WHERE i.id = :id"
+            ),
+            {"id": invoice_id},
+        ).fetchall()
+        ti_val = 1 if tax_included else 0
+        for r in rows:
+            if is_bill:
+                stmt = text(
+                    "UPDATE entries SET "
+                    "b_taxable=1, b_taxincluded=:ti, "
+                    "b_taxtable=:tt WHERE guid=:guid"
+                )
+            else:
+                stmt = text(
+                    "UPDATE entries SET "
+                    "i_taxable=1, i_taxincluded=:ti, "
+                    "i_taxtable=:tt WHERE guid=:guid"
+                )
+            book.session.execute(
+                stmt,
+                {
+                    "ti": ti_val,
+                    "tt": tt.guid,
+                    "guid": r.entry_guid,
+                },
+            )
+        book.save()
+
+
+class TestTaxtablePosting:
+    """End-to-end tests: invoice/bill with tax-bearing entries
+    posts to the correct split shape, with revenue/expense
+    splits separate from tax-payable splits."""
+
+    def _splits_by_account(self, gb, txn_guid):
+        """Helper: pull splits by account fullname from get_transaction."""
+        txn = gb.get_transaction(txn_guid)
+        out = {}
+        for s in txn["splits"]:
+            out.setdefault(s["account"], []).append(
+                Decimal(s["value"])
+            )
+        return out
+
+    def test_post_invoice_with_tax_exclusive_three_splits(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100.00",
+        )
+        # Seed tax on the entry (pre-Commit-4 workaround).
+        _set_entry_tax(gb, "000001", "GST 5%", tax_included=False)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        # Customer-facing total is gross.
+        assert Decimal(result["total"]) == Decimal("105.00")
+        # Three splits: A/R (debit 105), Income (credit -100),
+        # GST Payable (credit -5).
+        splits = self._splits_by_account(gb, result["transaction_guid"])
+        assert splits["Assets:Accounts Receivable"] == [Decimal("105.00")]
+        assert splits["Income:Sales"] == [Decimal("-100.00")]
+        assert splits["Liabilities:GST Payable"] == [Decimal("-5.00")]
+        # Sum to zero (the double-entry invariant).
+        assert sum(
+            sum(amounts) for amounts in splits.values()
+        ) == Decimal(0)
+
+    def test_post_invoice_tax_inclusive_extracts_pretax(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="105.00",  # gross, tax included
+        )
+        _set_entry_tax(gb, "000001", "GST 5%", tax_included=True)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        # Gross is the line value (tax-inclusive).
+        assert Decimal(result["total"]) == Decimal("105.00")
+        splits = self._splits_by_account(gb, result["transaction_guid"])
+        assert splits["Assets:Accounts Receivable"] == [Decimal("105.00")]
+        # Pretax = 100 extracted from gross.
+        assert splits["Income:Sales"] == [Decimal("-100.00")]
+        assert splits["Liabilities:GST Payable"] == [Decimal("-5.00")]
+
+    def test_post_invoice_composite_taxtable_four_splits(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="BC GST+PST",
+            entries=[
+                {"type": "percentage", "amount": "5",
+                 "account": gst},
+                {"type": "percentage", "amount": "7",
+                 "account": pst},
+            ],
+        )
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100.00",
+        )
+        _set_entry_tax(gb, "000001", "BC GST+PST")
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert Decimal(result["total"]) == Decimal("112.00")
+        splits = self._splits_by_account(gb, result["transaction_guid"])
+        # Four splits: A/R, Income, GST Payable, PST Payable.
+        assert splits["Assets:Accounts Receivable"] == [Decimal("112.00")]
+        assert splits["Income:Sales"] == [Decimal("-100.00")]
+        assert splits["Liabilities:GST Payable"] == [Decimal("-5.00")]
+        assert splits["Liabilities:PST Payable"] == [Decimal("-7.00")]
+        # Double-entry invariant.
+        assert sum(
+            sum(amounts) for amounts in splits.values()
+        ) == Decimal(0)
+
+    def test_post_invoice_no_tax_unchanged(self, business_book):
+        """Sanity: a non-tax invoice still posts identically to
+        pre-Commit-3 behavior — two splits, A/R and Income."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100.00",
+        )
+        # No tax seeding — entries default to taxable=0.
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        assert Decimal(result["total"]) == Decimal("100.00")
+        splits = self._splits_by_account(gb, result["transaction_guid"])
+        # Just two splits: A/R + Income.
+        assert set(splits.keys()) == {
+            "Assets:Accounts Receivable", "Income:Sales",
+        }
+
+    def test_post_bill_with_tax_routes_correctly(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        # Tax credit on vendor side often lives as an ASSET (input
+        # tax credit receivable). Using the LIABILITY account from
+        # the fixture is also valid — what matters is the routing.
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        _set_entry_tax(gb, "000001", "GST 5%", is_bill=True)
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        # Vendor-side signs are inverted: A/P credit (-), Expense
+        # debit (+), GST debit (+) for input tax credit.
+        assert Decimal(result["total"]) == Decimal("52.50")
+        splits = self._splits_by_account(gb, result["transaction_guid"])
+        assert splits["Liabilities:Accounts Payable"] == [Decimal("-52.50")]
+        assert splits["Expenses:Office Supplies"] == [Decimal("50.00")]
+        assert splits["Liabilities:GST Payable"] == [Decimal("2.50")]
+        assert sum(
+            sum(amounts) for amounts in splits.values()
+        ) == Decimal(0)
+
+
+class TestTaxtableCreditNoteReversal:
+    """Credit notes with tax reverse all splits including tax via
+    the existing XOR sign-flip — refunding a tax-inclusive sale
+    credits A/R, debits revenue, AND debits tax payable."""
+
+    def _splits_by_account(self, gb, txn_guid):
+        txn = gb.get_transaction(txn_guid)
+        out = {}
+        for s in txn["splits"]:
+            out.setdefault(s["account"], []).append(
+                Decimal(s["value"])
+            )
+        return out
+
+    def test_credit_note_reverses_revenue_and_tax(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        gb.create_customer(name="Acme Corp")
+        # First, a normal invoice to set the original numbers.
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100.00",
+        )
+        _set_entry_tax(gb, "000001", "GST 5%")
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+
+        # Now a credit note refunding the same amount.
+        gb.create_credit_note(
+            owner_type="customer",
+            owner_id="000001",
+        )
+        envelope = gb.list_invoices(
+            compact=False, owner_type="customer",
+        )
+        cn_doc = next(
+            (
+                d for d in envelope["invoices"]
+                if d.get("is_credit_note")
+            ),
+            None,
+        )
+        assert cn_doc is not None, "credit note not found via list"
+        gb.add_credit_note_entry(
+            credit_note_id=cn_doc["id"],
+            account="Income:Sales",
+            description="Widget refund",
+            quantity="1",
+            price="100.00",
+        )
+        _set_entry_tax(gb, cn_doc["id"], "GST 5%")
+        result = gb.post_invoice(
+            invoice_id=cn_doc["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        # Total stays positive (it's the magnitude of the refund);
+        # the sign-flip happens at the splits.
+        assert Decimal(result["total"]) == Decimal("105.00")
+        splits = self._splits_by_account(
+            gb, result["transaction_guid"],
+        )
+        # Credit-note sign-flip: A/R credit (negative), revenue
+        # debit (positive — reversing recognized revenue), tax
+        # payable debit (positive — reversing collected tax).
+        assert splits["Assets:Accounts Receivable"] == [Decimal("-105.00")]
+        assert splits["Income:Sales"] == [Decimal("100.00")]
+        assert splits["Liabilities:GST Payable"] == [Decimal("5.00")]
+        # Invariant.
+        assert sum(
+            sum(amounts) for amounts in splits.values()
+        ) == Decimal(0)
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3480,6 +3480,145 @@ class TestTaxtableDisplay:
         assert e["taxtable"] == "GST 5%"
 
 
+class TestTaxtableCrossCurrency:
+    """Cross-currency × tax interaction: EUR invoice with a
+    USD-denominated tax-payable account exercises the existing
+    _qty_for_split FX conversion on the tax component. The tax
+    math itself is currency-agnostic (rates and amounts apply
+    in invoice currency); FX kicks in only when the tax-payable
+    account's commodity differs from the invoice currency."""
+
+    def _setup_eur_with_usd_gst(self, business_book, rate="1.10"):
+        """Wire up: EUR commodity, EUR/USD price, USD GST Payable
+        account (in the book's default USD), EUR-denominated
+        customer + invoice. Returns the GnuCashBook handle."""
+        import piecash
+        from datetime import date as date_cls
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as bk:
+            eur = piecash.Commodity(
+                namespace="CURRENCY", mnemonic="EUR",
+                fullname="Euro", fraction=100,
+            )
+            bk.session.add(eur)
+            bk.flush()
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=bk.default_currency,
+                date=date_cls(2026, 5, 24),
+                value=rate, type="last",
+            ))
+            bk.save()
+        # USD GST Payable (book default commodity)
+        gb.create_account(
+            name="GST Payable",
+            account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": "Liabilities:GST Payable"}],
+        )
+        gb.create_customer(name="EUR Client")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+        )
+        return gb
+
+    def test_eur_invoice_with_usd_tax_payable(
+        self, business_book,
+    ):
+        """EUR 100 invoice with USD GST Payable at GST 5% → tax
+        component is EUR 5 in invoice currency, which converts to
+        USD 5.50 in the tax-payable account at the 1.10 rate."""
+        gb = self._setup_eur_with_usd_gst(business_book, rate="1.10")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="EUR work",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        result = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        # Customer-facing total in EUR (invoice currency).
+        assert Decimal(result["total"]) == Decimal("105.00")
+        txn = gb.get_transaction(result["transaction_guid"])
+        # Build a per-account dict keyed by fullname carrying
+        # both value (EUR — invoice currency) and quantity
+        # (account commodity — USD or EUR depending on side).
+        by_acct = {
+            s["account"]: (Decimal(s["value"]), Decimal(s["quantity"]))
+            for s in txn["splits"]
+        }
+        # A/R is RECEIVABLE in USD (fixture default). value is in
+        # EUR (transaction currency); quantity converts to USD.
+        ar_value, ar_quantity = by_acct["Assets:Accounts Receivable"]
+        assert ar_value == Decimal("105.00")
+        assert ar_quantity == Decimal("115.50")  # 105 × 1.10
+        # Income split is in USD (fixture default).
+        inc_value, inc_quantity = by_acct["Income:Sales"]
+        assert inc_value == Decimal("-100.00")
+        assert inc_quantity == Decimal("-110.00")
+        # Tax-payable split — the focal point of the test.
+        # Value (EUR): -5 (tax in invoice currency).
+        # Quantity (USD): -5.50 (converted at the rate).
+        gst_value, gst_quantity = by_acct["Liabilities:GST Payable"]
+        assert gst_value == Decimal("-5.00")
+        assert gst_quantity == Decimal("-5.50")
+        # Value-side sums to zero (the transaction-currency
+        # balance invariant — quantities don't need to balance
+        # across commodities).
+        value_sum = sum(v for v, _ in by_acct.values())
+        assert value_sum == Decimal(0)
+
+    def test_cross_currency_tax_requires_rate(
+        self, business_book,
+    ):
+        """When no price is on file for the EUR/USD pair near
+        post date, posting raises a clear error — the same
+        rate-not-found path already exercised by non-tax
+        cross-currency posting."""
+        import piecash
+        gb = GnuCashBook(str(business_book))
+        # Add EUR commodity but no price.
+        with gb.open(readonly=False) as bk:
+            eur = piecash.Commodity(
+                namespace="CURRENCY", mnemonic="EUR",
+                fullname="Euro", fraction=100,
+            )
+            bk.session.add(eur)
+            bk.save()
+        gb.create_account(
+            name="GST Payable",
+            account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": "Liabilities:GST Payable"}],
+        )
+        gb.create_customer(name="EUR Client")
+        gb.create_invoice(customer_id="000001", currency="EUR")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="EUR work",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        with pytest.raises(ValueError, match="exchange rate"):
+            gb.post_invoice(
+                invoice_id="000001",
+                post_account="Assets:Accounts Receivable",
+            )
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3619,6 +3619,128 @@ class TestTaxtableCrossCurrency:
             )
 
 
+class TestTaxtableCopilotReviewFollowups:
+    """Regression guards for Copilot PR #90 review findings."""
+
+    def test_audit_log_renders_leaf_account_name(self):
+        """``_fmt_taxtable_entry_line`` must render the leaf
+        account name (matching ``_taxtable_entry_summary`` and
+        ``list_taxtables``), not the fullname path. Pre-fix the
+        audit log showed ``5%→Liabilities:GST Payable`` while the
+        compact list showed ``5%→GST Payable`` — same data,
+        different rendering, scannability bug for the bookkeeper
+        reviewing the audit trail."""
+        from gnucash_mcp.logging_config import (
+            _fmt_taxtable_entry_line,
+        )
+        # Fullname input gets trimmed to the leaf.
+        assert _fmt_taxtable_entry_line({
+            "type": "percentage",
+            "amount": "5",
+            "account": "Liabilities:GST Payable",
+        }) == "5%→GST Payable"
+        # Bare-leaf input passes through unchanged.
+        assert _fmt_taxtable_entry_line({
+            "type": "percentage",
+            "amount": "7",
+            "account": "PST Payable",
+        }) == "7%→PST Payable"
+        # Value-type entry uses $-prefix.
+        assert _fmt_taxtable_entry_line({
+            "type": "value",
+            "amount": "5",
+            "account": "Liabilities:Eco Fee Payable",
+        }) == "$5→Eco Fee Payable"
+        # GUID fallback (no path map): leaf-trim is a no-op
+        # because the GUID has no ``:`` separator.
+        assert _fmt_taxtable_entry_line({
+            "type": "percentage",
+            "amount": "5",
+            "account_guid": "deadbeef" * 4,
+        }) == "5%→" + ("deadbeef" * 4)
+
+    def test_get_invoice_skips_taxtable_query_when_no_tax_entries(
+        self, business_book,
+    ):
+        """When no entry on the invoice references a taxtable,
+        ``get_invoice`` must not query the taxtables table.
+        Verified by creating taxtables and then asking for an
+        invoice that doesn't reference them — the query count
+        should not grow with taxtable count. Regression for
+        Copilot's O(N-taxtables-in-book) scan finding."""
+        gb = GnuCashBook(str(business_book))
+        gst, pst = _add_tax_accounts(gb)
+        # Create taxtables that the test invoice does NOT reference.
+        for n in range(5):
+            gb.create_taxtable(
+                name=f"Decoy {n}",
+                entries=[{"type": "percentage", "amount": "5",
+                          "account": gst}],
+            )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Plain",
+            quantity="1",
+            price="100",
+        )
+        # Spy on the session: count Taxtable.query invocations.
+        # Direct query-count instrumentation is awkward in
+        # SQLAlchemy 1.4; the simpler verification is that the
+        # response has no tax_summary key and no entry carries
+        # tax fields — both byproducts of the early-skip path.
+        inv = gb.get_invoice("000001")
+        assert "tax_summary" not in inv
+        assert "taxable" not in inv["entries"][0]
+
+    def test_get_invoice_filters_taxtable_query_to_referenced_only(
+        self, business_book,
+    ):
+        """When some entries reference taxtables but not all
+        taxtables in the book, ``get_invoice`` filters the
+        Taxtable query to just the needed GUIDs. The visible
+        contract is that the response correctly resolves the
+        referenced taxtable's name (regression guard: a buggy
+        filter that returned no rows would surface as a raw
+        GUID in the entry dict)."""
+        gb = GnuCashBook(str(business_book))
+        gst, _ = _add_tax_accounts(gb)
+        # Create extra decoy taxtables that the invoice doesn't
+        # reference. With the unconditional query removed, these
+        # are filtered out and don't appear in the response.
+        gb.create_taxtable(
+            name="GST 5%",
+            entries=[{"type": "percentage", "amount": "5",
+                      "account": gst}],
+        )
+        for n in range(3):
+            gb.create_taxtable(
+                name=f"Decoy {n}",
+                entries=[{"type": "percentage", "amount": "3",
+                          "account": gst}],
+            )
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="100",
+            taxtable="GST 5%",
+        )
+        inv = gb.get_invoice("000001")
+        # The referenced taxtable resolves to its name.
+        assert inv["entries"][0]["taxtable"] == "GST 5%"
+        # Tax summary references only the actually-applied
+        # taxtable, not the decoys.
+        assert list(inv["tax_summary"]["by_taxtable"].keys()) == [
+            "GST 5%"
+        ]
+
+
 class TestReceivablePayableAccountTypes:
     """Tests for RECEIVABLE and PAYABLE account type support."""
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,12 +80,12 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 26
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 101 —
+        """Total tools across all sub-modules should be 106 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
-        1 get_job_report added in v1.3."""
+        1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 101
+        assert total == 106
 
     def test_expected_modules_exist(self):
         """All expected sub-module names should be present after the
@@ -229,9 +229,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 101 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report)."""
+        """--modules=all should keep all 106 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 101
+        assert len(self._tool_names()) == 106
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -263,12 +263,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 101
+        assert len(self._tool_names()) == 106
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 101 tools."""
+        """'all' mixed with other modules should keep all 106 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 101
+        assert len(self._tool_names()) == 106
 
     def test_unknown_module_warns(self, capsys):
         """Unknown module names should produce a warning on stderr."""


### PR DESCRIPTION
## Summary

Completes the v1.3 business module by adding sales-tax-table support to invoice/bill/voucher/credit-note line items. Five new tools (`create_taxtable`, `list_taxtables`, `get_taxtable`, `update_taxtable`, `delete_taxtable`) plus optional `taxtable` + `tax_included` kwargs on the four `add_*_entry` tools. Tool count 101 → 106.

Per the spec ([`specs/TAXTABLES_SPEC.md`](specs/TAXTABLES_SPEC.md)), the work landed in six commits, each independently testable:

- **Commit 1 — Taxtable CRUD.** Greenfield: piecash `Taxtable` / `TaxtableEntry` are ORM-native (no raw-SQL blockers). Multi-entry composites (GST 5% + PST 7%) are structurally supported. Refcount maintained for desktop interop; SQL-computed counts authoritative for our own lifecycle guards.
- **Commit 2 — Per-quadrant tax math helper.** Pure `_compute_entry_tax` handling the four behavioral quadrants (taxable × tax_included), with mixed value+percentage algebra and residual-to-largest-rate rounding policy. 17 math tests cover all quadrants + JPY no-decimals.
- **Commit 3 — Posting math seam.** The structural turn: `_get_invoice_entries_and_total` resolves taxtables and folds tax-payable account splits into `acct_totals` so the existing `post_invoice` loop emits one split per account without knowing about tax. The XOR credit-note flip already handles tax reversal correctly.
- **Commit 4 — Entry wire-up + refcount discipline.** `add_*_entry` tools gain `taxtable` + `tax_included` kwargs. Refcount increments on entry create and decrements on invoice/bill/voucher delete (the entry-deletion path in `_delete_invoice_or_bill` tallies per-taxtable refs and decrements correctly).
- **Commit 5 — Display ripple.** `_entry_to_dict` conditionally emits per-line tax tags; `_invoice_to_dict` accepts an optional `tax_summary` block. `get_invoice` now wires the seam's math into both surfaces. Non-tax invoices keep byte-identical pre-v1.3 shape.
- **Commit 6 — Cross-currency tax tests.** EUR invoice with USD-denominated tax-payable account: posting produces splits whose value (EUR) and quantity (USD) differ by the FX rate. The existing `_qty_for_split` machinery covers it without new infrastructure.

**Phase 14 synthetic-book script deferred** to a follow-up PR.

**Live-tested against Alex Chen-Morales' book at three gates** (after Commits 1, 4, 5). One bug found and fixed at the Commit 1 gate (entry-replacement after-state was missing the resolved `account` field because piecash's FK column is `None` pre-flush — added `book.flush()` + a regression-guard assertion). End-to-end posting at Commit 4 produced 4 correct splits on a 3-entry mixed-taxtable invoice with refcount discipline holding through the unpost → delete → cleanup cycle.

Total: ~3,900 LOC including 601-line spec and 1909 lines of tests (113 new tests; 1320 total green).

## Test plan

- [ ] Bookkeeper review against Alex's book — recommend probing:
  - [ ] Multi-rate composite (e.g., BC GST+PST) on a single invoice: verify both payable accounts get distinct splits at posting
  - [ ] Tax-inclusive line: verify pretax is extracted, not added on top
  - [ ] Credit-note refund on a tax-inclusive sale: verify all three splits reverse (A/R credit, revenue debit, tax-payable debit)
  - [ ] Refcount lifecycle: create taxtable → add entries → verify refcount > 0 blocks `delete_taxtable` → delete invoice → verify refcount returns to 0 → `delete_taxtable` succeeds
  - [ ] Non-tax invoice via `get_invoice` returns byte-identical pre-v1.3 shape (no `tax_summary`, entries lack tax keys)
  - [ ] Cross-currency: EUR invoice with USD tax-payable account, verify FX conversion on tax split
- [ ] `uv run pytest` clean (1320 passing)
- [ ] `--modules=all` shows 106 tools