### PR TITLE
Branch 3: input boundaries + scheduled-transaction atomicity

### DIFF
--- a/src/gnucash_mcp/book/admin.py
+++ b/src/gnucash_mcp/book/admin.py
@@ -109,11 +109,14 @@ class AdminMixin:
         # HP-9 length cap. Encode to UTF-8 to count bytes (so a
         # multi-byte unicode payload can't sneak past a char-count
         # check). 64 KiB is generous for any real per-account
-        # metadata.
-        if len(value.encode("utf-8")) > _SLOT_VALUE_MAX_BYTES:
+        # metadata. Compute the byte length once; reusing
+        # ``value.encode(...)`` would allocate a fresh copy of the
+        # already-large string.
+        value_bytes = len(value.encode("utf-8"))
+        if value_bytes > _SLOT_VALUE_MAX_BYTES:
             raise ValueError(
                 f"Slot value too long: "
-                f"{len(value.encode('utf-8'))} bytes exceeds the "
+                f"{value_bytes} bytes exceeds the "
                 f"{_SLOT_VALUE_MAX_BYTES}-byte cap. Store large "
                 f"structured data outside the book."
             )

--- a/src/gnucash_mcp/book/admin.py
+++ b/src/gnucash_mcp/book/admin.py
@@ -126,8 +126,20 @@ class AdminMixin:
             log captures them from tool params.
 
         Raises:
-            ValueError: If account not found or key not found.
+            ValueError: If account not found, key contains disallowed
+                characters, or key not found.
         """
+        # Same regex gate as ``set_account_slot``. Pre-fix delete
+        # skipped the validator, so a user could target internal
+        # namespaced slots (``gnc-mcp/applies-to-invoice``, etc.)
+        # that the credit-note linkage and other internal features
+        # depend on. HP-11 from specs/CODE_REVIEW_v1_3.md.
+        if not _SLOT_KEY_RE.fullmatch(key):
+            raise ValueError(
+                f"Invalid slot key {key!r}: must match [A-Za-z0-9_.-]+. "
+                f"Embedded '/' would target hierarchical sub-slots "
+                f"(internal namespaced state); use flat keys."
+            )
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
             if not account:

--- a/src/gnucash_mcp/book/admin.py
+++ b/src/gnucash_mcp/book/admin.py
@@ -24,6 +24,15 @@ from gnucash_mcp.book._base import _slot_value_str  # noqa: F401  (re-exported f
 # USER input only.
 _SLOT_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
+# Upper bound on slot value length. 64 KiB is generous for any
+# legitimate per-account metadata (APR strings, credit limits,
+# statement-close-day, structured JSON config blobs) — well past
+# what real bookkeeping needs but short enough that a malicious
+# or runaway caller can't exhaust the book file with a single
+# slot write. Pre-fix slot values were unbounded; HP-9 from
+# specs/CODE_REVIEW_v1_3.md.
+_SLOT_VALUE_MAX_BYTES = 64 * 1024
+
 
 class AdminMixin:
     """Account slot operations.
@@ -96,6 +105,17 @@ class AdminMixin:
                 f"Invalid slot key {key!r}: must match [A-Za-z0-9_.-]+. "
                 f"Embedded '/' would create hierarchical sub-slots; "
                 f"use flat keys."
+            )
+        # HP-9 length cap. Encode to UTF-8 to count bytes (so a
+        # multi-byte unicode payload can't sneak past a char-count
+        # check). 64 KiB is generous for any real per-account
+        # metadata.
+        if len(value.encode("utf-8")) > _SLOT_VALUE_MAX_BYTES:
+            raise ValueError(
+                f"Slot value too long: "
+                f"{len(value.encode('utf-8'))} bytes exceeds the "
+                f"{_SLOT_VALUE_MAX_BYTES}-byte cap. Store large "
+                f"structured data outside the book."
             )
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -495,6 +495,20 @@ class ReconciliationMixin:
         """
         if not reason or not reason.strip():
             raise ValueError("Void reason is required")
+        # HP-9 length cap. 4 KiB covers any realistic void
+        # explanation — multi-paragraph context, audit trail
+        # notes, references to ticket numbers — while keeping a
+        # malicious or runaway caller from exhausting the book
+        # file with a single void. Byte-count (not char-count)
+        # so unicode payloads can't sneak past.
+        _VOID_REASON_MAX_BYTES = 4 * 1024
+        if len(reason.encode("utf-8")) > _VOID_REASON_MAX_BYTES:
+            raise ValueError(
+                f"Void reason too long: "
+                f"{len(reason.encode('utf-8'))} bytes exceeds the "
+                f"{_VOID_REASON_MAX_BYTES}-byte cap. Summarize the "
+                f"reason; keep detailed context outside the book."
+            )
 
         with self.open(readonly=False) as book:
             transaction = self._find_transaction(book, guid)

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -500,12 +500,15 @@ class ReconciliationMixin:
         # notes, references to ticket numbers — while keeping a
         # malicious or runaway caller from exhausting the book
         # file with a single void. Byte-count (not char-count)
-        # so unicode payloads can't sneak past.
+        # so unicode payloads can't sneak past. Compute the byte
+        # length once; ``reason.encode(...)`` would allocate a
+        # fresh copy of the already-large string.
         _VOID_REASON_MAX_BYTES = 4 * 1024
-        if len(reason.encode("utf-8")) > _VOID_REASON_MAX_BYTES:
+        reason_bytes = len(reason.encode("utf-8"))
+        if reason_bytes > _VOID_REASON_MAX_BYTES:
             raise ValueError(
                 f"Void reason too long: "
-                f"{len(reason.encode('utf-8'))} bytes exceeds the "
+                f"{reason_bytes} bytes exceeds the "
                 f"{_VOID_REASON_MAX_BYTES}-byte cap. Summarize the "
                 f"reason; keep detailed context outside the book."
             )

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -603,8 +603,32 @@ class SchedulingMixin:
     ) -> dict:
         """Create an actual transaction from a scheduled template.
 
-        Note: calls self.create_transaction (core, resolved via MRO)
-        in a separate session after the schedule update commits.
+        Three-phase write to keep the schedule advance and the
+        transaction in lockstep (SB-10):
+
+        1. **Read-only** session: resolve the scheduled-transaction
+           row, compute the target ``txn_date``, validate
+           preflight (frequency known, date past ``last_occur``,
+           splits non-empty). Captures everything needed for the
+           write without mutating anything.
+        2. ``self.create_transaction(...)`` runs in its own session.
+           On success this lands a transaction; on a raise the
+           schedule has not advanced and the caller's retry is
+           safe; on ``status="rejected"`` the duplicate detector
+           found an equivalent prior transaction (so an
+           equivalent transaction DOES exist for this period —
+           we treat that as a successful no-op and still advance
+           the schedule).
+        3. **Read-write** session: advance ``last_occur`` and
+           ``instance_count``. Reached only when phase 2 returned
+           without raising — so the schedule-advance-vs-transaction-
+           existence invariant holds in both the success and
+           duplicate-detected branches.
+
+        Pre-fix the schedule advanced BEFORE the transaction call;
+        any raise in phase 2 left the schedule moved with no
+        transaction posted, and a re-run would skip the period
+        entirely.
 
         Args:
             guid: Scheduled transaction GUID.
@@ -612,12 +636,24 @@ class SchedulingMixin:
                             Defaults to next occurrence date.
 
         Returns:
-            Dict with created transaction guid and updated schedule.
+            Dict with ``transaction_guid``, ``scheduled_transaction``
+            name, ``transaction_date``, ``instance_count``, and
+            ``status``. When the duplicate detector caught an
+            equivalent transaction, ``status="rejected"`` and a
+            ``reason="duplicate_exists"`` field is included so
+            downstream LLMs have explicit evidence to stop and
+            move on rather than retry the call. The duplicate
+            detector's ``duplicates`` TSV is forwarded too when
+            present, naming the matching prior transaction(s).
 
         Raises:
-            ValueError: If scheduled transaction not found or disabled.
+            ValueError: If scheduled transaction not found,
+                disabled, no upcoming occurrence, txn_date not
+                past last_occur, or splits empty. None of these
+                paths advance the schedule.
         """
-        with self.open(readonly=False) as book:
+        # ── Phase 1: read-only resolution. No mutation. ─────────
+        with self.open(readonly=True) as book:
             sx = self._find_scheduled_transaction(book, guid)
             if not sx:
                 raise ValueError(
@@ -662,10 +698,11 @@ class SchedulingMixin:
                         "No upcoming occurrence (past end date)"
                     )
 
-            # Preflight: refuse to instantiate an occurrence on or before
-            # last_occur. GnuCash desktop's "Since Last Run" updates
-            # last_occur when it auto-creates transactions; running this
-            # tool with a prior date would silently create a duplicate.
+            # Preflight: refuse to instantiate an occurrence on or
+            # before last_occur. GnuCash desktop's "Since Last Run"
+            # updates last_occur when it auto-creates transactions;
+            # running this tool with a prior date would silently
+            # create a duplicate.
             if last and txn_date <= last:
                 raise ValueError(
                     f"Transaction date {txn_date.isoformat()} is not "
@@ -681,30 +718,73 @@ class SchedulingMixin:
                     "transaction"
                 )
 
-            # Never rewind last_occur. If desktop pre-created ahead and
-            # we're backfilling an earlier gap, keep the later marker.
-            sx.last_occur = max(last, txn_date) if last else txn_date
-            sx.instance_count += 1
-
+            # Capture the few fields the later phases need so we
+            # don't have to re-resolve.
             sx_name = sx.name
-            instance_count = sx.instance_count
 
-            book.save()
-
-        # Create the actual transaction (separate session)
+        # ── Phase 2: create the transaction. ────────────────────
+        # On raise: schedule is unchanged (phase 3 not reached).
+        # On status="rejected": duplicate detector caught an
+        # equivalent prior transaction — for SB-10 purposes that
+        # transaction IS the one for this period, so we proceed
+        # to advance the schedule and forward the rejection signal
+        # to the caller in the response.
         txn_result = self.create_transaction(
             description=sx_name,
             splits=splits,
             trans_date=txn_date,
         )
 
-        return {
-            "transaction_guid": txn_result["guid"],
+        # ── Phase 3: advance the schedule. ──────────────────────
+        # Re-resolve under a read-write session and apply both
+        # mutations in one commit. We re-find by guid (the prior
+        # ORM object was detached when phase-1's session closed).
+        with self.open(readonly=False) as book:
+            sx = self._find_scheduled_transaction(book, guid)
+            if not sx:
+                # Edge case: schedule deleted concurrently between
+                # phases 1 and 3. The transaction exists; we
+                # surface a clean response noting the orphan
+                # rather than crash. Single-threaded MCP makes
+                # this practically unreachable but the defense
+                # is cheap.
+                instance_count = None
+            else:
+                # ``last`` was captured under the readonly session;
+                # if desktop pre-created ahead while phase 2 ran,
+                # use whatever's current. Never rewind.
+                current_last = sx.last_occur
+                if isinstance(current_last, datetime):
+                    current_last = current_last.date()
+                sx.last_occur = (
+                    max(current_last, txn_date)
+                    if current_last else txn_date
+                )
+                sx.instance_count += 1
+                instance_count = sx.instance_count
+                book.save()
+
+        # ── Phase 4: build response. ────────────────────────────
+        response = {
+            "transaction_guid": txn_result.get("guid"),
             "scheduled_transaction": sx_name,
             "transaction_date": txn_date.isoformat(),
             "instance_count": instance_count,
-            "status": "created",
+            "status": txn_result.get("status", "created"),
         }
+        if txn_result.get("status") == "rejected":
+            # Explicit evidence for downstream LLMs (including
+            # dumber models that might retry status="rejected"
+            # by default) that the rejection is the *correct*
+            # outcome — a transaction for this period already
+            # exists. Without this, the natural retry instinct
+            # would either re-trigger the dupe detector (best
+            # case) or, with --force_create, create the very
+            # duplicate the detector was preventing.
+            response["reason"] = "duplicate_exists"
+            if "duplicates" in txn_result:
+                response["duplicates"] = txn_result["duplicates"]
+        return response
 
     def update_scheduled_transaction(
         self,

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -756,15 +756,28 @@ class SchedulingMixin:
                 current_last = sx.last_occur
                 if isinstance(current_last, datetime):
                     current_last = current_last.date()
-                sx.last_occur = (
-                    max(current_last, txn_date)
-                    if current_last else txn_date
-                )
-                sx.instance_count += 1
+                # Only advance + increment when ``txn_date`` is
+                # actually beyond the current marker. If a
+                # concurrent writer covered this period between
+                # phases 2 and 3 (desktop's "Since Last Run", or
+                # another tool invocation), the schedule already
+                # registered the period — incrementing
+                # ``instance_count`` again would double-count.
+                # Copilot-flagged on PR #97. The MCP server runs
+                # single-threaded so this is practically
+                # unreachable today, but the gate is cheap and the
+                # invariant ("instance_count equals the number of
+                # distinct periods this schedule has produced")
+                # holds under any future multi-writer scenario.
+                if current_last is None or txn_date > current_last:
+                    sx.last_occur = txn_date
+                    sx.instance_count += 1
+                    book.save()
                 instance_count = sx.instance_count
-                book.save()
 
-        # ── Phase 4: build response. ────────────────────────────
+        # ── Build response. ─────────────────────────────────────
+        # Not a write phase — the docstring describes three
+        # write phases; this is the response-shaping step.
         response = {
             "transaction_guid": txn_result.get("guid"),
             "scheduled_transaction": sx_name,

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -80,9 +80,17 @@ class SplitInput(BaseModel):
     currency), and ``memo`` (optional).
     """
 
+    # ``extra="forbid"`` matches the server-global setting on
+    # ``ArgModelBase`` (set in server.py at import time). Pre-fix
+    # this used ``extra="ignore"``, which silently dropped typo'd
+    # keys: ``{"quantitiy": "10"}`` instead of ``{"quantity": "10"}``
+    # would discard the quantity entirely and the transaction would
+    # post with cross-currency value/quantity mismatch (or with the
+    # default-zero behavior, depending on the path). HP-10 from
+    # specs/CODE_REVIEW_v1_3.md.
     model_config = ConfigDict(
         coerce_numbers_to_str=True,
-        extra="ignore",
+        extra="forbid",
     )
 
     account: Annotated[

--- a/src/gnucash_mcp/tools/admin.py
+++ b/src/gnucash_mcp/tools/admin.py
@@ -3,6 +3,7 @@
 Registered only when the 'admin' module is enabled via --modules.
 """
 
+import re
 from datetime import datetime
 
 from gnucash_mcp.logging_config import (
@@ -10,6 +11,16 @@ from gnucash_mcp.logging_config import (
     get_log_dir,
 )
 from gnucash_mcp.tools._helpers import _json, safe_tool
+
+
+# Audit log filenames are exactly ``YYYY-MM-DD.txt``. Validate
+# ``log_date`` against this shape before constructing the path —
+# pre-fix, ``Path(audit_dir) / f"{log_date}.txt"`` would happily
+# interpolate ``../../../../etc/passwd`` and read arbitrary
+# ``*.txt`` files. Prompt injection through any free-text field
+# that surfaces into the audit log was the attack vector
+# (SB-15 from specs/CODE_REVIEW_v1_3.md).
+_LOG_DATE_RE = re.compile(r"\A\d{4}-\d{2}-\d{2}\Z")
 
 
 def register(mcp, get_book) -> None:
@@ -110,6 +121,19 @@ def register(mcp, get_book) -> None:
 
         audit_dir = log_dir / "audit"
         target_date = log_date or datetime.now().astimezone().strftime("%Y-%m-%d")
+        # SB-15 path-traversal gate. ``target_date`` is
+        # interpolated into the log path; reject anything that
+        # isn't a literal ``YYYY-MM-DD`` before the join so
+        # ``../../../../etc/passwd`` style inputs can't escape
+        # the audit directory.
+        if not _LOG_DATE_RE.fullmatch(target_date):
+            return _json({
+                "error": (
+                    f"Invalid log_date {target_date!r}: must be "
+                    f"YYYY-MM-DD (e.g. 2026-06-04)."
+                ),
+                "error_type": "validation_error",
+            })
         log_file = audit_dir / f"{target_date}.txt"
 
         if not log_file.exists():

--- a/src/gnucash_mcp/tools/admin.py
+++ b/src/gnucash_mcp/tools/admin.py
@@ -126,14 +126,19 @@ def register(mcp, get_book) -> None:
         # isn't a literal ``YYYY-MM-DD`` before the join so
         # ``../../../../etc/passwd`` style inputs can't escape
         # the audit directory.
+        #
+        # Raise rather than build the JSON envelope inline so
+        # ``safe_tool`` handles the rejection through its standard
+        # path: same JSON shape, plus the boundary-layer logger
+        # warning AND path redaction applied to the error message
+        # (``redact_paths`` in safe_tool's ValueError branch).
+        # Copilot-flagged on PR #97 — inline envelope duplicated
+        # the shape and skipped redaction.
         if not _LOG_DATE_RE.fullmatch(target_date):
-            return _json({
-                "error": (
-                    f"Invalid log_date {target_date!r}: must be "
-                    f"YYYY-MM-DD (e.g. 2026-06-04)."
-                ),
-                "error_type": "validation_error",
-            })
+            raise ValueError(
+                f"Invalid log_date {target_date!r}: must be "
+                f"YYYY-MM-DD (e.g. 2026-06-04)."
+            )
         log_file = audit_dir / f"{target_date}.txt"
 
         if not log_file.exists():

--- a/tests/test_float_precision.py
+++ b/tests/test_float_precision.py
@@ -95,13 +95,19 @@ class TestSplitInputCoercion:
         assert split.quantity == "100.0"
         assert Decimal(split.quantity) == Decimal("100.0")
 
-    def test_extras_ignored(self):
-        # Passing an unexpected key doesn't raise — existing callers
-        # that emit extra fields keep working.
-        split = SplitInput(
-            account="Assets:Checking", amount="1.00", unknown_key="x",
-        )
-        assert not hasattr(split, "unknown_key")
+    def test_extras_forbidden(self):
+        # HP-10: unknown keys now raise a ValidationError instead of
+        # silently dropping. Pre-Branch-3 the config was
+        # extra="ignore" — a typo like ``quantitiy`` would be
+        # silently discarded, leaving the transaction with a
+        # cross-currency value/quantity mismatch. extra="forbid"
+        # matches the server-global ArgModelBase config and
+        # surfaces typos as boundary errors.
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            SplitInput(
+                account="Assets:Checking", amount="1.00", unknown_key="x",
+            )
 
     def test_splits_to_dicts_converts_list(self):
         inputs = [

--- a/tests/test_input_boundaries.py
+++ b/tests/test_input_boundaries.py
@@ -272,3 +272,160 @@ class TestDeleteAccountSlotKeyValidation:
             assert not _SLOT_KEY_RE.fullmatch(k), (
                 f"regex regression: {k!r} should be rejected"
             )
+
+
+# ── HP-9: input length caps ────────────────────────────────────────
+
+
+class TestInputLengthCaps:
+    """HP-9: ``set_account_slot(value)`` and
+    ``void_transaction(reason)`` capped at sensible upper bounds.
+
+    Pre-fix both accepted arbitrary-length strings. A malicious or
+    runaway caller could exhaust the book file with a single write
+    by passing megabytes of payload. The caps are byte-count (UTF-8)
+    so a multi-byte unicode payload can't sneak past a char-count
+    check: 64 KiB for slot values (generous for any real per-account
+    metadata), 4 KiB for void reasons (generous for any realistic
+    audit explanation).
+    """
+
+    def test_set_account_slot_accepts_value_at_cap(self, test_book):
+        """A value exactly at the byte cap is accepted — the cap is
+        the inclusive boundary."""
+        from gnucash_mcp.book import GnuCashBook
+        from gnucash_mcp.book.admin import _SLOT_VALUE_MAX_BYTES
+        gb = GnuCashBook(str(test_book))
+        # Exactly at cap (ASCII payload — bytes == chars).
+        payload = "x" * _SLOT_VALUE_MAX_BYTES
+        result = gb.set_account_slot(
+            account_name="Assets:Checking",
+            key="big_blob",
+            value=payload,
+        )
+        assert result["status"] == "created"
+
+    def test_set_account_slot_rejects_oversize_value(self, test_book):
+        """One byte past the cap rejects with a clear error."""
+        from gnucash_mcp.book import GnuCashBook
+        from gnucash_mcp.book.admin import _SLOT_VALUE_MAX_BYTES
+        gb = GnuCashBook(str(test_book))
+        payload = "x" * (_SLOT_VALUE_MAX_BYTES + 1)
+        with pytest.raises(ValueError, match="too long"):
+            gb.set_account_slot(
+                account_name="Assets:Checking",
+                key="too_big",
+                value=payload,
+            )
+
+    def test_set_account_slot_counts_utf8_bytes_not_chars(self, test_book):
+        """A multi-byte UTF-8 payload that fits in chars but blows
+        the byte cap must reject. Catches the bug class where a
+        char-count check would let a 32 KiB string of CJK characters
+        (96 KiB in UTF-8) past a 64 KiB byte cap."""
+        from gnucash_mcp.book import GnuCashBook
+        from gnucash_mcp.book.admin import _SLOT_VALUE_MAX_BYTES
+        gb = GnuCashBook(str(test_book))
+        # "贵" is 3 bytes in UTF-8. Construct a payload that's
+        # 1/3 the byte cap in chars but over the byte cap in bytes.
+        char_count = (_SLOT_VALUE_MAX_BYTES // 3) + 1
+        payload = "贵" * char_count
+        assert len(payload) < _SLOT_VALUE_MAX_BYTES, (
+            "fixture math wrong: char count should be below cap"
+        )
+        assert len(payload.encode("utf-8")) > _SLOT_VALUE_MAX_BYTES, (
+            "fixture math wrong: byte count should be above cap"
+        )
+        with pytest.raises(ValueError, match="too long"):
+            gb.set_account_slot(
+                account_name="Assets:Checking",
+                key="unicode_blob",
+                value=payload,
+            )
+
+    def test_void_transaction_rejects_oversize_reason(self, test_book):
+        """``void_transaction(reason)`` cap is 4 KiB."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        # Find a transaction to void.
+        with gb.open(readonly=True) as pb:
+            txn = next(iter(pb.transactions))
+            txn_guid = txn.guid
+        # 4 KiB + 1 byte.
+        oversize_reason = "x" * (4 * 1024 + 1)
+        with pytest.raises(ValueError, match="too long"):
+            gb.void_transaction(guid=txn_guid, reason=oversize_reason)
+
+    def test_void_transaction_accepts_reasonable_reason(self, test_book):
+        """A normal-length reason still works end-to-end."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        with gb.open(readonly=True) as pb:
+            txn = next(iter(pb.transactions))
+            txn_guid = txn.guid
+        reason = (
+            "Voided after reconciliation found duplicate posting "
+            "from the imported OFX file. Original entry retained "
+            "for audit trail; new entry posted under " * 5
+        )
+        # ~700 chars — well under 4 KiB.
+        result = gb.void_transaction(guid=txn_guid, reason=reason)
+        assert result["status"] == "voided"
+
+
+# ── HP-10: SplitInput extra="forbid" ──────────────────────────────
+
+
+class TestSplitInputExtraForbid:
+    """HP-10: ``SplitInput`` must reject unknown kwargs.
+
+    Pre-fix ``model_config = ConfigDict(extra="ignore")`` silently
+    dropped typo'd keys: ``{"account": "...", "quantitiy": "10"}``
+    would discard the misspelled ``quantitiy`` entirely. With
+    ``extra="forbid"`` the typo raises a Pydantic validation error
+    at the boundary instead of corrupting the transaction shape
+    downstream. Matches the server-global ``ArgModelBase`` setting
+    PR #92 shipped.
+    """
+
+    def test_typo_in_quantity_raises(self):
+        """The canonical bug shape from the spec: ``quantitiy``
+        instead of ``quantity``."""
+        from pydantic import ValidationError
+        from gnucash_mcp.tools._helpers import SplitInput
+        with pytest.raises(ValidationError) as exc:
+            SplitInput(
+                account="Assets:Checking",
+                amount="10.00",
+                quantitiy="10",  # typo
+            )
+        # The error message should name the unknown field so the
+        # caller can identify the typo.
+        assert "quantitiy" in str(exc.value)
+
+    def test_known_fields_still_accepted(self):
+        """The legitimate field set still works end-to-end."""
+        from gnucash_mcp.tools._helpers import SplitInput
+        s = SplitInput(
+            account="Assets:Checking",
+            amount="10.00",
+            quantity="10.0000",
+            memo="test",
+        )
+        assert s.account == "Assets:Checking"
+        assert s.amount == "10.00"
+        assert s.quantity == "10.0000"
+        assert s.memo == "test"
+
+    def test_arbitrary_unknown_field_raises(self):
+        """Any field outside the declared set rejects — catches the
+        regression class where a future renamed-but-forgotten field
+        would silently drop."""
+        from pydantic import ValidationError
+        from gnucash_mcp.tools._helpers import SplitInput
+        with pytest.raises(ValidationError):
+            SplitInput(
+                account="Assets:Checking",
+                amount="10.00",
+                bogus_field="anything",
+            )

--- a/tests/test_input_boundaries.py
+++ b/tests/test_input_boundaries.py
@@ -609,3 +609,66 @@ class TestScheduledTransactionAtomicity:
             "reason field should only appear on rejected responses"
         )
         assert result["transaction_guid"]
+
+    def test_no_double_increment_under_concurrent_advance(
+        self, gb_with_schedule, monkeypatch,
+    ):
+        """Defense-in-depth: if a concurrent writer advances the
+        schedule between phases 1 and 3, phase 3 must not double-
+        count. The single-threaded MCP server makes this nearly
+        unreachable today, but the invariant ("instance_count
+        equals the number of distinct periods this schedule has
+        produced") must hold under any future multi-writer
+        scenario.
+
+        Simulated by monkeypatching ``create_transaction`` to
+        advance the schedule from inside phase 2 — the same
+        effect a concurrent ``create_transaction_from_scheduled``
+        or GnuCash desktop's "Since Last Run" would produce.
+        Copilot-flagged on PR #97."""
+        from datetime import date as _date
+        from gnucash_mcp.book import GnuCashBook
+        gb, sx_guid = gb_with_schedule
+        last_before, count_before = self._read_schedule_state(
+            gb, sx_guid,
+        )
+
+        real_create = GnuCashBook.create_transaction
+
+        def _create_then_concurrent_advance(self, *args, **kwargs):
+            # Run the real create_transaction first so the
+            # transaction lands as it normally would.
+            result = real_create(self, *args, **kwargs)
+            # Now simulate a concurrent writer advancing the
+            # schedule. Phase 3 will see this state when it
+            # re-resolves.
+            with self.open(readonly=False) as book:
+                sx = self._find_scheduled_transaction(book, sx_guid)
+                sx.last_occur = _date(2026, 1, 1)
+                sx.instance_count += 1
+                book.save()
+            return result
+
+        monkeypatch.setattr(
+            GnuCashBook, "create_transaction",
+            _create_then_concurrent_advance, raising=True,
+        )
+
+        gb.create_transaction_from_scheduled(
+            guid=sx_guid, transaction_date="2026-01-01",
+        )
+
+        last_after, count_after = self._read_schedule_state(
+            gb, sx_guid,
+        )
+        # Concurrent writer advanced once; phase 3's monotonic
+        # gate detected ``txn_date <= current_last`` and skipped
+        # the second increment.
+        assert count_after == count_before + 1, (
+            f"instance_count double-incremented under concurrent "
+            f"advance: {count_before} → {count_after} "
+            f"(expected {count_before + 1})"
+        )
+        # last_occur stays at the concurrent writer's value —
+        # never rewound.
+        assert last_after == _date(2026, 1, 1)

--- a/tests/test_input_boundaries.py
+++ b/tests/test_input_boundaries.py
@@ -173,3 +173,102 @@ class TestGetAuditLogPathTraversal:
             assert parsed.get("error_type") != "validation_error", (
                 f"default date path tripped validation gate: {result}"
             )
+
+
+# ── HP-11: delete_account_slot key validation ─────────────────────
+
+
+class TestDeleteAccountSlotKeyValidation:
+    """HP-11: ``delete_account_slot`` must apply the same
+    ``_SLOT_KEY_RE`` gate ``set_account_slot`` enforces.
+
+    Pre-fix delete skipped the validator. A user could pass
+    ``gnc-mcp/applies-to-invoice`` and delete an internal
+    namespaced slot that the credit-note linkage depends on —
+    the gate exists exactly to keep user input out of internal
+    sub-slot space (the ``/`` separator creates hierarchical
+    slots in piecash's KVP store).
+    """
+
+    def test_delete_rejects_namespaced_key(self, test_book):
+        """A ``gnc-mcp/applies-to-invoice``-style namespaced key
+        must be rejected, matching ``set_account_slot``'s gate.
+        Pre-fix this would have walked straight through to
+        ``account[key]`` lookup and either succeeded (deleting an
+        internal slot) or returned KeyError (depending on whether
+        that slot existed)."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Invalid slot key"):
+            gb.delete_account_slot(
+                account_name="Assets:Checking",
+                key="gnc-mcp/applies-to-invoice",
+            )
+
+    def test_delete_rejects_bare_slash(self, test_book):
+        """A bare ``/`` in the key fails the regex — it would
+        create a sub-slot reference under piecash's KVP semantics
+        and could target arbitrary internal state."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="Invalid slot key"):
+            gb.delete_account_slot(
+                account_name="Assets:Checking",
+                key="parent/child",
+            )
+
+    def test_delete_rejects_other_disallowed_chars(self, test_book):
+        """Anything outside ``[A-Za-z0-9_.-]`` rejects — spaces,
+        colons, etc. Match the set ``set_account_slot`` permits
+        exactly."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        for bad_key in ("has space", "has:colon", "has*star"):
+            with pytest.raises(ValueError, match="Invalid slot key"):
+                gb.delete_account_slot(
+                    account_name="Assets:Checking",
+                    key=bad_key,
+                )
+
+    def test_delete_accepts_legitimate_keys(self, test_book):
+        """Keys matching the regex still work end-to-end. Set a
+        slot via ``set_account_slot``, delete it via
+        ``delete_account_slot``, confirm both round-trip cleanly
+        without tripping the new gate."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(test_book))
+        # The classic flat-key cases the validator was always
+        # meant to allow.
+        gb.set_account_slot(
+            account_name="Assets:Checking",
+            key="apr",
+            value="3.5",
+        )
+        result = gb.delete_account_slot(
+            account_name="Assets:Checking",
+            key="apr",
+        )
+        assert result["status"] == "deleted"
+
+    def test_set_and_delete_have_matching_gates(self):
+        """Symmetry check: any key ``set_account_slot`` accepts,
+        ``delete_account_slot`` must accept too (and vice versa).
+        Catches a future divergence where one regex tightens but
+        the other doesn't."""
+        from gnucash_mcp.book.admin import _SLOT_KEY_RE
+        # Spot-check the canonical allowed and disallowed shapes.
+        # The actual contract is encoded in ``_SLOT_KEY_RE`` itself
+        # — both methods import the same regex, so the contract
+        # holds by construction. This test locks the import path
+        # (renaming the regex on one side without the other would
+        # be a regression).
+        allowed = ("apr", "credit_limit", "statement-close-day", "v1.2")
+        disallowed = ("has space", "gnc-mcp/applies", "has:colon")
+        for k in allowed:
+            assert _SLOT_KEY_RE.fullmatch(k), (
+                f"regex regression: {k!r} should be allowed"
+            )
+        for k in disallowed:
+            assert not _SLOT_KEY_RE.fullmatch(k), (
+                f"regex regression: {k!r} should be rejected"
+            )

--- a/tests/test_input_boundaries.py
+++ b/tests/test_input_boundaries.py
@@ -429,3 +429,183 @@ class TestSplitInputExtraForbid:
                 amount="10.00",
                 bogus_field="anything",
             )
+
+
+# ── SB-10: scheduled transaction atomicity ────────────────────────
+
+
+class TestScheduledTransactionAtomicity:
+    """SB-10: ``create_transaction_from_scheduled`` must not advance
+    the schedule unless an equivalent transaction exists.
+
+    Pre-fix the two-session order was: schedule advance commits FIRST,
+    then transaction create runs. If create raised — splits don't
+    balance, account got deleted, anything — the schedule had moved
+    but no transaction posted. Re-running advanced the schedule
+    again and skipped the period entirely.
+
+    Post-fix the order is reversed: transaction create runs first
+    (its own session), then the schedule advance runs in a second
+    session that's reached only if create returned without raising.
+    A raise leaves the schedule unchanged.
+
+    A ``status="rejected"`` return from the dupe detector counts as
+    "transaction exists for this period" (option (b) per the live-
+    tester discussion), so the schedule still advances — but the
+    response gains a ``reason="duplicate_exists"`` field so dumber
+    downstream LLMs don't reflexively retry the call (Gemini-style
+    retry would either re-trigger the dupe detector or, worse,
+    pass --force_create and post the very duplicate we were
+    preventing).
+    """
+
+    @pytest.fixture
+    def gb_with_schedule(self, scheduled_book):
+        """``scheduled_book`` with a monthly rent schedule already
+        created. Returns ``(gb, sx_guid)``."""
+        from gnucash_mcp.book import GnuCashBook
+        gb = GnuCashBook(str(scheduled_book))
+        sx = gb.create_scheduled_transaction(
+            name="Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        return gb, sx["guid"]
+
+    def _read_schedule_state(self, gb, sx_guid: str) -> tuple:
+        """Return ``(last_occur, instance_count)`` for the named
+        schedule. Returns a tuple of plain values (date-or-None
+        and int) so callers can compare cleanly."""
+        from datetime import datetime as _datetime
+        with gb.open(readonly=True) as book:
+            sx = gb._find_scheduled_transaction(book, sx_guid)
+            assert sx is not None, "schedule disappeared mid-test"
+            last = sx.last_occur
+            if isinstance(last, _datetime):
+                last = last.date()
+            return last, sx.instance_count
+
+    def test_create_raise_leaves_schedule_unchanged(
+        self, gb_with_schedule, monkeypatch,
+    ):
+        """If ``create_transaction`` raises (e.g. account got
+        deleted, splits malformed, etc.) the schedule must not
+        advance. Pre-fix this was the data-loss path — schedule
+        moved, transaction never landed.
+
+        We monkeypatch ``create_transaction`` to force a raise;
+        any raise shape exercises the same atomicity boundary."""
+        from gnucash_mcp.book import GnuCashBook
+        gb, sx_guid = gb_with_schedule
+
+        last_before, count_before = self._read_schedule_state(
+            gb, sx_guid,
+        )
+
+        def _boom(*args, **kwargs):
+            raise ValueError("simulated downstream failure")
+
+        monkeypatch.setattr(
+            GnuCashBook, "create_transaction", _boom, raising=True,
+        )
+
+        with pytest.raises(ValueError, match="simulated downstream"):
+            gb.create_transaction_from_scheduled(
+                guid=sx_guid, transaction_date="2026-01-01",
+            )
+
+        last_after, count_after = self._read_schedule_state(
+            gb, sx_guid,
+        )
+        assert last_after == last_before, (
+            f"last_occur advanced on raise: {last_before} → "
+            f"{last_after}"
+        )
+        assert count_after == count_before, (
+            f"instance_count advanced on raise: {count_before} → "
+            f"{count_after}"
+        )
+
+    def test_rejected_advances_schedule_with_reason(
+        self, gb_with_schedule, monkeypatch,
+    ):
+        """When ``create_transaction`` returns ``status="rejected"``
+        the dupe detector caught an equivalent prior transaction —
+        we treat that as a successful no-op (the duplicate IS the
+        transaction for this period) and advance the schedule.
+        The response gains ``reason="duplicate_exists"`` so
+        downstream LLMs see explicit evidence to stop and move on
+        rather than retry."""
+        from gnucash_mcp.book import GnuCashBook
+        gb, sx_guid = gb_with_schedule
+
+        last_before, count_before = self._read_schedule_state(
+            gb, sx_guid,
+        )
+
+        fake_duplicates = (
+            "HIGH\t12345678\t2026-01-01\t1850.00\tRent\tDAD"
+        )
+
+        def _rejected(*args, **kwargs):
+            return {
+                "status": "rejected",
+                "duplicates": fake_duplicates,
+            }
+
+        monkeypatch.setattr(
+            GnuCashBook, "create_transaction", _rejected,
+            raising=True,
+        )
+
+        result = gb.create_transaction_from_scheduled(
+            guid=sx_guid, transaction_date="2026-01-01",
+        )
+
+        # Schedule advanced — the duplicate IS the transaction
+        # for this period, so this counts as a completed period.
+        last_after, count_after = self._read_schedule_state(
+            gb, sx_guid,
+        )
+        from datetime import date as _date
+        assert last_after == _date(2026, 1, 1)
+        assert count_after == count_before + 1
+
+        # Response carries the rejection signal AND the reason
+        # field so a dumber LLM has explicit evidence to stop.
+        assert result["status"] == "rejected"
+        assert result["reason"] == "duplicate_exists"
+        assert result["duplicates"] == fake_duplicates
+
+    def test_success_path_advances_schedule_and_returns_created(
+        self, gb_with_schedule,
+    ):
+        """The happy path: real ``create_transaction`` call,
+        schedule advances, response says ``status="created"``.
+        Locks the contract that the refactor didn't change the
+        success-path semantics."""
+        gb, sx_guid = gb_with_schedule
+        last_before, count_before = self._read_schedule_state(
+            gb, sx_guid,
+        )
+
+        result = gb.create_transaction_from_scheduled(
+            guid=sx_guid, transaction_date="2026-01-01",
+        )
+
+        last_after, count_after = self._read_schedule_state(
+            gb, sx_guid,
+        )
+        from datetime import date as _date
+        assert last_after == _date(2026, 1, 1)
+        assert count_after == count_before + 1
+        assert result["status"] == "created"
+        assert "reason" not in result, (
+            "reason field should only appear on rejected responses"
+        )
+        assert result["transaction_guid"]

--- a/tests/test_input_boundaries.py
+++ b/tests/test_input_boundaries.py
@@ -1,0 +1,175 @@
+"""Regression tests for the Branch 3 input-boundary + atomicity work.
+
+Five bug classes the code review surfaced about untrusted input
+and write atomicity, each closed in its own commit:
+
+- ``TestGetAuditLogPathTraversal`` — SB-15 (this commit): the
+  ``log_date`` arg was interpolated into a ``Path`` without
+  validation. A regex gate now rejects anything that isn't
+  literally ``YYYY-MM-DD`` before path construction, blocking the
+  ``../../../../etc/passwd`` style prompt-injection exfiltration
+  vector.
+
+- ``TestDeleteAccountSlotKeyValidation`` — HP-11 (commit 2):
+  ``delete_account_slot`` skipped the ``_SLOT_KEY_RE`` gate
+  ``set_account_slot`` enforced, so a user could target internal
+  ``gnc-mcp/...`` slots the validator was meant to protect.
+
+- ``TestInputLengthCaps`` + ``TestSplitInputExtraForbid`` — HP-9
+  + HP-10 (commit 3): ``set_account_slot(value)`` and
+  ``void_transaction(reason)`` accepted arbitrary-length strings;
+  ``SplitInput`` used ``extra="ignore"`` which silently swallowed
+  typos like ``quantitiy``.
+
+- ``TestScheduledTransactionAtomicity`` — SB-10 (commit 4): the
+  two-session write where the schedule advanced before the
+  transaction landed could leave a half-state (schedule moved,
+  transaction missing) on raise. Restructured to create the
+  transaction first; a raise leaves the schedule unchanged. A
+  duplicate-detector ``rejected`` return is treated as success
+  (the duplicate IS the transaction for this period) with a
+  ``reason: "duplicate_exists"`` field added to the response so
+  downstream LLMs have explicit evidence to stop and move on
+  rather than retry.
+
+If any of these tests fails without an intentional change to the
+boundary contract, the bug class is open again.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ── SB-15: get_audit_log path traversal ────────────────────────────
+
+
+class TestGetAuditLogPathTraversal:
+    """SB-15: ``get_audit_log(log_date)`` must validate ``log_date``
+    against ``YYYY-MM-DD`` before constructing the file path.
+
+    Pre-fix the value was interpolated directly into
+    ``audit_dir / f"{log_date}.txt"``. ``log_date="../../../../etc/
+    passwd"`` resolved to ``/private/etc/passwd.txt`` on macOS —
+    any ``*.txt`` file readable by the server process could be
+    exfiltrated through a prompt-injection vector that influences
+    a user's call to this tool.
+    """
+
+    @pytest.fixture
+    def audit_tool(self, tmp_path, monkeypatch):
+        """Set up a server with the audit module loaded and the
+        log dir pointed at a temp location with one valid log
+        file ready to read."""
+        from gnucash_mcp.logging_config import setup_logging
+        from gnucash_mcp.server import (
+            _apply_module_filter,
+            _reset_lazy_load_state,
+            mcp,
+        )
+
+        # Fresh book + logging dir.
+        book_path = tmp_path / "test.gnucash"
+        book_path.touch()
+        setup_logging(book_path=str(book_path), debug=False)
+
+        # Seed a valid audit log file for the "well-formed
+        # date works" baseline test.
+        log_dir = tmp_path / "test.gnucash.mcp" / "audit"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "2026-06-04.txt").write_text(
+            "GNUCASH MCP AUDIT LOG\n\n"
+            "[entry placeholder]\n"
+        )
+
+        # Save + restore the loaded tools state so other tests
+        # aren't disturbed.
+        original = dict(mcp._tool_manager._tools)
+        try:
+            mcp._tool_manager._tools.clear()
+            _reset_lazy_load_state()
+            _apply_module_filter("audit")
+            yield mcp._tool_manager._tools["get_audit_log"]
+        finally:
+            mcp._tool_manager._tools.clear()
+            mcp._tool_manager._tools.update(original)
+            _reset_lazy_load_state()
+
+    def test_well_formed_date_works(self, audit_tool):
+        """``YYYY-MM-DD`` continues to work — the gate doesn't
+        break the happy path."""
+        result = audit_tool.fn(log_date="2026-06-04")
+        # The seeded file exists and has content; result should
+        # not be the "no audit log" path or an error.
+        assert "AUDIT LOG" in result or "[entry placeholder]" in result
+
+    def test_path_traversal_rejected(self, audit_tool):
+        """``../../../../etc/passwd`` (the canonical traversal
+        probe) must be rejected by the regex gate before any
+        filesystem access."""
+        result = audit_tool.fn(log_date="../../../../etc/passwd")
+        # The safe_tool decorator routes ValueError to a JSON
+        # error envelope. We rejected via _json(...) directly in
+        # the tool, so check for the validation_error envelope.
+        parsed = json.loads(result)
+        assert parsed["error_type"] == "validation_error"
+        assert "log_date" in parsed["error"].lower()
+
+    def test_traversal_via_url_encoded_dots_rejected(self, audit_tool):
+        """A URL-encoded traversal attempt would arrive as the
+        literal characters ``%2e%2e%2f...`` if any layer
+        decoded it. Regex still rejects (no hex chars in
+        ``YYYY-MM-DD``)."""
+        result = audit_tool.fn(log_date="%2e%2e/etc/passwd")
+        parsed = json.loads(result)
+        assert parsed["error_type"] == "validation_error"
+
+    def test_partial_date_shape_rejected(self, audit_tool):
+        """Almost-but-not-quite valid shapes get caught too:
+        ``2026-6-4`` (missing zero-padding) doesn't match the
+        ``\\d{4}-\\d{2}-\\d{2}`` pattern."""
+        result = audit_tool.fn(log_date="2026-6-4")
+        parsed = json.loads(result)
+        assert parsed["error_type"] == "validation_error"
+
+    def test_year_only_rejected(self, audit_tool):
+        """A bare year (``2026``) doesn't match the regex —
+        regression for a future relaxation that might fall back
+        to year-prefix matching."""
+        result = audit_tool.fn(log_date="2026")
+        parsed = json.loads(result)
+        assert parsed["error_type"] == "validation_error"
+
+    def test_empty_string_falls_back_to_today(self, audit_tool):
+        """Empty string is falsy in Python's ``or`` fallback, so it
+        behaves identically to ``log_date=None`` and resolves to
+        today's date — not a security hole (the regex still gates
+        the resulting target_date, and today's strftime output
+        always matches). Documented here as the intentional shape
+        of the falsy-fallback contract."""
+        result = audit_tool.fn(log_date="")
+        # Either today's file exists (string output) or it doesn't
+        # ("No audit log for ..."). Either way, NOT a
+        # validation_error envelope.
+        if result.startswith("{"):
+            parsed = json.loads(result)
+            assert parsed.get("error_type") != "validation_error", (
+                f"empty string tripped validation gate: {result}"
+            )
+
+    def test_default_date_works(self, audit_tool, tmp_path):
+        """``log_date=None`` falls through to today's date —
+        format is generated by ``strftime("%Y-%m-%d")`` which
+        always matches the regex. No false positive on the
+        default path."""
+        # Today's audit file may or may not exist; we only care
+        # that we don't hit the validation_error envelope.
+        result = audit_tool.fn()
+        if result.startswith("{"):
+            parsed = json.loads(result)
+            assert parsed.get("error_type") != "validation_error", (
+                f"default date path tripped validation gate: {result}"
+            )


### PR DESCRIPTION
## Summary

Closes the five input-validation and write-atomicity findings from `specs/CODE_REVIEW_v1_3.md`. Each fix is small and contained; SB-10 is the largest individual change but still scoped to one function.

- **SB-15** `fix(admin): regex-gate get_audit_log log_date` (`73538ec`) — path traversal. `tools/admin.py` interpolated `log_date` into `Path(audit_dir) / f"{log_date}.txt"` with no validation; `log_date="../../../../etc/passwd"` resolved outside the audit dir. Fix: `re.fullmatch(r"\d{4}-\d{2}-\d{2}")` before the path is constructed.

- **HP-11** `fix(admin): apply _SLOT_KEY_RE to delete_account_slot` (`07b0954`) — `set_account_slot` validated the slot key against `_SLOT_KEY_RE` (keeps user input out of piecash's hierarchical sub-slot space); `delete_account_slot` skipped the gate, letting a user delete internal namespaced slots (`gnc-mcp/applies-to-invoice`, etc.) the credit-note linkage depends on. Same gate applied at the same point.

- **HP-9 + HP-10** `fix: HP-9 length caps + HP-10 SplitInput extra="forbid"` (`031f6ee`) —
  - HP-9: `set_account_slot(value)` and `void_transaction(reason)` accepted arbitrary-length strings. Caps at 64 KiB (slot values) and 4 KiB (void reasons), UTF-8 byte count so multi-byte unicode payloads can't sneak past a char-count check.
  - HP-10: `SplitInput` used `extra="ignore"`, silently dropping typo'd keys (`quantitiy` → `quantity`). Changed to `extra="forbid"` to match the server-global `ArgModelBase` setting from PR #92.

- **SB-10** `fix(scheduling): atomic create_transaction_from_scheduled` (`556889b`) — the largest change. Pre-fix two-session order: schedule advance committed FIRST, then transaction create ran. Any raise in the second session left the schedule advanced with no transaction posted. Restructured to three phases — read-only resolution → transaction create → schedule advance — so a raise in phase 2 leaves the schedule untouched. A `status="rejected"` return from the dupe detector advances the schedule (the duplicate IS the transaction for this period) but the response gains a `reason="duplicate_exists"` field so dumber downstream LLMs (Gemini-style) don't reflexively retry on rejection. The duplicates TSV is forwarded too.

## Verification

**Test suite:** 1440 → 1463 passing (+23 new tests in `tests/test_input_boundaries.py` + 1 updated test in `test_float_precision.py` for the `extras_ignored` → `extras_forbidden` contract reversal). One existing test class (`TestCreateFromScheduled`) reorganized around the new three-phase shape; all 38 tests in `test_scheduled.py` still pass.

**No real-book capture rig** — like Branch 2, none of these changes move numeric outputs on Alex or Lin Wei. The fixes are about reject/accept boundaries (SB-15, HP-9, HP-10, HP-11) or write-order atomicity (SB-10); the visible-output behavior on the happy path is unchanged.

## Bookkeeper validation surface

Smaller than Branch 1 but worth a manual round on two surfaces:

1. **SB-10's `reason="duplicate_exists"` flow** — create a scheduled transaction, post a manual transaction matching the schedule's description/splits/date, then call `create_transaction_from_scheduled` for that date. The response should carry `status="rejected"`, `reason="duplicate_exists"`, and the `duplicates` TSV pointing at the manual transaction. The bookkeeper can judge whether the response is self-evident enough that a dumber downstream LLM would correctly not retry.

2. **HP-9 cap UX** — try `set_account_slot` with a deliberately-oversized value and verify the rejection message is clear enough to act on. The cap (64 KiB) is generous but the error path is on the user surface; if the message confuses the bookkeeper, easier to refine the phrasing now than later.

## Test plan

- [x] `uv run pytest` — 1463/1463 passing
- [x] `tests/test_input_boundaries.py` — 23 new tests across five classes (one per bug class)
- [x] `tests/test_scheduled.py` — 38/38 passing including the existing `test_updates_tracking`, `test_duplicate_occurrence_rejected`, `test_backfill_before_last_occur_rejected` (all exercise the new three-phase shape without changes)
- [x] `tests/test_float_precision.py::TestSplitInputCoercion` updated to reflect the new `extra="forbid"` contract
- [x] Optional bookkeeper round on the `reason="duplicate_exists"` response shape and HP-9 oversize-input error messages