### PR TITLE
fix(modules): all-is-validation-bypass + freelancer/business_complete redistribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ the leaves individually for a finer cut.
 | `core` | Ledger primitives — accounts, transactions, balances, slots, audit log, backups, balance sheet, **reconciliation**. **Always loaded.** | 29 |
 | `bookkeeper` | Run reports, manage budgets, schedule recurring transactions. The personal-finance management cluster. (Reconciliation moved into core — any configuration that handles money needs it.) | 17 |
 | `investor` | Cost-basis tracking + price/commodity management. Tax-lot accounting needs prices to compute gains, so the bundle is the useful unit. | 12 |
-| `freelancer` | Customer invoicing + sales tax (GST, VAT, US state sales tax). The solo-consultant surface. | 19 |
-| `business` | Full small-business package — group alias that expands to `freelancer` (invoicing) plus `business_complete` (vendors, employees, bills, vouchers, credit notes, jobs, billing terms). | 48 |
+| `freelancer` | Customer invoicing + sales tax, plus billterms (payment terms), jobs (per-project P&L rollups), and credit notes (customer refunds). The full solo-consultant toolkit. | 31 |
+| `business` | Full small-business package — group alias that expands to `freelancer` (invoicing) plus `business_complete` (vendors, employees, bills, vouchers, vendor reports). | 48 |
 
 Pick one or more, comma-separated:
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -349,15 +349,49 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_taxtable",
         "update_taxtable",
         "delete_taxtable",
+        # Billterms — payment-terms registry shared by customer
+        # invoices and vendor bills. Lives here because every
+        # invoice carries terms; a solo freelancer setting
+        # "Net 30" or "2/10 Net 30" on customer invoices needs
+        # the CRUD surface without pulling in vendor management.
+        "create_billterm",
+        "list_billterms",
+        # Jobs — project-level grouping over invoices/bills for
+        # a single customer or vendor. Polymorphic on owner_type
+        # via the same _gate_owner_type pattern as the invoice
+        # tools: a freelancer-only user can create customer jobs
+        # but vendor jobs require business_complete to be loaded.
+        # Lives here because per-client P&L is a freelancer's
+        # natural year-end view.
+        "create_job",
+        "list_jobs",
+        "get_job",
+        "update_job",
+        "delete_job",
+        "get_job_report",
+        # Credit notes — refund/return documents. Polymorphic on
+        # owner_type. A freelancer issuing a customer refund
+        # works in this surface; vendor-side credit notes
+        # require business_complete via the gate.
+        "create_credit_note",
+        "add_credit_note_entry",
+        "delete_credit_note",
+        "apply_credit_note",
     ],
-    # ``business_complete`` — the vendor/employee/bills/credit-
-    # notes/jobs/billing-terms surface. Together with
-    # ``freelancer`` (the invoice surface), forms the full small-
-    # business toolkit. Both leaves expand together under the
-    # ``business`` group alias in MODULE_GROUPS. Pre-v1.3 this
-    # was named ``business`` and treated as a standalone — a UX
-    # trap that gave business-mode users only half the surface
-    # they expected.
+    # ``business_complete`` — vendor + employee surface only.
+    # Together with ``freelancer`` (which now owns billterms,
+    # jobs, and credit notes via the v1.3.1 redistribution),
+    # forms the full small-business toolkit. Both leaves expand
+    # together under the ``business`` group alias in
+    # MODULE_GROUPS.
+    #
+    # Polymorphic tools (jobs, credit notes) live in freelancer
+    # — a freelancer-only user uses them for customer-side
+    # operations; vendor-side use requires ``business_complete``
+    # via the _gate_owner_type check. This module owns the
+    # *entities* (vendors, employees) and the *vendor-side
+    # workflows* (bills, vouchers, vendor_spending_report) that
+    # don't make sense without those entities.
     "business_complete": [
         "create_vendor",
         "list_vendors",
@@ -378,29 +412,6 @@ TOOL_MODULES: dict[str, list[str]] = {
         "create_voucher",
         "add_voucher_entry",
         "delete_voucher",
-        # Credit notes (v1.3). Customer and vendor only —
-        # employees deliberately excluded (no GnuCash desktop
-        # equivalent). Lifecycle (post / unpost / pay / apply)
-        # flows through the polymorphic invoice tools in
-        # freelancer, detecting the credit-note slot to reverse
-        # posting direction.
-        "create_credit_note",
-        "add_credit_note_entry",
-        "delete_credit_note",
-        "apply_credit_note",
-        # Jobs (v1.3). Project-level grouping over invoices/bills
-        # for a single customer or vendor. No posted state — only
-        # active/inactive. Linked invoices route through the
-        # polymorphic owner_type=3 dispatch (see create_invoice's
-        # job_id parameter).
-        "create_job",
-        "list_jobs",
-        "get_job",
-        "update_job",
-        "delete_job",
-        "get_job_report",
-        "create_billterm",
-        "list_billterms",
         "vendor_spending_report",
     ],
 }
@@ -808,15 +819,17 @@ Options:
                                       17 tools.
                          investor     tax_lots + portfolio (cost basis
                                       + prices). 12 tools.
-                         freelancer   Customer invoicing + sales tax
-                                      (taxtables for GST / VAT /
-                                      US state sales tax). 19 tools.
+                         freelancer   Customer invoicing + sales tax,
+                                      plus billterms (payment terms),
+                                      jobs (per-project P&L), and
+                                      credit notes (customer refunds).
+                                      The full solo-consultant
+                                      toolkit. 31 tools.
                          business     Full small-business package:
                                       freelancer (invoicing) +
                                       business_complete (vendors,
                                       employees, bills, vouchers,
-                                      credit notes, jobs, billterms).
-                                      48 tools.
+                                      vendor reports). 48 tools.
 
                        Leaf modules (pick individually for finer
                        control, or as members of the groups above):

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -531,6 +531,59 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
     else:
         requested = {m.strip() for m in modules_str.split(",")}
 
+    # Fail-fast on names that don't resolve to a known sub-module
+    # or group. Pre-v1.3.0 this was a stderr warning, then partial
+    # load — silent in practice because Claude Desktop captures
+    # MCP server stderr into a log file the user never sees. A
+    # typo'd ``--modules=bookeeper`` (missing the 'k') would
+    # silently load only ``core``, leaving the user unable to
+    # tell whether the tools they wanted are missing because
+    # they typed it wrong or because the server is broken.
+    # Bookkeeper-found bug on the PR #92 review pass; same
+    # principle as ``extra="forbid"`` on tool kwargs — financial
+    # software shouldn't silently swallow typos in configuration
+    # either.
+    #
+    # **Validation runs BEFORE the ``all`` check** so a typo'd
+    # name alongside ``all`` (e.g. ``--modules=bookeeper,all``)
+    # still rejects. Pre-v1.3.1 ``all`` shortcut past validation
+    # to "load everything" and any typos in the list were
+    # silently ignored — the typo would only surface later if the
+    # user removed ``all`` and got a different failure mode. v1.3
+    # treats ``all`` as a loading instruction, not a validation
+    # bypass: every supplied name must be a real module or group.
+    known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
+    unknown = requested - known - {"all"}
+    if unknown:
+        # Per-typo, suggest the closest known name (did-you-mean).
+        # Use simple shared-character ratio; close enough for the
+        # typo-class we're trying to catch without pulling in a
+        # Levenshtein dependency.
+        import difflib
+        lines = ["Unknown module name(s) on --modules / GNUCASH_MCP_MODULES:"]
+        for bad in sorted(unknown):
+            matches = difflib.get_close_matches(
+                bad, sorted(known), n=1, cutoff=0.6,
+            )
+            if matches:
+                lines.append(f"  - {bad!r}  (did you mean {matches[0]!r}?)")
+            else:
+                lines.append(f"  - {bad!r}")
+        lines.append("")
+        lines.append(
+            f"Valid names: {', '.join(sorted(known))}, all"
+        )
+        lines.append("")
+        lines.append(
+            "Fix the typo and restart the server. Partial-load "
+            "was the previous behavior; v1.3 fails fast so "
+            "configuration errors surface at startup instead "
+            "of as missing tools downstream."
+        )
+        message = "\n".join(lines)
+        print(message, file=sys.stderr)
+        raise SystemExit(2)
+
     if "all" in requested:
         enabled_modules = set(TOOL_MODULES.keys())
         groups_used: list[str] = ["all"]
@@ -551,50 +604,6 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
                 groups_used.append(name)
             else:
                 enabled_modules.add(name)
-
-        # Fail-fast on names that don't resolve to a known sub-module
-        # or group. Pre-v1.3.0 this was a stderr warning, then partial
-        # load — silent in practice because Claude Desktop captures
-        # MCP server stderr into a log file the user never sees. A
-        # typo'd ``--modules=bookeeper`` (missing the 'k') would
-        # silently load only ``core``, leaving the user unable to
-        # tell whether the tools they wanted are missing because
-        # they typed it wrong or because the server is broken.
-        # Bookkeeper-found bug on the PR #92 review pass; same
-        # principle as ``extra="forbid"`` on tool kwargs — financial
-        # software shouldn't silently swallow typos in configuration
-        # either.
-        known = set(TOOL_MODULES.keys()) | set(MODULE_GROUPS.keys())
-        unknown = requested - known - {"all"}
-        if unknown:
-            # Per-typo, suggest the closest known name (did-you-mean).
-            # Use simple shared-character ratio; close enough for the
-            # typo-class we're trying to catch without pulling in a
-            # Levenshtein dependency.
-            import difflib
-            lines = ["Unknown module name(s) on --modules / GNUCASH_MCP_MODULES:"]
-            for bad in sorted(unknown):
-                matches = difflib.get_close_matches(
-                    bad, sorted(known), n=1, cutoff=0.6,
-                )
-                if matches:
-                    lines.append(f"  - {bad!r}  (did you mean {matches[0]!r}?)")
-                else:
-                    lines.append(f"  - {bad!r}")
-            lines.append("")
-            lines.append(
-                f"Valid names: {', '.join(sorted(known))}, all"
-            )
-            lines.append("")
-            lines.append(
-                "Fix the typo and restart the server. Partial-load "
-                "was the previous behavior; v1.3 fails fast so "
-                "configuration errors surface at startup instead "
-                "of as missing tools downstream."
-            )
-            message = "\n".join(lines)
-            print(message, file=sys.stderr)
-            raise SystemExit(2)
 
     # Keep only known sub-module names. Group expansion above may
     # have introduced names that aren't TOOL_MODULES keys if the

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -338,6 +338,38 @@ class TestApplyModuleFilter:
             _apply_module_filter("bookeeper,investor")
         assert exc_info.value.code == 2
 
+    def test_freelancer_carries_jobs_credit_notes_billterms(self):
+        """v1.3.1 redistribution: billterms, jobs, and credit notes
+        moved from business_complete to freelancer.
+
+        Principle: polymorphic-on-owner_type tools + shared
+        infrastructure live in freelancer; vendor-specific surface
+        stays in business_complete. A solo freelancer setting
+        payment terms on customer invoices, running per-project
+        P&L, or issuing customer refunds needs these without
+        pulling in vendor management. The polymorphic gate in
+        _gate_owner_type still restricts vendor-side use of the
+        polymorphic tools (jobs / credit notes) to business mode.
+        """
+        _apply_module_filter("freelancer")
+        remaining = self._tool_names()
+        # Billterms (shared infrastructure).
+        assert "create_billterm" in remaining
+        assert "list_billterms" in remaining
+        # Jobs (polymorphic; customer-side usable in freelancer).
+        assert "create_job" in remaining
+        assert "list_jobs" in remaining
+        assert "get_job_report" in remaining
+        # Credit notes (polymorphic; customer refunds usable).
+        assert "create_credit_note" in remaining
+        assert "apply_credit_note" in remaining
+        # Vendor-specific surface must remain absent.
+        assert "create_vendor" not in remaining
+        assert "create_bill" not in remaining
+        assert "create_employee" not in remaining
+        assert "create_voucher" not in remaining
+        assert "vendor_spending_report" not in remaining
+
     def test_unknown_module_alongside_all_still_fails(self, capsys):
         """``all`` is a loading instruction, not a validation bypass.
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -338,6 +338,42 @@ class TestApplyModuleFilter:
             _apply_module_filter("bookeeper,investor")
         assert exc_info.value.code == 2
 
+    def test_unknown_module_alongside_all_still_fails(self, capsys):
+        """``all`` is a loading instruction, not a validation bypass.
+
+        Bookkeeper-found bug post-PR #92 merge: when ``all`` was
+        present alongside a typo'd module name (e.g.
+        ``--modules=bookkeper,all``), the server happily loaded
+        every tool — the ``all`` branch short-circuited past the
+        unknown-name check. The typo would only surface later if
+        the user removed ``all`` and got a different failure mode.
+
+        Validation must run on every supplied name regardless of
+        whether ``all`` is also present. A typo is still a signal
+        that something's wrong — maybe the user is testing module
+        isolation and accidentally left ``all`` in, or they'll
+        later remove ``all`` and be surprised the misspelled one
+        silently does nothing.
+        """
+        import pytest
+        # Single typo + all → reject.
+        with pytest.raises(SystemExit) as exc_info:
+            _apply_module_filter("bookkeper,all")
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "bookkeper" in captured.err
+        assert "did you mean 'bookkeeper'" in captured.err
+
+    def test_multiple_typos_plus_all_still_fails(self, capsys):
+        """Even with valid modules AND all present, any typo
+        rejects."""
+        import pytest
+        with pytest.raises(SystemExit) as exc_info:
+            _apply_module_filter("business,bookkeper,all")
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "bookkeper" in captured.err
+
     def test_whitespace_in_module_names(self):
         """Whitespace around module names should be stripped."""
         _apply_module_filter("core , reporting")


### PR DESCRIPTION
## Summary

Two related module-surface fixes branched off develop after PR #92 merged:

**1. `all` is no longer a validation bypass** (commit 775b281)

Bookkeeper-found bug after PR #92 merge. `--modules=bookkeper,all` (typo + all) silently loaded all 106 tools — the `all` branch shortcut past the unknown-name validation.

Root cause: validation logic sat inside the `else` branch of `if "all" in requested`. Fix: hoist validation outside the if/else so every supplied name is checked before any loading decision.

Test cases now verified:

| Input | Behavior |
|---|---|
| `--modules=bookkeeper` | Loads cleanly |
| `--modules=bookkeper` | Fail-fast with did-you-mean (existing) |
| `--modules=all` | Loads everything |
| `--modules=bookkeper,all` | **Fail-fast** (was loading all) |
| `--modules=business,bookkeper,all` | **Fail-fast** |

**2. Move billterms, jobs, credit notes from business_complete to freelancer** (commit 835d005)

Unfinished work from PR #92 — we discussed and agreed on this redistribution while preparing the early-payment-discount spec, but the move never made it into the code before #92 merged. Documenting the intent and executing it now.

The principle: **polymorphic-on-owner_type tools + shared infrastructure live in freelancer; vendor-specific surface stays in business_complete.**

Moved to freelancer:
- **Billterms (2)** — payment-terms registry. Shared by customer invoices and vendor bills; freelancers setting "Net 30" on customer invoices need the CRUD surface without pulling in vendor management.
- **Jobs (6)** — polymorphic on owner_type. Solo freelancers use jobs for per-project P&L on customer work.
- **Credit notes (4)** — polymorphic on owner_type. Customer refunds usable in freelancer alone.

Vendor-side use of the polymorphic tools still requires `business_complete` via `_gate_owner_type` — a freelancer-only user calling `create_job(owner_type="vendor")` or `create_credit_note(owner_type="vendor")` gets the existing explicit error.

Tool counts:
- freelancer: 19 → 31
- business_complete: 29 → 17
- `business` group: 48 unchanged (sum preserved)

## Test plan

- [x] `--modules=bookkeper,all` → fail-fast with did-you-mean
- [x] `--modules=freelancer` → loads jobs, credit notes, billterms; vendor-side tools absent
- [x] `--modules=business` → loads everything (group expansion)
- [x] Polymorphic gate semantics: freelancer-only user calling `create_job(owner_type="vendor")` still rejected
- [x] `uv run pytest` clean (1,394 passing — +3 from new regression tests)