### PR TITLE
fix(v1.3): release-prep correctness + UX sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,194 @@
 # Changelog
 
+## v1.3.0 — Business module complete, role-aligned modules
+
+v1.2.1 fixed everything the business module *should* have been at first
+ship. v1.3 finishes the headline features the bookkeeper had been
+asking for since v1.2 and reshapes the public module surface around
+how real users actually deploy the server.
+
+**Business module — the four big features.**
+
+- **Employee expense vouchers** (`create_voucher`, `add_voucher_entry`,
+  `post_invoice` / `pay_invoice` / `unpost_invoice` /
+  `delete_voucher` polymorphic). The third half of the invoice
+  lifecycle alongside customer invoices and vendor bills. Employees
+  submit reimbursable expenses; voucher posts to A/P, payment hits
+  the chosen cash account. Same `owner_type='employee'` dispatch the
+  other invoice tools already understood.
+- **Credit notes** (`create_credit_note`, `add_credit_note_entry`,
+  `apply_credit_note`, plus the shared `post_invoice` /
+  `unpost_invoice` / `delete_credit_note` path). Refund and return
+  documents for customers and vendors. Posts as a negative invoice;
+  applies against an outstanding invoice or bill to net the
+  payable/receivable down. Lifecycle tracks
+  `gnc-mcp/applies-to-invoice` so the link survives between sessions.
+- **Jobs** (`create_job`, `get_job`, `list_jobs`, `update_job`,
+  `get_job_report`, `delete_job`). Project-level grouping over
+  invoices and bills for a single customer or vendor. A jobs-level
+  P&L (`get_job_report`) shows revenue, costs, net by project — the
+  view a freelancer needs at year-end without manually slicing every
+  client's transactions. Invoices and bills accept an optional
+  `job_id` at creation; existing tools see job-attached documents
+  through the same surfaces.
+- **Tax tables** (`create_taxtable`, `add_taxtable_entry`,
+  `update_taxtable`, `list_taxtables`, `get_taxtable`,
+  `delete_taxtable`). Composite tax rates (e.g. state + local
+  sales tax stacked) attached to invoice/bill/voucher line items.
+  Posting builds the tax splits at post-time from each entry's
+  taxable amount × applicable rate, with residual-to-largest-rate
+  rounding so totals tie exactly. Tax-inclusive pricing (`price` is
+  gross, pretax extracted at post) handled symmetrically. Refcount
+  discipline blocks deletion of in-use taxtables.
+
+The Stage 3 surface adds 19 tools to the catalog (87 → 106), each
+exercised against the synthetic test books before release.
+
+**Module surface — role-aligned partition.**
+
+`--modules` previously partitioned by code organization
+(`core / admin / backup / investments / business`). The new partition
+matches how people actually use the server:
+
+- **`core`** (26 tools) — always-on ledger primitives: accounts,
+  transactions, slots, audit, backup, balance sheet, summary,
+  diagnostics. Now a group alias expanding to eight independently-
+  selectable sub-modules; you can opt into the group or pick the
+  sub-modules à la carte.
+- **`bookkeeper`** (20 tools) — personal-finance management:
+  reconciliation, reporting, budgets, scheduling. Group alias for
+  the four underlying modules.
+- **`investor`** (12 tools) — group alias for `portfolio`
+  (commodities + prices, the multi-currency primitive) plus
+  `tax_lots` (cost basis tracking).
+- **`freelancer`** (19 tools) — customer-facing invoicing: invoice
+  creation, posting, payment, outstanding-invoices, taxtables.
+- **`business`** (29 tools) — vendor management, employee
+  expenses, jobs, credit notes, customers, billing terms.
+
+`get_server_config` renders the loaded modules as
+`core[accounts, audit, ...], reporting, ...` so it's clear what's
+inside each group without reading source. Group expansion is single-
+pass; the partition is deliberately flat. See the README's "Choosing
+a module set" table for which modules to load for which use case.
+
+**Reconciliation — bulk mode for OFX-import workflows.**
+
+- **`reconcile_all=true`** reconciles every unreconciled split on
+  the account in one call. The common case for "I just imported a
+  bank statement — everything matches; reconcile it all." No
+  GUID round-trip; one call instead of ~100 if a month's worth of
+  transactions are involved.
+- **`except_guids=[...]`** carves exceptions out of the bulk set.
+  When the statement matches the book *except* for one pending
+  ACH or a manual split the bank doesn't know about yet, two
+  prefix tokens describe the exception instead of the 100+ a full
+  `split_guids` listing would cost.
+- **`through_date`** filters bulk mode to splits on or before a
+  date — useful when you're reconciling a mid-month statement.
+- **Account shortcuts** accepted everywhere the older
+  reconciliation tools wanted full paths. `%2e78c86` flows in and
+  out of `reconcile_account` the same way it does in every other
+  account-aware tool.
+
+**Dashboard refinements.**
+
+- **Overdue counts** on the receivables and payables lines —
+  *"Receivables: USD 7,420 outstanding (3 invoices, 1 overdue ⚠)"*.
+  The headline number was already there; what was missing was
+  whether any of it was overdue.
+- **Active jobs** line when at least one job is open —
+  *"Jobs: 4 active"*. Surfaces the new entity in the same place
+  the LLM already looks for "what's open."
+- **Foreign-currency conversion in `spending_by_category` and
+  `income_by_source`.** Pre-fix, these reports summed raw split
+  quantities across commodities — a USD spend and a CNY spend
+  added together to a meaningless number. Now each split is
+  converted to the book's default currency via the latest market
+  rate (with cost-basis fallback for unpriced commodities), the
+  same pattern `balance_sheet` and `net_worth` already used.
+
+**Security — Stage 6 hardening.**
+
+- **Path-traversal hardening on `.mcp` sidecar directories.** Backup
+  and audit-log paths derive from `GNUCASH_BOOK_PATH`; the sidecar
+  resolution now checks symlink targets, ownership, and world-
+  writable bits before trusting an existing directory. Sticky-bit
+  dirs (the `/tmp` class) get no exemption — sticky-bit prevents
+  deletion, not symlink creation. The optional `GNUCASH_LOG_DIR`
+  override lets containerized deployments redirect logs without
+  defeating the resolution checks.
+- **Path leak redaction at the MCP error boundary.** Tool error
+  responses now route through `redact_paths()` so absolute paths
+  on the host filesystem don't leak into error strings sent to the
+  LLM. Internal logger calls keep the full paths for debugging;
+  the boundary is the wire.
+- **Write rate-limiting via token bucket.** Defends against a
+  runaway agent loop accidentally hammering the database with
+  thousands of writes per second. Default: 60 writes/minute with
+  short bursts allowed; configurable via `GNUCASH_MCP_RATE_LIMIT`.
+  Read tools are unaffected.
+
+**Strict argument validation.**
+
+`extra="forbid"` is now the default on every tool's Pydantic
+argument model. Unknown kwargs — typos like `except=[...]` instead
+of `except_guids=[...]`, or stale-spec parameter names from older
+docs — fail loudly at the MCP boundary with `Extra inputs are not
+permitted` instead of silently no-opping. Bookkeeper-found bug:
+a `reconcile_account` call with the wrong exclusion parameter name
+ran with no exclusion at all and only surfaced as a downstream
+balance mismatch.
+
+**Parameter normalization.**
+
+`delete_invoice`, `delete_bill`, `delete_voucher`, and
+`delete_credit_note` now accept `id` (the standard name across
+`get_invoice` / `post_invoice` / `unpost_invoice` / `pay_invoice`)
+in addition to the legacy `<entity>_id`. Pass exactly one; back-
+compat preserved for existing callers.
+
+**Server instructions — 59% smaller.**
+
+The orientation block sent to MCP clients on connect went from
+~2,500 chars to 1,522 (24% under the 2K cap). Same coverage
+— double-entry sign convention, account ref formats, GUID
+conventions, investment workflow, safety rules — denser phrasing.
+Frees ~1KB of every client's context budget.
+
+**Internal refactors (no behavior change).**
+
+- **`CurrencyMixin` extraction.** The conversion-factor logic
+  (`_account_conversion_factors`, `_latest_market_rates`,
+  `_split_in_default_currency`) hoisted into a single mixin
+  composed unconditionally into `BaseGnuCashBook`. Four prior
+  copies of the `type='transaction'` price filter collapse to one
+  call site.
+- **`_compute_fx_gain_loss`** extracted from `pay_invoice`. The
+  tri-currency realized-FX delta calculation is now a standalone
+  helper, reusable across any future cross-currency payment path.
+- **`get_book_summary` decomposition.** The 460-line monolith
+  split into `_render_*` helpers per section, plus a single-pass
+  materialization of `book.accounts` and `book.transactions` that
+  shaves ~30% off the call's wall time on large books.
+- **`QueryMixin`** consolidates indexed `.filter_by(guid=...)`
+  finders that had previously been open-coded in each consumer.
+
+**1.4 roadmap.** Unrealized-gains synthetic equity line (closes
+the gap between market-value Assets and cost-basis Equity on
+investment-heavy books), accrual A/R revaluation, future-dated
+transaction warnings, and the v1.2.1 deferred-lows backlog. The
+bookkeeper's daily flow remains the production signal.
+
+**Tests:** 1,366 passing (was 1,114 at v1.2.1). New regression
+classes cover the four Stage 3 features end-to-end, the strict-
+kwargs contract, the `id` alias mutex, the FX-correct breakdowns,
+and the role-aligned module groups. The two synthetic test
+personas (Alex, Lin Wei) and the bookkeeper's real-book
+validation remain the verification harness.
+
+---
+
 ## v1.2.1 — Business module shipped, multi-currency hardened
 
 The long-tail completion of the v1.2 business-module promise. v1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,19 @@ outstanding invoices:
 After both fixes, A = L + E holds by construction across the
 three tools that compute net worth.
 
+**Heads-up for users tracking trajectory month-over-month:** the
+net-worth number — and every historical anchor (12mo / 6mo / 3mo
+/ 1mo ago) — now includes outstanding A/R minus A/P. On books
+with active business activity this is a meaningful restatement
+of the trajectory. Alex's "now" anchor moves from ~$189K (pre-
+v1.3) to $204K because $15K of A/R that was previously
+excluded now sits in the total. Historical anchors shift by
+whatever A/R / A/P existed on those dates. This is the
+accounting-correct number; the pre-v1.3 view was "tangible net
+worth excluding outstanding business activity," which doesn't
+have a standard name and disagreed with the canonical balance-
+sheet identity.
+
 **Dashboard refinements.**
 
 - **Overdue counts** on the receivables and payables lines —
@@ -178,7 +191,7 @@ balance mismatch.
 in addition to the legacy `<entity>_id`. Pass exactly one; back-
 compat preserved for existing callers.
 
-**Server instructions — 59% smaller.**
+**Server instructions — 39% smaller.**
 
 The orientation block sent to MCP clients on connect went from
 ~2,500 chars to 1,522 (24% under the 2K cap). Same coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,16 @@ vendor_spending fix is structurally verified.
 
 **Security — Stage 6 hardening.**
 
+- **Book directory path redacted from routine LLM-visible
+  responses.** `get_server_config` and `get_book_summary` used
+  to render the full absolute path to the loaded book — every
+  orientation call and every "what's loaded?" diagnostic was
+  leaking the username, home directory layout, and book filename
+  into the LLM transcript. Now shown as filename only. Always-on
+  for the book path specifically; backup-tool responses
+  (`create_backup` restore hint, `list_backups` path field) still
+  carry full paths because the restore use case functionally
+  needs them.
 - **Path-traversal hardening on `.mcp` sidecar directories.** Backup
   and audit-log paths derive from `GNUCASH_BOOK_PATH`; the sidecar
   resolution now checks symlink targets, ownership, and world-
@@ -255,7 +265,7 @@ transaction warnings are the next correctness items on the
 backlog. The bookkeeper's daily flow remains the production
 signal.
 
-**Tests:** 1,376 passing (was 1,114 at v1.2.1). New regression
+**Tests:** 1,377 passing (was 1,114 at v1.2.1). New regression
 classes cover the four Stage 3 features end-to-end, the strict-
 kwargs contract, the `id` alias mutex, the FX-correct
 breakdowns (now extended to monthly net, runway, budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,9 +210,10 @@ vendor_spending fix is structurally verified.
   the boundary is the wire.
 - **Write rate-limiting via token bucket.** Defends against a
   runaway agent loop accidentally hammering the database with
-  thousands of writes per second. Default: 60 writes/minute with
-  short bursts allowed; configurable via `GNUCASH_MCP_RATE_LIMIT`.
-  Read tools are unaffected.
+  thousands of writes per second. Disabled by default; opt-in via
+  `GNUCASH_WRITE_RATE_LIMIT` (tokens-per-second, positive float)
+  with `GNUCASH_WRITE_BURST` (max bucket size, default 10). Read
+  tools are unaffected.
 
 **Strict argument validation.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,38 @@ worth excluding outstanding business activity," which doesn't
 have a standard name and disagreed with the canonical balance-
 sheet identity.
 
+**Multi-currency aggregation sweep.**
+
+A class of bugs that v1.2.1's "FX correctness in
+spending_by_category / income_by_source" fix addressed for two
+reports, but left lurking in four other places that nobody
+flagged until the v1.3 pre-release audit:
+
+- **Monthly net** in `get_book_summary` was summing INCOME and
+  EXPENSE splits by `split.value` raw. The docstring called this
+  out as a known limitation "rare in practice for personal /
+  household books"; it isn't rare for the bookkeeper's
+  freelancer-with-foreign-clients case.
+- **Budget headline** actuals were summing `split.quantity` raw
+  across budgeted accounts. EUR-budgeted expense accounts
+  contributed raw EUR quantity to used_pct comparisons against
+  USD budget targets.
+- **Daily expense burn** (the runway divisor) summed EXPENSE
+  splits by raw value. On Lin Wei (CNY-default with USD
+  subscriptions) the burn was understated by the USD spot-rate
+  factor — overstating runway days.
+- **Vendor spending report** summed each bill's grand_total at
+  face value. A vendor list mixing USD and EUR bills produced
+  per-vendor and grand totals that were the sum of numbers in
+  unrelated units.
+
+All four now route through `_account_conversion_factors` and
+`_split_in_default_currency` (or latest-rate × bill total for
+vendor_spending), the same pattern `spending_by_category` and
+`income_by_source` already used. Three regression tests in
+TestMultiCurrencyDashboardHelpers cover the helpers; the
+vendor_spending fix is structurally verified.
+
 **Dashboard refinements.**
 
 - **Overdue counts** on the receivables and payables lines —
@@ -223,15 +255,16 @@ transaction warnings are the next correctness items on the
 backlog. The bookkeeper's daily flow remains the production
 signal.
 
-**Tests:** 1,372 passing (was 1,114 at v1.2.1). New regression
+**Tests:** 1,376 passing (was 1,114 at v1.2.1). New regression
 classes cover the four Stage 3 features end-to-end, the strict-
 kwargs contract, the `id` alias mutex, the FX-correct
-breakdowns, the role-aligned module groups, the balance-sheet
-equation closure across simple, multi-currency, and A/R-bearing
-books, and the synthetic Unrealized Gain/Loss line's presence/
-absence semantics. The two synthetic test personas (Alex, Lin
-Wei) and the bookkeeper's real-book validation remain the
-verification harness.
+breakdowns (now extended to monthly net, runway, budget
+headline, and vendor spending), the role-aligned module groups,
+the balance-sheet equation closure across simple, multi-
+currency, and A/R-bearing books, and the synthetic Unrealized
+Gain/Loss line's presence/absence semantics. The two synthetic
+test personas (Alex, Lin Wei) and the bookkeeper's real-book
+validation remain the verification harness.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,18 @@ exercised against the synthetic test books before release.
 (`core / admin / backup / investments / business`). The new partition
 matches how people actually use the server:
 
-- **`core`** (26 tools) — always-on ledger primitives: accounts,
-  transactions, slots, audit, backup, balance sheet, summary,
-  diagnostics. Now a group alias expanding to eight independently-
-  selectable sub-modules; you can opt into the group or pick the
-  sub-modules à la carte.
-- **`bookkeeper`** (20 tools) — personal-finance management:
-  reconciliation, reporting, budgets, scheduling. Group alias for
-  the four underlying modules.
+- **`core`** (29 tools) — always-on ledger primitives:
+  accounts, transactions, slots, audit, backup, balance sheet,
+  summary, diagnostics, reconciliation. Now a group alias
+  expanding to nine independently-selectable sub-modules; you
+  can opt into the group or pick the sub-modules à la carte.
+  *Reconciliation joined core late in the v1.3 cycle —
+  bookkeeper-flagged that reconciliation touches money and
+  every configuration touches money, so excluding it from any
+  persona produced a server that couldn't reconcile statements.*
+- **`bookkeeper`** (17 tools) — personal-finance management:
+  reporting, budgets, scheduling. Group alias for the three
+  underlying modules.
 - **`investor`** (12 tools) — group alias for `portfolio`
   (commodities + prices, the multi-currency primitive) plus
   `tax_lots` (cost basis tracking).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,37 @@ a module set" table for which modules to load for which use case.
   out of `reconcile_account` the same way it does in every other
   account-aware tool.
 
+**Early-payment discounts now actually honored.**
+
+`create_billterm` had been accepting `discount_days` and
+`discount_percent` since v1.3 launched. The fields stored
+correctly, `get_billterm` returned them correctly — and
+`pay_invoice` ignored them entirely. A freelancer with `2/10 Net
+30` terms whose customer paid $980 of $1,000 on day 5 got a
+partial-payment record with $20 still outstanding instead of
+the clean settlement they expected.
+
+The pay path now supports an explicit `apply_discount=True`
+mode that validates terms exist, the payment date is within the
+discount window, and the shortfall matches the expected discount
+on pre-tax principal (tax is collected on behalf of the
+government at the gross rate and is NOT reduced — discounting
+it would short the GST/PST remittance). Each failure mode
+rejects with a specific error; no silent downgrades to partial.
+
+The discount split routes via the same auto-resolver pattern as
+`fx_account`: explicit `discount_account=` parameter > leaf-name
+match on `INCOME`/`EXPENSE` accounts > canonical default
+(`Expenses:Sales Discounts` for customer payments,
+`Income:Purchase Discounts Taken` for vendor bill payments —
+auto-created on first use).
+
+`get_invoice` verbose mode now surfaces a `discount_available`
+block (or `discount_expired` once the window passes) with the
+eligible-until date and dollar amount, so the LLM can
+proactively offer "you can save $X by paying this by Y" without
+the freelancer having to ask.
+
 **`balance_sheet` now actually balances.**
 
 Two unrelated bugs were producing a silent A ≠ L + E identity
@@ -266,7 +297,7 @@ transaction warnings are the next correctness items on the
 backlog. The bookkeeper's daily flow remains the production
 signal.
 
-**Tests:** 1,377 passing (was 1,114 at v1.2.1). New regression
+**Tests:** 1,390 passing (was 1,114 at v1.2.1). New regression
 classes cover the four Stage 3 features end-to-end, the strict-
 kwargs contract, the `id` alias mutex, the FX-correct
 breakdowns (now extended to monthly net, runway, budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,40 @@ a module set" table for which modules to load for which use case.
   out of `reconcile_account` the same way it does in every other
   account-aware tool.
 
+**Token bloat trimmed on read tools and business responses.**
+
+Bookkeeper-found during PR #92 review. Two patterns wasted
+tokens with no callable benefit:
+
+- **`get_transaction` and `list_transactions(verbose=True)`** were
+  emitting full 32-char GUIDs for transaction, split, and lot
+  fields. The compact path of `list_transactions` already
+  emitted collision-safe 8-char prefixes via the cached
+  `_transaction_prefix_map`; verbose didn't. Every tool that
+  accepts a GUID accepts an 8+ char prefix via `_resolve_guid`,
+  so the extra 24 chars per GUID was dead weight. On a 50-
+  transaction verbose list with 2-3 splits each, that's ~6-8K
+  chars saved per call.
+- **Business-object `guid` fields** (customer, vendor, employee,
+  job, billterm, taxtable, invoice, entry) — bookkeeper-
+  validated as never used by any consumer. Every business
+  object is addressed by its human-readable handle (ID like
+  "000001" or name like "BC GST+PST 12%"). The 32-char GUID
+  on every read and write response was pure overhead.
+  Stripped entirely from response shapes.
+
+The `transaction_guid` field on business write responses
+(post_invoice, pay_invoice, apply_credit_note) is preserved —
+it's the one business-tool surface that emits a core-
+transaction GUID consumers actually use (passed to
+get_transaction to verify splits). It's now emitted as a short
+prefix too.
+
+Two new cached prefix maps in `BaseGnuCashBook`
+(`_split_prefix_map`, `_lot_prefix_map`) parallel the existing
+`_transaction_prefix_map` — same mtime-keyed invalidation,
+same collision-safety guarantees against `_resolve_guid`.
+
 **Early-payment discounts now actually honored.**
 
 `create_billterm` had been accepting `discount_days` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,36 @@ a module set" table for which modules to load for which use case.
   out of `reconcile_account` the same way it does in every other
   account-aware tool.
 
+**`balance_sheet` now actually balances.**
+
+Two unrelated bugs were producing a silent A ≠ L + E identity
+failure on every multi-currency book and every book with
+outstanding invoices:
+
+- **RECEIVABLE and PAYABLE were excluded from balance_sheet's
+  asset/liability buckets.** Posted-but-unpaid invoices were
+  invisible — Alex's $16,200 of outstanding A/R didn't appear in
+  Assets at all. Both account types now sit in their natural
+  buckets across `balance_sheet`, `net_worth`, and the
+  `get_book_summary` trajectory anchor (cross-tool agreement on
+  net worth was the calibration the bookkeeper review pattern
+  catches).
+- **A synthetic "Unrealized Gain/Loss" equity row.** Assets
+  render at market value (factor × quantity for commodities and
+  foreign-currency cash) while equity rolls up at historical-
+  cost split values. The gap — investment market drift on
+  STOCK/MUTUAL plus FX translation adjustment on foreign-
+  currency holdings — now appears as a single signed line in the
+  equity section, computed as the balancing residual. Display-
+  only; no journal entry is booked, the ledger remains at cost
+  exactly the way GnuCash itself stores it. Positive = unrealized
+  gain; negative = unrealized loss. On Alex's book the line
+  reconciles a ~$13K gap; on Lin Wei's book the FX translation
+  effect is similarly absorbed.
+
+After both fixes, A = L + E holds by construction across the
+three tools that compute net worth.
+
 **Dashboard refinements.**
 
 - **Overdue counts** on the receivables and payables lines —
@@ -174,18 +204,21 @@ Frees ~1KB of every client's context budget.
 - **`QueryMixin`** consolidates indexed `.filter_by(guid=...)`
   finders that had previously been open-coded in each consumer.
 
-**1.4 roadmap.** Unrealized-gains synthetic equity line (closes
-the gap between market-value Assets and cost-basis Equity on
-investment-heavy books), accrual A/R revaluation, future-dated
-transaction warnings, and the v1.2.1 deferred-lows backlog. The
-bookkeeper's daily flow remains the production signal.
+**Looking ahead.** Accrual A/R revaluation (mark-to-market open
+foreign-currency invoices at reporting dates) and future-dated
+transaction warnings are the next correctness items on the
+backlog. The bookkeeper's daily flow remains the production
+signal.
 
-**Tests:** 1,366 passing (was 1,114 at v1.2.1). New regression
+**Tests:** 1,372 passing (was 1,114 at v1.2.1). New regression
 classes cover the four Stage 3 features end-to-end, the strict-
-kwargs contract, the `id` alias mutex, the FX-correct breakdowns,
-and the role-aligned module groups. The two synthetic test
-personas (Alex, Lin Wei) and the bookkeeper's real-book
-validation remain the verification harness.
+kwargs contract, the `id` alias mutex, the FX-correct
+breakdowns, the role-aligned module groups, the balance-sheet
+equation closure across simple, multi-currency, and A/R-bearing
+books, and the synthetic Unrealized Gain/Loss line's presence/
+absence semantics. The two synthetic test personas (Alex, Lin
+Wei) and the bookkeeper's real-book validation remain the
+verification harness.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -268,20 +268,20 @@ the leaves individually for a finer cut.
 
 | Role | What it gives you | Tools |
 |---|---|---|
-| `core` | Ledger primitives — accounts, transactions, balances, slots, audit log, backups, balance sheet. **Always loaded.** | 26 |
-| `bookkeeper` | Reconcile bank statements, run reports, manage budgets, schedule recurring transactions. The personal-finance management cluster. | 20 |
+| `core` | Ledger primitives — accounts, transactions, balances, slots, audit log, backups, balance sheet, **reconciliation**. **Always loaded.** | 29 |
+| `bookkeeper` | Run reports, manage budgets, schedule recurring transactions. The personal-finance management cluster. (Reconciliation moved into core — any configuration that handles money needs it.) | 17 |
 | `investor` | Cost-basis tracking + price/commodity management. Tax-lot accounting needs prices to compute gains, so the bundle is the useful unit. | 12 |
 | `freelancer` | Customer invoicing + sales tax (GST, VAT, US state sales tax). The solo-consultant surface. | 19 |
-| `business` | Vendors, employees, bills, vouchers, credit notes, jobs, billing terms. Additive to `freelancer` for a full small-business workflow. | 29 |
+| `business` | Full small-business package — group alias that expands to `freelancer` (invoicing) plus `business_complete` (vendors, employees, bills, vouchers, credit notes, jobs, billing terms). | 48 |
 
 Pick one or more, comma-separated:
 
 ```json
-"args": ["--modules=core,bookkeeper"]               // personal finance
-"args": ["--modules=core,investor"]                 // self-directed investor
-"args": ["--modules=core,freelancer"]               // solo contractor
-"args": ["--modules=core,freelancer,business"]     // small business
-"args": ["--modules=core,bookkeeper,investor,freelancer"]  // most things
+"args": ["--modules=bookkeeper"]            // personal finance
+"args": ["--modules=investor"]              // self-directed investor
+"args": ["--modules=freelancer"]            // solo contractor
+"args": ["--modules=business"]              // small business (= freelancer + business_complete)
+"args": ["--modules=bookkeeper,investor,freelancer"]  // most things
 ```
 
 `core` is force-added regardless; the explicit listing in the

--- a/README.md
+++ b/README.md
@@ -140,19 +140,20 @@ for the full breakdown of what's in each.
 
 ```bash
 git clone https://github.com/ninetails-io/gnucash-mcp.git
-cd gnucash-mcp
+uv tool install --editable ./gnucash-mcp
 ```
 
-Then either:
-
-```bash
-uv sync                # if you have uv (recommended)
-# or
-pip install -e .       # if you have pip
-```
+That gives you a `gnucash-mcp` command on your PATH. `--editable`
+keeps it tracking the source, so a `git pull` shows up in the
+running server the next time it restarts. Skip `--editable` if
+you don't plan to update.
 
 > If you don't have `uv`, install it with one line:
 > `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+> For developers working against multiple worktrees, plain
+> `uv sync` inside the project directory still works — see
+> [For developers](#for-developers) below.
 
 ### 2. Make a working copy of a sample book
 
@@ -172,22 +173,15 @@ Find your Claude Desktop config:
 - **Mac:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add this (replace the two paths with your actual paths):
+Add this (replace the `GNUCASH_BOOK_PATH` value with your actual
+path):
 
 ```json
 {
   "mcpServers": {
     "gnucash": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--directory",
-        "/path/to/gnucash-mcp",
-        "python",
-        "-m",
-        "gnucash_mcp",
-        "--modules=all"
-      ],
+      "command": "gnucash-mcp",
+      "args": ["--modules=all"],
       "env": {
         "GNUCASH_BOOK_PATH": "/Users/yourname/gnucash-mcp-scratch/alex.gnucash"
       }
@@ -195,6 +189,10 @@ Add this (replace the two paths with your actual paths):
   }
 }
 ```
+
+`--modules=all` loads every tool (106 of them) so you can poke at
+anything. Once you know what you actually use, narrow it — see
+[choosing a module set](#choosing-a-module-set) below.
 
 Quit Claude Desktop completely (not just close the window —
 quit) and reopen it. Look for the hammer 🔨 icon next to the
@@ -251,11 +249,46 @@ This is an [MCP](https://modelcontextprotocol.io/) server, so
 it works with any client that speaks MCP. Notes for non–Claude
 Desktop clients:
 
-- **Claude Code**: `claude mcp add-json gnucash '{"command":"uv","args":["run","--directory","/path/to/gnucash-mcp","python","-m","gnucash_mcp","--modules=all"],"env":{"GNUCASH_BOOK_PATH":"/path/to/your/book.gnucash"}}'`
+- **Claude Code**: `claude mcp add-json gnucash '{"command":"gnucash-mcp","args":["--modules=all"],"env":{"GNUCASH_BOOK_PATH":"/path/to/your/book.gnucash"}}'`
   Add `--scope user` for all projects, `--scope project` for
   this one only.
 - **Anything else**: set `GNUCASH_BOOK_PATH` and run
-  `uv run gnucash-mcp` (or `gnucash-mcp` if installed via pip).
+  `gnucash-mcp` directly. Any client that can spawn a command
+  and speak MCP over stdio will work.
+
+---
+
+## Choosing a module set
+
+`--modules=all` is the easy default — every tool, 106 of them.
+For day-to-day use you'll probably want less. Pick the role that
+matches how you'll talk to the server. Each role is a *group*
+that expands to the underlying tool modules; you can also pick
+the leaves individually for a finer cut.
+
+| Role | What it gives you | Tools |
+|---|---|---|
+| `core` | Ledger primitives — accounts, transactions, balances, slots, audit log, backups, balance sheet. **Always loaded.** | 26 |
+| `bookkeeper` | Reconcile bank statements, run reports, manage budgets, schedule recurring transactions. The personal-finance management cluster. | 20 |
+| `investor` | Cost-basis tracking + price/commodity management. Tax-lot accounting needs prices to compute gains, so the bundle is the useful unit. | 12 |
+| `freelancer` | Customer invoicing + sales tax (GST, VAT, US state sales tax). The solo-consultant surface. | 19 |
+| `business` | Vendors, employees, bills, vouchers, credit notes, jobs, billing terms. Additive to `freelancer` for a full small-business workflow. | 29 |
+
+Pick one or more, comma-separated:
+
+```json
+"args": ["--modules=core,bookkeeper"]               // personal finance
+"args": ["--modules=core,investor"]                 // self-directed investor
+"args": ["--modules=core,freelancer"]               // solo contractor
+"args": ["--modules=core,freelancer,business"]     // small business
+"args": ["--modules=core,bookkeeper,investor,freelancer"]  // most things
+```
+
+`core` is force-added regardless; the explicit listing in the
+examples above is for clarity. The leaf modules behind each
+group (`reconciliation`, `reporting`, `budgets`, `scheduling`,
+`tax_lots`, `portfolio`, etc.) are individually selectable too —
+run `gnucash-mcp --help` for the full menu.
 
 ---
 
@@ -377,37 +410,16 @@ you which one it's doing.
 
 ## Limiting what the AI can see
 
-By default the server exposes its full toolset (87 tools as
-of v1.2.1). Each tool's description lives in the AI's system
-prompt, which costs context on every message. If you only use
-some features — say, no investments and no business module —
-you can tell the server to load only those modules:
+Each tool's description lives in the AI's system prompt, which
+costs context on every message. Narrowing the toolset to what
+you actually use makes every conversation cheaper. See
+[choosing a module set](#choosing-a-module-set) above for the
+five role-based options (`core`, `bookkeeper`, `investor`,
+`freelancer`, `business`).
 
-```json
-"args": [
-  "run", "--directory", "/path/to/gnucash-mcp",
-  "python", "-m", "gnucash_mcp",
-  "--modules=core,reporting,budgets,scheduling"
-]
-```
-
-| Module | What it gives you |
-|---|---|
-| `core` | Accounts, transactions, the dashboard. Always loaded. |
-| `reconciliation` | Bank reconciliation, void/unvoid |
-| `reporting` | Spending, income, balance sheet, net worth, cash flow, debt payoff |
-| `budgets` | Create budgets, set targets, track variance |
-| `scheduling` | Recurring transactions, upcoming bills |
-| `investments` | Stocks, mutual funds, lots, capital-gain tracking |
-| `business` | Customers, vendors, employees, invoices, bills, payments |
-| `admin` | Account-level metadata (APR, credit limit, etc.) |
-| `backup` | Manual snapshot tools |
-
-Use `--modules=all` to load everything (the default for the
-sample-book quickstart above), or list a subset to keep your
-context light. You can also set
-`GNUCASH_MCP_MODULES=core,reporting` as an environment
-variable instead.
+You can also set `GNUCASH_MCP_MODULES=core,bookkeeper` as an
+environment variable instead of `--modules=...` in the JSON
+args.
 
 ---
 
@@ -512,10 +524,16 @@ Contributor guide and design notes live in
 
 ```bash
 uv sync --extra dev
-uv run pytest                       # 1,044 tests as of v1.2.1
+uv run pytest                       # 1,355 tests as of v1.3.0
 uv run ruff check src/ tests/
 uv run black --check src/ tests/
 ```
+
+For dev work the `uv run --directory PATH ...` form is the
+escape hatch — it lets you point Claude Desktop at a specific
+worktree without installing. The `uv tool install --editable`
+path from the Quick Start is generally cleaner for everyday
+use because the `gnucash-mcp` binary tracks your source.
 
 The server is built on
 [piecash](https://github.com/sdementen/piecash) (Python

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ repo, so copy the book somewhere outside the repo first:
 
 ```bash
 mkdir -p ~/gnucash-mcp-scratch
-cp samples/alex-chen-morales.gnucash ~/gnucash-mcp-scratch/alex.gnucash
+cp gnucash-mcp/samples/alex-chen-morales.gnucash ~/gnucash-mcp-scratch/alex.gnucash
 ```
 
 ### 3. Tell Claude Desktop about the server

--- a/specs/EARLY_PAYMENT_DISCOUNT_SPEC.md
+++ b/specs/EARLY_PAYMENT_DISCOUNT_SPEC.md
@@ -1,0 +1,270 @@
+# Early-Payment Discount Specification
+## GnuCash MCP Server v1.3 — Billterms Correctness
+
+**Status:** Draft for review
+**Target:** v1.3 (on `feat/v1.3-blockers` — this is a release-blocker correctness fix)
+**Prerequisites:** v1.3 billterms (already shipped — fields stored, never honored)
+
+---
+
+## Executive Summary
+
+`create_billterm` accepts `discount_days` and `discount_percent`
+fields. They're stored. They're returned by `get_billterm`. And
+`pay_invoice` ignores them entirely.
+
+A freelancer setting "2/10 Net 30" terms on a $1,000 invoice
+expects the math to honor the early-payment discount. When the
+customer pays $980 on day 8, today's behavior records a partial
+payment — $20 stays outstanding, the invoice never closes, and
+the freelancer has to either chase the customer for the $20
+(awkward) or manually write off the $20 (audit nightmare with no
+link to the term that authorized it).
+
+Configured-but-silently-ignored fields are exactly the
+"financial software that lies to its user" pattern the project
+has repeatedly rejected (Strict-kwargs validation;
+RECEIVABLE/PAYABLE inclusion in balance_sheet; fail-fast on
+typo'd modules). This spec fixes pay_invoice to honor the
+discount terms.
+
+Implementation expectation: **~250 LOC + ~12 tests, 2 commits.**
+
+---
+
+## Background: Discount Term Semantics
+
+Standard convention: `"2/10 Net 30"` means "2% discount if paid
+within 10 days; otherwise full amount due in 30 days." The
+discount applies only to the principal — taxes are computed on
+gross then NOT reduced by the discount (or are, depending on
+jurisdiction — but the simpler "discount on principal only"
+convention is what GnuCash's billterm model encodes).
+
+Two GAAP-accepted accounting treatments:
+
+- **Gross method (proposed default):** invoice books at $1,000.
+  Customer pays $980. Books record cash +$980, A/R −$1,000,
+  Discount Expense (or Sales Discount contra-revenue) +$20.
+  A/R clears fully. This is the standard small-business
+  approach.
+- **Net method:** invoice books at $980 (presumed-discounted)
+  with $20 in an "Interest Income on Late Payment" contra
+  account. If customer pays late at $1,000, the $20 is
+  recognized as interest income. Less common; not proposed.
+
+Gross method is what create_billterm's fields imply (discount
+configured as a reduction taken at payment time, not a
+pre-recognized reduction in revenue).
+
+---
+
+## Tool Surface Changes
+
+`pay_invoice` gains two new parameters:
+
+```python
+def pay_invoice(
+    self,
+    invoice_id: str,
+    payment_account: str,
+    amount: str,
+    payment_date: str | None = None,
+    description: str | None = None,
+    owner_type: str | None = None,
+    fx_account: str | None = None,
+    apply_discount: bool = False,              # NEW
+    discount_account: str | None = None,       # NEW
+) -> dict:
+    """...
+    Args:
+        ...existing args...
+        apply_discount: When True, treat the payment as
+            early-payment-discount eligible. The tool validates
+            that the invoice has discount terms AND the payment
+            date is within the discount window AND the shortfall
+            (grand_total - amount) matches the expected discount
+            within commodity precision. If validation passes, the
+            shortfall books as a separate split to
+            ``discount_account`` (auto-resolved per the FX-account
+            pattern). If validation fails, the call rejects with a
+            clear error rather than silently treating as a partial
+            payment. Default False — explicit opt-in surfaces what
+            the freelancer intends.
+        discount_account: Optional account to receive the discount
+            shortfall. Accepts a full path, ``%short`` GUID, or
+            full 32-char GUID. Must be an INCOME or EXPENSE
+            account. Same auto-resolution pattern as
+            ``fx_account``: explicit > name-match in book >
+            canonical auto-create.
+    """
+```
+
+---
+
+## Design Decisions
+
+### D1: Detection — explicit opt-in, not auto-detect
+
+**Decision: `apply_discount: bool = False`, explicit parameter, default opt-out.**
+
+Two reasons:
+
+1. **Auto-detection is risky.** A customer paying $980 of $1000 *could* be taking the discount (within window) or *could* be making a partial payment that coincidentally matches. Math-based detection ("if shortfall ≈ expected discount, it's a discount") risks false positives — exactly the kind of silent inference financial software should not make.
+
+2. **Opt-in surfaces intent.** The freelancer calling `pay_invoice(amount="980", apply_discount=True)` is stating "this payment closes the invoice via discount." The tool validates that statement; if any condition fails (no terms set, outside window, amount doesn't match expected discount), it rejects with a specific reason. The user knows exactly what happened.
+
+Reject reasons cover:
+
+- Invoice has no billterm
+- Billterm has no `discount_days`/`discount_percent` set
+- `payment_date - invoice.date_opened > discount_days`
+- `(grand_total - amount) ≠ expected_discount` within `_commodity_quantum`
+
+Each surface a distinct error message.
+
+### D2: Discount account resolution
+
+Follow the `fx_account` pattern (D2 from the FX gain/loss spec):
+
+1. **Explicit `discount_account`** if supplied. Validate exists, validate is INCOME or EXPENSE.
+2. **Search book by leaf-name match** for common discount-account names:
+   - Customer-side (`owner_type='customer'`): `"sales discounts"`, `"discounts given"`, `"customer discounts"`, `"sales discount"`
+   - Vendor-side (`owner_type='vendor'`): `"purchase discounts"`, `"discounts taken"`, `"purchase discount"`, `"vendor discounts"`
+3. **Canonical auto-create** if no match:
+   - Customer-side: `Expenses:Sales Discounts` (gross-method convention; the discount is a cost of getting paid fast)
+   - Vendor-side: `Income:Purchase Discounts Taken`
+
+If multiple candidates match the leaf-name search, include a `discount_notice` field in the response listing them, so the caller can pass `discount_account=` explicitly next time. Same UX as the FX `fx_notice`.
+
+### D3: Cross-currency interaction
+
+Order of operations: **discount first, then FX gain/loss.**
+
+A EUR invoice for €1,000 with 2/10 Net 30. Customer pays €980 within window in USD on a USD-default book.
+
+1. Compute discount in invoice currency: €20
+2. Effective invoice amount: €980 (gross-method: A/R clears full €1,000, discount books €20 to Expenses:Sales Discounts in EUR-converted-to-USD-at-payment-date-rate)
+3. Customer's USD payment converts to €980 at the payment-date EUR/USD rate
+4. If the rate moved between post-date and pay-date, the FX gain/loss split absorbs the delta (existing v1.2.1 logic)
+
+The discount and FX gain/loss splits are independent — discount is "what the invoice settlement reduced by"; FX gain/loss is "what the rate movement contributed." Both can exist on the same payment transaction; the math composes cleanly.
+
+### D4: Vendor side parity
+
+Same logic, mirrored. A vendor offering us "2/10 Net 30" on a $1000 bill: we pay $980 within window, take the $20 as `Income:Purchase Discounts Taken`. The polymorphic `owner_type` dispatch handles routing.
+
+### D5: Partial payments within window
+
+What if customer pays $500 of $1000 within the discount window?
+
+**Decision: partial payment, no discount applied, no error.** The `apply_discount=True` flag *means* "this payment closes the invoice via discount." A partial payment doesn't close anything, so the flag is incorrect for that call. The tool should reject the call with a specific error: `"apply_discount=True requires a full settlement payment; got 500.00 of 1000.00 outstanding"`.
+
+The freelancer wanting partial payment within window omits `apply_discount`. The remaining $500 stays open and can still be settled with the discount on a subsequent call if all conditions hold then.
+
+Edge case: what if the user makes multiple payments and the *last* one closes the invoice via discount? Then that last call uses `apply_discount=True` and the math works on the remaining balance. This naturally falls out — `expected_discount` is computed from the original `grand_total × discount_percent / 100`, the shortfall on the closing payment matches, the tool accepts.
+
+### D6: Past the window but matches discount amount
+
+Customer pays $980 of $1000 on day 15 (window is 10). User calls `pay_invoice(amount="980", apply_discount=True)`.
+
+**Decision: reject with clear error.** The discount terms are *time-conditional*. Paying late and claiming the discount is a renegotiation, not an automatic right. Tool rejects: `"Payment date 2026-05-20 is beyond billterm discount window (10 days from 2026-05-05; deadline was 2026-05-15)"`.
+
+The freelancer wanting to grant the discount anyway has two paths:
+- Issue a credit note for $20 to clear the remainder (formal write-off, audit trail)
+- Reduce the invoice amount via `update_invoice` if it's not posted; otherwise unpost → adjust → repost (existing workflow)
+
+Either path leaves a real record of the negotiated outcome.
+
+### D7: Same-payment-different-account
+
+What if the user wants to record the discount but to a different account than the auto-resolved default? They pass `discount_account=` explicitly. Same shape as `fx_account=`. No additional design.
+
+---
+
+## Testing Strategy
+
+Three layers, mirroring the existing test patterns:
+
+### Same-currency happy path (4 tests)
+
+- Customer invoice with 2/10 Net 30, pay within window, full discount applies, A/R clears, Sales Discounts expense booked.
+- Same but vendor side: pay vendor bill within their discount window, Purchase Discounts Taken income booked.
+- Pay at the discount boundary (day 10 exactly) — accepted.
+- Pay at day 11 — rejected with deadline-passed error.
+
+### Validation rejections (5 tests)
+
+- `apply_discount=True` on invoice without billterm → "no billterm" error
+- `apply_discount=True` on billterm without discount → "term has no discount" error
+- `apply_discount=True` past window → "outside window" error
+- `apply_discount=True` with wrong amount → "amount doesn't match expected discount" error
+- `apply_discount=True` on partial payment → "requires full settlement" error
+
+### Account resolution + cross-currency (3 tests)
+
+- Explicit `discount_account=` — used as-is
+- Auto-resolution via leaf-name match — finds existing "Sales Discounts" account
+- Cross-currency invoice (EUR billed on USD book) with discount + FX gain/loss — both splits land correctly, transaction balances in invoice currency
+
+---
+
+## Implementation Plan
+
+Two commits on the existing `feat/v1.3-blockers` branch:
+
+**Commit 1: `feat(business): early-payment discount in pay_invoice`**
+- `_resolve_discount_account` helper paralleling the FX helper
+- `apply_discount` + `discount_account` parameters on book-layer `pay_invoice`
+- Validation chain (terms exist? has discount? in window? amount matches?)
+- Discount split written alongside payment + A/R clear
+- Cross-currency interaction with existing `_compute_fx_gain_loss`
+
+**Commit 2: `feat(business): early-payment discount tool params + tests`**
+- Expose new parameters on the `pay_invoice` tool wrapper in `tools/business.py`
+- 12 regression tests across same-currency, validation, and cross-currency cases
+- CHANGELOG entry under "Multi-currency aggregation sweep" (same v1.3 release-prep section)
+
+No split into a separate branch — this is correctness on a feature that already shipped (billterms in v1.3 Stage 3). Belongs on the release-blockers branch alongside the other corrections.
+
+---
+
+## Open Questions
+
+These need a decision before commit 1:
+
+- [ ] **Account convention naming.** Proposed: `Expenses:Sales Discounts` (customer-side) and `Income:Purchase Discounts Taken` (vendor-side). Alternatives: `Income:Sales Discounts Given` (treating as contra-revenue), `Expenses:Purchase Discounts` (treating taken discounts as cost reduction). Both alternatives are valid GAAP; the proposed convention matches more small-business accounting templates.
+- [ ] **Discount on tax included in line items?** GnuCash's billterm convention: discount applies to pre-tax principal only. Sales tax is computed on gross then NOT reduced. Confirm this matches your bookkeeper-validated expectation.
+- [ ] **`apply_discount=True` on a credit-note payment?** Currently credit notes flow through `pay_invoice` with the inverse-amount convention. Probably want to reject `apply_discount=True` on credit notes entirely (no semantic meaning for "discount on a refund").
+- [ ] **`get_invoice` verbose mode.** Should the response include a computed `discount_eligible_until` date and `discount_amount` when the invoice has discount terms? Forward-looking signal for the LLM: "you could close this with discount until X." Cheap to add; helpful for the freelancer workflow.
+
+---
+
+## Out of Scope (not v1.3)
+
+- **Net-method accounting treatment.** Gross method only.
+- **Discount on credit notes.** Rejected.
+- **Multi-tier discounts.** GnuCash billterm only supports one discount window; "5/10, 2/20, Net 30" would need a different data model.
+- **Discount on partial payments.** The closing payment can take the discount on the remainder; intermediate payments cannot.
+- **Discount expiration warning in `get_book_summary`.** "3 invoices with discounts expiring this week" would be useful but is a dashboard feature, separable.
+
+---
+
+## Why This Lands on v1.3 (Not Deferred)
+
+Per the bookkeeper-validation memory just filed: financial-math
+bugs surface from code review, not bookkeeper signoff. This one
+came from a predecessor's "I haven't verified..." note that
+never got verified. Shipping v1.3 with the feature documented
+but unimplemented would be the same silent-lie pattern strict-
+kwargs rejected.
+
+The freelancer persona (just promoted to a coherent module in
+the previous commit) IS the target user for this feature. Solo
+invoicers with discount terms ARE who v1.3's freelancer module
+markets to. Shipping that persona with a known broken term-
+handling path while highlighting freelancer mode in the README
+would be the kind of mismatch that erodes trust.
+
+Per "we don't have the resources to take shortcuts" — this is
+the correct work.

--- a/specs/v1_3_RELEASE_PREP.md
+++ b/specs/v1_3_RELEASE_PREP.md
@@ -1,0 +1,102 @@
+# v1.3 Release Prep — Tasks for Claude Code
+
+## 1. `reconcile_account` — add `except` parameter
+
+**Value:** When reconciling a statement, the common case is "all
+splits except one or two." Currently the LLM must either pass 106
+GUIDs to include, or use `reconcile_all=true` which grabs
+everything. The `except` parameter lets the LLM say
+`reconcile_all=true, except=["guid1", "guid2"]` — 2 tokens
+instead of 106. Complement to `through_date` for cases where the
+exclusions aren't date-based (pending ACH, reversed holds, manual
+splits the bank doesn't know about yet).
+
+**Spec:**
+- New optional parameter `except: list[str]` on `reconcile_account`
+- Only valid when `reconcile_all=true` (reject otherwise)
+- Fetch all unreconciled splits, remove any whose GUID prefix
+  matches an entry in `except`, reconcile the rest
+- Validate: remaining splits + existing reconciled balance ==
+  statement_balance
+
+## 2. Server instructions block rewrite
+
+Replace the current `instructions` parameter in server config with
+this (1,490 chars, 27% under the 2K cap):
+
+```python
+instructions="""GnuCash MCP Server — Double-Entry Accounting Tools
+ORIENTATION:
+- Call get_book_summary first. It returns structure, currency, balances, warnings, and reconciliation status.
+- Use list_accounts to get exact paths and short GUIDs before writing.
+- Use search_transactions before creating to avoid duplicates.
+- Every transaction has splits that MUST sum to zero.
+ACCOUNT REFERENCES:
+- Tools accept full paths ("Expenses:Groceries"), short GUIDs ("%2e78c86"), or full 32-char GUIDs.
+- list_accounts emits short GUIDs at line start: "%2e78c86\\tAssets:Savings [BANK]". Reuse them — ~80% smaller than paths.
+- Paths are colon-delimited, case-sensitive. Use paths when naming new accounts or reasoning about hierarchy; short GUIDs for everything else.
+- Account short GUIDs: 7+ hex chars with leading "%". Transaction/split GUIDs: 8+ bare hex prefix, no marker.
+DOUBLE-ENTRY SIGN CONVENTION:
+- Positive = debit (increases Asset/Expense, decreases Liability/Income/Equity).
+- Negative = credit (reverse).
+- Credit card payment: checking -200, card +200. Income: checking +3000, income -3000.
+INVESTMENT FLOW: create_lot → create_transaction (with quantity/cost) → assign_split_to_lot → create_price → calculate_lot_gain.
+SLOTS: get_account_slots / set_account_slot store per-account metadata (APR, credit limit, statement day) as strings.
+SAFETY: Reconciled splits are protected (use force=true to override). Prefer void_transaction over delete for audit trail. delete_account is blocked if account has children or transactions.
+"""
+```
+
+## 3. Parameter inconsistency: `invoice_id` vs `id`
+
+`delete_invoice` takes `invoice_id`. Every other invoice tool
+(`get_invoice`, `post_invoice`, `unpost_invoice`, `pay_invoice`)
+takes `id`. Same for `delete_bill`, `delete_voucher`,
+`delete_credit_note`.
+
+Standardize: accept both `id` and `invoice_id` (alias), prefer
+`id` in documentation. Don't break existing callers — just add
+the alias.
+
+## 4. CHANGELOG for v1.3
+
+Write `CHANGELOG.md` entry for v1.3. Key additions since v1.2.1:
+
+- Expense vouchers (create, post, pay employee reimbursements)
+- Credit notes (create, post, apply against invoices/bills)
+- Jobs (project-level grouping over invoices/bills per customer/vendor)
+- Tax tables (composite rates, tax-inclusive pricing, refcount lifecycle)
+- Billing terms
+- `reconcile_all=true` bulk reconciliation mode
+- `except` parameter on reconcile_account
+- `through_date` filter on reconcile_account
+- Account shortcut support in reconcile_account
+- `get_book_summary` enhancements: overdue invoice warnings, receivable/payable counts, business entity summary
+- FX fix: `spending_by_category` and `income_by_source` now convert foreign-currency splits to book default currency
+- Currency-mixin refactor (code organization, no behavior change)
+- FX gain/loss extraction to `_compute_fx_gain_loss` helper (code organization, no behavior change)
+- Server instructions block rewrite (59% smaller)
+- Parameter alias: `id` accepted on delete_invoice/bill/voucher/credit_note
+
+Tool count: 76 → 106 (30 new tools).
+Test count: 1,101 → 1,320+.
+
+## 5. README update
+
+Update tool count, add real `get_book_summary` output as example
+(use Alex's book — it exercises business features). Update any
+version references from 1.2.1 to 1.3.
+
+## 6. Lin Wei cleanup
+
+Restore from backup:
+```
+mv lin-wei.gnucash lin-wei.gnucash.broken
+cp .../backups/lin-wei-20260522T014728650225-manual-pre-fx-extraction-test.gnucash lin-wei.gnucash
+```
+Book currently has test invoice 000022 + payment + USD price from
+FX extraction testing.
+
+## 7. Version bump
+
+Update version string from 1.2.1 to 1.3.0 wherever it appears
+(pyproject.toml, server config, any __version__ constants).

--- a/specs/v1_3_RELEASE_PREP.md
+++ b/specs/v1_3_RELEASE_PREP.md
@@ -1,5 +1,13 @@
 # v1.3 Release Prep — Tasks for Claude Code
 
+> **Implementation note (post-merge):** The `except` parameter
+> was renamed to `except_guids` during implementation because
+> `except` is a Python reserved keyword. With v1.3's
+> `extra="forbid"` strict-kwargs validation, calling the tool
+> with `except=[...]` now raises a clear validation error. The
+> spec below is preserved as authored; the shipped name is
+> `except_guids` everywhere.
+
 ## 1. `reconcile_account` — add `except` parameter
 
 **Value:** When reconciling a statement, the common case is "all

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -16,6 +16,7 @@ Two pieces:
   plug in its own entity name.
 """
 
+import os
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import TypeVar
 
@@ -81,6 +82,39 @@ def _format_number(
         return s or "0"
 
     return format(rounded, "f")
+
+
+# ── Path display ───────────────────────────────────────────────────
+
+
+def _book_display_name(book_path) -> str:
+    """Render a book path as filename only — no directory leakage.
+
+    Routine LLM-visible responses (``get_server_config``,
+    ``get_book_summary``'s orientation line) used to include the full
+    absolute path to the GnuCash book. That leaks the user's
+    username, home directory layout, and any custom organization
+    (``~/Finances/``, ``~/Documents/Books/``) into every transcript
+    — a privacy concern for a tool that gets used on real personal
+    financial data and a security concern for screenshots / shared
+    sessions.
+
+    The filename alone is sufficient to verify *which* book is
+    loaded ("yes, this is Alex's book, not Lin Wei's"); the path
+    components leading to it are the sensitive bit.
+
+    This is an always-on redaction for the book path specifically,
+    distinct from :func:`gnucash_mcp.logging_config.redact_paths`
+    which is opt-in via ``GNUCASH_REDACT_PATHS=1`` and aimed at
+    error-message paths (where the directory may be load-bearing
+    debugging signal).
+
+    Returns ``"not set"`` for falsy input so the orientation reads
+    sensibly when ``GNUCASH_BOOK_PATH`` was never set.
+    """
+    if not book_path:
+        return "not set"
+    return os.path.basename(str(book_path))
 
 
 # ── Limit enforcement ──────────────────────────────────────────────

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -360,20 +360,47 @@ def _account_to_compact_line(account: piecash.Account) -> str:
     return fullname
 
 
-def _split_to_dict(split: piecash.Split) -> dict:
-    """Convert a piecash Split to a full serializable dict."""
+def _split_to_dict(
+    split: piecash.Split,
+    split_prefixes: dict[str, str] | None = None,
+    lot_prefixes: dict[str, str] | None = None,
+) -> dict:
+    """Convert a piecash Split to a full serializable dict.
+
+    When ``split_prefixes`` / ``lot_prefixes`` are provided, the
+    emitted ``guid`` and ``lot_guid`` fields are truncated to
+    collision-safe short forms (typically 8 chars) via lookup in
+    the prefix maps. When omitted, falls back to full 32-char
+    GUIDs — preserved for any caller that hasn't migrated to the
+    prefix-aware path. v1.3.1 bookkeeper feedback drove the
+    prefix path on read tools (get_transaction, verbose
+    list_transactions) where the full GUIDs were dead-weight
+    tokens the LLM never used.
+    """
     rec_date = split.reconcile_date
     if rec_date and rec_date.year <= 1970:
         rec_date = None
+    split_guid = (
+        split_prefixes.get(split.guid, split.guid)
+        if split_prefixes is not None
+        else split.guid
+    )
+    lot_guid = None
+    if split.lot is not None:
+        lot_guid = (
+            lot_prefixes.get(split.lot.guid, split.lot.guid)
+            if lot_prefixes is not None
+            else split.lot.guid
+        )
     return {
-        "guid": split.guid,
+        "guid": split_guid,
         "account": split.account.fullname,
         "value": str(split.value),
         "quantity": str(split.quantity),
         "memo": split.memo or "",
         "reconcile_state": split.reconcile_state,
         "reconcile_date": rec_date.isoformat() if rec_date else None,
-        "lot_guid": split.lot.guid if split.lot else None,
+        "lot_guid": lot_guid,
     }
 
 
@@ -414,14 +441,42 @@ def _split_to_compact_dict(split: piecash.Split) -> dict:
     return result
 
 
-def _transaction_to_dict(transaction: piecash.Transaction) -> dict:
-    """Convert a piecash Transaction to a serializable dict."""
+def _transaction_to_dict(
+    transaction: piecash.Transaction,
+    txn_prefixes: dict[str, str] | None = None,
+    split_prefixes: dict[str, str] | None = None,
+    lot_prefixes: dict[str, str] | None = None,
+) -> dict:
+    """Convert a piecash Transaction to a serializable dict.
+
+    When the three prefix maps are provided (typically by callers
+    that have access to the BaseGnuCashBook cached prefix
+    helpers), the emitted ``guid`` field on the transaction and
+    on each nested split is truncated to its collision-safe short
+    form. When omitted, full 32-char GUIDs are emitted — a back-
+    compat fallback for any caller that hasn't been migrated.
+
+    All three maps come from the same book-mtime-keyed cache, so
+    repeated calls against an unchanged book skip the rebuild.
+    """
+    txn_guid = (
+        txn_prefixes.get(transaction.guid, transaction.guid)
+        if txn_prefixes is not None
+        else transaction.guid
+    )
     result = {
-        "guid": transaction.guid,
+        "guid": txn_guid,
         "date": transaction.post_date.isoformat(),
         "description": transaction.description,
         "currency": transaction.currency.mnemonic,
-        "splits": [_split_to_dict(s) for s in transaction.splits],
+        "splits": [
+            _split_to_dict(
+                s,
+                split_prefixes=split_prefixes,
+                lot_prefixes=lot_prefixes,
+            )
+            for s in transaction.splits
+        ],
     }
     if transaction.notes:
         result["notes"] = transaction.notes
@@ -758,6 +813,12 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         # other writer) invalidates the cache on the next request.
         # Shape: ``(mtime_ns, prefix_dict)`` or ``None`` when empty.
         self._txn_prefix_cache: tuple[int, dict[str, str]] | None = None
+        # Same cache shape for split and lot GUID prefix maps — used
+        # by get_transaction and verbose list_transactions to emit
+        # collision-safe short GUIDs alongside transaction prefixes.
+        # All three caches invalidate on book mtime change together.
+        self._split_prefix_cache: tuple[int, dict[str, str]] | None = None
+        self._lot_prefix_cache: tuple[int, dict[str, str]] | None = None
 
     def _stage_audit_before(self, state: dict | None) -> None:
         """Stage a before-state dict for the next audit-log consume.
@@ -1022,6 +1083,52 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
             return self._txn_prefix_cache[1]
         prefix_map = _guid_prefix_map(t.guid for t in book.transactions)
         self._txn_prefix_cache = (mtime_ns, prefix_map)
+        return prefix_map
+
+    def _split_prefix_map(
+        self, book: piecash.Book
+    ) -> dict[str, str]:
+        """Return the full-table split-GUID prefix map, cached.
+
+        Same mtime-keyed pattern as ``_transaction_prefix_map``.
+        Used by ``get_transaction`` and verbose ``list_transactions``
+        to emit collision-safe short split GUIDs in responses. Pre-
+        v1.3.1 these surfaces emitted full 32-char split GUIDs —
+        24 wasted chars per split per call, identified by the
+        bookkeeper as token bloat in real LLM workflows.
+        """
+        mtime_ns = self.book_path.stat().st_mtime_ns
+        if (
+            self._split_prefix_cache is not None
+            and self._split_prefix_cache[0] == mtime_ns
+        ):
+            return self._split_prefix_cache[1]
+        prefix_map = _guid_prefix_map(
+            s.guid for t in book.transactions for s in t.splits
+        )
+        self._split_prefix_cache = (mtime_ns, prefix_map)
+        return prefix_map
+
+    def _lot_prefix_map(
+        self, book: piecash.Book
+    ) -> dict[str, str]:
+        """Return the full-table lot-GUID prefix map, cached.
+
+        Sibling to ``_transaction_prefix_map`` / ``_split_prefix_map``.
+        Lots are nested under accounts; same mtime invalidation
+        applies because any lot change goes through the same SQLite
+        write path.
+        """
+        mtime_ns = self.book_path.stat().st_mtime_ns
+        if (
+            self._lot_prefix_cache is not None
+            and self._lot_prefix_cache[0] == mtime_ns
+        ):
+            return self._lot_prefix_cache[1]
+        prefix_map = _guid_prefix_map(
+            lot.guid for acct in book.accounts for lot in acct.lots
+        )
+        self._lot_prefix_cache = (mtime_ns, prefix_map)
         return prefix_map
 
     def _resolve_account(

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -22,6 +22,7 @@ import piecash
 from gnucash_mcp.book._base import (
     _slot_value_str,
     _to_decimal,
+    _unique_prefix,
     _verify_composite_write,
     _verify_write,
 )
@@ -1149,9 +1150,16 @@ class BusinessMixin:
 
     @staticmethod
     def _customer_to_dict(customer) -> dict:
-        """Convert a piecash Customer to a serializable dict."""
+        """Convert a piecash Customer to a serializable dict.
+
+        Business-object GUIDs are deliberately omitted from the
+        response. Bookkeeper-validated finding: every consumer
+        addresses customers via ``id`` (human-readable, like
+        "000001"); the 32-char GUID is dead weight on every read.
+        Same treatment applies to vendor, employee, job, billterm,
+        taxtable, invoice, and entry response shapes.
+        """
         result = {
-            "guid": customer.guid,
             "id": customer.id,
             "name": customer.name,
             "currency": customer.currency.mnemonic if customer.currency else None,
@@ -1165,9 +1173,11 @@ class BusinessMixin:
 
     @staticmethod
     def _vendor_to_dict(vendor) -> dict:
-        """Convert a piecash Vendor to a serializable dict."""
+        """Convert a piecash Vendor to a serializable dict.
+
+        ``guid`` omitted — see _customer_to_dict for the rationale.
+        """
         result = {
-            "guid": vendor.guid,
             "id": vendor.id,
             "name": vendor.name,
             "currency": vendor.currency.mnemonic if vendor.currency else None,
@@ -1188,9 +1198,10 @@ class BusinessMixin:
         shape omits the ``notes`` key. Employee-specific fields
         (``acl`` / ``language`` / ``workday`` / ``rate``) are out of
         scope for the 1.3.0 CRUD surface and are not serialized.
+
+        ``guid`` omitted — see _customer_to_dict for the rationale.
         """
         result = {
-            "guid": employee.guid,
             "id": employee.id,
             "name": employee.name,
             "currency": employee.currency.mnemonic if employee.currency else None,
@@ -1225,9 +1236,11 @@ class BusinessMixin:
         human-readable ``owner_type`` string for symmetry with
         every other tool's owner-typed response. ``owner_name``
         is resolved by the caller (static-method shape can't
-        query the session)."""
+        query the session).
+
+        ``guid`` omitted — see _customer_to_dict for the rationale.
+        """
         return {
-            "guid": job.guid,
             "id": job.id,
             "name": job.name,
             "reference": job.reference or "",
@@ -1262,9 +1275,11 @@ class BusinessMixin:
 
     @staticmethod
     def _billterm_to_dict(bt) -> dict:
-        """Convert a Billterm to a serializable dict."""
+        """Convert a Billterm to a serializable dict.
+
+        ``guid`` omitted — billterms are addressed by ``name``.
+        """
         return {
-            "guid": bt.guid,
             "name": bt.name,
             "description": bt.description or "",
             "type": bt.type,
@@ -1326,8 +1341,8 @@ class BusinessMixin:
             )
             for e in tt.entries
         ]
+        # ``guid`` omitted — taxtables are addressed by ``name``.
         return {
-            "guid": tt.guid,
             "name": tt.name,
             "refcount": (
                 refcount if refcount is not None else tt.refcount
@@ -1429,8 +1444,8 @@ class BusinessMixin:
                 invoice.owner_type, "invoice",
             )
 
+        # ``guid`` omitted — invoices are addressed by ``id``.
         result = {
-            "guid": invoice.guid,
             "id": invoice.id,
             "type": type_field,
             "owner_name": owner_name,
@@ -1618,8 +1633,10 @@ class BusinessMixin:
         else:
             date_str = str(raw_date.date())
 
+        # ``guid`` omitted — entries are nested under invoices and
+        # have no standalone tool surface (no delete_entry,
+        # update_entry, etc.). Bookkeeper-validated: never used.
         result = {
-            "guid": entry_row.guid,
             "date": date_str,
             "description": entry_row.description or "",
             "quantity": str(quantity),
@@ -2083,8 +2100,10 @@ class BusinessMixin:
         )
         book.save()
 
+        # v1.3.1: business-object ``guid`` dropped from write
+        # responses (bookkeeper-validated as unused on the LLM
+        # surface). ``id`` is the working handle.
         return {
-            "guid": entity.guid,
             "id": entity.id,
             "name": entity.name,
             "currency": currency_obj.mnemonic,
@@ -2250,8 +2269,8 @@ class BusinessMixin:
 
         book.save()
 
+        # v1.3.1: ``guid`` dropped — see _create_business_person.
         return {
-            "guid": entity.guid,
             "id": entity.id,
             "status": "updated",
             **changed,
@@ -2652,8 +2671,8 @@ class BusinessMixin:
 
             book.save()
 
+            # v1.3.1: ``guid`` dropped — billterms addressed by ``name``.
             return {
-                "guid": bt_guid,
                 "name": name,
                 "due_days": due_days,
                 "status": "created",
@@ -3094,8 +3113,8 @@ class BusinessMixin:
 
             book.save()
 
+            # v1.3.1: ``guid`` dropped — taxtables addressed by ``name``.
             return {
-                "guid": tt_guid,
                 "name": tt_name,
                 "entry_count": len(entry_dicts),
                 "entries": entry_dicts,
@@ -3326,8 +3345,8 @@ class BusinessMixin:
             book.save()
 
             if not changed:
+                # v1.3.1: ``guid`` dropped.
                 return {
-                    "guid": tt_guid,
                     "name": name,
                     "status": "unchanged",
                 }
@@ -3893,8 +3912,9 @@ class BusinessMixin:
 
             book.save()
 
+            # v1.3.1: ``guid`` dropped — invoices/bills/vouchers/
+            # credit notes addressed by ``id``.
             return {
-                "guid": inv_guid,
                 "id": doc_id,
                 config["owner_id_key"]: owner_id,
                 "date_opened": str(open_date.date()),
@@ -4672,8 +4692,9 @@ class BusinessMixin:
             book.save()
 
             total = qty * unit_price
+            # v1.3.1: entry ``guid`` dropped — no tool surface
+            # consumes a standalone entry GUID.
             return {
-                "guid": entry_guid,
                 cfg["id_param"]: doc_id,
                 "description": description,
                 "quantity": str(qty),
@@ -5408,8 +5429,19 @@ class BusinessMixin:
                 "status": "posted",
                 "total": str(grand_total),
                 "post_date": str(parsed_date),
-                "transaction_guid": txn.guid,
-                "lot_guid": lot.guid,
+                # Transaction + lot GUIDs are USED by consumers
+                # (e.g. bookkeeper passes transaction_guid to
+                # get_transaction to verify splits). Emit short
+                # prefixes via the cached prefix maps — every
+                # tool accepts 8+ char prefixes via _resolve_guid.
+                "transaction_guid": _unique_prefix(
+                    txn.guid,
+                    self._transaction_prefix_map(book).keys(),
+                ),
+                "lot_guid": _unique_prefix(
+                    lot.guid,
+                    self._lot_prefix_map(book).keys(),
+                ),
                 "post_account": post_acct.fullname,
             }
 
@@ -6086,7 +6118,13 @@ class BusinessMixin:
                 "status": "paid",
                 "amount_paid": str(payment_amount),
                 "remaining_balance": str(abs(remaining)),
-                "transaction_guid": txn.guid,
+                # Transaction GUID emitted as a short prefix —
+                # consumers (e.g. get_transaction lookup) accept
+                # 8+ char prefixes via _resolve_guid.
+                "transaction_guid": _unique_prefix(
+                    txn.guid,
+                    self._transaction_prefix_map(book).keys(),
+                ),
                 "payment_account": pay_acct.fullname,
                 "payment_date": str(parsed_date),
             }
@@ -6473,7 +6511,12 @@ class BusinessMixin:
                 "target_remaining": str(
                     new_target_remaining.quantize(quantum)
                 ),
-                "transaction_guid": txn.guid,
+                # Short prefix for the netting transaction GUID —
+                # see pay_invoice for the rationale.
+                "transaction_guid": _unique_prefix(
+                    txn.guid,
+                    self._transaction_prefix_map(book).keys(),
+                ),
                 "apply_date": str(parsed_date),
                 "status": "applied",
             }
@@ -6717,9 +6760,9 @@ class BusinessMixin:
             book.session.delete(entity)
             book.save()
 
+            # v1.3.1: ``guid`` dropped from delete responses too.
             return {
                 "id": entity_id,
-                "guid": entity_guid,
                 "name": entity_name,
                 "type": entity_label.lower(),
                 "status": "deleted",
@@ -6947,8 +6990,8 @@ class BusinessMixin:
                 f"Job '{name}'",
             )
 
+            # v1.3.1: ``guid`` dropped — jobs addressed by ``id``.
             return {
-                "guid": job.guid,
                 "id": job.id,
                 "name": name,
                 "reference": reference,
@@ -7151,9 +7194,9 @@ class BusinessMixin:
 
             book.save()
 
+            # v1.3.1: ``guid`` dropped from update responses.
             return {
                 "id": job.id,
-                "guid": job.guid,
                 "status": "updated",
                 **changed,
             }
@@ -7226,9 +7269,9 @@ class BusinessMixin:
                 f"Job '{job_id}'",
             )
 
+            # v1.3.1: ``guid`` dropped from delete response.
             return {
                 "id": job_id,
-                "guid": job_guid,
                 "name": job_name,
                 "reparented_count": reparented_count,
                 "status": "deleted",

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -7153,9 +7153,16 @@ class BusinessMixin:
             # Capture default currency for the compact formatter —
             # pre-fix the table emitted ``$`` regardless of book
             # setting.
-            default_currency_mnemonic = (
-                self._require_default_currency(book).mnemonic
-            )
+            default_currency = self._require_default_currency(book)
+            default_currency_mnemonic = default_currency.mnemonic
+
+            # Latest market rates for FX conversion. A book with
+            # USD vendors AND EUR vendors needs each bill's
+            # grand_total converted to default currency before
+            # summing — raw-sum across currencies is the same
+            # multi-currency bug spending_by_category and
+            # income_by_source carried until v1.3.0.
+            latest_rates = self._rates_as_of(book)
 
             query = book.session.query(Invoice).filter(
                 Invoice.owner_type == 4,
@@ -7232,6 +7239,27 @@ class BusinessMixin:
 
                 outstanding = abs(balance)
                 paid = total - outstanding
+
+                # Convert each per-bill total from the bill's own
+                # currency to the book default before summing. A
+                # USD-default book with a EUR bill: bill.currency
+                # is EUR, total is in EUR; we multiply by the
+                # current EUR→USD rate (or 1 if same-currency).
+                # Without conversion the grand totals mixed
+                # currencies — a EUR €2,500 bill and a USD $3,000
+                # bill summed to "5,500" of nothing in particular.
+                if bill.currency != default_currency:
+                    rate = latest_rates.get(bill.currency.guid)
+                    if rate is not None:
+                        total = total * rate
+                        paid = paid * rate
+                        outstanding = outstanding * rate
+                    # If no rate is on file, fall back to the
+                    # un-converted figures rather than dropping the
+                    # bill silently. The bookkeeper sees a mixed-
+                    # currency total that's wrong by the FX delta,
+                    # which is the same fallback the rest of the
+                    # codebase uses for unpriced commodities.
 
                 vendor_data[v_name]["total_billed"] += total
                 vendor_data[v_name]["total_paid"] += paid

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -354,6 +354,37 @@ class BusinessMixin:
         "currency translation",
     )
 
+    # ── Early-payment discount account convention ────────────────────
+    #
+    # Standard small-business GAAP routing for early-payment discounts.
+    # Customer-side: discount given is an expense to the seller (the
+    # cost of getting paid faster). Vendor-side: discount taken on a
+    # supplier bill is income (a cost reduction).
+    #
+    # Larger businesses sometimes prefer contra-revenue / contra-
+    # expense treatment (Income:Sales Discounts Given as a negative
+    # against Revenue). The bookkeeper's call for v1.3 was the small-
+    # business convention below; the user can override via the
+    # ``discount_account`` parameter on pay_invoice if they want
+    # contra accounts instead.
+    SALES_DISCOUNTS_PATH = "Expenses:Sales Discounts"
+    PURCHASE_DISCOUNTS_PATH = "Income:Purchase Discounts Taken"
+
+    _SALES_DISCOUNT_NAME_KEYWORDS = (
+        "sales discount",
+        "sales discounts",
+        "discounts given",
+        "customer discount",
+        "customer discounts",
+    )
+    _PURCHASE_DISCOUNT_NAME_KEYWORDS = (
+        "purchase discount",
+        "purchase discounts",
+        "discounts taken",
+        "vendor discount",
+        "vendor discounts",
+    )
+
     def _get_or_create_fx_account(self, book, fx_account: str | None = None):
         """Find or lazily create the FX-gain/loss account.
 
@@ -465,6 +496,216 @@ class BusinessMixin:
             ),
         )
         return fx_acct, notice
+
+    def _get_or_create_discount_account(
+        self, book, owner_type_is_bill: bool,
+        discount_account: str | None = None,
+    ):
+        """Find or lazily create the early-payment-discount account.
+
+        Direct parallel to ``_get_or_create_fx_account`` — same three-
+        layer resolution (explicit > fuzzy match > canonical default
+        with optional auto-create).
+
+        Args:
+            owner_type_is_bill: When True, we're paying a vendor bill
+                (or refunding a customer credit note) and the discount
+                is INCOME (Purchase Discounts Taken). When False,
+                customer invoice payment and the discount is EXPENSE
+                (Sales Discounts). Same effective_is_bill the rest of
+                pay_invoice uses.
+            discount_account: Optional override (path, %short, full
+                GUID). Validated for existence and INCOME/EXPENSE
+                type.
+
+        Returns ``(account, notice)`` where ``notice`` is None unless
+        the fuzzy match found multiple candidates and we fell back to
+        the canonical default — same shape as the FX helper.
+        """
+        if owner_type_is_bill:
+            canonical_path = self.PURCHASE_DISCOUNTS_PATH
+            canonical_type = "INCOME"
+            canonical_parent_path = "Income"
+            keywords = self._PURCHASE_DISCOUNT_NAME_KEYWORDS
+            side_label = "purchase discounts taken"
+        else:
+            canonical_path = self.SALES_DISCOUNTS_PATH
+            canonical_type = "EXPENSE"
+            canonical_parent_path = "Expenses"
+            keywords = self._SALES_DISCOUNT_NAME_KEYWORDS
+            side_label = "sales discounts"
+
+        # Layer 1: caller-supplied account wins.
+        if discount_account is not None:
+            acct = self._resolve_account(book, discount_account)
+            if acct is None:
+                raise ValueError(
+                    f"discount_account not found: {discount_account!r}. "
+                    f"Pass a full path, %short GUID, or full 32-char "
+                    f"GUID of an INCOME or EXPENSE account."
+                )
+            if acct.type not in {"INCOME", "EXPENSE"}:
+                raise ValueError(
+                    f"discount_account {acct.fullname!r} is type "
+                    f"{acct.type}; must be INCOME or EXPENSE to "
+                    f"receive an early-payment-discount split."
+                )
+            return acct, None
+
+        # Layer 2: fuzzy match by leaf-name substring.
+        candidates = []
+        for account in book.accounts:
+            if account.type not in {"INCOME", "EXPENSE"}:
+                continue
+            name_lower = account.name.lower()
+            if any(kw in name_lower for kw in keywords):
+                candidates.append(account)
+
+        notice = None
+        if len(candidates) == 1:
+            return candidates[0], None
+        if len(candidates) > 1:
+            sorted_paths = sorted(c.fullname for c in candidates)
+            notice = {
+                "type": "ambiguous_discount_account",
+                "candidates": sorted_paths,
+                "message": (
+                    f"Found {len(candidates)} candidate {side_label} "
+                    f"accounts ({', '.join(sorted_paths)}). Routed to "
+                    f"{canonical_path} as the canonical default; pass "
+                    f"discount_account explicitly to disambiguate."
+                ),
+            }
+            # Fall through to canonical default below.
+
+        # Layer 3: canonical default (existing or auto-create).
+        disc_acct = self._find_account(book, canonical_path)
+        if disc_acct is not None:
+            return disc_acct, notice
+
+        parent = self._find_account(book, canonical_parent_path)
+        if parent is None:
+            raise ValueError(
+                f"Early-payment discount on this payment needs an "
+                f"{canonical_parent_path} parent account, but none "
+                f"exists. Create {canonical_parent_path} (type="
+                f"{canonical_type}, placeholder) first."
+            )
+
+        default_currency = self._require_default_currency(book)
+        # Don't flush here; the caller is still building the payment
+        # transaction. Same rationale as the FX-account auto-create.
+        leaf_name = canonical_path.split(":")[-1]
+        disc_acct = piecash.Account(
+            name=leaf_name,
+            type=canonical_type,
+            parent=parent,
+            commodity=default_currency,
+            description=(
+                f"Early-payment discounts {'taken on supplier bills' if owner_type_is_bill else 'given to customers'}, "
+                f"booked when pay_invoice is called with "
+                f"apply_discount=True and the term + window + amount "
+                f"validation passes. Auto-created on first use."
+            ),
+        )
+        return disc_acct, notice
+
+    def _get_invoice_billterm(self, book, inv):
+        """Return the piecash Billterm linked to the invoice, or None.
+
+        Reads the ``terms`` column via raw SQL — same pattern as
+        :meth:`_resolve_invoice_due_date`, because the ORM
+        ``inv.terms`` relationship has historical reliability issues
+        depending on access path. Returns the Billterm ORM object so
+        the caller can read ``.duedays``, ``.discountdays``,
+        ``.discount`` directly.
+        """
+        from sqlalchemy import text
+        from piecash.business.invoice import Billterm
+
+        terms_row = book.session.execute(
+            text("SELECT terms FROM invoices WHERE guid = :guid"),
+            {"guid": inv.guid},
+        ).first()
+        term_guid = terms_row[0] if terms_row else None
+        if not term_guid:
+            return None
+        return (
+            book.session.query(Billterm)
+            .filter_by(guid=term_guid)
+            .first()
+        )
+
+    def _compute_discount_summary(self, book, inv) -> dict | None:
+        """Return discount summary for an invoice, or None when not
+        applicable.
+
+        The summary is what ``get_invoice`` verbose mode surfaces and
+        what ``pay_invoice`` validation references. Pure read; no
+        side effects. None when:
+        - Invoice isn't posted (date_posted needed for the window
+          calculation)
+        - Invoice has no billterm linkage
+        - Billterm has no discount configured (discountdays == 0 or
+          discount == 0)
+
+        Returned dict shape::
+
+            {
+                "discount_days": int,
+                "discount_percent": Decimal,
+                "expected_discount": Decimal,  # subtotal × pct / 100,
+                                                # in invoice currency,
+                                                # quantized
+                "eligible_until": date,
+                "currency": str,                # invoice currency mnemonic
+            }
+
+        ``expected_discount`` is computed off the pre-tax ``subtotal``
+        per the bookkeeper-validated convention: GST/PST is collected
+        on behalf of the tax authority at the gross rate and is NOT
+        reduced by the discount. Discounting tax would short the
+        remittance.
+        """
+        if not _is_invoice_posted(inv):
+            return None
+        bt = self._get_invoice_billterm(book, inv)
+        if bt is None:
+            return None
+        discount_days = int(bt.discountdays) if bt.discountdays else 0
+        discount_pct = Decimal(str(bt.discount)) if bt.discount else Decimal("0")
+        if discount_days <= 0 or discount_pct <= 0:
+            return None
+
+        # Use date_opened as the discount-window anchor — that's the
+        # invoice issuance date (what's printed on the invoice the
+        # customer received). date_posted is when it hit A/R, often
+        # the same day but not guaranteed; the customer's discount
+        # eligibility is measured from when they got the invoice.
+        anchor = inv.date_opened
+        if isinstance(anchor, datetime):
+            anchor = anchor.date()
+        eligible_until = anchor + timedelta(days=discount_days)
+
+        # Pre-tax principal for discount calculation. Catch the rare
+        # corrupted-entries case the same way other callers do.
+        try:
+            totals = self._get_invoice_entries_and_total(book, inv)
+            subtotal = totals["subtotal"]
+        except (ValueError, KeyError):
+            return None
+
+        expected = (subtotal * discount_pct / Decimal(100)).quantize(
+            _commodity_quantum(inv.currency)
+        )
+
+        return {
+            "discount_days": discount_days,
+            "discount_percent": discount_pct,
+            "expected_discount": expected,
+            "eligible_until": eligible_until,
+            "currency": inv.currency.mnemonic,
+        }
 
     @staticmethod
     def _rate_from_post_transaction(post_txn, target_commodity):
@@ -4857,6 +5098,37 @@ class BusinessMixin:
                 tax_summary=tax_summary,
             )
             result["total"] = str(total)
+
+            # Forward signal: when this invoice has discount terms,
+            # surface the eligible-until date and the dollar amount
+            # of discount available. Makes get_invoice actionable for
+            # the LLM as a bookkeeper — "you can save $X if you pay
+            # this by Y" — without the caller having to read the
+            # billterm separately and do the math.
+            #
+            # Three states:
+            #   - No discount terms → no block
+            #   - Discount terms + within window → ``discount_available``
+            #     block with the amount + deadline
+            #   - Discount terms + past deadline → ``discount_expired``
+            #     block with the same fields so the audit-log reader
+            #     can see what was offered
+            disc_summary = self._compute_discount_summary(book, inv)
+            if disc_summary is not None:
+                today = date.today()
+                block_key = (
+                    "discount_available"
+                    if today <= disc_summary["eligible_until"]
+                    else "discount_expired"
+                )
+                result[block_key] = {
+                    "amount": str(disc_summary["expected_discount"]),
+                    "currency": disc_summary["currency"],
+                    "percent": str(disc_summary["discount_percent"]),
+                    "eligible_until": (
+                        disc_summary["eligible_until"].isoformat()
+                    ),
+                }
             return result
 
     def post_invoice(
@@ -5306,6 +5578,8 @@ class BusinessMixin:
         description: str | None = None,
         owner_type: str | None = None,
         fx_account: str | None = None,
+        apply_discount: bool = False,
+        discount_account: str | None = None,
     ) -> dict:
         """Record a payment against a posted invoice or bill.
 
@@ -5350,16 +5624,40 @@ class BusinessMixin:
                 gain/loss (cross-currency payments only). Accepts a
                 full path, ``%short`` GUID, or full 32-char GUID.
                 Must be an INCOME or EXPENSE account.
+            apply_discount: When True, settle this invoice using the
+                early-payment discount from its billterm. The tool
+                validates that the invoice has discount terms, the
+                payment date is within the discount window, and the
+                shortfall (remaining lot balance − amount) matches
+                the expected discount on pre-tax principal. Each
+                failure mode rejects with a specific error rather
+                than silently downgrading to a partial payment.
+                Default False — explicit opt-in surfaces caller
+                intent.
+            discount_account: Optional account to receive the
+                discount split. Accepts a full path, ``%short`` GUID,
+                or full 32-char GUID. Must be INCOME or EXPENSE.
+                Auto-resolved when omitted (same pattern as
+                ``fx_account``): explicit > name-match in book >
+                canonical default
+                (``Expenses:Sales Discounts`` for customer payments,
+                ``Income:Purchase Discounts Taken`` for vendor bill
+                payments; auto-created on first use).
 
         Returns:
             Dict with payment details and remaining balance. For cross-
             currency payments also includes ``exchange_rate`` and
-            ``payment_account_amount``.
+            ``payment_account_amount``. For discount-eligible
+            payments also includes a ``discount`` block describing
+            the amount booked and the discount account it landed in.
 
         Raises:
             ValueError: If invoice not found, not posted, invalid account,
                 cross-currency payment with no exchange rate available,
-                or ``fx_account`` is supplied but invalid.
+                ``fx_account`` is supplied but invalid, or
+                ``apply_discount=True`` fails any of its validation
+                checks (no terms, no discount field, outside window,
+                amount mismatch, partial payment, credit-note target).
         """
         ot = self._parse_owner_type(owner_type)
 
@@ -5537,13 +5835,158 @@ class BusinessMixin:
             is_credit_note = self._get_is_credit_note(inv)
             effective_is_bill = is_bill ^ is_credit_note
 
+            # ── Early-payment discount validation ────────────────
+            # Five rejection cases, each with a distinct error so
+            # the caller can see exactly which precondition failed.
+            # Per the spec: discount is an explicit opt-in (no
+            # auto-detect from coincidental shortfall) — when
+            # apply_discount=True, the call either honors all
+            # invariants and books the discount split, or rejects.
+            discount_split: piecash.Split | None = None
+            discount_acct = None
+            discount_notice = None
+            discount_amount_invoice_ccy = Decimal("0")
+            if apply_discount:
+                if is_credit_note:
+                    raise ValueError(
+                        "Discounts cannot be applied to credit note "
+                        "settlements. A credit note is a reversal, "
+                        "not a payment; discounting it has no "
+                        "accounting meaning."
+                    )
+                disc_summary = self._compute_discount_summary(book, inv)
+                if disc_summary is None:
+                    # Two reasons _compute_discount_summary returns
+                    # None: no billterm linked, or billterm has no
+                    # discount. Distinguish for the caller.
+                    bt = self._get_invoice_billterm(book, inv)
+                    if bt is None:
+                        raise ValueError(
+                            f"apply_discount=True on invoice "
+                            f"{invoice_id} which has no billterm "
+                            f"linked. Set terms at invoice creation "
+                            f"(via create_invoice or create_bill's "
+                            f"``term`` parameter), repost, then retry."
+                        )
+                    raise ValueError(
+                        f"apply_discount=True on invoice "
+                        f"{invoice_id} whose billterm has no early-"
+                        f"payment discount configured "
+                        f"(discount_days={int(bt.discountdays) if bt.discountdays else 0}, "
+                        f"discount_percent={Decimal(str(bt.discount)) if bt.discount else 0}). "
+                        f"Recreate the billterm with both "
+                        f"discount_days and discount_percent > 0 to "
+                        f"enable early-payment discounts on invoices "
+                        f"that use it."
+                    )
+
+                eligible_until = disc_summary["eligible_until"]
+                if parsed_date > eligible_until:
+                    anchor = inv.date_opened
+                    if isinstance(anchor, datetime):
+                        anchor = anchor.date()
+                    raise ValueError(
+                        f"Payment date {parsed_date.isoformat()} is "
+                        f"beyond the billterm discount window "
+                        f"({disc_summary['discount_days']} days "
+                        f"from {anchor.isoformat()}; deadline was "
+                        f"{eligible_until.isoformat()}). Pay without "
+                        f"apply_discount for a normal late payment, "
+                        f"or issue a credit note to formally write "
+                        f"off the would-be discount amount with an "
+                        f"audit trail."
+                    )
+
+                # Use the CURRENT remaining lot balance as the
+                # principal to settle — not the original grand_total.
+                # This makes the closing-payment-of-a-multi-pay-
+                # invoice case work naturally: customer paid $500
+                # earlier without discount, now pays $480 with
+                # apply_discount=True → remaining=$500, amount=$480,
+                # shortfall=$20, expected=$20 (on original $1000) →
+                # honored.
+                remaining_before = abs(
+                    self._calculate_lot_balance(lot_obj)
+                )
+                shortfall = remaining_before - payment_amount
+                expected = disc_summary["expected_discount"]
+                quantum = _commodity_quantum(inv.currency)
+
+                if shortfall < 0:
+                    raise ValueError(
+                        f"apply_discount=True with payment_amount "
+                        f"{payment_amount} {inv.currency.mnemonic} "
+                        f"exceeds the outstanding lot balance "
+                        f"{remaining_before} {inv.currency.mnemonic}. "
+                        f"Overpayment cannot be discount-settled."
+                    )
+
+                if abs(shortfall - expected) > quantum:
+                    raise ValueError(
+                        f"apply_discount=True but the payment "
+                        f"shortfall doesn't match the expected "
+                        f"discount. Outstanding balance: "
+                        f"{remaining_before} {inv.currency.mnemonic}; "
+                        f"amount: {payment_amount}; shortfall: "
+                        f"{shortfall}; expected discount on pre-tax "
+                        f"principal: {expected} "
+                        f"{inv.currency.mnemonic} "
+                        f"({disc_summary['discount_percent']}%). "
+                        f"Either adjust amount to "
+                        f"{(remaining_before - expected).quantize(quantum)} "
+                        f"to take the full discount, or pay without "
+                        f"apply_discount for a partial payment."
+                    )
+
+                # All validation passed — resolve the discount account
+                # and build the split. Quantize to the discount
+                # account's commodity quantum after cross-currency
+                # conversion (rare but possible — discount account
+                # commodity might differ from invoice currency).
+                discount_acct, discount_notice = (
+                    self._get_or_create_discount_account(
+                        book,
+                        owner_type_is_bill=effective_is_bill,
+                        discount_account=discount_account,
+                    )
+                )
+                disc_quantity, _disc_rate = _convert(
+                    expected, discount_acct.commodity,
+                )
+                # Customer payment: discount is EXPENSE (debit), +value
+                # Vendor bill payment: discount is INCOME (credit), -value
+                disc_value_sign = -1 if effective_is_bill else 1
+                discount_split = piecash.Split(
+                    account=discount_acct,
+                    value=disc_value_sign * expected,
+                    quantity=disc_value_sign * disc_quantity,
+                    memo="Early-payment discount",
+                )
+                discount_amount_invoice_ccy = expected
+
+                # When discount applies, the A/R/A/P side absorbs the
+                # FULL remaining_balance — not just payment_amount.
+                # The discount split makes up the difference so the
+                # transaction balances. Recompute the A/R-side
+                # quantity in the post account's commodity.
+                full_settle_amount = remaining_before
+                full_settle_post_qty, _ = _convert(
+                    full_settle_amount, post_acct.commodity,
+                )
+            else:
+                full_settle_amount = payment_amount
+                full_settle_post_qty = post_quantity
+
             if effective_is_bill:
                 # Pay vendor bill (or refund customer credit note):
-                # debit A/P (positive), credit bank (negative)
+                # debit A/P (positive), credit bank (negative). When
+                # apply_discount=True, A/P clears FULL outstanding
+                # balance (full_settle_amount); the discount split
+                # absorbs the difference.
                 ar_ap_split = piecash.Split(
                     account=post_acct,
-                    value=payment_amount,
-                    quantity=post_quantity,
+                    value=full_settle_amount,
+                    quantity=full_settle_post_qty,
                     memo="",
                     action="Payment",
                 )
@@ -5556,11 +5999,12 @@ class BusinessMixin:
             else:
                 # Receive customer payment (or refund-in from a
                 # vendor credit note): credit A/R (negative),
-                # debit bank (positive)
+                # debit bank (positive). With apply_discount=True,
+                # A/R clears FULL outstanding balance.
                 ar_ap_split = piecash.Split(
                     account=post_acct,
-                    value=-payment_amount,
-                    quantity=-post_quantity,
+                    value=-full_settle_amount,
+                    quantity=-full_settle_post_qty,
                     memo="",
                     action="Payment",
                 )
@@ -5585,6 +6029,8 @@ class BusinessMixin:
             # quadrants are testable as unit cases rather than only
             # via end-to-end ``pay_invoice``.
             splits = [ar_ap_split, bank_split]
+            if discount_split is not None:
+                splits.append(discount_split)
             fx_result: dict | None = None
             default_currency = self._require_default_currency(book)
             if exchange_rate is not None:
@@ -5671,6 +6117,19 @@ class BusinessMixin:
                     }
                     if fx_result["fx_notice"] is not None:
                         result["fx_notice"] = fx_result["fx_notice"]
+            if discount_split is not None:
+                # Surface what was booked so the caller can confirm the
+                # discount applied without re-reading the transaction.
+                # ``account`` is the canonical full path (handles the
+                # case where the auto-resolver picked an account the
+                # caller didn't supply explicitly).
+                result["discount"] = {
+                    "amount": str(discount_amount_invoice_ccy),
+                    "currency": inv.currency.mnemonic,
+                    "account": discount_acct.fullname,
+                }
+                if discount_notice is not None:
+                    result["discount_notice"] = discount_notice
 
         return result
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1967,8 +1967,15 @@ class CoreMixin:
             ))
 
             # --- Build output ---
+            # Book line shows filename only — no directory leak.
+            # See _book_display_name for the privacy rationale; the
+            # filename is enough for the LLM to confirm which book
+            # is loaded ("alex.gnucash" vs "lin-wei.gnucash") while
+            # keeping the user's filesystem layout out of every
+            # transcript and screenshot.
+            from gnucash_mcp._format import _book_display_name
             lines = []
-            lines.append(f"Book: {self.book_path}")
+            lines.append(f"Book: {_book_display_name(self.book_path)}")
             lines.append(f"Currency: {currency}")
 
             if first_date and last_date:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -153,21 +153,32 @@ class CoreMixin:
         # We rely on the Lot balance (not raw invoice total) so
         # partially-paid invoices show as the still-owed amount,
         # and credit notes / payments reduce the count correctly.
+        #
+        # Pre-index accounts and lots once, not per-invoice — this
+        # method runs inside get_book_summary on every dashboard
+        # call. The pre-fix loop did one SQL query per invoice to
+        # resolve the post account, then a linear scan of
+        # post_acct.lots to find the matching lot. On a book with
+        # 100 posted invoices that's 100 round-trips plus 100
+        # linear scans against potentially hundreds of lots each —
+        # noticeable latency on every summary call. Copilot
+        # flagged it; pre-indexing is the standard N+1 fix.
+        accounts_by_guid = {
+            acct.guid: acct for acct in book.accounts
+        }
+        lots_by_guid: dict[str, object] = {}
+        for acct in book.accounts:
+            for lot in acct.lots:
+                lots_by_guid[lot.guid] = lot
+
         for inv in book.session.query(Invoice).filter(
             Invoice.date_posted.isnot(None),
         ).all():
             try:
-                post_acc_guid = inv.post_acc_guid
-                post_acct = book.session.query(
-                    piecash.Account,
-                ).filter_by(guid=post_acc_guid).first()
+                post_acct = accounts_by_guid.get(inv.post_acc_guid)
                 if post_acct is None:
                     continue
-                lot_obj = None
-                for lot in post_acct.lots:
-                    if lot.guid == inv.post_lot_guid:
-                        lot_obj = lot
-                        break
+                lot_obj = lots_by_guid.get(inv.post_lot_guid)
                 if lot_obj is None:
                     continue
                 balance = calc_lot_balance(lot_obj)

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1866,18 +1866,31 @@ class CoreMixin:
             def _r2(v: Decimal) -> Decimal:
                 return v.quantize(Decimal("0.01"))
 
-            assets_total = _r2(
-                sum((v for _, v, _ in asset_leaves), Decimal("0"))
-            )
-            credit_total = _r2(sum(b for _, b in credit_cards) if credit_cards else Decimal(0))
-            loan_total = _r2(sum(b for _, b in loan_accts) if loan_accts else Decimal(0))
-            other_liab_total = _r2(sum(b for _, b in other_liab_accts) if other_liab_accts else Decimal(0))
-            liabilities_total = _r2(credit_total + loan_total + other_liab_total)
+            # Receivables and payables roll into Assets / Liabilities
+            # totals (standard accounting — A/R is an asset, A/P is a
+            # liability) AND get their own dedicated dashboard
+            # sections below for at-a-glance "what's outstanding."
+            # Appearing in both places is intentional: the rolled-up
+            # totals tie to balance_sheet and the trajectory anchor;
+            # the breakout gives the bookkeeper an action lens. Pre-
+            # v1.3.0 only the breakouts existed — the headline
+            # Assets / Liabilities numbers excluded business
+            # activity, breaking cross-tool consistency.
             receivables_total = _r2(
                 sum((b for _, b in receivable_accts), Decimal("0"))
             )
             payables_total = _r2(
                 sum((b for _, b in payable_accts), Decimal("0"))
+            )
+            assets_total = _r2(
+                sum((v for _, v, _ in asset_leaves), Decimal("0"))
+                + receivables_total
+            )
+            credit_total = _r2(sum(b for _, b in credit_cards) if credit_cards else Decimal(0))
+            loan_total = _r2(sum(b for _, b in loan_accts) if loan_accts else Decimal(0))
+            other_liab_total = _r2(sum(b for _, b in other_liab_accts) if other_liab_accts else Decimal(0))
+            liabilities_total = _r2(
+                credit_total + loan_total + other_liab_total + payables_total
             )
             net_worth = _r2(assets_total - liabilities_total)
 
@@ -1986,8 +1999,13 @@ class CoreMixin:
 
             lines.append(f"Accounts: {total_accounts} total")
 
-            # Assets section — leaf accounts with USD-valued balances
-            lines.append(f"Assets: {len(asset_leaves)} accounts, {currency} {assets_total}")
+            # Assets section — leaf accounts with USD-valued balances.
+            # Count includes A/R accounts (which roll into assets_total)
+            # so the headline N agrees with the total; per-account
+            # detail for A/R is shown in the Receivables section below
+            # rather than duplicated here.
+            assets_count = len(asset_leaves) + len(receivable_accts)
+            lines.append(f"Assets: {assets_count} accounts, {currency} {assets_total}")
             for name, usd_value, note in sorted(
                 asset_leaves, key=lambda x: x[1], reverse=True
             ):
@@ -1998,8 +2016,14 @@ class CoreMixin:
                         f"  {name}: {note} ({currency} {_r2(usd_value)})"
                     )
 
-            # Liabilities section — grouped subtotals + top 3
-            liab_count = len(credit_cards) + len(loan_accts) + len(other_liab_accts)
+            # Liabilities section — grouped subtotals + top 3.
+            # A/P accounts (rolled into liabilities_total) are
+            # included in the count; per-account detail lives in the
+            # Payables breakout below.
+            liab_count = (
+                len(credit_cards) + len(loan_accts)
+                + len(other_liab_accts) + len(payable_accts)
+            )
             lines.append(f"Liabilities: {liab_count} accounts, {currency} {liabilities_total}")
             if credit_cards:
                 lines.append(f"  Credit cards ({len(credit_cards)}): {currency} {credit_total}")

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1160,6 +1160,14 @@ class CoreMixin:
         # value flows for splits in budgeted accounts. INCOME is
         # stored negative; flip to a positive contribution to match
         # the spend-vs-target framing.
+        #
+        # Each split is converted to the book's default currency at
+        # the most recent market rate so foreign-currency budgeted
+        # accounts contribute their default-currency-equivalent
+        # spend, not raw quantity. Pre-v1.3.0 a EUR expense account
+        # budgeted at $X contributed raw EUR quantities to the
+        # actuals comparison, wildly miscalibrating used_pct.
+        factors = self._account_conversion_factors(book)
         actuals = Decimal("0")
         for txn in transactions:
             if txn.post_date < period_start or txn.post_date > period_end:
@@ -1167,10 +1175,18 @@ class CoreMixin:
             for s in txn.splits:
                 if s.account.guid not in budgeted_account_guids:
                     continue
-                if s.account.type == "EXPENSE" and s.quantity > 0:
-                    actuals += s.quantity
-                elif s.account.type == "INCOME" and s.quantity < 0:
-                    actuals += -s.quantity
+                atype = s.account.type
+                if atype not in ("EXPENSE", "INCOME"):
+                    continue
+                amt = self._split_in_default_currency(
+                    s, s.account, factors.get(s.account.guid),
+                )
+                # EXPENSE: positive value = spend (count). INCOME:
+                # negative value = revenue (count as positive).
+                if atype == "EXPENSE" and amt > 0:
+                    actuals += amt
+                elif atype == "INCOME" and amt < 0:
+                    actuals += -amt
 
         # Period progression.
         total_days = (period_end - period_start).days + 1
@@ -1212,18 +1228,28 @@ class CoreMixin:
 
         Returns ``Decimal("0")`` when no expense activity in window
         — caller treats that as "no daily-burn signal."
+
+        Each EXPENSE split is converted to the book's default
+        currency at the most recent market rate. Pre-v1.3.0 this
+        summed ``split.value`` raw, mixing currencies on books with
+        foreign-currency expenses; on Lin Wei (CNY-default with
+        USD subscriptions) the burn was understated by the USD
+        component's spot-rate factor.
         """
         if days is None:
             days = self._RUNWAY_BURN_DAYS
         today = date.today()
         window_start = today - timedelta(days=days)
+        factors = self._account_conversion_factors(book)
         expenses = Decimal("0")
         for txn in transactions:
             if txn.post_date < window_start or txn.post_date > today:
                 continue
             for s in txn.splits:
                 if s.account.type == "EXPENSE":
-                    expenses += Decimal(str(s.value))
+                    expenses += self._split_in_default_currency(
+                        s, s.account, factors.get(s.account.guid),
+                    )
         return expenses / Decimal(days)
 
     def _runway_metrics(
@@ -1397,16 +1423,16 @@ class CoreMixin:
         expense activity at all — the caller should omit the section
         entirely rather than emit six "+0" lines that say nothing.
 
-        Multi-currency caveat: ``split.value`` is in transaction
-        currency, not account commodity. For typical books where
-        income/expense accounts share the book default currency
-        (and transactions are recorded in that currency), the sum is
-        accurate. Cross-currency income/expense activity sums raw
-        without per-month FX conversion — flagged as a refinement
-        target in the spec; rare in practice for personal/household
-        books.
+        Multi-currency handling: each split is converted to the
+        book's default currency at the most recent market rate via
+        ``_split_in_default_currency``. Pre-v1.3.0 this summed
+        ``split.value`` raw across currencies — a EUR invoice
+        for €4,200 and a USD invoice for $5,000 mixed as 9,200 of
+        nothing-in-particular. Correct on USD-only books, silently
+        wrong on any book with foreign-currency income/expense.
         """
         today = date.today()
+        factors = self._account_conversion_factors(book)
 
         # Build the calendar-month windows, oldest → newest. Plain
         # arithmetic on (year, month) avoids a dateutil dependency
@@ -1459,12 +1485,18 @@ class CoreMixin:
                 continue
             for s in txn.splits:
                 atype = s.account.type
+                if atype not in ("INCOME", "EXPENSE"):
+                    continue
+                amt = self._split_in_default_currency(
+                    s, s.account, factors.get(s.account.guid),
+                )
                 if atype == "INCOME":
-                    nets[idx] += -Decimal(str(s.value))
-                    has_activity = True
-                elif atype == "EXPENSE":
-                    nets[idx] -= Decimal(str(s.value))
-                    has_activity = True
+                    # INCOME stored negative (credit-natural); flip
+                    # to positive contribution to monthly net.
+                    nets[idx] += -amt
+                else:  # EXPENSE
+                    nets[idx] -= amt
+                has_activity = True
 
         if not has_activity:
             return []

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -117,6 +117,103 @@ class CoreMixin:
     # pending before reconciliation makes sense.
     _LAST_ENTRY_WARN_DAYS = 14
 
+    def _business_summary_counts(self, book) -> dict:
+        """Action-signal counts for the get_book_summary business
+        lines: open invoices, open bills, how many overdue, and
+        active jobs. Returns zeros when BusinessMixin isn't loaded
+        (helpers like ``_calculate_lot_balance`` then come back
+        ``None``) — the rendering layer omits the lines anyway
+        when there's no Receivables/Payables activity.
+
+        The bookkeeper's principle for the summary: "tell the LLM
+        what needs attention, not what exists." Invoice counts
+        and overdue counts are actionable; account counts are
+        structural and already shown via the nested per-account
+        breakdown below each line.
+        """
+        out = {
+            "open_invoices": 0,
+            "overdue_invoices": 0,
+            "open_bills": 0,
+            "overdue_bills": 0,
+            "active_jobs": 0,
+        }
+        calc_lot_balance = getattr(self, "_calculate_lot_balance", None)
+        if calc_lot_balance is None:
+            return out
+        try:
+            from piecash.business.invoice import Invoice, Job
+        except ImportError:
+            return out
+
+        today = date.today()
+        resolve_due = getattr(self, "_resolve_invoice_due_date", None)
+
+        # Posted invoices/bills with non-zero lot balance = open.
+        # We rely on the Lot balance (not raw invoice total) so
+        # partially-paid invoices show as the still-owed amount,
+        # and credit notes / payments reduce the count correctly.
+        for inv in book.session.query(Invoice).filter(
+            Invoice.date_posted.isnot(None),
+        ).all():
+            try:
+                post_acc_guid = inv.post_acc_guid
+                post_acct = book.session.query(
+                    piecash.Account,
+                ).filter_by(guid=post_acc_guid).first()
+                if post_acct is None:
+                    continue
+                lot_obj = None
+                for lot in post_acct.lots:
+                    if lot.guid == inv.post_lot_guid:
+                        lot_obj = lot
+                        break
+                if lot_obj is None:
+                    continue
+                balance = calc_lot_balance(lot_obj)
+                if balance == 0:
+                    continue
+            except Exception:
+                continue
+
+            is_overdue = False
+            if resolve_due is not None:
+                try:
+                    due_date, _ = resolve_due(book, inv)
+                    if due_date is not None and due_date < today:
+                        is_overdue = True
+                except Exception:
+                    pass
+
+            if inv.owner_type == 4:  # vendor bill
+                out["open_bills"] += 1
+                if is_overdue:
+                    out["overdue_bills"] += 1
+            else:
+                # owner_type 2 (customer), 3 (job), 5 (voucher) all
+                # render as customer-side receivables here. Voucher
+                # liabilities are A/P from the company's view but
+                # the LLM-facing count is "things the business
+                # owes employees" — folded into open_bills below
+                # when post_account.type == PAYABLE.
+                if post_acct.type == "PAYABLE":
+                    out["open_bills"] += 1
+                    if is_overdue:
+                        out["overdue_bills"] += 1
+                else:
+                    out["open_invoices"] += 1
+                    if is_overdue:
+                        out["overdue_invoices"] += 1
+
+        try:
+            out["active_jobs"] = book.session.query(Job).filter(
+                Job.active == 1,
+            ).count()
+        except Exception:
+            pass
+
+        return out
+
     def _account_reconciliation_status(
         self, book: piecash.Book, accounts: list,
     ) -> list[dict]:
@@ -1910,23 +2007,51 @@ class CoreMixin:
                 top_parts = [f"{n} {currency} {_r2(b)}" for n, b in top_n]
                 lines.append(f"  Top {len(top_n)}: {', '.join(top_parts)}")
 
-            # Receivables / Payables — only if non-zero
+            # Receivables / Payables — only if non-zero. The
+            # parenthesized action signal (open count + overdue)
+            # is the bookkeeper-asked-for addition: the LLM should
+            # see "2 overdue" and know to ask about collections,
+            # without us having to spell that out.
+            biz_counts = self._business_summary_counts(book)
             if receivable_accts:
+                inv_n = biz_counts["open_invoices"]
+                overdue = biz_counts["overdue_invoices"]
+                signal = (
+                    f" ({inv_n} invoice"
+                    f"{'s' if inv_n != 1 else ''}, "
+                    f"{overdue} overdue)"
+                ) if inv_n else ""
                 lines.append(
                     f"Receivables: {len(receivable_accts)} account"
                     f"{'s' if len(receivable_accts) != 1 else ''}, "
-                    f"{currency} {receivables_total}"
+                    f"{currency} {receivables_total}{signal}"
                 )
                 for name, bal in sorted(receivable_accts, key=lambda x: x[1], reverse=True):
                     lines.append(f"  {name}: {currency} {_r2(bal)}")
             if payable_accts:
+                bill_n = biz_counts["open_bills"]
+                overdue = biz_counts["overdue_bills"]
+                signal = (
+                    f" ({bill_n} bill"
+                    f"{'s' if bill_n != 1 else ''}, "
+                    f"{overdue} overdue)"
+                ) if bill_n else ""
                 lines.append(
                     f"Payables: {len(payable_accts)} account"
                     f"{'s' if len(payable_accts) != 1 else ''}, "
-                    f"{currency} {payables_total}"
+                    f"{currency} {payables_total}{signal}"
                 )
                 for name, bal in sorted(payable_accts, key=lambda x: x[1], reverse=True):
                     lines.append(f"  {name}: {currency} {_r2(bal)}")
+
+            # Jobs: one conditional line. Tells the LLM the
+            # job-grouping feature is in use on this book; absence
+            # is a stronger signal than "Jobs: 0 active". Per the
+            # bookkeeper: "Jobs existing doesn't need attention"
+            # but knowing they're in play points to the right
+            # drill-down tool (``get_job_report``).
+            if biz_counts["active_jobs"] > 0:
+                lines.append(f"Jobs: {biz_counts['active_jobs']} active")
 
             lines.append(f"Income: {income_active} active ({income_total} total)")
             lines.append(f"Expenses: {expense_active} active ({expense_total} total)")

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2434,7 +2434,25 @@ class CoreMixin:
                     lines.append(notice)
                 return "\n".join(lines)
             else:
-                return [_transaction_to_dict(t) for t in filtered]
+                # Verbose mode: emit short prefixes for transaction
+                # GUIDs, split GUIDs, and lot GUIDs so the bookkeeper
+                # workflow doesn't pay 24 wasted chars per GUID per
+                # row. Compact mode already does this; pre-v1.3.1
+                # verbose left them at full 32-char width even
+                # though every consuming tool accepts 8+ char
+                # prefixes via ``_resolve_guid``.
+                txn_prefixes = self._transaction_prefix_map(book)
+                split_prefixes = self._split_prefix_map(book)
+                lot_prefixes = self._lot_prefix_map(book)
+                return [
+                    _transaction_to_dict(
+                        t,
+                        txn_prefixes=txn_prefixes,
+                        split_prefixes=split_prefixes,
+                        lot_prefixes=lot_prefixes,
+                    )
+                    for t in filtered
+                ]
 
     @staticmethod
     def _truncation_notice(
@@ -2479,13 +2497,25 @@ class CoreMixin:
             guid: Transaction GUID (32-character hex string).
 
         Returns:
-            Transaction dict if found, None otherwise.
+            Transaction dict if found, None otherwise. The emitted
+            ``guid`` field (on the transaction and on each nested
+            split) and the ``lot_guid`` field carry collision-safe
+            short prefixes (typically 8 chars) — same format the
+            compact list_transactions emits. The full GUID is
+            redundant for caller-side use because every tool that
+            takes a GUID accepts an 8+ char prefix via
+            ``_resolve_guid``.
         """
         with self.open(readonly=True) as book:
             transaction = self._find_transaction(book, guid)
-            if transaction:
-                return _transaction_to_dict(transaction)
-            return None
+            if not transaction:
+                return None
+            return _transaction_to_dict(
+                transaction,
+                txn_prefixes=self._transaction_prefix_map(book),
+                split_prefixes=self._split_prefix_map(book),
+                lot_prefixes=self._lot_prefix_map(book),
+            )
 
     _FUNDING_ACCOUNT_TYPES = {
         "BANK", "CASH", "ASSET", "CREDIT", "LIABILITY", "EQUITY",

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -343,14 +343,19 @@ class CoreMixin:
         return results
 
     # Asset-side and liability-side type sets used by the net-worth
-    # computation. Mirrors the existing in-summary breakdown — the
-    # asset section iterates these types into per-leaf rows; the
-    # liability section iterates the liability set. Receivables and
-    # payables are intentionally excluded from net worth — they live
-    # in their own dedicated sections of the summary and aren't part
-    # of the assets_total − liabilities_total convention.
-    _NW_ASSET_TYPES = frozenset({"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"})
-    _NW_LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT"})
+    # trajectory in get_book_summary. RECEIVABLE and PAYABLE belong
+    # here despite having dedicated dashboard sections elsewhere in
+    # the summary — accounting-wise, A/R is an asset and A/P a
+    # liability, so the trajectory's "now" anchor (and every past-
+    # anchor reconstruction) must include them to agree with
+    # balance_sheet and net_worth. Pre-v1.3.0 these were excluded
+    # here while balance_sheet excluded them too; both were wrong in
+    # the same direction, so the cross-tool numbers happened to
+    # agree. Fixing balance_sheet (v1.3) forces this set to follow
+    # so the dashboard's headline net worth doesn't drift from the
+    # canonical balance-sheet identity.
+    _NW_ASSET_TYPES = frozenset({"ASSET", "BANK", "CASH", "STOCK", "MUTUAL", "RECEIVABLE"})
+    _NW_LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT", "PAYABLE"})
 
     def _compute_net_worth_at(
         self,

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -247,6 +247,7 @@ class ReconciliationMixin:
         *,
         reconcile_all: bool = False,
         through_date: date | None = None,
+        except_guids: list[str] | None = None,
     ) -> dict:
         """Reconcile multiple splits against a statement balance.
 
@@ -289,6 +290,14 @@ class ReconciliationMixin:
                 included. When ``None`` (default), no date filter
                 is applied — every unreconciled split gets
                 reconciled, regardless of date.
+            except_guids: Optional list of split GUID prefixes to
+                exclude from the bulk reconcile. Useful when the
+                statement covers "everything except this one
+                pending ACH" — 2 tokens for the exclusion instead
+                of 100+ for an explicit ``split_guids`` listing.
+                Only valid with ``reconcile_all=True``. Prefixes
+                that don't resolve are silently ignored (no
+                effect on the reconcile set anyway).
 
         Returns:
             Dict with reconciliation results: ``splits_reconciled``,
@@ -312,6 +321,12 @@ class ReconciliationMixin:
                 "Must provide split_guids for targeted reconciliation, "
                 "or set reconcile_all=True for bulk mode."
             )
+        if except_guids and not reconcile_all:
+            raise ValueError(
+                "except_guids is only valid with reconcile_all=True. "
+                "For targeted reconciliation, just include the splits "
+                "you want in split_guids."
+            )
 
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
@@ -327,6 +342,19 @@ class ReconciliationMixin:
             reconciling_total = Decimal("0")
 
             if reconcile_all:
+                # Pre-resolve except_guids prefixes to full GUIDs so
+                # the per-split skip check is a fast set lookup. A
+                # prefix that doesn't resolve to any split is
+                # silently dropped — the goal is "exclude these if
+                # present", and a non-resolving entry has no effect
+                # on the reconcile set.
+                exempt_guids: set[str] = set()
+                if except_guids:
+                    for prefix in except_guids:
+                        found = self._find_split(book, prefix)
+                        if found is not None:
+                            exempt_guids.add(found.guid)
+
                 # Walk the account's own splits — by construction every
                 # entry is on this account, so no membership check
                 # needed. Apply the optional date filter only when the
@@ -336,6 +364,8 @@ class ReconciliationMixin:
                 # of when payments cleared.
                 for split in account.splits:
                     if split.reconcile_state == "y":
+                        continue
+                    if split.guid in exempt_guids:
                         continue
                     if (
                         through_date is not None

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -32,8 +32,18 @@ from gnucash_mcp._format import _format_number
 # Account-type groups used across the reports. Defined at module level
 # so the SQL IN() clauses share a single canonical definition rather
 # than drifting across methods.
-_ASSET_TYPES = frozenset({"ASSET", "BANK", "CASH", "STOCK", "MUTUAL"})
-_LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT"})
+# Type sets for balance_sheet / net_worth bucketing.
+#
+# RECEIVABLE and PAYABLE belong here despite GnuCash treating them
+# as their own first-class account types. Accounting-wise, A/R is
+# an asset (someone owes us money) and A/P is a liability (we owe
+# someone money); both flow through the balance sheet's totals and
+# the canonical "net worth = total assets − total liabilities"
+# identity. Pre-v1.3.0 these were excluded — invoices issued to
+# customers were invisible on balance_sheet, breaking A = L + E by
+# the outstanding-invoice amount.
+_ASSET_TYPES = frozenset({"ASSET", "BANK", "CASH", "STOCK", "MUTUAL", "RECEIVABLE"})
+_LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT", "PAYABLE"})
 _EQUITY_TYPES = frozenset({"EQUITY"})
 _NET_INCOME_TYPES = frozenset({"INCOME", "EXPENSE"})
 _CASH_TYPES = frozenset({"BANK", "CASH"})
@@ -465,10 +475,42 @@ class ReportingMixin:
                 sum(i["usd"] for i in liabilities.values())
                 if liabilities else Decimal("0")
             )
-            equity_total = (
-                (sum(i["usd"] for i in equity.values()) if equity else Decimal("0"))
-                + net_income
+
+            # ── Unrealized gain/loss (balancing adjustment) ──────────
+            # Assets render at market value (factor × quantity for
+            # commodities and foreign-currency cash). Equity rolls
+            # up from the splits' raw values, which capture the
+            # historical-cost view. The two views differ by:
+            #
+            # 1. **Investment market drift** — STOCK/MUTUAL holdings
+            #    on a default-currency-denominated brokerage have
+            #    market value (shares × current_price) above or
+            #    below the recorded cost basis (split.value, in
+            #    default currency).
+            # 2. **FX translation adjustment** — foreign-currency
+            #    accounts have current default-currency value
+            #    (quantity × current_FX_rate) that drifts from the
+            #    historical default-currency equivalent at post
+            #    time. Same effect on both sides of foreign-
+            #    currency transactions, but cross-currency
+            #    settlements introduce per-currency imbalances.
+            #
+            # Both effects belong under the same equity adjustment in
+            # GAAP terms (accumulated other comprehensive income).
+            # Computed as the balancing residual so A = L + E holds
+            # by construction, regardless of the underlying mix.
+            # Surfacing the decomposition (how much is investment
+            # drift vs. how much is FX) is a separate feature; for
+            # the balance sheet's purpose ("does it balance?"), the
+            # single line is sufficient.
+            equity_acct_total = (
+                sum(i["usd"] for i in equity.values()) if equity else Decimal("0")
             )
+            unrealized = (
+                assets_total - liabilities_total
+                - equity_acct_total - net_income
+            )
+            equity_total = equity_acct_total + net_income + unrealized
 
             def format_accounts(accounts_dict: dict[str, dict]) -> list[dict]:
                 """Render each account row with the right balance shape.
@@ -557,6 +599,19 @@ class ReportingMixin:
                             "balance": _format_number(net_income, decimals=2),
                         }]
                         if net_income != 0 else []
+                    ) + (
+                        # Synthetic — closes A = L + E when assets
+                        # render at market value. Single signed line
+                        # (positive = unrealized gain; negative =
+                        # unrealized loss) keeps the report compact
+                        # and matches how analytical accounting
+                        # treats it under "Accumulated OCI" before
+                        # a mark-to-market entry is booked.
+                        [{
+                            "account": "Unrealized Gain/Loss",
+                            "balance": _format_number(unrealized, decimals=2),
+                        }]
+                        if unrealized != 0 else []
                     ),
                 },
             }

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -256,10 +256,18 @@ class ReportingMixin:
                 account_types=frozenset({"EXPENSE"}),
             )
 
+            # Convert each split to the book's default currency.
+            # Without this, a EUR expense in a USD-default book
+            # contributes raw EUR to the same totals dict as USD
+            # entries — silently wrong sums on multi-currency books.
+            factors = self._account_conversion_factors(book)
+
             totals: dict[str, Decimal] = {}
             for split, _txn, account in rows:
                 # Expense splits are positive when money is spent.
-                amount = split.quantity
+                amount = self._split_in_default_currency(
+                    split, account, factors.get(account.guid),
+                )
                 if amount <= 0:
                     continue
                 group_account = self._get_account_at_depth(
@@ -321,11 +329,18 @@ class ReportingMixin:
                 account_types=frozenset({"INCOME"}),
             )
 
+            # Convert each split to the book's default currency.
+            # Multi-currency-book correctness: see spending_by_category
+            # for the rationale — same bug, same fix.
+            factors = self._account_conversion_factors(book)
+
             totals: dict[str, Decimal] = {}
             for split, _txn, account in rows:
                 # Income splits are stored negative (money coming in);
                 # flip to positive for the "how much did I earn" view.
-                amount = -split.quantity
+                amount = -self._split_in_default_currency(
+                    split, account, factors.get(account.guid),
+                )
                 if amount <= 0:
                     continue
                 group_account = self._get_account_at_depth(

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -85,22 +85,31 @@ SAFETY: Reconciled splits are protected (use force=true to override). Prefer voi
 # add cycle detection then.
 # ---------------------------------------------------------------------------
 MODULE_GROUPS: dict[str, list[str]] = {
-    # ``core`` expands to its eight ledger sub-modules. Always-on
+    # ``core`` expands to its nine ledger sub-modules. Always-on
     # (force-added in _apply_module_filter), so a user with no
-    # --modules flag gets all eight. Users can ALSO pick individual
+    # --modules flag gets all nine. Users can ALSO pick individual
     # sub-modules — e.g. ``--modules=accounts`` is valid but doesn't
     # change the fact that core is loaded too.
+    #
+    # ``reconciliation`` joined core in v1.3.1 — bookkeeper-flagged
+    # that reconciliation touches money and every configuration
+    # touches money, so excluding it from any persona-aligned cut
+    # produced a server that couldn't reconcile statements (a hole
+    # in the "any configuration that handles ledgers" promise).
+    # Moved from the bookkeeper group to core; now always loaded.
     "core": [
         "summary", "accounts", "transactions", "slots",
         "audit", "backup", "balance_sheet", "diagnostic",
+        "reconciliation",
     ],
     # ``bookkeeper`` bundles the personal-finance management
-    # cluster: reconcile bank statements, run reports, manage
-    # budgets, schedule recurring transactions. The four
-    # underlying modules stay separately selectable for users
-    # who want a finer cut.
+    # cluster: run reports, manage budgets, schedule recurring
+    # transactions. The three underlying modules stay separately
+    # selectable for users who want a finer cut.
+    # (Reconciliation used to live here too — moved to core in
+    # v1.3.1, see the comment above.)
     "bookkeeper": [
-        "reconciliation", "reporting", "budgets", "scheduling",
+        "reporting", "budgets", "scheduling",
     ],
     # ``investor`` bundles the two halves of the legacy
     # ``investments`` module: ``tax_lots`` (cost-basis tracking)
@@ -141,9 +150,10 @@ MODULE_GROUPS: dict[str, list[str]] = {
 #
 # Pre-restructure the mapping was 1:1 (module ``X`` → tool file
 # ``tools/X.py`` → mixin ``XMixin``). The restructure breaks that:
-# Core's 26 tools include void/unvoid (from ``reconciliation.py``),
-# the slot tools + audit log (from ``admin.py``), and the backup tools
-# (from ``backup.py``). The mixin classes still live in their original
+# Core's 29 tools include void/unvoid AND the reconciliation
+# surface (both from ``reconciliation.py``), the slot tools +
+# audit log (from ``admin.py``), and the backup tools (from
+# ``backup.py``). The mixin classes still live in their original
 # files; this dict tells ``_apply_module_filter`` which tool files to
 # lazy-load AND ``main()`` which mixins to compose for the requested
 # module set.
@@ -778,15 +788,15 @@ Usage: gnucash-mcp [OPTIONS]
 
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
-                       Default: core (26 tools, always-on). Use "all"
+                       Default: core (29 tools, always-on). Use "all"
                        for every module (106 tools).
 
                        Role-based selections (group aliases that
                        expand to underlying modules — start here):
-                         core         Ledger primitives. Always on
-                                      regardless. 26 tools.
-                         bookkeeper   Reconciliation + reporting +
-                                      budgets + scheduling. 20 tools.
+                         core         Ledger primitives + reconciliation.
+                                      Always on regardless. 29 tools.
+                         bookkeeper   Reporting + budgets + scheduling.
+                                      17 tools.
                          investor     tax_lots + portfolio (cost basis
                                       + prices). 12 tools.
                          freelancer   Customer invoicing + sales tax
@@ -802,12 +812,12 @@ Options:
                        Leaf modules (pick individually for finer
                        control, or as members of the groups above):
 
-                       Core sub-modules (8): summary, accounts,
+                       Core sub-modules (9): summary, accounts,
                        transactions, slots, audit, backup,
-                       balance_sheet, diagnostic.
+                       balance_sheet, diagnostic, reconciliation.
 
-                       Bookkeeper members (4): reconciliation,
-                       reporting, budgets, scheduling.
+                       Bookkeeper members (3): reporting, budgets,
+                       scheduling.
 
                        Investor members (2): tax_lots, portfolio.
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -113,6 +113,25 @@ MODULE_GROUPS: dict[str, list[str]] = {
     "investor": [
         "tax_lots", "portfolio",
     ],
+    # ``business`` is the small-business persona alias. It expands
+    # to ``freelancer`` (the 19 customer-facing invoice tools) plus
+    # ``business_complete`` (the 29 vendor/employee/jobs/credit-
+    # notes/billing-terms tools). Pre-v1.3 ``business`` was a
+    # standalone leaf containing only the second half — a user
+    # picking ``--modules=business`` for "small business workflow"
+    # got vendor management but couldn't create or post a customer
+    # invoice. Bookkeeper-found on PR #92 review; the fix
+    # restructures business into the natural superset.
+    #
+    # The two leaves stay independently selectable for users who
+    # want a finer cut (a solo freelancer with no vendor activity
+    # uses ``--modules=freelancer``; a back-office bookkeeper
+    # managing only vendor side could pick
+    # ``--modules=business_complete`` though that's a less common
+    # carve-out).
+    "business": [
+        "freelancer", "business_complete",
+    ],
 }
 
 
@@ -156,11 +175,19 @@ MODULE_BACKED_BY: dict[str, set[str]] = {
     # surface.
     "portfolio": {"investments"},
     "tax_lots": {"investments"},
-    # ``freelancer`` (customer-facing invoicing) and ``business``
-    # (vendor + employee management, vendor bills) split the legacy
-    # ``business`` module along persona lines.
+    # ``freelancer`` (customer-facing invoicing) and
+    # ``business_complete`` (vendor + employee management, vendor
+    # bills, jobs, credit notes, billing terms) split the legacy
+    # ``business`` module along persona lines. Both back onto the
+    # same ``tools/business.py`` file — the public modules are
+    # subsets of one underlying registration.
+    #
+    # The ``business`` PUBLIC name is a MODULE_GROUPS alias that
+    # expands to both halves (see MODULE_GROUPS above); it doesn't
+    # appear here because groups never need their own backing
+    # entry — they resolve via their members' backings.
     "freelancer": {"business"},
-    "business": {"business"},
+    "business_complete": {"business"},
 }
 
 
@@ -313,7 +340,15 @@ TOOL_MODULES: dict[str, list[str]] = {
         "update_taxtable",
         "delete_taxtable",
     ],
-    "business": [
+    # ``business_complete`` — the vendor/employee/bills/credit-
+    # notes/jobs/billing-terms surface. Together with
+    # ``freelancer`` (the invoice surface), forms the full small-
+    # business toolkit. Both leaves expand together under the
+    # ``business`` group alias in MODULE_GROUPS. Pre-v1.3 this
+    # was named ``business`` and treated as a standalone — a UX
+    # trap that gave business-mode users only half the surface
+    # they expected.
+    "business_complete": [
         "create_vendor",
         "list_vendors",
         "get_vendor",
@@ -752,15 +787,17 @@ Options:
                                       regardless. 26 tools.
                          bookkeeper   Reconciliation + reporting +
                                       budgets + scheduling. 20 tools.
-                         investor    tax_lots + portfolio (cost basis
+                         investor     tax_lots + portfolio (cost basis
                                       + prices). 12 tools.
-                         freelancer  Customer invoicing + sales tax
+                         freelancer   Customer invoicing + sales tax
                                       (taxtables for GST / VAT /
                                       US state sales tax). 19 tools.
-                         business     Additive to freelancer:
-                                      vendors, employees, bills,
-                                      vouchers, credit notes, jobs,
-                                      billterms. 29 tools.
+                         business     Full small-business package:
+                                      freelancer (invoicing) +
+                                      business_complete (vendors,
+                                      employees, bills, vouchers,
+                                      credit notes, jobs, billterms).
+                                      48 tools.
 
                        Leaf modules (pick individually for finer
                        control, or as members of the groups above):
@@ -774,11 +811,16 @@ Options:
 
                        Investor members (2): tax_lots, portfolio.
 
+                       Business members (2): freelancer,
+                       business_complete.
+
                        Example: --modules=freelancer for a solo
-                       invoicer; --modules=bookkeeper for personal
-                       finance; --modules=freelancer,business for a
-                       small business with vendor management.
-                       ``core`` is always added regardless.
+                       invoicer with no vendor activity;
+                       --modules=bookkeeper for personal finance;
+                       --modules=business for a complete small-
+                       business workflow (invoices + vendor + employee
+                       management). ``core`` is always added
+                       regardless.
   --debug              Enable debug logging (MCP protocol traffic, timing)
   --noaudit            Disable audit logging
   -h, --help           Show this help message

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -48,57 +48,23 @@ logger = logging.getLogger(__name__)
 mcp = FastMCP(
     "gnucash-mcp",
     instructions="""GnuCash MCP Server — Double-Entry Accounting Tools
-
 ORIENTATION:
-- Call get_book_summary first to understand the book's structure, currency, and account hierarchy.
-- Use list_accounts to find exact account paths before creating transactions.
+- Call get_book_summary first. It returns structure, currency, balances, warnings, and reconciliation status.
+- Use list_accounts to get exact paths and short GUIDs before writing.
 - Use search_transactions before creating to avoid duplicates.
-
-DOUBLE-ENTRY BASICS:
-- Every transaction has splits that MUST balance to zero.
-- Debits are positive for Asset/Expense accounts, negative for Liability/Income/Equity.
-- Credit card payment example: checking -200 (credit), credit card +200 (debit) — reduces both balances.
-- Income received: checking +3000 (debit), income -3000 (credit).
-
+- Every transaction has splits that MUST sum to zero.
 ACCOUNT REFERENCES:
-- Anywhere a tool takes an account, you can pass a full path
-  ("Expenses:Groceries"), a short GUID ("%2e78c86"), or a full
-  32-char GUID. All three resolve to the same account.
-- Short GUIDs are emitted by list_accounts at the start of each line:
-  "%2e78c86<TAB>Assets:Current Assets:Savings Account [BANK]". Reuse
-  them in subsequent calls — they're ~80% smaller than full paths.
-- Paths remain useful when you're naming a new account or when your
-  reasoning depends on the hierarchy. Short GUIDs win for everything
-  else (transactions, balances, slots, lots, invoices, budgets).
-- Paths are colon-delimited and case-sensitive.
-
-GUID PREFIXES (transactions, splits, etc.):
-- All tools accepting GUIDs also accept 8+ character prefixes.
-- Use the short prefix from list_transactions output — no need to look up full GUIDs.
-- Account short GUIDs are 7+ hex chars *with* a leading "%" marker.
-  Transaction/split GUID prefixes are bare hex (no marker).
-
-RECONCILIATION WORKFLOW:
-1. list_transactions for the account and date range
-2. Match each statement line to an existing transaction or create missing ones
-3. Verify balance matches statement with get_balance
-4. Use reconcile_account to mark splits as reconciled
-
-INVESTMENT WORKFLOW:
-1. create_lot for each purchase
-2. create_transaction with quantity (shares) and amount (cost)
-3. assign_split_to_lot to link the investment split
-4. create_price to record the share price
-5. calculate_lot_gain to check performance
-
-SLOTS (CUSTOM METADATA):
-- Use get_account_slots / set_account_slot to store per-account data like APR, credit limit, statement close day.
-- Values are stored as strings. Store numbers as strings: set_account_slot("...", "apr", "23.49").
-
-SAFETY:
-- Reconciled splits are protected. Use force=true only when intentionally modifying reconciled data.
-- void_transaction preserves audit trail. Prefer void over delete for posted transactions.
-- delete_account is blocked if account has children or transactions.
+- Tools accept full paths ("Expenses:Groceries"), short GUIDs ("%2e78c86"), or full 32-char GUIDs.
+- list_accounts emits short GUIDs at line start: "%2e78c86\\tAssets:Savings [BANK]". Reuse them — ~80% smaller than paths.
+- Paths are colon-delimited, case-sensitive. Use paths when naming new accounts or reasoning about hierarchy; short GUIDs for everything else.
+- Account short GUIDs: 7+ hex chars with leading "%". Transaction/split GUIDs: 8+ bare hex prefix, no marker.
+DOUBLE-ENTRY SIGN CONVENTION:
+- Positive = debit (increases Asset/Expense, decreases Liability/Income/Equity).
+- Negative = credit (reverse).
+- Credit card payment: checking -200, card +200. Income: checking +3000, income -3000.
+INVESTMENT FLOW: create_lot → create_transaction (with quantity/cost) → assign_split_to_lot → create_price → calculate_lot_gain.
+SLOTS: get_account_slots / set_account_slot store per-account metadata (APR, credit limit, statement day) as strings.
+SAFETY: Reconciled splits are protected (use force=true to override). Prefer void_transaction over delete for audit trail. delete_account is blocked if account has children or transactions.
 """,
 )
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -661,14 +661,17 @@ def accounts_resource() -> str:
 def _get_server_config_impl() -> str:
     """Return current server configuration and runtime state.
 
-    Reports loaded modules, tool count, book path, debug mode,
+    Reports loaded modules, tool count, book filename, debug mode,
     and version so the client can verify its own tool inventory.
+    The book is shown as filename only — see
+    ``_book_display_name`` for the privacy rationale.
     """
     from gnucash_mcp import __version__
+    from gnucash_mcp._format import _book_display_name
     lines = [
         f"Modules loaded: {_server_state.get('modules', 'unknown')}",
         f"Tools available: {_server_state.get('tool_count', 'unknown')}",
-        f"Book path: {_server_state.get('book_path', 'not set')}",
+        f"Book: {_book_display_name(_server_state.get('book_path'))}",
         f"Debug mode: {str(_server_state.get('debug', False)).lower()}",
         f"Version: {__version__}",
     ]

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -507,16 +507,49 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
             else:
                 enabled_modules.add(name)
 
-        # Warn on names that don't resolve to a known sub-module.
+        # Fail-fast on names that don't resolve to a known sub-module
+        # or group. Pre-v1.3.0 this was a stderr warning, then partial
+        # load — silent in practice because Claude Desktop captures
+        # MCP server stderr into a log file the user never sees. A
+        # typo'd ``--modules=bookeeper`` (missing the 'k') would
+        # silently load only ``core``, leaving the user unable to
+        # tell whether the tools they wanted are missing because
+        # they typed it wrong or because the server is broken.
+        # Bookkeeper-found bug on the PR #92 review pass; same
+        # principle as ``extra="forbid"`` on tool kwargs — financial
+        # software shouldn't silently swallow typos in configuration
+        # either.
         known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
-        all_referenced = requested | enabled_modules
-        unknown = all_referenced - known - {"all"}
+        unknown = requested - known - {"all"}
         if unknown:
-            print(
-                f"Warning: Unknown module(s): {', '.join(sorted(unknown))}. "
-                f"Available: {', '.join(sorted(known))}, all",
-                file=sys.stderr,
+            # Per-typo, suggest the closest known name (did-you-mean).
+            # Use simple shared-character ratio; close enough for the
+            # typo-class we're trying to catch without pulling in a
+            # Levenshtein dependency.
+            import difflib
+            lines = ["Unknown module name(s) on --modules / GNUCASH_MCP_MODULES:"]
+            for bad in sorted(unknown):
+                matches = difflib.get_close_matches(
+                    bad, sorted(known), n=1, cutoff=0.6,
+                )
+                if matches:
+                    lines.append(f"  - {bad!r}  (did you mean {matches[0]!r}?)")
+                else:
+                    lines.append(f"  - {bad!r}")
+            lines.append("")
+            lines.append(
+                f"Valid names: {', '.join(sorted(known))}, all"
             )
+            lines.append("")
+            lines.append(
+                "Fix the typo and restart the server. Partial-load "
+                "was the previous behavior; v1.3 fails fast so "
+                "configuration errors surface at startup instead "
+                "of as missing tools downstream."
+            )
+            message = "\n".join(lines)
+            print(message, file=sys.stderr)
+            raise SystemExit(2)
 
     # Keep only known sub-module names. Group expansion above may
     # have introduced names that aren't TOOL_MODULES keys if the

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -12,6 +12,31 @@ from pydantic import Field
 
 from mcp.server.fastmcp import FastMCP
 
+# Strict tool-argument validation: reject unknown kwargs at the MCP
+# boundary instead of silently ignoring them.
+#
+# FastMCP generates a Pydantic model per tool from the function
+# signature, all inheriting from ``ArgModelBase``. The base class's
+# default config doesn't set ``extra``, so Pydantic falls back to
+# ``"ignore"`` — typo'd or stale-spec parameter names silently
+# no-op. Bookkeeper-found bug on PR #92 review: calling
+# ``reconcile_account`` with ``except=[...]`` (the spec's name)
+# instead of ``except_guids=[...]`` (the actual Python-safe param)
+# ran the tool with no exclusion at all, surfacing only as a
+# balance mismatch downstream.
+#
+# Patching ``ArgModelBase.model_config`` to include
+# ``extra="forbid"`` makes the dynamically-created arg models
+# reject unknown fields with a clear ``"Extra inputs are not
+# permitted"`` error. Applied at import time, before any tool
+# module loads.
+from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase
+
+ArgModelBase.model_config = {
+    **ArgModelBase.model_config,
+    "extra": "forbid",
+}
+
 from gnucash_mcp.book import GnuCashBook, build_book_class, extracted_modules
 from gnucash_mcp.logging_config import audit_log, debug_log, setup_logging
 from gnucash_mcp.tools._helpers import _json, safe_tool

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -103,6 +103,25 @@ MODULE_GROUPS: dict[str, list[str]] = {
         "summary", "accounts", "transactions", "slots",
         "audit", "backup", "balance_sheet", "diagnostic",
     ],
+    # ``bookkeeper`` bundles the personal-finance management
+    # cluster: reconcile bank statements, run reports, manage
+    # budgets, schedule recurring transactions. The four
+    # underlying modules stay separately selectable for users
+    # who want a finer cut.
+    "bookkeeper": [
+        "reconciliation", "reporting", "budgets", "scheduling",
+    ],
+    # ``investor`` bundles the two halves of the legacy
+    # ``investments`` module: ``tax_lots`` (cost-basis tracking)
+    # and ``portfolio`` (commodities + prices, the multi-currency
+    # primitive). A user typing ``--modules=investor`` wants both
+    # because tax-lot accounting is meaningless without prices.
+    # The split is preserved at the leaf-module level so a
+    # multi-currency household without a brokerage can still
+    # pick ``portfolio`` alone.
+    "investor": [
+        "tax_lots", "portfolio",
+    ],
 }
 
 
@@ -139,10 +158,13 @@ MODULE_BACKED_BY: dict[str, set[str]] = {
     "backup": {"backup"},
     "balance_sheet": {"reporting"},
     "diagnostic": set(),
-    # ``portfolio`` (prices / commodities) and ``investor`` (tax lots)
-    # are the two halves of what used to be the ``investments`` module.
+    # ``portfolio`` (prices / commodities) and ``tax_lots`` (cost-
+    # basis tracking) are the two halves of what used to be the
+    # ``investments`` module. The ``investor`` group alias in
+    # MODULE_GROUPS pulls them both in for users who want the full
+    # surface.
     "portfolio": {"investments"},
-    "investor": {"investments"},
+    "tax_lots": {"investments"},
     # ``freelancer`` (customer-facing invoicing) and ``business``
     # (vendor + employee management, vendor bills) split the legacy
     # ``business`` module along persona lines.
@@ -253,7 +275,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_latest_price",
         "delete_price",
     ],
-    "investor": [
+    "tax_lots": [
         "create_lot",
         "list_lots",
         "get_lot",
@@ -697,52 +719,39 @@ Options:
                        Default: core (26 tools, always-on). Use "all"
                        for every module (106 tools).
 
-                       Modules (role-aligned, flat partition; pick
-                       what fits your workflow):
+                       Role-based selections (group aliases that
+                       expand to underlying modules — start here):
+                         core         Ledger primitives. Always on
+                                      regardless. 26 tools.
+                         bookkeeper   Reconciliation + reporting +
+                                      budgets + scheduling. 20 tools.
+                         investor    tax_lots + portfolio (cost basis
+                                      + prices). 12 tools.
+                         freelancer  Customer invoicing + sales tax
+                                      (taxtables for GST / VAT /
+                                      US state sales tax). 19 tools.
+                         business     Additive to freelancer:
+                                      vendors, employees, bills,
+                                      vouchers, credit notes, jobs,
+                                      billterms. 29 tools.
 
-                       Core sub-modules — always loaded via the
-                       ``core`` group alias; selectable individually
-                       too:
-                         summary      get_book_summary dashboard.
-                         accounts     Account CRUD + balance/list.
-                         transactions Transaction CRUD + search +
-                                      void/unvoid.
-                         slots        Per-account metadata (APR,
-                                      credit_limit, statement-close).
-                         audit        get_audit_log reader.
-                         backup       Manual backup CRUD (the
-                                      auto-snapshot hook runs
-                                      unconditionally).
-                         balance_sheet
-                                      THE canonical accounting report.
-                         diagnostic   get_server_config introspection.
+                       Leaf modules (pick individually for finer
+                       control, or as members of the groups above):
 
-                       Optional modules:
-                         budgets      Budget creation + variance.
-                         scheduling   Recurring transactions.
-                         reconciliation
-                                      Bank-statement reconciliation.
-                         reporting    Analytical reports (net_worth,
-                                      cash_flow, spending/income
-                                      breakdowns, debt_payoff_plan).
-                         portfolio    Commodities + prices —
-                                      the multi-currency primitive.
-                         investor     Tax-lot management.
-                         freelancer   Customer invoicing + sales-tax
-                                      configuration (taxtables for
-                                      GST / VAT / US state sales tax).
-                         business     Vendor + employee management,
-                                      vendor bills, jobs, credit
-                                      notes, billterms (additive to
-                                      freelancer for full business
-                                      workflow).
+                       Core sub-modules (8): summary, accounts,
+                       transactions, slots, audit, backup,
+                       balance_sheet, diagnostic.
+
+                       Bookkeeper members (4): reconciliation,
+                       reporting, budgets, scheduling.
+
+                       Investor members (2): tax_lots, portfolio.
 
                        Example: --modules=freelancer for a solo
-                       invoicer; --modules=budgets,scheduling,reporting
-                       for a personal-finance user;
-                       --modules=freelancer,business for a small
-                       business with vendor management. ``core`` is
-                       always added regardless.
+                       invoicer; --modules=bookkeeper for personal
+                       finance; --modules=freelancer,business for a
+                       small business with vendor management.
+                       ``core`` is always added regardless.
   --debug              Enable debug logging (MCP protocol traffic, timing)
   --noaudit            Disable audit logging
   -h, --help           Show this help message

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -222,23 +222,31 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
     """
     from gnucash_mcp.server import is_module_enabled
 
-    if is_module_enabled("business"):
+    # ``business_complete`` is the leaf that owns vendor + employee
+    # management. The ``business`` MODULE_GROUPS alias expands to
+    # ``freelancer + business_complete`` for the small-business
+    # persona, so ``--modules=business`` enables both naturally.
+    # Gate-check the leaf directly so a user who explicitly picked
+    # only ``business_complete`` (uncommon but valid) also gets
+    # vendor/employee functionality unlocked.
+    if is_module_enabled("business_complete"):
         return owner_type  # All three halves available; no gating.
 
     if owner_type == "vendor":
         raise ValueError(
-            "owner_type='vendor' requires the Business module. "
-            "Restart the server with --modules=...,Business to access "
+            "owner_type='vendor' requires the business module. "
+            "Restart the server with --modules=business (or add "
+            "business_complete to your current selection) to access "
             "vendor bills, or omit owner_type to operate on customer "
             "invoices only."
         )
     if owner_type == "employee":
         raise ValueError(
-            "owner_type='employee' requires the Business module. "
+            "owner_type='employee' requires the business module. "
             "Employee expense vouchers live with employee "
-            "management, which the Business module owns. Restart "
-            "the server with --modules=...,Business or omit "
-            "owner_type to operate on customer invoices only."
+            "management. Restart the server with --modules=business "
+            "(or add business_complete to your current selection) "
+            "or omit owner_type to operate on customer invoices only."
         )
     # Only None and 'customer' fall through to "customer" coercion.
     # Anything else (typos like 'venddor', unknown future types) is

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -257,6 +257,45 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
     return "customer"
 
 
+def _resolve_id_alias(
+    id: str | None,
+    legacy: str | None,
+    legacy_name: str,
+) -> str:
+    """Resolve the ``id`` / ``<entity>_id`` parameter pair on
+    delete_invoice / delete_bill / delete_voucher / delete_credit_note.
+
+    The standard parameter across the invoice tool surface
+    (get_invoice, post_invoice, unpost_invoice, pay_invoice) is
+    ``id``. The delete tools historically used ``<entity>_id``.
+    To converge without breaking older callers, both names are
+    accepted on the delete tools — but exactly one must be set.
+
+    - Both omitted → ``ValueError`` (caller forgot the ID)
+    - Both provided → ``ValueError`` (ambiguous; pick one)
+    - One provided → return it
+
+    Args:
+        id: Value passed under the preferred ``id`` parameter.
+        legacy: Value passed under the legacy ``<entity>_id``
+            parameter.
+        legacy_name: The legacy parameter name (``"invoice_id"``,
+            ``"bill_id"``, etc.) — used only in the error message.
+    """
+    if id is not None and legacy is not None:
+        raise ValueError(
+            f"Pass exactly one of 'id' or {legacy_name!r}, not both. "
+            f"'id' is the standard parameter name; {legacy_name!r} is "
+            f"a legacy alias kept for back-compat."
+        )
+    if id is None and legacy is None:
+        raise ValueError(
+            f"Missing required parameter: pass 'id' (preferred) or "
+            f"{legacy_name!r} (legacy alias)."
+        )
+    return id if id is not None else legacy  # type: ignore[return-value]
+
+
 def safe_tool(func: Callable) -> Callable:
     """Decorator that wraps tool functions with comprehensive error handling.
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1415,11 +1415,16 @@ def register(mcp, get_book) -> None:
         # handled owner_type; vendor_id needs its own check.
         if vendor_id is not None:
             from gnucash_mcp.server import is_module_enabled
-            if not is_module_enabled("business"):
+            # Check the leaf (``business_complete``) rather than the
+            # ``business`` group alias, so a user who explicitly
+            # picked the vendor-side carve-out also gets vendor_id
+            # filtering. See _gate_owner_type for the rationale.
+            if not is_module_enabled("business_complete"):
                 raise ValueError(
-                    "vendor_id filtering requires the Business module. "
-                    "Restart with --modules=...,Business to access "
-                    "vendor bills."
+                    "vendor_id filtering requires the business module. "
+                    "Restart with --modules=business (or add "
+                    "business_complete to your current selection) to "
+                    "access vendor bills."
                 )
         book = get_book()
         result = book.get_outstanding_invoices(

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1069,6 +1069,8 @@ def register(mcp, get_book) -> None:
         description: str | None = None,
         owner_type: str | None = None,
         fx_account: str | None = None,
+        apply_discount: bool = False,
+        discount_account: str | None = None,
     ) -> str:
         """Record a payment against a posted invoice or bill.
 
@@ -1087,6 +1089,19 @@ def register(mcp, get_book) -> None:
         ambiguous candidates so you can pass ``fx_account``
         explicitly next time.
 
+        For invoices with early-payment-discount terms (e.g.,
+        "2/10 Net 30" = 2% off if paid within 10 days), pass
+        ``apply_discount=True`` to settle via discount. The tool
+        validates that the invoice has discount terms, the payment
+        date is within the discount window, and the shortfall
+        matches the expected discount on pre-tax principal. Each
+        failure mode rejects with a specific error rather than
+        silently downgrading to a partial payment. ``discount_account``
+        controls routing the same way ``fx_account`` does
+        (auto-resolves to ``Expenses:Sales Discounts`` for customer
+        payments, ``Income:Purchase Discounts Taken`` for vendor
+        bill payments).
+
         Args:
             id: Invoice or bill ID (e.g., "000001").
             payment_account: Bank or cash account for payment (e.g., "Assets:Checking").
@@ -1097,6 +1112,15 @@ def register(mcp, get_book) -> None:
             fx_account: Optional INCOME or EXPENSE account to receive
                 realized FX gain/loss (cross-currency payments only).
                 Accepts a full path, %short GUID, or full 32-char GUID.
+            apply_discount: When True, treat this payment as the
+                final settlement and absorb the early-payment
+                discount from the invoice's billterm. Default False
+                — explicit opt-in. Hard-rejects on credit notes
+                (refunds don't take discounts).
+            discount_account: Optional INCOME or EXPENSE account to
+                receive the discount split. Auto-resolves when
+                omitted. Accepts full path, %short GUID, or full
+                32-char GUID.
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -1108,6 +1132,8 @@ def register(mcp, get_book) -> None:
             description=description,
             owner_type=owner_type,
             fx_account=fx_account,
+            apply_discount=apply_discount,
+            discount_account=discount_account,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -6,7 +6,7 @@ Registered only when the 'business' module is enabled via --modules.
 import json
 
 from gnucash_mcp.logging_config import audit_log
-from gnucash_mcp.tools._helpers import _gate_owner_type, _json, safe_tool
+from gnucash_mcp.tools._helpers import _gate_owner_type, _json, _resolve_id_alias, safe_tool
 
 
 def register(mcp, get_book) -> None:
@@ -712,7 +712,10 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="voucher")
-    def delete_voucher(voucher_id: str) -> str:
+    def delete_voucher(
+        id: str | None = None,
+        voucher_id: str | None = None,
+    ) -> str:
         """Delete an unposted employee expense voucher.
 
         Automatically removes associated entries. Posted vouchers
@@ -720,10 +723,15 @@ def register(mcp, get_book) -> None:
         then delete.
 
         Args:
-            voucher_id: Voucher ID (e.g., "000001").
+            id: Voucher ID (e.g., "000001"). Preferred parameter
+                name — matches get_invoice / post_invoice / etc.
+            voucher_id: Legacy alias for ``id``. Accepted for
+                back-compat; pass exactly one of ``id`` or
+                ``voucher_id``.
         """
+        resolved_id = _resolve_id_alias(id, voucher_id, "voucher_id")
         book = get_book()
-        result = book.delete_voucher(voucher_id=voucher_id)
+        result = book.delete_voucher(voucher_id=resolved_id)
         return _json(result)
 
     @mcp.tool()
@@ -894,7 +902,8 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="credit_note")
     def delete_credit_note(
-        credit_note_id: str,
+        id: str | None = None,
+        credit_note_id: str | None = None,
         owner_type: str | None = None,
     ) -> str:
         """Delete an unposted credit note.
@@ -904,14 +913,19 @@ def register(mcp, get_book) -> None:
         ``unpost_invoice``, then delete.
 
         Args:
-            credit_note_id: Credit note ID.
+            id: Credit note ID. Preferred parameter name — matches
+                get_invoice / post_invoice / etc.
+            credit_note_id: Legacy alias for ``id``. Accepted for
+                back-compat; pass exactly one of ``id`` or
+                ``credit_note_id``.
             owner_type: Optional "customer" or "vendor"
                 disambiguator for ID collisions.
         """
+        resolved_id = _resolve_id_alias(id, credit_note_id, "credit_note_id")
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.delete_credit_note(
-            credit_note_id=credit_note_id,
+            credit_note_id=resolved_id,
             owner_type=owner_type,
         )
         return _json(result)
@@ -1100,33 +1114,51 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="invoice")
-    def delete_invoice(invoice_id: str) -> str:
+    def delete_invoice(
+        id: str | None = None,
+        invoice_id: str | None = None,
+    ) -> str:
         """Delete an unposted customer invoice.
 
         Automatically removes associated entries (line items). Posted invoices
         cannot be deleted — void them or issue a credit note instead.
 
         Args:
-            invoice_id: Invoice ID (e.g., "000001" or "INV-2026-001").
+            id: Invoice ID (e.g., "000001" or "INV-2026-001").
+                Preferred parameter name — matches get_invoice /
+                post_invoice / etc.
+            invoice_id: Legacy alias for ``id``. Accepted for
+                back-compat; pass exactly one of ``id`` or
+                ``invoice_id``.
         """
+        resolved_id = _resolve_id_alias(id, invoice_id, "invoice_id")
         book = get_book()
-        result = book.delete_invoice(invoice_id=invoice_id)
+        result = book.delete_invoice(invoice_id=resolved_id)
         return _json(result)
 
     @mcp.tool()
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="bill")
-    def delete_bill(bill_id: str) -> str:
+    def delete_bill(
+        id: str | None = None,
+        bill_id: str | None = None,
+    ) -> str:
         """Delete an unposted vendor bill.
 
         Automatically removes associated entries (line items). Posted bills
         cannot be deleted — void them or issue a credit note instead.
 
         Args:
-            bill_id: Bill ID (e.g., "000001" or "BILL-2026-001").
+            id: Bill ID (e.g., "000001" or "BILL-2026-001").
+                Preferred parameter name — matches get_invoice /
+                post_invoice / etc.
+            bill_id: Legacy alias for ``id``. Accepted for
+                back-compat; pass exactly one of ``id`` or
+                ``bill_id``.
         """
+        resolved_id = _resolve_id_alias(id, bill_id, "bill_id")
         book = get_book()
-        result = book.delete_bill(bill_id=bill_id)
+        result = book.delete_bill(bill_id=resolved_id)
         return _json(result)
 
     @mcp.tool()

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -123,6 +123,21 @@ def register(mcp, get_book) -> None:
                 default=None,
             ),
         ] = None,
+        except_guids: Annotated[
+            list[str] | None,
+            Field(
+                description=(
+                    "Optional list of split GUID prefixes to "
+                    "exclude from the bulk reconcile. Useful for "
+                    "\"everything on the statement except this "
+                    "pending ACH\" — 2 tokens vs the 100+ a "
+                    "full split_guids listing would cost. Only "
+                    "valid with reconcile_all=true; prefixes "
+                    "that don't resolve are silently ignored."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> str:
         """Reconcile splits against a statement balance.
 
@@ -159,6 +174,7 @@ def register(mcp, get_book) -> None:
             split_guids=split_guids,
             reconcile_all=reconcile_all,
             through_date=through,
+            except_guids=except_guids,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -89,7 +89,16 @@ def register(mcp, get_book) -> None:
                 explicit date for historical snapshots.
         """
         book = get_book()
-        d = date.fromisoformat(as_of_date) if as_of_date else date.today()
+        # Distinguish "not provided" (None → today) from "provided
+        # but empty/garbage" (raise). Pre-fix, an empty-string
+        # ``as_of_date=""`` silently fell back to today — a caller
+        # bug that produced silently wrong-dated reports. Copilot
+        # PR #92 review caught this; the strict-kwargs pattern
+        # extends to the value, not just the parameter name.
+        if as_of_date is None:
+            d = date.today()
+        else:
+            d = date.fromisoformat(as_of_date)
         result = book.balance_sheet(as_of_date=d)
         return _json(result)
 

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -74,16 +74,23 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def balance_sheet(as_of_date: str) -> str:
+    def balance_sheet(as_of_date: str | None = None) -> str:
         """Generate a balance sheet as of a specific date.
 
         Shows assets, liabilities, and equity with account breakdowns.
+        A = L + E holds by construction; non-zero unrealized P&L
+        appears as a synthetic equity row.
 
         Args:
-            as_of_date: Date to calculate balances as of (YYYY-MM-DD)
+            as_of_date: Date in ISO format (YYYY-MM-DD). Defaults to
+                today — matching ``get_book_summary``'s implicit
+                cutoff so cross-tool comparisons agree without
+                threading the same date into both calls. Pass an
+                explicit date for historical snapshots.
         """
         book = get_book()
-        result = book.balance_sheet(as_of_date=date.fromisoformat(as_of_date))
+        d = date.fromisoformat(as_of_date) if as_of_date else date.today()
+        result = book.balance_sheet(as_of_date=d)
         return _json(result)
 
     @mcp.tool()

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7416,6 +7416,88 @@ class TestReconcileAccount:
         )
         assert len(unreconciled["splits"]) >= 1
 
+    def test_except_guids_requires_reconcile_all(self, test_book: Path):
+        """``except_guids`` only makes sense with bulk mode — in
+        targeted mode the caller already controls which splits
+        get reconciled."""
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="only valid with reconcile_all"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 31),
+                statement_balance="0",
+                split_guids=["deadbeef00000000"],
+                except_guids=["cafef00d00000000"],
+            )
+
+    def test_except_guids_skips_listed_splits(self, test_book: Path):
+        """The common case: reconcile everything except one
+        pending split. Bookkeeper's example was a CareCredit
+        payoff with one ACH still in flight — list it in
+        except_guids and the statement balance ties cleanly."""
+        gc_book = GnuCashBook(str(test_book))
+
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        assert len(unreconciled["splits"]) >= 2, (
+            "Test setup: need at least 2 unreconciled splits."
+        )
+        # Pick one to exclude — use its short prefix to also
+        # exercise the prefix-resolution path.
+        excluded = unreconciled["splits"][0]
+        excluded_guid = excluded["guid"]
+        excluded_amt = Decimal(excluded["amount"])
+        # Statement balance = sum of everything except the excluded.
+        remaining_total = sum(
+            (
+                Decimal(s["amount"])
+                for s in unreconciled["splits"]
+                if s["guid"] != excluded_guid
+            ),
+            Decimal("0"),
+        )
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(remaining_total),
+            reconcile_all=True,
+            except_guids=[excluded_guid[:8]],
+        )
+        assert result["status"] == "reconciled"
+        assert result["splits_reconciled"] == (
+            len(unreconciled["splits"]) - 1
+        )
+        # The excluded split is still unreconciled.
+        after = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        remaining_guids = {s["guid"] for s in after["splits"]}
+        assert excluded_guid in remaining_guids
+
+    def test_except_guids_unknown_prefix_ignored(self, test_book: Path):
+        """A prefix that doesn't resolve to any split is silently
+        dropped — the goal is \"exclude these if present\", and
+        a non-matching prefix has no effect on the set."""
+        gc_book = GnuCashBook(str(test_book))
+        unreconciled = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        total = sum(
+            (Decimal(s["amount"]) for s in unreconciled["splits"]),
+            Decimal("0"),
+        )
+        # Bogus prefix — well-formed hex but doesn't exist.
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(total),
+            reconcile_all=True,
+            except_guids=["deadbeef" * 4],
+        )
+        # All splits reconciled despite the bogus exclusion.
+        assert result["splits_reconciled"] == len(unreconciled["splits"])
+
 
 class TestVoidTransaction:
     """Tests for void_transaction method."""

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -153,10 +153,26 @@ class TestGetBookSummary:
         assert "Currency: USD" in result
 
     def test_get_book_summary_book_path(self, test_book: Path):
-        """Should include the book file path."""
+        """Should include the book filename only, no directory leak.
+
+        Privacy hardening shipped in v1.3.0: the "Book:" line used
+        to expose the full absolute path on every orientation call,
+        leaking the user's filesystem layout into every transcript.
+        Filename alone is enough for the LLM to confirm which book
+        is loaded — see ``_book_display_name``.
+        """
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.get_book_summary()
-        assert f"Book: {test_book}" in result
+        # First line should be ``Book: <filename>``.
+        first_line = result.split("\n", 1)[0]
+        assert first_line == f"Book: {test_book.name}", (
+            f"unexpected Book line: {first_line!r}"
+        )
+        # And the directory components must NOT appear anywhere.
+        parent_path = str(test_book.parent)
+        assert parent_path not in result, (
+            f"directory leaked into summary: {parent_path!r}"
+        )
 
     def test_data_range_uses_transaction_dates_not_prices(
         self, test_book: Path,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8378,6 +8378,135 @@ class TestMultiCurrencyBalances:
         assert len(result["sources"]) == 1
         assert result["sources"][0]["account"] == "Income:Salary"
 
+    def test_spending_by_category_converts_foreign_currency(
+        self, multi_currency_book: Path,
+    ):
+        """Bookkeeper-found bug (v1.3 blocker): EUR-denominated
+        expense splits used to be summed as raw EUR alongside USD
+        — silent wrong totals on multi-currency books. With the
+        ``_split_in_default_currency`` conversion in place, the
+        EUR amount converts at the book's EUR/USD price."""
+        import piecash
+        gc_book = GnuCashBook(str(multi_currency_book))
+        # Build a EUR-denominated expense account and one EUR
+        # expense transaction, plus a EUR/USD price the converter
+        # can use.
+        with gc_book.open(readonly=False) as bk:
+            eur = next(
+                c for c in bk.commodities if c.mnemonic == "EUR"
+            )
+            usd = bk.default_currency
+            expenses = next(
+                a for a in bk.accounts
+                if a.fullname == "Expenses"
+            )
+            travel_eur = piecash.Account(
+                name="Travel EUR", type="EXPENSE",
+                parent=expenses, commodity=eur,
+            )
+            bk.session.add(travel_eur)
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date(2024, 6, 1),
+                value="1.10", type="last",
+            ))
+            checking = next(
+                a for a in bk.accounts
+                if a.fullname == "Assets:Checking"
+            )
+            bk.session.add(piecash.Transaction(
+                currency=eur,
+                description="Berlin trip — €100",
+                post_date=date(2024, 6, 15),
+                splits=[
+                    piecash.Split(
+                        account=travel_eur,
+                        value="100", quantity="100",
+                    ),
+                    piecash.Split(
+                        account=checking,
+                        value="-100", quantity="-110",
+                    ),
+                ],
+            ))
+            bk.save()
+        # Existing USD groceries: $200. New EUR travel: €100 ×
+        # 1.10 = $110. Total in default currency: $310.
+        result = gc_book.spending_by_category(
+            compact=False,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            depth=2,
+        )
+        assert Decimal(result["total"]) == Decimal("310")
+        amounts = {
+            r["account"]: Decimal(r["amount"])
+            for r in result["categories"]
+        }
+        assert amounts["Expenses:Groceries"] == Decimal("200")
+        assert amounts["Expenses:Travel EUR"] == Decimal("110")
+
+    def test_income_by_source_converts_foreign_currency(
+        self, multi_currency_book: Path,
+    ):
+        """Mirror of the spending fix on the income side."""
+        import piecash
+        gc_book = GnuCashBook(str(multi_currency_book))
+        with gc_book.open(readonly=False) as bk:
+            eur = next(
+                c for c in bk.commodities if c.mnemonic == "EUR"
+            )
+            usd = bk.default_currency
+            income = next(
+                a for a in bk.accounts
+                if a.fullname == "Income"
+            )
+            consulting_eur = piecash.Account(
+                name="Consulting EUR", type="INCOME",
+                parent=income, commodity=eur,
+            )
+            bk.session.add(consulting_eur)
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date(2024, 6, 1),
+                value="1.10", type="last",
+            ))
+            checking = next(
+                a for a in bk.accounts
+                if a.fullname == "Assets:Checking"
+            )
+            bk.session.add(piecash.Transaction(
+                currency=eur,
+                description="Berlin client — €500",
+                post_date=date(2024, 7, 1),
+                splits=[
+                    piecash.Split(
+                        account=consulting_eur,
+                        value="-500", quantity="-500",
+                    ),
+                    piecash.Split(
+                        account=checking,
+                        value="500", quantity="550",
+                    ),
+                ],
+            ))
+            bk.save()
+        # Existing USD salary: $3000. New EUR consulting: €500 ×
+        # 1.10 = $550. Total in default currency: $3550.
+        result = gc_book.income_by_source(
+            compact=False,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            depth=2,
+        )
+        assert Decimal(result["total"]) == Decimal("3550")
+        amounts = {
+            r["account"]: Decimal(r["amount"])
+            for r in result["sources"]
+        }
+        assert amounts["Income:Salary"] == Decimal("3000")
+        assert amounts["Income:Consulting EUR"] == Decimal("550")
+
 
 class TestCreateCommodity:
     """Tests for create_commodity method."""

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -9038,26 +9038,79 @@ class TestMultiCurrencyDashboardHelpers:
         self, multi_currency_book: Path,
     ):
         """Each bill's grand_total is in the BILL's currency. Pre-
-        fix, EUR bills and USD bills were summed without conversion,
-        producing meaningless grand totals."""
-        # multi_currency_book has no posted bills; use Alex's book
-        # as the integration anchor.
-        # Direct unit test: just verify the conversion is applied.
-        # If Alex's book had EUR vendors, their billed totals would
-        # be USD-equivalent post-fix. For now, lock the contract:
-        # vendor_spending_report invokes _rates_as_of (the lookup
-        # path that any FX-converted bill would route through).
-        import inspect
-        from gnucash_mcp.book import business
-        src = inspect.getsource(business.BusinessMixin.vendor_spending_report)
-        assert "_rates_as_of" in src or "rate" in src.lower(), (
-            "vendor_spending_report no longer references FX rate "
-            "lookup; the multi-currency fix may have regressed"
+        fix, EUR bills and USD bills were summed raw alongside USD
+        bills, producing meaningless grand totals. Post-fix, each
+        bill's total converts to default currency at the latest
+        market rate before summing.
+
+        Copilot PR #92 review caught that the original version of
+        this test used ``inspect.getsource`` to look for the
+        helper references — brittle against renames/refactors,
+        and didn't catch regressions where the function still
+        contained the string but applied conversion incorrectly.
+        Replaced with an end-to-end test that posts a EUR vendor
+        bill, runs the report, and asserts on the USD-converted
+        grand totals.
+        """
+        import piecash
+        gc_book = GnuCashBook(str(multi_currency_book))
+        # Build a EUR vendor, an A/P account, a EUR-denominated
+        # posted bill, and a EUR/USD price. After posting we run
+        # vendor_spending_report and assert the totals come back
+        # in USD (the book default), not raw EUR.
+        with gc_book.open(readonly=False) as bk:
+            eur = next(c for c in bk.commodities if c.mnemonic == "EUR")
+            usd = bk.default_currency
+            assets = next(a for a in bk.accounts if a.fullname == "Assets")
+            liabilities = piecash.Account(
+                name="Liabilities", type="LIABILITY", parent=bk.root_account,
+                commodity=usd, placeholder=True,
+            )
+            ap = piecash.Account(
+                name="Accounts Payable", type="PAYABLE",
+                parent=liabilities, commodity=usd,
+            )
+            expenses = next(a for a in bk.accounts if a.fullname == "Expenses")
+            office_eur = piecash.Account(
+                name="Office Supplies EUR", type="EXPENSE",
+                parent=expenses, commodity=eur,
+            )
+            bk.session.add_all([liabilities, ap, office_eur])
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date(2024, 6, 1),
+                value="1.10", type="last",
+            ))
+            bk.save()
+        # Create the vendor + EUR bill via the public API.
+        gc_book.create_vendor(name="Berlin Supplies", currency="EUR")
+        gc_book.create_bill(vendor_id="000001", currency="EUR")
+        gc_book.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies EUR",
+            description="EUR supplies",
+            quantity="1", price="500.00",
         )
-        assert "default_currency" in src, (
-            "vendor_spending_report no longer references default "
-            "currency; the multi-currency fix may have regressed"
+        gc_book.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date="2024-06-15",
         )
+        # Run the report; verify totals come back as USD-converted.
+        result = gc_book.vendor_spending_report(
+            start_date="2024-01-01", end_date="2024-12-31",
+            compact=False,
+        )
+        # €500 × 1.10 = $550. Pre-fix the report would have summed
+        # 500 raw — wrong unit.
+        assert Decimal(result["totals"]["total_billed"]) == Decimal("550.00")
+        assert Decimal(result["totals"]["outstanding"]) == Decimal("550.00")
+        # Per-vendor row also in USD.
+        berlin = next(
+            v for v in result["vendors"] if v["vendor_name"] == "Berlin Supplies"
+        )
+        assert Decimal(berlin["total_billed"]) == Decimal("550.00")
 
 
 class TestCreateCommodity:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7807,6 +7807,159 @@ class TestBalanceSheetNumericContract:
             )
 
 
+class TestBalanceSheetEquationCloses:
+    """Pre-v1.3.0, ``balance_sheet`` could fail the fundamental
+    accounting identity A = L + E for two unrelated reasons:
+
+    1. ``_ASSET_TYPES`` / ``_LIABILITY_TYPES`` excluded RECEIVABLE
+       and PAYABLE — outstanding invoices issued to customers were
+       invisible in the totals.
+    2. Assets render at market value (factor × quantity for
+       commodities and foreign-currency cash) while equity rolls
+       up at historical-cost split values. The gap between the
+       two views (investment market drift + FX translation
+       adjustment) had no home on the equity side.
+
+    Both fixes land together: A/R / A/P join the right buckets,
+    and a synthetic "Unrealized Gain/Loss" equity line absorbs the
+    remaining mark-to-market gap. After v1.3.0, A = L + E holds by
+    construction on every book.
+    """
+
+    def test_equation_closes_on_simple_usd_book(self, test_book: Path):
+        from decimal import Decimal
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        A = Decimal(result["assets"]["total"])
+        L = Decimal(result["liabilities"]["total"])
+        E = Decimal(result["equity"]["total"])
+        # Strict equality — no rounding slop.
+        assert A - L - E == 0, f"A={A} L={L} E={E}, gap={A - L - E}"
+
+    def test_equation_closes_on_multi_currency_book(
+        self, multi_currency_book: Path,
+    ):
+        from decimal import Decimal
+        gc_book = GnuCashBook(str(multi_currency_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        A = Decimal(result["assets"]["total"])
+        L = Decimal(result["liabilities"]["total"])
+        E = Decimal(result["equity"]["total"])
+        # Cross-currency transfer ($1100 USD → €1000 EUR) puts the
+        # current EUR balance at a different USD value than the
+        # historical post-time rate. The synthetic equity line
+        # absorbs that translation adjustment.
+        assert A - L - E == 0, f"A={A} L={L} E={E}, gap={A - L - E}"
+
+    def test_unrealized_line_present_when_book_has_market_drift(
+        self, multi_currency_book: Path,
+    ):
+        from decimal import Decimal
+        gc_book = GnuCashBook(str(multi_currency_book))
+        # Lock a EUR price that differs from the historical post-time
+        # rate so unrealized != 0.
+        with gc_book.open(readonly=False) as book:
+            eur = next(c for c in book.commodities if c.mnemonic == "EUR")
+            piecash.Price(
+                commodity=eur,
+                currency=book.default_currency,
+                date=date(2024, 12, 31),
+                value=Decimal("1.20"),  # vs. historical 1.10
+                type="last",
+                source="user:price",
+            )
+            book.save()
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        eq_names = [a["account"] for a in result["equity"]["accounts"]]
+        assert "Unrealized Gain/Loss" in eq_names, (
+            f"missing synthetic line on book with FX drift: "
+            f"equity accounts = {eq_names}"
+        )
+
+    def test_unrealized_line_omitted_when_no_drift(
+        self, test_book: Path,
+    ):
+        # Single-currency USD test book with no investments — market
+        # == cost trivially, so the synthetic line should be absent.
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        eq_names = [a["account"] for a in result["equity"]["accounts"]]
+        assert "Unrealized Gain/Loss" not in eq_names, (
+            f"synthetic line present despite no drift: "
+            f"equity accounts = {eq_names}"
+        )
+
+
+class TestBalanceSheetIncludesReceivablePayable:
+    """RECEIVABLE and PAYABLE join the asset / liability buckets in
+    v1.3.0 so balance_sheet reflects outstanding business activity.
+    Pre-fix, every posted invoice was invisible on the balance
+    sheet by the amount of the receivable.
+    """
+
+    def _setup_book_with_invoice(self, tmp_path: Path) -> Path:
+        from decimal import Decimal
+        book_path = tmp_path / "ar.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="USD", overwrite=True,
+        )
+        root = book.root_account
+        usd = book.default_currency
+        assets = piecash.Account(
+            name="Assets", type="ASSET", parent=root, commodity=usd,
+            placeholder=True,
+        )
+        ar = piecash.Account(
+            name="Accounts Receivable", type="RECEIVABLE",
+            parent=assets, commodity=usd,
+        )
+        income = piecash.Account(
+            name="Consulting", type="INCOME", parent=root, commodity=usd,
+        )
+        equity_p = piecash.Account(
+            name="Equity", type="EQUITY", parent=root, commodity=usd,
+            placeholder=True,
+        )
+        opening = piecash.Account(
+            name="Opening", type="EQUITY", parent=equity_p, commodity=usd,
+        )
+        book.save()
+        # Single posted-invoice transaction: $1500 to A/R, $1500
+        # revenue. Both sides default currency, so nothing exotic.
+        t = piecash.Transaction(
+            currency=usd,
+            description="Posted invoice",
+            post_date=date(2024, 6, 1),
+            splits=[
+                piecash.Split(account=ar, value=Decimal("1500")),
+                piecash.Split(account=income, value=Decimal("-1500")),
+            ],
+        )
+        book.session.add(t)
+        book.save()
+        return book_path
+
+    def test_receivable_appears_in_assets(self, tmp_path: Path):
+        path = self._setup_book_with_invoice(tmp_path)
+        gc_book = GnuCashBook(str(path))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        asset_names = [a["account"] for a in result["assets"]["accounts"]]
+        assert any("Receivable" in n for n in asset_names), (
+            f"A/R missing from assets section: {asset_names}"
+        )
+
+    def test_receivable_book_balances(self, tmp_path: Path):
+        from decimal import Decimal
+        path = self._setup_book_with_invoice(tmp_path)
+        gc_book = GnuCashBook(str(path))
+        result = gc_book.balance_sheet(as_of_date=date(2024, 12, 31))
+        A = Decimal(result["assets"]["total"])
+        L = Decimal(result["liabilities"]["total"])
+        E = Decimal(result["equity"]["total"])
+        assert A == Decimal("1500.00")
+        assert A - L - E == 0
+
+
 class TestCrossToolPriceAgreement:
     """Bookkeeper-flagged: ``get_book_summary`` was using stale prices
     (latest <= today) while ``balance_sheet`` used the absolute latest

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -2967,6 +2967,121 @@ class TestGetBookSummaryReconciliationSplitCount:
         assert "⚠" in recon_line
 
 
+class TestGetBookSummaryBusinessSignals:
+    """Bookkeeper-asked-for additions to the summary (v1.3 blocker):
+
+      - Receivables / Payables lines append ``(N invoice(s), M
+        overdue)`` — actionable signal beyond the "USD 13,500" total.
+      - ``Jobs: N active`` line emitted conditionally when the
+        feature is in use; absent when no jobs exist.
+    """
+
+    def _setup_overdue_invoice(self, gb):
+        """Create + post one invoice dated 60 days ago with a
+        30-day term, so it lands as overdue today."""
+        from datetime import date as _date, timedelta
+        gb.create_customer(name="Acme Corp")
+        gb.create_billterm(name="Net 30", due_days=30)
+        opened = _date.today() - timedelta(days=60)
+        gb.create_invoice(
+            customer_id="000001",
+            date_opened=opened.isoformat(),
+            term="Net 30",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Widget",
+            quantity="1",
+            price="500",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date=opened.isoformat(),
+        )
+
+    def _setup_current_bill(self, gb):
+        """Create + post one bill dated today (not overdue)."""
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+
+    def test_receivables_signal_shows_overdue(
+        self, business_book: Path,
+    ):
+        gc = GnuCashBook(str(business_book))
+        self._setup_overdue_invoice(gc)
+        result = gc.get_book_summary()
+        recv = next(
+            ln for ln in result.splitlines()
+            if ln.startswith("Receivables:")
+        )
+        assert "1 invoice" in recv
+        assert "1 overdue" in recv
+
+    def test_payables_signal_shows_open_count(
+        self, business_book: Path,
+    ):
+        gc = GnuCashBook(str(business_book))
+        self._setup_current_bill(gc)
+        result = gc.get_book_summary()
+        pay = next(
+            ln for ln in result.splitlines()
+            if ln.startswith("Payables:")
+        )
+        assert "1 bill" in pay
+        assert "0 overdue" in pay
+
+    def test_jobs_line_present_when_active(
+        self, business_book: Path,
+    ):
+        gc = GnuCashBook(str(business_book))
+        gc.create_customer(name="Acme")
+        gc.create_job(
+            owner_id="000001",
+            owner_type="customer",
+            name="API Rewrite",
+        )
+        result = gc.get_book_summary()
+        # One active job — exact "1 active" since "1" pluralizes
+        # to nothing extra in the rendered line.
+        assert "Jobs: 1 active" in result
+
+    def test_jobs_line_absent_when_none(
+        self, business_book: Path,
+    ):
+        """No jobs created — the line is omitted entirely.
+        Absence is the signal (per bookkeeper: 'Jobs existing
+        doesn't need attention')."""
+        gc = GnuCashBook(str(business_book))
+        result = gc.get_book_summary()
+        assert "Jobs:" not in result
+
+    def test_no_business_no_signals(self, test_book: Path):
+        """A non-business book (no posted invoices) still produces
+        a clean summary — no spurious '0 invoices' phrase, no
+        Jobs line. The signals only appear when there's something
+        to act on."""
+        gc = GnuCashBook(str(test_book))
+        result = gc.get_book_summary()
+        # No invoice/bill activity → no signal phrases.
+        assert "0 invoices" not in result
+        assert "0 bills" not in result
+        assert "Jobs:" not in result
+
+
 class TestMissingDefaultCurrency:
     """Tests for books with no default currency."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8858,6 +8858,192 @@ class TestMultiCurrencyBalances:
         assert amounts["Income:Consulting EUR"] == Decimal("550")
 
 
+class TestMultiCurrencyDashboardHelpers:
+    """v1.3.0 follow-up to the spending/income FX-conversion fix:
+    three dashboard helpers (``_monthly_net_income``,
+    ``_daily_expense_burn``, ``_budget_headline``) and one report
+    (``vendor_spending_report``) were summing ``split.value`` /
+    ``split.quantity`` raw across currencies. Same class of bug —
+    silently wrong on any book with foreign-currency activity.
+
+    The helpers feed get_book_summary's monthly-net section, runway
+    calculation, and budget headline; vendor_spending_report is a
+    standalone tool the bookkeeper uses. After v1.3.0 each routes
+    through ``_split_in_default_currency`` / latest-rate conversion
+    so foreign-currency activity contributes the default-currency-
+    equivalent amount, not raw foreign-currency quantities.
+    """
+
+    def _add_eur_consulting_income(
+        self,
+        book_path: Path,
+        amount_eur: str,
+        on_date: date,
+        rate: str = "1.10",
+    ) -> None:
+        """Seed a EUR income transaction + EUR/USD rate."""
+        import piecash
+        gc_book = GnuCashBook(str(book_path))
+        with gc_book.open(readonly=False) as bk:
+            eur = next(c for c in bk.commodities if c.mnemonic == "EUR")
+            usd = bk.default_currency
+            income = next(a for a in bk.accounts if a.fullname == "Income")
+            consulting_eur = next(
+                (a for a in bk.accounts if a.fullname == "Income:Consulting EUR"),
+                None,
+            )
+            if consulting_eur is None:
+                consulting_eur = piecash.Account(
+                    name="Consulting EUR", type="INCOME",
+                    parent=income, commodity=eur,
+                )
+                bk.session.add(consulting_eur)
+            ar_eur = next(
+                (a for a in bk.accounts if a.fullname == "Assets:A/R EUR"),
+                None,
+            )
+            if ar_eur is None:
+                assets = next(a for a in bk.accounts if a.fullname == "Assets")
+                ar_eur = piecash.Account(
+                    name="A/R EUR", type="ASSET",
+                    parent=assets, commodity=eur,
+                )
+                bk.session.add(ar_eur)
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=on_date, value=rate, type="last",
+            ))
+            bk.session.add(piecash.Transaction(
+                currency=eur,
+                description=f"EUR consulting €{amount_eur}",
+                post_date=on_date,
+                splits=[
+                    piecash.Split(
+                        account=consulting_eur,
+                        value=f"-{amount_eur}", quantity=f"-{amount_eur}",
+                    ),
+                    piecash.Split(
+                        account=ar_eur,
+                        value=amount_eur, quantity=amount_eur,
+                    ),
+                ],
+            ))
+            bk.save()
+
+    def test_monthly_net_converts_foreign_currency_income(
+        self, multi_currency_book: Path,
+    ):
+        """Pre-fix, a EUR income split for €1,000 contributed
+        Decimal('1000') to that month's net — mixing units. Post-
+        fix, it contributes €1,000 × EUR/USD rate."""
+        today = date.today()
+        first_of_month = date(today.year, today.month, 1)
+        # Seed €1,000 of EUR consulting income this month.
+        self._add_eur_consulting_income(
+            multi_currency_book,
+            amount_eur="1000",
+            on_date=first_of_month,
+            rate="1.20",
+        )
+        gc_book = GnuCashBook(str(multi_currency_book))
+        summary = gc_book.get_book_summary()
+        # Find the current-month "(MTD)" line and parse the net.
+        mtd_line = next(
+            (l for l in summary.split("\n") if "(MTD)" in l),
+            None,
+        )
+        assert mtd_line is not None, (
+            f"no MTD line in summary:\n{summary}"
+        )
+        # Net = EUR income €1,000 × 1.20 = $1,200 (in USD).
+        # Pre-fix this would have rendered as +1,000 (raw EUR).
+        assert "+1,200" in mtd_line, (
+            f"expected +1,200 in MTD line, got: {mtd_line!r}"
+        )
+
+    def test_daily_expense_burn_converts_foreign_currency_expense(
+        self, multi_currency_book: Path,
+    ):
+        """Runway's daily-burn divisor must reflect foreign-currency
+        expenses at their USD value, not raw foreign quantity."""
+        import piecash
+        gc_book = GnuCashBook(str(multi_currency_book))
+        today = date.today()
+        with gc_book.open(readonly=False) as bk:
+            eur = next(c for c in bk.commodities if c.mnemonic == "EUR")
+            usd = bk.default_currency
+            expenses = next(a for a in bk.accounts if a.fullname == "Expenses")
+            travel_eur = piecash.Account(
+                name="Travel EUR", type="EXPENSE",
+                parent=expenses, commodity=eur,
+            )
+            bk.session.add(travel_eur)
+            checking = next(
+                a for a in bk.accounts if a.fullname == "Assets:Checking"
+            )
+            bk.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=today, value="1.50", type="last",
+            ))
+            # €200 expense today.
+            bk.session.add(piecash.Transaction(
+                currency=eur,
+                description="Berlin trip",
+                post_date=today,
+                splits=[
+                    piecash.Split(
+                        account=travel_eur,
+                        value="200", quantity="200",
+                    ),
+                    piecash.Split(
+                        account=checking,
+                        value="-200", quantity="-300",
+                    ),
+                ],
+            ))
+            bk.save()
+            # _daily_expense_burn is an instance method requiring a
+            # book session — call it within an open block.
+            transactions = list(bk.transactions)
+            from datetime import timedelta
+            burn = gc_book._daily_expense_burn(
+                bk, transactions, days=30,
+            )
+            # €200 × 1.50 = $300 of expense in default currency.
+            # Without conversion it'd have been raw 200. Allow
+            # other USD expenses in the fixture to contribute too;
+            # what matters is the EUR side converts.
+            from decimal import Decimal as Dec
+            assert burn >= Dec("300") / Dec("30"), (
+                f"burn too low — EUR expense not converted: {burn}"
+            )
+
+    def test_vendor_spending_converts_foreign_currency_bills(
+        self, multi_currency_book: Path,
+    ):
+        """Each bill's grand_total is in the BILL's currency. Pre-
+        fix, EUR bills and USD bills were summed without conversion,
+        producing meaningless grand totals."""
+        # multi_currency_book has no posted bills; use Alex's book
+        # as the integration anchor.
+        # Direct unit test: just verify the conversion is applied.
+        # If Alex's book had EUR vendors, their billed totals would
+        # be USD-equivalent post-fix. For now, lock the contract:
+        # vendor_spending_report invokes _rates_as_of (the lookup
+        # path that any FX-converted bill would route through).
+        import inspect
+        from gnucash_mcp.book import business
+        src = inspect.getsource(business.BusinessMixin.vendor_spending_report)
+        assert "_rates_as_of" in src or "rate" in src.lower(), (
+            "vendor_spending_report no longer references FX rate "
+            "lookup; the multi-currency fix may have regressed"
+        )
+        assert "default_currency" in src, (
+            "vendor_spending_report no longer references default "
+            "currency; the multi-currency fix may have regressed"
+        )
+
+
 class TestCreateCommodity:
     """Tests for create_commodity method."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1,6 +1,7 @@
 """Tests for business tools: customers, vendors, billterms, invoices, bills."""
 
 import json
+from datetime import date, timedelta
 from decimal import Decimal
 import pytest
 from gnucash_mcp.book import GnuCashBook
@@ -8410,6 +8411,333 @@ class TestPayInvoice:
                 payment_date="2026-03-20",
                 fx_account="Income:Typo Account That Does Not Exist",
             )
+
+
+# ============== Early-payment discount ==============
+
+
+class TestPayInvoiceEarlyPaymentDiscount:
+    """Verify ``pay_invoice`` honors the discount fields on
+    billterms — discount_days, discount_percent. Pre-v1.3.0
+    these fields were stored at billterm creation but ignored
+    at payment time (silent feature lie).
+
+    Validation chain rejects every failure mode loudly. Customer
+    and vendor sides both supported. Cross-currency interaction
+    composes cleanly with the existing FX gain/loss logic.
+    """
+
+    def _setup_invoice_with_terms(
+        self,
+        gb: GnuCashBook,
+        amount: str = "1000.00",
+        discount_days: int = 10,
+        discount_percent: str = "2",
+        invoice_date: date | None = None,
+    ) -> str:
+        """Create customer + billterm + posted invoice with terms."""
+        gb.create_customer(name="Acme Corp")
+        gb.create_billterm(
+            name="2/10 Net 30",
+            due_days=30,
+            discount_days=discount_days,
+            discount_percent=discount_percent,
+        )
+        gb.create_invoice(
+            customer_id="000001",
+            term="2/10 Net 30",
+            date_opened=invoice_date.isoformat() if invoice_date else None,
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date=invoice_date.isoformat() if invoice_date else None,
+        )
+        return "000001"
+
+    def _setup_bill_with_terms(
+        self,
+        gb: GnuCashBook,
+        amount: str = "1000.00",
+        discount_days: int = 10,
+        discount_percent: str = "2",
+        bill_date: date | None = None,
+    ) -> str:
+        gb.create_vendor(name="Supplier Co")
+        gb.create_billterm(
+            name="2/10 Net 30",
+            due_days=30,
+            discount_days=discount_days,
+            discount_percent=discount_percent,
+        )
+        gb.create_bill(
+            vendor_id="000001",
+            term="2/10 Net 30",
+            date_opened=bill_date.isoformat() if bill_date else None,
+        )
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+            post_date=bill_date.isoformat() if bill_date else None,
+        )
+        return "000001"
+
+    # ── Happy paths ───────────────────────────────────────────
+
+    def test_customer_invoice_within_window_full_discount(
+        self, business_book,
+    ):
+        """Customer pays $980 of $1000 on day 5 within 2/10 window
+        → A/R clears full $1000, $20 books to Expenses:Sales Discounts.
+        """
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="980",
+            payment_date="2026-05-06",  # day 5 within window
+            apply_discount=True,
+        )
+        assert result["status"] == "paid"
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+        assert "discount" in result
+        assert Decimal(result["discount"]["amount"]) == Decimal("20.00")
+        assert "Sales Discounts" in result["discount"]["account"]
+
+    def test_vendor_bill_within_window_full_discount(self, business_book):
+        """Vendor offers us 2/10 Net 30 on $1000 bill, we pay $980 on day 8
+        → A/P clears full $1000, $20 books to Income:Purchase Discounts Taken.
+        """
+        gb = GnuCashBook(str(business_book))
+        bill_date = date(2026, 5, 1)
+        self._setup_bill_with_terms(
+            gb, amount="1000.00", bill_date=bill_date,
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="980",
+            payment_date="2026-05-09",  # day 8 within window
+            apply_discount=True,
+            owner_type="vendor",
+        )
+        assert result["status"] == "paid"
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+        assert "discount" in result
+        assert "Purchase Discounts" in result["discount"]["account"]
+
+    def test_payment_at_window_boundary_accepted(self, business_book):
+        """Payment on exactly day 10 of a 2/10 window → accepted."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="980",
+            payment_date="2026-05-11",  # exactly day 10
+            apply_discount=True,
+        )
+        assert result["status"] == "paid"
+
+    # ── Validation rejections ────────────────────────────────
+
+    def test_reject_no_billterm(self, business_book):
+        """apply_discount=True on invoice with no terms → error."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="X", quantity="1", price="1000",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        with pytest.raises(ValueError, match="no billterm linked"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="980",
+                apply_discount=True,
+            )
+
+    def test_reject_billterm_without_discount(self, business_book):
+        """apply_discount=True on a billterm with no discount → error."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme")
+        gb.create_billterm(
+            name="Net 30",
+            due_days=30,
+            discount_days=0,
+            discount_percent="0",
+        )
+        gb.create_invoice(customer_id="000001", term="Net 30")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Sales",
+            description="X", quantity="1", price="1000",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        with pytest.raises(ValueError, match="no early-payment discount"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="980",
+                apply_discount=True,
+            )
+
+    def test_reject_past_window(self, business_book):
+        """Payment day 11 of a 10-day window → rejected."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        with pytest.raises(ValueError, match="beyond the billterm discount window"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="980",
+                payment_date="2026-05-12",  # day 11
+                apply_discount=True,
+            )
+
+    def test_reject_wrong_amount(self, business_book):
+        """apply_discount=True with amount that doesn't match expected
+        shortfall → reject with the correct amount suggestion."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        with pytest.raises(ValueError, match="shortfall doesn't match"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="500",  # not a discount-shortfall; intended partial
+                payment_date="2026-05-06",
+                apply_discount=True,
+            )
+
+    def test_reject_credit_note(self, business_book):
+        """apply_discount=True on a credit note → loud reject."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        # Set up a posted credit note (no terms — discounting credit
+        # notes is semantically nonsensical regardless of terms).
+        gb.create_customer(name="Acme")
+        gb.create_credit_note(
+            owner_type="customer", owner_id="000001",
+            date_opened=invoice_date.isoformat(),
+        )
+        gb.add_credit_note_entry(
+            credit_note_id="000001", account="Income:Sales",
+            description="Refund", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+            post_date=invoice_date.isoformat(),
+        )
+        with pytest.raises(ValueError, match="Discounts cannot be applied to credit note"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="98",
+                payment_date="2026-05-06",
+                apply_discount=True,
+            )
+
+    # ── Closing-payment-after-partials ───────────────────────
+
+    def test_partial_then_discount_settlement(self, business_book):
+        """Customer pays $500 early without discount, then $480 with
+        discount to close. Should succeed: shortfall on closing
+        payment ($500 - $480 = $20) matches expected discount on
+        original $1000 invoice."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date(2026, 5, 1)
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        # First payment: $500 without discount
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+            payment_date="2026-05-03",
+        )
+        # Second payment: $480 with discount, should close
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="480",
+            payment_date="2026-05-08",  # still within window
+            apply_discount=True,
+        )
+        assert result["status"] == "paid"
+        assert Decimal(result["remaining_balance"]) == Decimal("0")
+        assert Decimal(result["discount"]["amount"]) == Decimal("20.00")
+
+    # ── Get_invoice forward signal ────────────────────────────
+
+    def test_get_invoice_surfaces_discount_available(self, business_book):
+        """get_invoice on an invoice with active discount terms
+        should include discount_available block with eligible_until +
+        amount, so the LLM can proactively surface "save $X by Y"."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date.today()  # within window today
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        result = gb.get_invoice(invoice_id="000001")
+        assert "discount_available" in result, (
+            f"discount_available block missing: {result}"
+        )
+        assert Decimal(result["discount_available"]["amount"]) == Decimal("20.00")
+        eligible = date.fromisoformat(
+            result["discount_available"]["eligible_until"]
+        )
+        assert eligible == invoice_date + timedelta(days=10)
+
+    def test_get_invoice_marks_expired_discount(self, business_book):
+        """When the discount window has passed, get_invoice shows the
+        same fields under ``discount_expired`` rather than dropping
+        them — caller can see what was offered, audit trail intact."""
+        gb = GnuCashBook(str(business_book))
+        invoice_date = date.today() - timedelta(days=20)  # past window
+        self._setup_invoice_with_terms(
+            gb, amount="1000.00", invoice_date=invoice_date,
+        )
+        result = gb.get_invoice(invoice_id="000001")
+        assert "discount_expired" in result
+        assert "discount_available" not in result
 
 
 # ============== _compute_fx_gain_loss Unit Tests ==============

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -16,7 +16,6 @@ class TestCreateCustomer:
         assert result["status"] == "created"
         assert result["name"] == "Acme Corp"
         assert result["id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_auto_id_increments(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -103,7 +102,9 @@ class TestListCustomers:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Acme Corp"
-        assert "guid" in result[0]
+        # v1.3.1: business-object guid field dropped (bookkeeper
+        # never used it). Customers are addressed by ``id``.
+        assert "id" in result[0]
         assert "address" in result[0]
 
 
@@ -133,7 +134,6 @@ class TestCreateVendor:
         assert result["status"] == "created"
         assert result["name"] == "Office Depot"
         assert result["id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_auto_id_increments(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -213,7 +213,6 @@ class TestCreateEmployee:
         assert result["status"] == "created"
         assert result["name"] == "Jane Smith"
         assert result["id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_auto_id_increments(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -297,7 +296,9 @@ class TestListEmployees:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Jane Smith"
-        assert "guid" in result[0]
+        # v1.3.1: business-object guid field dropped; employees
+        # addressed by ``id``.
+        assert "id" in result[0]
         # notes key absent (schema difference)
         assert "notes" not in result[0]
 
@@ -372,7 +373,6 @@ class TestCreateJob:
         assert result["active"] is True
         # counter_job advances independently from invoice/bill
         assert result["id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_create_vendor_job(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1658,7 +1658,6 @@ class TestCreateBillterm:
         assert result["status"] == "created"
         assert result["name"] == "Net 30"
         assert result["due_days"] == 30
-        assert len(result["guid"]) == 32
 
     def test_custom_due_days(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1748,7 +1747,6 @@ class TestCreateTaxtable:
         assert result["status"] == "created"
         assert result["name"] == "GST 5%"
         assert result["entry_count"] == 1
-        assert len(result["guid"]) == 32
         assert result["entries"][0]["type"] == "percentage"
         assert result["entries"][0]["amount"] == "5"
         assert result["entries"][0]["account"] == gst
@@ -2118,10 +2116,16 @@ class TestUpdateTaxtable:
             entries=[{"type": "percentage", "amount": "5",
                       "account": gst}],
         )
-        tt = gb.get_taxtable("GST 5%")
-        # Insert a phantom Entry row referencing the taxtable so
-        # the refcount-computer reports > 0.
+        # Look up the taxtable guid via raw SQL (v1.3.1:
+        # get_taxtable no longer surfaces guid — bookkeeper-
+        # validated as unused on the LLM surface). Needed here as
+        # a foreign-key target for the phantom Entry row that
+        # exercises the refcount path.
         with gb.open(readonly=False) as book:
+            tt_guid = book.session.execute(
+                text("SELECT guid FROM taxtables WHERE name = :n"),
+                {"n": "GST 5%"},
+            ).scalar()
             book.session.execute(
                 text(
                     "INSERT INTO entries "
@@ -2144,7 +2148,7 @@ class TestUpdateTaxtable:
                 {
                     "guid": "deadbeef" * 4,
                     "now": "2026-01-01 00:00:00",
-                    "ttg": tt["guid"],
+                    "ttg": tt_guid,
                 },
             )
             book.save()
@@ -2164,8 +2168,13 @@ class TestUpdateTaxtable:
             entries=[{"type": "percentage", "amount": "5",
                       "account": gst}],
         )
-        tt = gb.get_taxtable("GST 5%")
         with gb.open(readonly=False) as book:
+            # v1.3.1: taxtable guid not on response; look up
+            # directly for the foreign-key target.
+            tt_guid = book.session.execute(
+                text("SELECT guid FROM taxtables WHERE name = :n"),
+                {"n": "GST 5%"},
+            ).scalar()
             book.session.execute(
                 text(
                     "INSERT INTO entries "
@@ -2188,7 +2197,7 @@ class TestUpdateTaxtable:
                 {
                     "guid": "deadbeef" * 4,
                     "now": "2026-01-01 00:00:00",
-                    "ttg": tt["guid"],
+                    "ttg": tt_guid,
                 },
             )
             book.save()
@@ -2233,8 +2242,13 @@ class TestDeleteTaxtable:
             entries=[{"type": "percentage", "amount": "5",
                       "account": gst}],
         )
-        tt = gb.get_taxtable("GST 5%")
         with gb.open(readonly=False) as book:
+            # v1.3.1: taxtable guid not on response; look up
+            # directly for the foreign-key target.
+            tt_guid = book.session.execute(
+                text("SELECT guid FROM taxtables WHERE name = :n"),
+                {"n": "GST 5%"},
+            ).scalar()
             book.session.execute(
                 text(
                     "INSERT INTO entries "
@@ -2257,7 +2271,7 @@ class TestDeleteTaxtable:
                 {
                     "guid": "deadbeef" * 4,
                     "now": "2026-01-01 00:00:00",
-                    "ttg": tt["guid"],
+                    "ttg": tt_guid,
                 },
             )
             book.save()
@@ -2292,12 +2306,17 @@ class TestTaxtableRefcount:
             entries=[{"type": "percentage", "amount": "5",
                       "account": gst}],
         )
-        tt = gb.get_taxtable("GST 5%")
         # Insert one i_taxtable row and one b_taxtable row.
         with gb.open(readonly=False) as book:
+            # v1.3.1: lookup the taxtable guid directly (response
+            # dict no longer surfaces it).
+            tt_guid = book.session.execute(
+                text("SELECT guid FROM taxtables WHERE name = :n"),
+                {"n": "GST 5%"},
+            ).scalar()
             for tag, payload in (
-                ("i", {"i_tt": tt["guid"], "b_tt": None}),
-                ("b", {"i_tt": None, "b_tt": tt["guid"]}),
+                ("i", {"i_tt": tt_guid, "b_tt": None}),
+                ("b", {"i_tt": None, "b_tt": tt_guid}),
             ):
                 book.session.execute(
                     text(
@@ -3326,8 +3345,9 @@ class TestTaxtableDisplay:
         )
         inv = gb.get_invoice("000001")
         assert "tax_summary" not in inv
+        # v1.3.1: entry "guid" dropped from response shape.
         assert inv["entries"][0].keys() == {
-            "guid", "date", "description",
+            "date", "description",
             "quantity", "price", "total", "account",
         }
 
@@ -3791,7 +3811,6 @@ class TestCreateInvoice:
         assert result["status"] == "created"
         assert result["id"] == "000001"
         assert result["customer_id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_auto_id_increments(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -4314,7 +4333,6 @@ class TestCreateVoucher:
         assert result["employee_id"] == "000001"
         # Voucher counter starts at 0; first auto-id is 000001.
         assert result["id"] == "000001"
-        assert len(result["guid"]) == 32
 
     def test_employee_not_found(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -4404,7 +4422,9 @@ class TestAddVoucherEntry:
             description="Client lunch",
             quantity="1", price="100.00",
         )
-        assert e1["guid"] != e2["guid"]
+        # v1.3.1: entry guid dropped; uniqueness still validated
+        # implicitly by the fact that both writes succeeded.
+        assert e1["description"] != e2["description"]
 
     def test_income_account_rejected(self, business_book):
         """Voucher entries take EXPENSE/ASSET only — same as
@@ -4657,8 +4677,13 @@ class TestCreditNoteSlotHelpers:
             cn = book.session.query(Invoice).filter_by(
                 id=credit["id"],
             ).first()
+            # v1.3.1: create_invoice no longer surfaces ``guid``;
+            # look up the source invoice's guid via the ORM.
+            source_inv = book.session.query(Invoice).filter_by(
+                id=source["id"],
+            ).first()
             BusinessMixin._set_is_credit_note(cn, True)
-            BusinessMixin._set_applies_to_invoice_guid(cn, source["guid"])
+            BusinessMixin._set_applies_to_invoice_guid(cn, source_inv.guid)
             book.save()
         with gb.open(readonly=True) as book:
             from piecash.business.invoice import Invoice
@@ -6110,7 +6135,8 @@ class TestGetInvoice:
         )
         result = gb.get_invoice("000001")
         entry = result["entries"][0]
-        assert "guid" in entry
+        # v1.3.1: entry guid dropped — no standalone tool surface
+        # consumes it.
         assert entry["description"] == "Widget"
         assert Decimal(entry["quantity"]) == Decimal("3")
         assert Decimal(entry["price"]) == Decimal("25")
@@ -6387,8 +6413,11 @@ class TestPostInvoice:
         )
         assert result["status"] == "posted"
         assert Decimal(result["total"]) == Decimal("500")
-        assert len(result["transaction_guid"]) == 32
-        assert len(result["lot_guid"]) == 32
+        # v1.3.1: transaction_guid + lot_guid emitted as short
+        # collision-safe prefixes (min 8 chars) rather than full
+        # 32-char. Consumers accept 8+ char prefixes via _resolve_guid.
+        assert len(result["transaction_guid"]) >= 8
+        assert len(result["lot_guid"]) >= 8
         assert result["post_account"] == "Assets:Accounts Receivable"
 
     def test_post_marks_invoice_posted(self, business_book):
@@ -6534,12 +6563,23 @@ class TestPostInvoice:
             post_account="Assets:Accounts Receivable",
             due_date="2026-04-01",
         )
-        txn_guid = result["transaction_guid"]
-        lot_guid = result["lot_guid"]
+        # v1.3.1: result now carries short prefixes. Resolve back
+        # to full GUIDs for the direct-sqlite3 equality queries
+        # below.
+        txn_guid_prefix = result["transaction_guid"]
+        lot_guid_prefix = result["lot_guid"]
 
         # Read slots from the database directly
         conn = sqlite3.connect(str(business_book))
         try:
+            txn_guid = conn.execute(
+                "SELECT guid FROM transactions WHERE guid LIKE ?",
+                (txn_guid_prefix + "%",),
+            ).fetchone()[0]
+            lot_guid = conn.execute(
+                "SELECT guid FROM lots WHERE guid LIKE ?",
+                (lot_guid_prefix + "%",),
+            ).fetchone()[0]
             # Transaction num should be invoice ID
             txn = conn.execute(
                 "SELECT num, description FROM transactions "
@@ -6619,10 +6659,16 @@ class TestPostInvoice:
             post_account="Liabilities:Accounts Payable",
             owner_type="vendor",
         )
-        txn_guid = result["transaction_guid"]
+        txn_guid_prefix = result["transaction_guid"]
 
         conn = sqlite3.connect(str(business_book))
         try:
+            # Resolve short prefix → full GUID for the equality
+            # queries below (v1.3.1 short-prefix change).
+            txn_guid = conn.execute(
+                "SELECT guid FROM transactions WHERE guid LIKE ?",
+                (txn_guid_prefix + "%",),
+            ).fetchone()[0]
             txn = conn.execute(
                 "SELECT description FROM transactions WHERE guid = ?",
                 (txn_guid,),
@@ -7258,10 +7304,16 @@ class TestPayInvoice:
             payment_account="Assets:Checking",
             amount="500",
         )
-        txn_guid = result["transaction_guid"]
+        txn_guid_prefix = result["transaction_guid"]
 
         conn = sqlite3.connect(str(business_book))
         try:
+            # Resolve short prefix → full GUID for the equality
+            # queries below (v1.3.1 short-prefix change).
+            txn_guid = conn.execute(
+                "SELECT guid FROM transactions WHERE guid LIKE ?",
+                (txn_guid_prefix + "%",),
+            ).fetchone()[0]
             # Description should be customer name
             txn = conn.execute(
                 "SELECT description FROM transactions WHERE guid = ?",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 
 import pytest
 
-from gnucash_mcp.tools._helpers import _apply_limit, _format_number
+from gnucash_mcp.tools._helpers import _apply_limit, _format_number, _resolve_id_alias
 
 
 class TestFormatNumber:
@@ -250,3 +250,40 @@ class TestSafeToolWriteVerificationRouting:
 
         result = json.loads(fake_tool())
         assert result["error_type"] == "validation_error"
+
+
+class TestResolveIdAlias:
+    """``_resolve_id_alias`` lets delete_invoice / delete_bill /
+    delete_voucher / delete_credit_note accept both ``id`` (the
+    standard name across get_invoice / post_invoice / unpost_invoice /
+    pay_invoice) and the legacy ``<entity>_id`` parameter for
+    back-compat.
+
+    Required because ``extra="forbid"`` on tool arg models (shipped
+    on PR #92) forbids silent kwarg aliasing — both names have to be
+    declared parameters on the wrapper, and the helper picks the
+    right one.
+    """
+
+    def test_prefers_id_when_only_id_set(self):
+        assert _resolve_id_alias("000001", None, "invoice_id") == "000001"
+
+    def test_accepts_legacy_when_only_legacy_set(self):
+        assert _resolve_id_alias(None, "000001", "invoice_id") == "000001"
+
+    def test_rejects_both_set(self):
+        with pytest.raises(ValueError, match="exactly one"):
+            _resolve_id_alias("000001", "000002", "invoice_id")
+
+    def test_rejects_both_missing(self):
+        with pytest.raises(ValueError, match="Missing required parameter"):
+            _resolve_id_alias(None, None, "invoice_id")
+
+    def test_error_message_names_the_legacy_parameter(self):
+        # Useful for the LLM debug loop — the error needs to say
+        # which alias it was looking for so the caller can fix
+        # their call.
+        with pytest.raises(ValueError, match="bill_id"):
+            _resolve_id_alias(None, None, "bill_id")
+        with pytest.raises(ValueError, match="voucher_id"):
+            _resolve_id_alias("a", "b", "voucher_id")

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -446,10 +446,17 @@ class TestCalculateLotGain:
         book.assign_split_to_lot(
             split_guid=buy_guid, lot_guid=lot["guid"],
         )
-        # Find and void the buy transaction.
+        # Find and void the buy transaction. v1.3.1: ``buy_guid``
+        # is now a short prefix (get_transaction returns prefixes,
+        # not full GUIDs). Resolve to full guid via
+        # ``_resolve_guid("splits", ...)`` for the direct ORM
+        # equality query.
+        full_buy_guid = book._resolve_guid("splits", buy_guid)
         with book.open(readonly=True) as b:
             from piecash.core.transaction import Split
-            split = b.session.query(Split).filter_by(guid=buy_guid).first()
+            split = b.session.query(Split).filter_by(
+                guid=full_buy_guid,
+            ).first()
             buy_txn_guid = split.transaction.guid
         book.void_transaction(
             guid=buy_txn_guid, reason="Mistaken purchase",

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -53,7 +53,7 @@ class TestToolModulesMapping:
         """Every TOOL_MODULES key must back onto extracted-module
         files. After the restructure the relationship is no longer
         ``TOOL_MODULES.keys() ⊆ extracted_modules()``: ``portfolio``
-        and ``investor`` are new public modules that don't have
+        and ``tax_lots`` are new public modules that don't have
         their own tool files (they're slices of the legacy
         ``investments`` file, mapped via MODULE_BACKED_BY).
         """
@@ -88,23 +88,32 @@ class TestToolModulesMapping:
         assert total == 106
 
     def test_expected_modules_exist(self):
-        """All expected sub-module names should be present after the
-        Core-chop. ``core`` is no longer a TOOL_MODULES key — it's
-        a MODULE_GROUPS alias expanding to the eight sub-modules."""
+        """All expected leaf-module names should be present.
+        ``core``, ``bookkeeper``, and ``investor`` are group
+        aliases (in MODULE_GROUPS) — not TOOL_MODULES keys."""
         expected = {
             # Core sub-modules
             "summary", "accounts", "transactions", "slots",
             "audit", "backup", "balance_sheet", "diagnostic",
-            # Optional modules
-            "reconciliation", "reporting", "budgets",
-            "scheduling", "portfolio", "investor",
+            # Bookkeeper-cluster leaves
+            "reconciliation", "reporting", "budgets", "scheduling",
+            # Investor-cluster leaves
+            "portfolio", "tax_lots",
+            # Business-side
             "freelancer", "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
-        # And ``core`` is the group alias.
+        # Group aliases — ``core`` always-on plus the two new
+        # role groups landing in v1.3.
         assert set(MODULE_GROUPS["core"]) == {
             "summary", "accounts", "transactions", "slots",
             "audit", "backup", "balance_sheet", "diagnostic",
+        }
+        assert set(MODULE_GROUPS["bookkeeper"]) == {
+            "reconciliation", "reporting", "budgets", "scheduling",
+        }
+        assert set(MODULE_GROUPS["investor"]) == {
+            "tax_lots", "portfolio",
         }
 
     def test_validate_tool_modules_passes(self):
@@ -303,11 +312,12 @@ class TestApplyModuleFilter:
         assert "list_accounts" in remaining
         assert "create_account" in remaining
 
-    def test_portfolio_and_investor_split(self):
-        """``portfolio`` (commodities + prices) and ``investor``
-        (tax lots) used to be one ``investments`` module. After the
-        split they're independently selectable: a multi-currency
-        household without a brokerage picks portfolio alone."""
+    def test_portfolio_and_tax_lots_split(self):
+        """``portfolio`` (commodities + prices) and ``tax_lots``
+        (cost-basis tracking) are the two leaves of what used to
+        be the ``investments`` module — independently selectable
+        for a finer cut. The ``investor`` group bundles them; see
+        test_investor_group_bundles_both below for that path."""
         # portfolio alone — price tools yes, lot tools no
         _apply_module_filter("portfolio")
         remaining = self._tool_names()
@@ -320,15 +330,45 @@ class TestApplyModuleFilter:
         # Non-selected modules not present
         assert "spending_by_category" not in remaining
 
-        # investor alone — lot tools yes, price tools no
+        # tax_lots alone — lot tools yes, price tools no
         _reset_lazy_load_state()
         mcp._tool_manager._tools.clear()
-        _apply_module_filter("investor")
+        _apply_module_filter("tax_lots")
         remaining = self._tool_names()
         assert "create_lot" in remaining
         assert "calculate_lot_gain" in remaining
         assert "list_commodities" not in remaining
         assert "create_price" not in remaining
+
+    def test_investor_group_bundles_both(self):
+        """``--modules=investor`` (the group alias) loads
+        tax_lots + portfolio together. Tax-lot accounting needs
+        market prices to compute gains, so the bundle is the
+        useful unit; the leaf modules exist for fine-grained
+        users."""
+        _apply_module_filter("investor")
+        remaining = self._tool_names()
+        # Both halves present.
+        assert "create_lot" in remaining
+        assert "calculate_lot_gain" in remaining
+        assert "list_commodities" in remaining
+        assert "create_price" in remaining
+
+    def test_bookkeeper_group_bundles_four_modules(self):
+        """``--modules=bookkeeper`` loads reconciliation +
+        reporting + budgets + scheduling — the personal-finance
+        management cluster."""
+        _apply_module_filter("bookkeeper")
+        remaining = self._tool_names()
+        # One probe per member module.
+        assert "reconcile_account" in remaining       # reconciliation
+        assert "spending_by_category" in remaining    # reporting
+        assert "create_budget" in remaining           # budgets
+        assert "create_scheduled_transaction" in remaining
+        # Core always loaded; non-bookkeeper modules absent.
+        assert "list_accounts" in remaining
+        assert "create_invoice" not in remaining      # freelancer
+        assert "create_lot" not in remaining          # tax_lots
 
     def test_filter_is_subtractive(self):
         """Filtering should only remove tools, never add non-existent ones."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -279,19 +279,49 @@ class TestApplyModuleFilter:
         _apply_module_filter("scheduling,reconciliation,all")
         assert len(self._tool_names()) == 106
 
-    def test_unknown_module_warns(self, capsys):
-        """Unknown module names should produce a warning on stderr."""
-        _apply_module_filter("core,nonexistent")
+    def test_unknown_module_fails_fast(self, capsys):
+        """Unknown module names fail-fast at startup with SystemExit.
+
+        Bookkeeper-found on PR #92 review: pre-fix, a typo'd module
+        name (e.g. ``--modules=bookeeper`` missing the 'k') printed
+        a warning to stderr and then silently partial-loaded. Claude
+        Desktop captures MCP server stderr into a log file the user
+        never sees, so the warning was effectively invisible — the
+        user observed "the tools I expected aren't there" and could
+        not tell whether it was a typo or a server bug. v1.3 fails
+        fast so configuration errors surface immediately.
+        """
+        import pytest
+        with pytest.raises(SystemExit) as exc_info:
+            _apply_module_filter("core,nonexistent")
+        assert exc_info.value.code == 2
         captured = capsys.readouterr()
         assert "nonexistent" in captured.err
         assert "Unknown module" in captured.err
+        assert "Valid names:" in captured.err
 
-    def test_unknown_module_still_loads_core(self, capsys):
-        """Unknown modules should not prevent the ``core`` group from
-        loading."""
-        _apply_module_filter("nonexistent")
-        remaining = self._tool_names()
-        assert _core_tool_names().issubset(remaining)
+    def test_unknown_module_did_you_mean_suggestion(self, capsys):
+        """Typos close to a known name should surface a did-you-mean
+        hint so the user can self-correct on the next restart without
+        scrolling through the full valid-names list.
+        """
+        import pytest
+        with pytest.raises(SystemExit):
+            _apply_module_filter("bookeeper")  # missing 'k'
+        captured = capsys.readouterr()
+        assert "bookeeper" in captured.err
+        assert "did you mean 'bookkeeper'" in captured.err
+
+    def test_unknown_module_alongside_valid_still_fails(self, capsys):
+        """Mixed valid + invalid input fails the whole startup. No
+        partial-load mode where the valid modules quietly load and
+        the invalid one is dropped — that was the silent-failure
+        regime fail-fast replaces.
+        """
+        import pytest
+        with pytest.raises(SystemExit) as exc_info:
+            _apply_module_filter("bookeeper,investor")
+        assert exc_info.value.code == 2
 
     def test_whitespace_in_module_names(self):
         """Whitespace around module names should be stripped."""
@@ -401,14 +431,17 @@ class TestApplyModuleFilter:
         assert result == sorted(MODULE_GROUPS["core"])
 
     def test_returns_excludes_unknown_modules(self):
-        """Unknown module names should not appear in return value.
-        The ``core`` group's sub-modules are always present even
-        when the user-supplied list contained only garbage."""
-        result = _apply_module_filter("reporting,nonexistent")
-        assert "nonexistent" not in result
-        # One representative Core sub-module is enough.
-        assert "accounts" in result
-        assert "reporting" in result
+        """Unknown module names trigger fail-fast (v1.3 behavior).
+
+        Pre-v1.3 the function returned a sorted list excluding
+        unknown names. After the fail-fast change, the function
+        raises SystemExit instead — the "excluded" behavior is now
+        "rejected at startup" so it can't surface downstream as
+        missing tools. Test repurposed to lock the new contract.
+        """
+        import pytest
+        with pytest.raises(SystemExit):
+            _apply_module_filter("reporting,nonexistent")
 
 
 class TestExtractedModuleLazyLoading:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -507,7 +507,9 @@ class TestGetServerConfig:
         output = _get_server_config_impl()
         assert "Modules loaded: core,reporting" in output
         assert "Tools available: 20" in output
-        assert "Book path: /tmp/test.gnucash" in output
+        # Book line shows filename only — see _book_display_name
+        # for the privacy rationale. Path leak hardened in v1.3.0.
+        assert "Book: test.gnucash" in output
         assert "Debug mode: true" in output
         assert "Version:" in output
 
@@ -517,8 +519,34 @@ class TestGetServerConfig:
         output = _get_server_config_impl()
         assert "Modules loaded: unknown" in output
         assert "Tools available: unknown" in output
-        assert "Book path: not set" in output
+        assert "Book: not set" in output
         assert "Debug mode: false" in output
+
+    def test_impl_does_not_leak_directory_path(self):
+        """The book directory must not appear in the response.
+
+        Privacy hardening shipped in v1.3.0: routine LLM-visible
+        responses used to include the full absolute path to the
+        GnuCash book, leaking username and home directory layout
+        into every transcript and screenshot. The filename alone is
+        sufficient for the LLM to confirm which book is loaded.
+        """
+        _server_state.update({
+            "modules": "core",
+            "tool_count": 10,
+            "book_path": "/Users/alice/Finances/personal-2026.gnucash",
+            "debug": False,
+        })
+        output = _get_server_config_impl()
+        # Username and directory must NOT appear.
+        assert "/Users/" not in output, (
+            f"directory path leaked into output:\n{output}"
+        )
+        assert "alice" not in output
+        assert "Finances" not in output
+        # But the filename SHOULD appear so the caller can verify
+        # which book is loaded.
+        assert "personal-2026.gnucash" in output
 
     def test_impl_output_is_plain_text(self):
         """Output should be plain text, not JSON."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -99,12 +99,15 @@ class TestToolModulesMapping:
             "reconciliation", "reporting", "budgets", "scheduling",
             # Investor-cluster leaves
             "portfolio", "tax_lots",
-            # Business-side
-            "freelancer", "business",
+            # Business-cluster leaves (``business`` is now a group
+            # alias expanding to these two; the standalone of the
+            # same name was the pre-v1.3 design, retired because it
+            # left small-business users without invoice tools).
+            "freelancer", "business_complete",
         }
         assert set(TOOL_MODULES.keys()) == expected
-        # Group aliases — ``core`` always-on plus the two new
-        # role groups landing in v1.3.
+        # Group aliases — ``core`` always-on plus the three role
+        # groups (bookkeeper, investor, business) landing in v1.3.
         assert set(MODULE_GROUPS["core"]) == {
             "summary", "accounts", "transactions", "slots",
             "audit", "backup", "balance_sheet", "diagnostic",
@@ -114,6 +117,9 @@ class TestToolModulesMapping:
         }
         assert set(MODULE_GROUPS["investor"]) == {
             "tax_lots", "portfolio",
+        }
+        assert set(MODULE_GROUPS["business"]) == {
+            "freelancer", "business_complete",
         }
 
     def test_validate_tool_modules_passes(self):
@@ -622,13 +628,17 @@ class TestOwnerTypeGating:
         _LOADED_MODULES.update(original)
 
     def test_business_loaded_passes_through(self):
-        """With business enabled, _gate_owner_type returns its input
-        unchanged — both halves of the polymorphic dispatch work."""
+        """With business_complete enabled (whether explicitly or via
+        the ``business`` group alias), _gate_owner_type returns its
+        input unchanged — both halves of the polymorphic dispatch work.
+        """
         from gnucash_mcp.server import _LOADED_MODULES
         from gnucash_mcp.tools._helpers import _gate_owner_type
 
         _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({"core", "freelancer", "business"})
+        _LOADED_MODULES.update({
+            "core", "freelancer", "business_complete", "business",
+        })
         assert _gate_owner_type("customer") == "customer"
         assert _gate_owner_type("vendor") == "vendor"
         assert _gate_owner_type(None) is None
@@ -655,7 +665,7 @@ class TestOwnerTypeGating:
 
         _LOADED_MODULES.clear()
         _LOADED_MODULES.update({"core", "freelancer"})
-        with pytest.raises(ValueError, match="requires the Business module"):
+        with pytest.raises(ValueError, match="requires the business module"):
             _gate_owner_type("vendor")
 
     def test_business_absent_rejects_explicit_employee(self):
@@ -670,7 +680,7 @@ class TestOwnerTypeGating:
 
         _LOADED_MODULES.clear()
         _LOADED_MODULES.update({"core", "freelancer"})
-        with pytest.raises(ValueError, match="requires the Business module"):
+        with pytest.raises(ValueError, match="requires the business module"):
             _gate_owner_type("employee")
 
     def test_business_absent_rejects_typo(self):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -73,11 +73,15 @@ class TestToolModulesMapping:
                 assert tool not in seen, f"{tool} appears in multiple modules"
                 seen.add(tool)
 
-    def test_core_group_resolves_to_26_tools(self):
-        """The ``core`` group expands to 26 tools across its eight
+    def test_core_group_resolves_to_29_tools(self):
+        """The ``core`` group expands to 29 tools across its nine
         sub-modules (summary 1 + accounts 7 + transactions 9 + slots
-        3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1)."""
-        assert len(_core_tool_names()) == 26
+        3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
+        reconciliation 3). Reconciliation joined core in v1.3.1
+        per the bookkeeper-driven principle that any configuration
+        which handles money must include reconciliation.
+        """
+        assert len(_core_tool_names()) == 29
 
     def test_total_tool_count(self):
         """Total tools across all sub-modules should be 106 —
@@ -92,11 +96,12 @@ class TestToolModulesMapping:
         ``core``, ``bookkeeper``, and ``investor`` are group
         aliases (in MODULE_GROUPS) — not TOOL_MODULES keys."""
         expected = {
-            # Core sub-modules
+            # Core sub-modules (reconciliation joined core in v1.3.1)
             "summary", "accounts", "transactions", "slots",
             "audit", "backup", "balance_sheet", "diagnostic",
+            "reconciliation",
             # Bookkeeper-cluster leaves
-            "reconciliation", "reporting", "budgets", "scheduling",
+            "reporting", "budgets", "scheduling",
             # Investor-cluster leaves
             "portfolio", "tax_lots",
             # Business-cluster leaves (``business`` is now a group
@@ -108,12 +113,16 @@ class TestToolModulesMapping:
         assert set(TOOL_MODULES.keys()) == expected
         # Group aliases — ``core`` always-on plus the three role
         # groups (bookkeeper, investor, business) landing in v1.3.
+        # core grew to 9 in v1.3.1 — reconciliation moved here
+        # from bookkeeper so it loads in every configuration that
+        # handles money (which is all of them).
         assert set(MODULE_GROUPS["core"]) == {
             "summary", "accounts", "transactions", "slots",
             "audit", "backup", "balance_sheet", "diagnostic",
+            "reconciliation",
         }
         assert set(MODULE_GROUPS["bookkeeper"]) == {
-            "reconciliation", "reporting", "budgets", "scheduling",
+            "reporting", "budgets", "scheduling",
         }
         assert set(MODULE_GROUPS["investor"]) == {
             "tax_lots", "portfolio",
@@ -144,7 +153,7 @@ class TestToolFileVsModulesMapping:
 
     Pre-restructure this was a per-module 1:1 check (each
     ``tools/<X>.py`` matched ``TOOL_MODULES[X]`` exactly). The Core
-    restructure broke that bijection — Core's 26 tools span
+    restructure broke that bijection — Core's 29 tools span
     ``tools/core.py`` + ``tools/reconciliation.py`` +
     ``tools/admin.py`` + ``tools/backup.py``. The contract is now
     bidirectional-totality: every decorated tool maps to some
@@ -390,21 +399,41 @@ class TestApplyModuleFilter:
         assert "list_commodities" in remaining
         assert "create_price" in remaining
 
-    def test_bookkeeper_group_bundles_four_modules(self):
-        """``--modules=bookkeeper`` loads reconciliation +
-        reporting + budgets + scheduling — the personal-finance
-        management cluster."""
+    def test_bookkeeper_group_bundles_three_modules(self):
+        """``--modules=bookkeeper`` loads reporting + budgets +
+        scheduling — the personal-finance management cluster.
+        Reconciliation moved to core in v1.3.1 and is now
+        always-on regardless of group selection."""
         _apply_module_filter("bookkeeper")
         remaining = self._tool_names()
-        # One probe per member module.
-        assert "reconcile_account" in remaining       # reconciliation
+        # One probe per bookkeeper member module.
         assert "spending_by_category" in remaining    # reporting
         assert "create_budget" in remaining           # budgets
         assert "create_scheduled_transaction" in remaining
+        # reconciliation is now always-on via core.
+        assert "reconcile_account" in remaining
         # Core always loaded; non-bookkeeper modules absent.
         assert "list_accounts" in remaining
         assert "create_invoice" not in remaining      # freelancer
         assert "create_lot" not in remaining          # tax_lots
+
+    def test_reconciliation_loads_with_core_by_default(self):
+        """v1.3.1 invariant: any configuration loads reconciliation.
+
+        The bookkeeper-flagged principle: reconciliation touches
+        money and every configuration touches money. Moved from
+        the bookkeeper group to core so a freelancer / investor /
+        business persona doesn't ship without statement-
+        reconciliation tools.
+        """
+        for modules in ("freelancer", "investor", "business", None):
+            _apply_module_filter(modules)
+            remaining = self._tool_names()
+            assert "reconcile_account" in remaining, (
+                f"reconcile_account missing for --modules={modules}"
+            )
+            assert "set_reconcile_state" in remaining
+            assert "get_unreconciled_splits" in remaining
 
     def test_filter_is_subtractive(self):
         """Filtering should only remove tools, never add non-existent ones."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1065,6 +1065,27 @@ class TestBalanceSheetTool:
         data = json.loads(result)
         assert data["as_of_date"] == date.today().isoformat()
 
+    def test_balance_sheet_rejects_empty_string_as_of_date(
+        self, setup_book_env,
+    ):
+        """Copilot-flagged on PR #92 review: empty string is a
+        caller bug (probably a stale-template / missing-variable
+        substitution), not a "use today" signal. Pre-fix the falsy
+        check treated ``as_of_date=""`` the same as ``None`` and
+        silently substituted today, producing a wrong-dated
+        report the caller had no way to notice. Strict-kwargs
+        philosophy extends to the value: empty string → loud
+        validation error.
+        """
+        result = server_module.balance_sheet(as_of_date="")
+        data = json.loads(result)
+        # safe_tool wraps the ValueError from date.fromisoformat("")
+        # into a structured validation_error response.
+        assert data.get("error_type") == "validation_error", (
+            f"expected validation_error for empty as_of_date, got: "
+            f"{data!r}"
+        )
+
 
 class TestNetWorthTool:
     """Tests for net_worth tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1051,6 +1051,20 @@ class TestBalanceSheetTool:
         assert "liabilities" in data
         assert "equity" in data
 
+    def test_balance_sheet_defaults_to_today(self, setup_book_env):
+        """Bookkeeper-flagged: cross-tool comparison silently broke
+        because balance_sheet required an explicit date while
+        get_book_summary used today implicitly. As of v1.3.0,
+        balance_sheet defaults to today so the natural side-by-side
+        ``balance_sheet()`` vs. ``get_book_summary()`` call agrees
+        without threading the same date into both.
+        """
+        from datetime import date
+        # No as_of_date provided.
+        result = server_module.balance_sheet()
+        data = json.loads(result)
+        assert data["as_of_date"] == date.today().isoformat()
+
 
 class TestNetWorthTool:
     """Tests for net_worth tool."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1282,3 +1282,75 @@ class TestNonAsciiJsonEncoding:
         assert "Rückversicherungs" in result
         data = json.loads(result)
         assert data["fullname"] == "Münchener Rückversicherungs-Gesellschaft"
+
+
+class TestStrictToolKwargs:
+    """Bookkeeper-found bug from PR #92 review: calling
+    ``reconcile_account`` with ``except=[...]`` instead of the
+    actual ``except_guids=[...]`` parameter ran the tool with no
+    exclusion at all. FastMCP's per-tool Pydantic arg model
+    inherited from ``ArgModelBase`` with no ``extra`` config,
+    defaulting to ``"ignore"`` — unknown kwargs silently dropped.
+
+    ``server.py`` monkey-patches ``ArgModelBase.model_config`` to
+    ``extra="forbid"`` at import time so any unknown kwarg raises
+    a clear validation error at the MCP boundary instead of
+    surfacing as a downstream balance mismatch.
+    """
+
+    def _arg_model_for(self, tool_name: str):
+        """Return the Pydantic arg model for a registered tool.
+
+        Tests bind ``tool.fn`` directly to ``server_module`` (see
+        the module-scoped ``_load_all_extracted_tool_modules``
+        fixture), which bypasses Pydantic validation entirely.
+        Grab the arg_model off the FastMCP tool entry to exercise
+        the same validation path the MCP wire boundary uses.
+        """
+        tool = server_module.mcp._tool_manager._tools[tool_name]
+        return tool.fn_metadata.arg_model
+
+    def test_unknown_kwarg_is_rejected(self):
+        from pydantic import ValidationError
+
+        arg_model = self._arg_model_for("reconcile_account")
+        with pytest.raises(ValidationError) as exc_info:
+            arg_model.model_validate({
+                "account": "Assets:Bank:Checking",
+                "statement_date": "2026-04-30",
+                "statement_balance": "1000.00",
+                # Bookkeeper's typo: ``except`` instead of ``except_guids``.
+                "except": ["deadbeef"],
+                "reconcile_all": True,
+            })
+        # Pydantic's standard message for extra="forbid".
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+
+    def test_known_kwargs_still_validate(self):
+        """Sanity check: rejecting extras must not block legitimate calls."""
+        arg_model = self._arg_model_for("reconcile_account")
+        # Should not raise — every key is a real parameter.
+        arg_model.model_validate({
+            "account": "Assets:Bank:Checking",
+            "statement_date": "2026-04-30",
+            "statement_balance": "1000.00",
+            "except_guids": ["deadbeef"],
+            "reconcile_all": True,
+        })
+
+    def test_forbid_applies_to_all_tools(self):
+        """Spot-check a sample of unrelated tools — patch is global,
+        not per-tool. If a future FastMCP upgrade breaks the
+        ``ArgModelBase`` monkey-patch (e.g. by switching to a
+        non-inheriting model factory), this test fails loudly
+        across the surface rather than only on one tool.
+        """
+        from pydantic import ValidationError
+
+        for tool_name in ("get_balance", "create_transaction", "list_accounts"):
+            arg_model = self._arg_model_for(tool_name)
+            assert arg_model.model_config.get("extra") == "forbid", (
+                f"{tool_name} arg model is not strict — extras would be ignored"
+            )
+            with pytest.raises(ValidationError):
+                arg_model.model_validate({"this_is_not_a_real_kwarg": "x"})

--- a/tests/test_write_verification.py
+++ b/tests/test_write_verification.py
@@ -194,9 +194,13 @@ class TestVerifyDelete:
         book_obj = GnuCashBook(str(business_book))
         book_obj.create_customer("Verify Client")
         inv = book_obj.create_invoice(customer_id="000001")
-        inv_guid = inv["guid"]
-
+        # v1.3.1: create_invoice no longer surfaces ``guid``;
+        # look up via the ORM for direct-SQL deletion below.
         with book_obj.open(readonly=False) as book:
+            inv_guid = book.session.query(Invoice).filter_by(
+                id=inv["id"],
+            ).first().guid
+
             book.session.execute(
                 Invoice.__table__.delete().where(
                     Invoice.__table__.c.guid == inv_guid


### PR DESCRIPTION
## Summary

PR #92 started as two v1.3-blocker bookkeeper items and grew into the full release-prep correctness sweep as additional findings surfaced during review. Three bookkeeper-review rounds, two Copilot-review rounds, ~30 commits. Scope:

**Multi-currency correctness** (the original finding, plus a sweep when the same pattern was found in five more places)
- `spending_by_category` / `income_by_source` now route through `_split_in_default_currency` so EUR/CAD splits contribute their default-currency value, not raw foreign quantity.
- Same fix applied to `_monthly_net_income`, `_budget_headline`, `_daily_expense_burn` (runway divisor), and `vendor_spending_report` — all four were silently summing raw across currencies.

**`balance_sheet` now actually balances** (A = L + E by construction)
- `_ASSET_TYPES` / `_LIABILITY_TYPES` now include RECEIVABLE / PAYABLE so posted invoices appear in the report. Pre-fix Alex's $15.5K of outstanding A/R was invisible.
- New synthetic Unrealized Gain/Loss equity row absorbs investment market drift + FX translation gap so the equation closes.
- `_NW_ASSET_TYPES` / `_NW_LIABILITY_TYPES` updated to match — get_book_summary's trajectory anchor agrees with balance_sheet.
- Dashboard's "Assets:" / "Liabilities:" headline counts and totals also updated.

**Early-payment discounts now actually honored**
- `create_billterm` had been accepting `discount_days` / `discount_percent` since v1.3 launched; `pay_invoice` silently ignored them. A freelancer setting 2/10 Net 30 terms got a partial-payment record with the discount amount still outstanding instead of a clean settlement.
- New `apply_discount=True` parameter on `pay_invoice` validates terms exist, payment is within window, and shortfall matches expected discount on pre-tax principal. Every failure mode rejects loudly. Discount account routes via same auto-resolver pattern as `fx_account`.
- `get_invoice` verbose mode surfaces a `discount_available` block (or `discount_expired` once the window passes) so the LLM can proactively offer "you can save $X by paying this by Y."

**Reconciliation moved to core**
- Bookkeeper-flagged: reconciliation touches money and every configuration touches money. Pre-fix `--modules=freelancer/investor/business` shipped without reconcile tools. Moved from the bookkeeper group to core; reconciliation now loads in every configuration regardless of `--modules` selection.
- Core: 26 → 29 tools. Bookkeeper: 20 → 17.

**Reconciliation tool refinements**
- `except_guids` parameter on `reconcile_account` — bulk-mode escape hatch for "everything on the statement except this pending ACH."

**Module surface restructure**
- `business` is now a group alias expanding to `freelancer` + `business_complete` (the renamed leaf with vendor/employee/jobs surface). Pre-fix `--modules=business` loaded only the vendor side — a documented persona that couldn't post a customer invoice. `--modules=business` now loads the full 48-tool small-business package.
- New `bookkeeper` and `investor` group aliases added at the same time.
- Fail-fast on unknown `--modules` names with did-you-mean suggestion via difflib. Pre-fix typos like `--modules=bookkeper` silently partial-loaded and confused the user about which tools were available.

**Token efficiency** (bookkeeper-found)
- `get_transaction` and `list_transactions(verbose=True)` emit short collision-safe GUID prefixes for transaction, split, and lot fields. Compact `list_transactions` already did; verbose was emitting full 32-char GUIDs. ~6-8K chars saved per verbose-50 call.
- Business-object `guid` fields stripped from response shapes (customer, vendor, employee, job, billterm, taxtable, invoice, entry). Bookkeeper validated: every consumer addresses business objects by id or name; the 32-char GUID was dead weight.
- `transaction_guid` on post_invoice / pay_invoice / apply_credit_note preserved (consumers DO use it) but emitted as a short prefix.

**Strict tool-argument validation**
- `extra="forbid"` patched onto FastMCP's `ArgModelBase` so unknown kwargs raise a `ValidationError` instead of silently no-opping. Bookkeeper-found: a `reconcile_account` call with `except=[...]` (Python keyword forces the actual name to `except_guids`) silently dropped the exclusion and produced a balance mismatch.
- Empty-string `as_of_date` on `balance_sheet` now raises rather than silently substituting today (Copilot finding).

**Parameter normalization**
- `id` accepted as an alias for `<entity>_id` on `delete_invoice / delete_bill / delete_voucher / delete_credit_note`, matching every other invoice-surface tool. Mutex-validated (exactly one).

**Dashboard refinements**
- Receivables/Payables lines append `(N invoice(s), M overdue)`. Conditional `Jobs: N active` line when jobs exist.
- N+1 query in `_business_summary_counts` fixed by pre-indexing accounts/lots once before the invoice loop (Copilot round-2 finding).
- `balance_sheet` tool's `as_of_date` parameter is now optional, defaulting to today (matches `get_book_summary`'s implicit cutoff).

**Security: book-path redaction**
- `get_server_config` and `get_book_summary` now show the book as filename only. Pre-fix the full absolute path leaked the username and home directory layout into every transcript.

**Server instructions block rewrite**
- ~2,500 chars → 1,522 (39% smaller). Same coverage, denser phrasing.

**Docs**
- CHANGELOG v1.3.0 entry covering everything above plus the Stage 3 features (vouchers, credit notes, jobs, taxtables) merged earlier in the v1.3 cycle.
- README role/module table updated to reflect the restructure (core 29 / bookkeeper 17 / investor 12 / freelancer 19 / business 48).
- `specs/v1_3_RELEASE_PREP.md`, `specs/EARLY_PAYMENT_DISCOUNT_SPEC.md`, `specs/PRICE_UPDATE_SPEC.md` archived as historical record.

## Test plan

- [x] Bookkeeper bounce + cross-tool check on Alex: `get_book_summary` Assets / Liabilities / "now" anchor agree with `balance_sheet` A / L / A−L (= E). Numbers will shift from pre-fix because A/R now counts; that's the trajectory restatement disclosed in CHANGELOG.
- [x] Verify `--modules=freelancer` (or investor, business) loads reconciliation tools.
- [x] Verify `--modules=<typo>` fails fast with did-you-mean.
- [x] Verify `pay_invoice(apply_discount=true)` honors billterm discount terms, rejects loudly for all five failure modes (no terms / no discount / past window / amount mismatch / credit note).
- [x] Verify `get_invoice` surfaces `discount_available` block on invoices with active discount terms.
- [x] Verify `get_transaction` returns short GUIDs (transaction, split, lot).
- [x] Verify `get_server_config` shows filename only.
- [x] `uv run pytest` clean (1,391 passing).