### PR TITLE
Branch 5: design-call resolutions (SB-5 cash_flow transfer filter, HP-8 reconciliation count unification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,9 +408,9 @@ books" into "what do I need to do next":
 - **Budget headline** — *"41% used / 33% elapsed (+8% over pace)"*
   for the current period.
 - **Reconciliation backlog with split counts** —
-  *"Checking: 47 splits unreconciled since 2025-12-30 (4 months
-  behind) ⚠"*. Scope, not just staleness. 12 splits is a single
-  sitting; 400 is "let's narrow by month."
+  *"Checking: 47 splits unreconciled, last reconciled 2025-12-30
+  (4 months behind) ⚠"*. Scope, not just staleness. 12 splits is a
+  single sitting; 400 is "let's narrow by month."
 - **Upcoming scheduled** rolled into the Scheduled line —
   *"Scheduled: 13 recurring, 3 due in next 7 days (CNY 15,650)"*.
   No second tool call needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,9 +408,11 @@ books" into "what do I need to do next":
 - **Budget headline** — *"41% used / 33% elapsed (+8% over pace)"*
   for the current period.
 - **Reconciliation backlog with split counts** —
-  *"Checking: 47 splits unreconciled, last reconciled 2025-12-30
-  (4 months behind) ⚠"*. Scope, not just staleness. 12 splits is a
-  single sitting; 400 is "let's narrow by month."
+  *"Checking: 47 splits unreconciled (4 months behind, oldest:
+  2025-12-30) ⚠"*. Scope, not just staleness. 12 splits is a single
+  sitting; 400 is "let's narrow by month." The lag is computed from
+  the OLDEST unreconciled split so "behind" tells you the planning
+  number — not how long ago the last reconciliation closed.
 - **Upcoming scheduled** rolled into the Scheduled line —
   *"Scheduled: 13 recurring, 3 due in next 7 days (CNY 15,650)"*.
   No second tool call needed.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Receivables: 3 accounts, USD 10246.46
   Accounts Receivable: USD 3500.00
   Accounts Receivable CAD: USD 1837.50
 Reconciliation:
-  Checking Account: 174 splits unreconciled since 2025-12-30 (4 months behind) ⚠
+  Checking Account: 174 splits unreconciled, last reconciled 2025-12-30 (4 months behind) ⚠
   7 accounts never reconciled ⚠
 Net worth trajectory:
   12mo ago: USD 187,925

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Receivables: 3 accounts, USD 10246.46
   Accounts Receivable: USD 3500.00
   Accounts Receivable CAD: USD 1837.50
 Reconciliation:
-  Checking Account: 174 splits unreconciled, last reconciled 2025-12-30 (4 months behind) ⚠
+  Checking Account: 174 splits unreconciled (4 months behind, oldest: 2025-12-30) ⚠
   7 accounts never reconciled ⚠
 Net worth trajectory:
   12mo ago: USD 187,925

--- a/specs/REMAINING_ARC.md
+++ b/specs/REMAINING_ARC.md
@@ -13,21 +13,20 @@ what's been decided, what still needs the user's call.
 
 ## Status snapshot
 
-**Branch 4 in progress on `feat/math-ux-correctness`.** Scope: 9 of
-the 11 Branch 4 items (SB-5 and HP-8 deferred as design calls
-needing the user awake — see "Open decisions" below). One PR
-planned, four thematic commits matching Groups A/B'/C'/D from
-this doc.
+**26 of the 27 substantive review items are closed.** Branches 1-5
+all merged to develop. The two deferred design calls (SB-5, HP-8)
+were resolved on Stephen's call and shipped in PR #99 on
+`feat/design-call-resolutions`. Only MP-1 remains — design call on
+whether `get_server_config` needs an `@audit_log` decorator (default
+keep deferred, formally documented).
 
-15 of the 27 substantive review items are closed across three PRs.
-Every SB-* in scope of Branches 1-3 is done. The bookkeeper-found
-off-by-one (not in the original review) was also closed in Branch 1.
-
-| Branch | PR  | Status   | Items closed                                                                                  |
-| ------ | --- | -------- | --------------------------------------------------------------------------------------------- |
-| 1      | #95 | ✅ merged | SB-1, SB-2, SB-3, SB-4 (rates), SB-11, SB-12, SB-13, SB-14, HP-3, bookkeeper off-by-one      |
-| 2      | #96 | ✅ merged | HP-1, HP-2                                                                                    |
-| 3      | #97 | ✅ merged | SB-15, SB-10, HP-9, HP-10, HP-11                                                              |
+| Branch | PR   | Status   | Items closed                                                                                  |
+| ------ | ---- | -------- | --------------------------------------------------------------------------------------------- |
+| 1      | #95  | ✅ merged | SB-1, SB-2, SB-3, SB-4 (rates), SB-11, SB-12, SB-13, SB-14, HP-3, bookkeeper off-by-one      |
+| 2      | #96  | ✅ merged | HP-1, HP-2                                                                                    |
+| 3      | #97  | ✅ merged | SB-15, SB-10, HP-9, HP-10, HP-11                                                              |
+| 4      | #98  | ✅ merged | SB-6, SB-7, SB-8, SB-9, HP-4, HP-5, HP-6, HP-7, HP-12 (+ Copilot docs cleanup, bookkeeper signoff) |
+| 5      | #99  | ✅ in branch | SB-5 (cash_flow transfer filter), HP-8 (reconciliation backlog count unification)        |
 
 The per-branch capture rigs (Branch 1's `scripts/branch_1/capture.py`
 + `specs/branch_1_captures/`) document the behavioral evidence.
@@ -198,6 +197,27 @@ before release:**
   UPDATE→MOVE remap lives in `_format_audit_entry_text`. Tests
   document this attribution.
 
+- **SB-5 (`cash_flow` internal transfer filter):** filter by
+  default. Stephen's home-book example: when running `cash_flow`
+  to analyze credit-card payments, double-counting every internal
+  transfer (Checking → Cash App → Card → ...) inflated inflows and
+  outflows by every funding hop. That's not cash flow; that's
+  moving money between pockets. The cash-flow framing answers
+  "where did money come from and where did it go?" — transfers
+  are noise. New `include_transfers: bool = False` param restores
+  the gross flow for bank-statement reconciliation. "No amount of
+  loud documentation fixes a default that gives the wrong answer."
+
+- **HP-8 (reconciliation backlog count):** unify on the
+  `get_unreconciled_splits` rule (all non-y, non-voided splits).
+  The summary is the dashboard. If the dashboard says 47 and the
+  detail tool says 63, the bookkeeper's first instinct is "the
+  book is wrong" — not "oh, these tools count differently." Old
+  unreconciled splits predating `latest_y_date` (skipped during a
+  partial reconciliation, opening balances never stamped) are
+  exactly the ones that tend to be problems and must be visible
+  in both surfaces.
+
 ---
 
 ## Open decisions worth surfacing
@@ -207,12 +227,6 @@ before release:**
   Stage 3 features (taxtables, credit_notes, vouchers, jobs) have
   realistic exposure on both books. This affects which branch L-7
   lands in (could be its own pre-release branch).
-
-- **Branch 4 vs split:** Group A/B/C/D as one PR (four commits)
-  vs. two PRs (A+B as "correctness," C+D as "polish + sweep").
-  Lean toward one — the dependencies are loose but the theme
-  ("review-fallout cleanup") is coherent. Could split if Copilot
-  review surfaces dimension-specific concerns.
 
 - **`samples/lin-wei.gnucash` drift:** three options listed above.
   The "extend" option pairs cleanly with L-7.

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -105,6 +105,30 @@ def _is_voided(split) -> bool:
     return split.reconcile_state == "v"
 
 
+def _is_unreconciled(split) -> bool:
+    """True iff ``split`` counts as pending reconciliation work.
+
+    Single source of truth for "is this split unreconciled" — the
+    same predicate ``get_unreconciled_splits`` (the detail tool)
+    and ``_account_reconciliation_status`` (the dashboard count)
+    both consult. Routing both sites through this helper enforces
+    HP-8's convergence structurally instead of by docstring promise.
+
+    ``state == "n"`` (new) and ``state == "c"`` (cleared) both
+    count — cleared splits are not finalized; they're the
+    bookkeeper's tentative state before a final ``"y"`` mark.
+    ``state == "y"`` (reconciled) and voided zombies are excluded.
+
+    Pre-HP-8 the dashboard count and the detail tool disagreed on
+    pre-``latest_y_date`` unreconciled splits (the dashboard scoped
+    its count to splits AFTER the most recent ``y``; the detail
+    tool returned all non-y). The fix landed at both sites by
+    hand-aligning the predicate; this helper chokepoints it so a
+    future change can't recreate HP-8 in a new shape.
+    """
+    return split.reconcile_state != "y" and not _is_voided(split)
+
+
 def _to_decimal(value) -> Decimal:
     """Safe Decimal construction for user-supplied monetary values.
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -125,6 +125,19 @@ def _is_unreconciled(split) -> bool:
     tool returned all non-y). The fix landed at both sites by
     hand-aligning the predicate; this helper chokepoints it so a
     future change can't recreate HP-8 in a new shape.
+
+    Scope: this is the **as-of-today** predicate. The dashboard
+    surface (``_account_reconciliation_status`` →
+    ``get_book_summary``) is the morning-check view and
+    intentionally has no historical-tie-out parameter. The detail
+    tool (``get_unreconciled_splits``) accepts a separate
+    ``as_of_date`` arg that filters out post-``as_of`` splits — a
+    different scoping concern layered ON TOP of this predicate, not
+    a reason to thread date into the chokepoint. Counts at the two
+    surfaces agree by construction when ``as_of_date`` is unset;
+    they're expected to diverge when it's used, and that's the
+    detail tool's contract — the morning-check view doesn't reach
+    into history.
     """
     return split.reconcile_state != "y" and not _is_voided(split)
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -288,17 +288,17 @@ class CoreMixin:
             #   - latest_y_date (most recent reconciled split)
             #   - has_yc (any 'y' or 'c' for the ASSET gate)
             #   - any_splits (used vs. unused account)
-            # Pre-fix this method walked ``account.splits`` twice:
-            # once for the ASSET-passes-only-with-yc check, once
-            # for the latest-y_date scan, and (in some branches)
-            # a third time for the unreconciled count. One sweep
-            # collects everything; the count itself can't be
-            # computed up front because it depends on
-            # latest_y_date, but we capture all the inputs in the
-            # single pass and run the count after.
+            #   - unreconciled_count (total non-y, non-voided)
+            # Post-HP-8 the count is state-only (doesn't depend on
+            # ``latest_y_date``), so it folds into the existing
+            # sweep — half the splits work per dashboard call.
+            # ``_is_unreconciled`` is the chokepoint shared with
+            # ``get_unreconciled_splits`` so the dashboard count
+            # and the detail tool agree by construction.
             latest_y_date = None
             has_yc = False
             any_splits = False
+            unreconciled_count = 0
             for s in account.splits:
                 any_splits = True
                 rstate = s.reconcile_state
@@ -308,6 +308,8 @@ class CoreMixin:
                     pd = s.transaction.post_date
                     if latest_y_date is None or pd > latest_y_date:
                         latest_y_date = pd
+                if _is_unreconciled(s):
+                    unreconciled_count += 1
 
             # ASSET passes only when it has reconcilable history.
             # Investment positions / real estate / vehicles carry
@@ -319,29 +321,6 @@ class CoreMixin:
                 # No activity at all — not "behind," just unused.
                 continue
 
-            # Count unreconciled splits — total non-y, non-voided.
-            # Same ground-truth definition as
-            # ``get_unreconciled_splits``. The LLM uses the count to
-            # plan the reconciliation pass: 12 splits is a single
-            # sitting, 400 is "let's narrow by month." 'c' (cleared)
-            # splits count as unreconciled for this purpose; they're
-            # not finalized. Voided ('v') splits are excluded —
-            # they're zombies from void_transaction, not pending
-            # bookkeeping work.
-            #
-            # HP-8: pre-fix the "has latest_y_date" branch added
-            # ``s.transaction.post_date > latest_y_date`` which
-            # silently dropped old unreconciled splits predating the
-            # last reconciliation — skipped during partial passes,
-            # opening balances never stamped, edge cases that fell
-            # through. Those are exactly the ones that tend to be
-            # problems. Pre-fix the dashboard NOT counting them while
-            # ``get_unreconciled_splits`` DID broke the bookkeeper's
-            # first instinct that the dashboard summary equals the
-            # detail-tool truth. One rule now, both surfaces.
-            unreconciled_count = sum(
-                1 for s in account.splits if _is_unreconciled(s)
-            )
             if latest_y_date is None:
                 results.append({
                     "account": account.fullname,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -318,22 +318,31 @@ class CoreMixin:
                 # No activity at all — not "behind," just unused.
                 continue
 
-            # Count unreconciled splits past the last 'y' date (or
-            # all of them when never reconciled). This becomes the
-            # "47 splits unreconciled since DATE" payload — the LLM
-            # uses the count to plan the reconciliation pass: 12
-            # splits is a single sitting, 400 is "let's narrow by
-            # month." 'c' (cleared) splits count as unreconciled
-            # for this purpose; they're not finalized.
+            # Count unreconciled splits — total non-y, non-voided.
+            # Same ground-truth definition as
+            # ``get_unreconciled_splits``. The LLM uses the count to
+            # plan the reconciliation pass: 12 splits is a single
+            # sitting, 400 is "let's narrow by month." 'c' (cleared)
+            # splits count as unreconciled for this purpose; they're
+            # not finalized. Voided ('v') splits are excluded —
+            # they're zombies from void_transaction, not pending
+            # bookkeeping work.
+            #
+            # HP-8: pre-fix the "has latest_y_date" branch added
+            # ``s.transaction.post_date > latest_y_date`` which
+            # silently dropped old unreconciled splits predating the
+            # last reconciliation — skipped during partial passes,
+            # opening balances never stamped, edge cases that fell
+            # through. Those are exactly the ones that tend to be
+            # problems. Pre-fix the dashboard NOT counting them while
+            # ``get_unreconciled_splits`` DID broke the bookkeeper's
+            # first instinct that the dashboard summary equals the
+            # detail-tool truth. One rule now, both surfaces.
+            unreconciled_count = sum(
+                1 for s in account.splits
+                if s.reconcile_state != "y" and not _is_voided(s)
+            )
             if latest_y_date is None:
-                # Voided splits are excluded — they're zombies from
-                # void_transaction, not pending bookkeeping work. Pre-
-                # fix the filter was ``state != "y"`` which counted
-                # them; ``_is_voided`` is now the chokepoint.
-                unreconciled_count = sum(
-                    1 for s in account.splits
-                    if s.reconcile_state != "y" and not _is_voided(s)
-                )
                 results.append({
                     "account": account.fullname,
                     "status": "never reconciled",
@@ -342,12 +351,6 @@ class CoreMixin:
                 })
             else:
                 days_behind = (today - latest_y_date).days
-                unreconciled_count = sum(
-                    1 for s in account.splits
-                    if s.reconcile_state != "y"
-                    and not _is_voided(s)
-                    and s.transaction.post_date > latest_y_date
-                )
                 results.append({
                     "account": account.fullname,
                     "status": f"through {latest_y_date.isoformat()}",
@@ -1697,18 +1700,23 @@ class CoreMixin:
         for entry in stale:
             leaf = entry["account"].split(":")[-1]
             lag = self._format_reconciliation_lag(entry["days_behind"])
-            # Sub-line shape: "47 splits unreconciled since
-            # 2025-12-30 (4 months behind) ⚠". The split count
-            # tells the LLM the *scope* of the reconciliation
-            # work — 12 splits is one sitting; 400 needs a
-            # month-by-month strategy.
+            # Sub-line shape: "47 splits unreconciled, last
+            # reconciled 2025-12-30 (4 months behind) ⚠". The
+            # split count tells the LLM the *scope* of the
+            # reconciliation work — 12 splits is one sitting;
+            # 400 needs a month-by-month strategy. HP-8: the
+            # count is total outstanding (matches
+            # ``get_unreconciled_splits``), so the previous
+            # "since DATE" phrasing — which implied "only splits
+            # after this date" — was reworded to "last
+            # reconciled DATE" as supplementary context.
             n = entry["unreconciled_count"]
             if n > 0 and "latest_y_date" in entry:
                 plural = "s" if n != 1 else ""
                 since = entry["latest_y_date"]
                 out.append(
-                    f"  {leaf}: {n} split{plural} "
-                    f"unreconciled since {since} {lag} ⚠"
+                    f"  {leaf}: {n} split{plural} unreconciled, "
+                    f"last reconciled {since} {lag} ⚠"
                 )
             else:
                 out.append(

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -289,16 +289,25 @@ class CoreMixin:
             #   - has_yc (any 'y' or 'c' for the ASSET gate)
             #   - any_splits (used vs. unused account)
             #   - unreconciled_count (total non-y, non-voided)
+            #   - oldest_unreconciled_date (oldest pending work)
             # Post-HP-8 the count is state-only (doesn't depend on
             # ``latest_y_date``), so it folds into the existing
             # sweep — half the splits work per dashboard call.
             # ``_is_unreconciled`` is the chokepoint shared with
             # ``get_unreconciled_splits`` so the dashboard count
             # and the detail tool agree by construction.
+            #
+            # Chokepoint scope note: ``_is_unreconciled`` is the
+            # as-of-today predicate. ``get_unreconciled_splits``
+            # accepts a separate ``as_of_date`` arg for historical
+            # tie-outs; the dashboard intentionally has no such
+            # parameter (it's the morning-check surface, not the
+            # reporting surface). Documented at the helper.
             latest_y_date = None
             has_yc = False
             any_splits = False
             unreconciled_count = 0
+            oldest_unreconciled_date = None
             for s in account.splits:
                 any_splits = True
                 rstate = s.reconcile_state
@@ -310,6 +319,10 @@ class CoreMixin:
                         latest_y_date = pd
                 if _is_unreconciled(s):
                     unreconciled_count += 1
+                    pd = s.transaction.post_date
+                    if (oldest_unreconciled_date is None
+                            or pd < oldest_unreconciled_date):
+                        oldest_unreconciled_date = pd
 
             # ASSET passes only when it has reconcilable history.
             # Investment positions / real estate / vehicles carry
@@ -329,14 +342,36 @@ class CoreMixin:
                     "unreconciled_count": unreconciled_count,
                 })
             else:
-                days_behind = (today - latest_y_date).days
-                results.append({
-                    "account": account.fullname,
-                    "status": f"through {latest_y_date.isoformat()}",
-                    "days_behind": days_behind,
-                    "unreconciled_count": unreconciled_count,
-                    "latest_y_date": latest_y_date.isoformat(),
-                })
+                # Lag is computed from the OLDEST unreconciled split
+                # when there's pending work — the honest scope-of-
+                # work signal the bookkeeper plans against. "4 months
+                # behind" on an account whose oldest unreconciled
+                # split is from 2020 would cost a day of mismatched
+                # expectations ("one-sitting catch-up" vs "gather six
+                # years of statements"). Fully-caught-up accounts
+                # (unreconciled_count == 0) fall back to
+                # latest_y_date as the staleness signal.
+                if unreconciled_count > 0 \
+                        and oldest_unreconciled_date is not None:
+                    days_behind = (today - oldest_unreconciled_date).days
+                    results.append({
+                        "account": account.fullname,
+                        "status": f"through {latest_y_date.isoformat()}",
+                        "days_behind": days_behind,
+                        "unreconciled_count": unreconciled_count,
+                        "latest_y_date": latest_y_date.isoformat(),
+                        "oldest_unreconciled_date":
+                            oldest_unreconciled_date.isoformat(),
+                    })
+                else:
+                    days_behind = (today - latest_y_date).days
+                    results.append({
+                        "account": account.fullname,
+                        "status": f"through {latest_y_date.isoformat()}",
+                        "days_behind": days_behind,
+                        "unreconciled_count": unreconciled_count,
+                        "latest_y_date": latest_y_date.isoformat(),
+                    })
 
         results.sort(key=lambda r: r["account"])
         return results
@@ -1588,9 +1623,11 @@ class CoreMixin:
 
 
     @staticmethod
-    def _format_reconciliation_lag(days_behind: int) -> str:
-        """Render a parenthesized "(N months behind)" / "(N days
-        behind)" suffix for a reconciliation status warning.
+    def _format_reconciliation_lag(
+        days_behind: int, with_parens: bool = True,
+    ) -> str:
+        """Render a "(N years behind)" / "(N months behind)" /
+        "(N days behind)" suffix for a reconciliation status warning.
 
         Months scale once we're past 60 days because that's how users
         think about reconciliation lag — "two months behind" reads
@@ -1604,11 +1641,24 @@ class CoreMixin:
         off-by-one nudge that ``// 30`` produced (90 → 3 vs 91 → 3,
         but 30 → 1 vs 60 → 2 was sharp; reasonable enough most of
         the time but humans round to nearest unit, not floor).
+
+        Past 24 months we shift to years for the same reason — "6
+        years behind" is the bookkeeper's planning number; "72
+        months behind" reads as a typo.
+
+        ``with_parens=False`` returns the bare phrase so callers
+        composing larger strings ("(6 years behind, oldest: ...)" )
+        can join without double-paren artifacts.
         """
-        if days_behind >= 60:
+        if days_behind >= 730:  # 24 months in days
+            years = round(days_behind / 365.25)
+            inner = f"{years} year{'s' if years != 1 else ''} behind"
+        elif days_behind >= 60:
             months = round(days_behind / 30.44)
-            return f"({months} months behind)"
-        return f"({days_behind} days behind)"
+            inner = f"{months} months behind"
+        else:
+            inner = f"{days_behind} days behind"
+        return f"({inner})" if with_parens else inner
 
     # ── Section renderers ─────────────────────────────────────────────
     #
@@ -1679,23 +1729,33 @@ class CoreMixin:
         for entry in stale:
             leaf = entry["account"].split(":")[-1]
             lag = self._format_reconciliation_lag(entry["days_behind"])
-            # Sub-line shape: "47 splits unreconciled, last
-            # reconciled 2025-12-30 (4 months behind) ⚠". The
-            # split count tells the LLM the *scope* of the
-            # reconciliation work — 12 splits is one sitting;
-            # 400 needs a month-by-month strategy. HP-8: the
-            # count is total outstanding (matches
-            # ``get_unreconciled_splits``), so the previous
-            # "since DATE" phrasing — which implied "only splits
-            # after this date" — was reworded to "last
-            # reconciled DATE" as supplementary context.
+            # Sub-line shape: "47 splits unreconciled (6 years
+            # behind, oldest: 2020-03-15) ⚠". The split count
+            # tells the LLM the *scope* of the work — 12 splits
+            # is one sitting; 400 needs a month-by-month strategy
+            # — and the lag is computed from the OLDEST
+            # unreconciled split (set in
+            # ``_account_reconciliation_status``) so "behind"
+            # measures the true scope, not just time-since-last-
+            # reconcile. A bookkeeper looking at "4 months
+            # behind" expects a one-session catch-up; the new
+            # phrasing surfaces "6 years behind" when that's the
+            # honest scope, so they bring six years of statements
+            # instead of one quarter's.
+            #
+            # The "oldest: DATE" suffix carries the exact anchor
+            # — useful when the bookkeeper is deciding which
+            # source documents to pull.
             n = entry["unreconciled_count"]
-            if n > 0 and "latest_y_date" in entry:
+            if n > 0 and "oldest_unreconciled_date" in entry:
                 plural = "s" if n != 1 else ""
-                since = entry["latest_y_date"]
+                oldest = entry["oldest_unreconciled_date"]
+                lag_inner = self._format_reconciliation_lag(
+                    entry["days_behind"], with_parens=False,
+                )
                 out.append(
-                    f"  {leaf}: {n} split{plural} unreconciled, "
-                    f"last reconciled {since} {lag} ⚠"
+                    f"  {leaf}: {n} split{plural} unreconciled "
+                    f"({lag_inner}, oldest: {oldest}) ⚠"
                 )
             else:
                 out.append(

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -35,6 +35,7 @@ from gnucash_mcp.book._base import (
     _account_to_dict,
     _guid_prefix_map,
     _is_market_price,
+    _is_unreconciled,
     _is_voided,
     _split_to_compact_dict,
     _split_to_dict,
@@ -339,8 +340,7 @@ class CoreMixin:
             # first instinct that the dashboard summary equals the
             # detail-tool truth. One rule now, both surfaces.
             unreconciled_count = sum(
-                1 for s in account.splits
-                if s.reconcile_state != "y" and not _is_voided(s)
+                1 for s in account.splits if _is_unreconciled(s)
             )
             if latest_y_date is None:
                 results.append({

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 
 from gnucash_mcp.book._base import (
     _guid_prefix_map,
+    _is_unreconciled,
     _is_voided,
     _split_to_compact_dict,
     _to_decimal,
@@ -191,11 +192,14 @@ class ReconciliationMixin:
                 if as_of_date and split.transaction.post_date > as_of_date:
                     continue
 
-                # Include splits in states ``n`` or ``c`` only.
-                # Pre-fix the filter was ``state != "y"`` which admitted
-                # voided (state=``v``) splits as if they were pending
-                # bookkeeping work. ``_is_voided`` is the chokepoint.
-                if split.reconcile_state == "y" or _is_voided(split):
+                # Skip reconciled and voided splits — only states
+                # ``n`` (new) and ``c`` (cleared) count as pending
+                # bookkeeping work. ``_is_unreconciled`` is the
+                # chokepoint shared with the dashboard count
+                # (``_account_reconciliation_status``) so HP-8
+                # convergence is structural rather than
+                # docstring-promised.
+                if not _is_unreconciled(split):
                     continue
                 split_dict = {
                     "guid": split.guid,

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -21,7 +21,7 @@ Depends on shared helpers from BaseGnuCashBook:
   - self.open, self._find_account
 """
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal, InvalidOperation
 
 import piecash
@@ -803,16 +803,37 @@ class ReportingMixin:
         start_date: date,
         end_date: date,
         account: str | None = None,
+        include_transfers: bool = False,
     ) -> dict:
         """Calculate cash flow (inflows and outflows) for a period.
+
+        By default, internal transfers between cash/bank/credit/
+        asset accounts are filtered out. A transaction with no
+        INCOME or EXPENSE leg is a pure rearrangement — transfer
+        to savings, credit-card payoff, currency wallet shuffle —
+        neither inflow nor outflow in cash-flow terms. Filtering
+        that noise is what makes the totals answer "where did
+        money come from and where did it go?" rather than "every
+        debit and credit that touched a cash account, including
+        same-pocket reshuffling." SB-5.
 
         Args:
             start_date: Start of period (inclusive).
             end_date: End of period (inclusive).
-            account: Optional account to filter (e.g., specific bank account).
+            account: Optional account to filter to a single
+                cash/bank account.
+            include_transfers: When ``False`` (default), skip
+                transactions with no INCOME or EXPENSE split. When
+                ``True``, include every cash/bank movement — useful
+                for reconciliation against a bank statement, which
+                shows every debit and credit regardless of category.
 
         Returns:
-            Dict with inflows, outflows, and net cash flow.
+            Dict with ``account``, ``inflows``, ``outflows``, and —
+            when any transfers were filtered — ``transfers_excluded``
+            (count of distinct transactions skipped, surfaced so the
+            LLM can mention the ``include_transfers=true`` escape
+            hatch when relevant).
         """
         with self.open(readonly=True) as book:
             # Two filter modes: a named account (one-GUID IN() clause)
@@ -836,12 +857,31 @@ class ReportingMixin:
                     account_types=_CASH_TYPES,
                 )
 
+            # SB-5: build the set of transaction GUIDs in the
+            # period that have at least one INCOME or EXPENSE
+            # split — the "real" cash flow events. Transactions
+            # outside this set are internal transfers (pure
+            # asset/liability/equity rearrangement) and get
+            # filtered unless include_transfers is True. One
+            # indexed SQL query — no N+1 over txn.splits.
+            if not include_transfers:
+                cashflow_txn_guids = self._cashflow_txn_guids(
+                    book, start_date, end_date
+                )
+            else:
+                cashflow_txn_guids = None  # don't filter
+
             # Factors anchored to ``end_date`` — same historical-
             # rates discipline as the period breakdowns.
             factors = self._account_conversion_factors(book, end_date)
             inflows = Decimal("0")
             outflows = Decimal("0")
-            for split, _txn, acct in rows:
+            transfers_excluded: set[str] = set()
+            for split, txn, acct in rows:
+                if cashflow_txn_guids is not None \
+                        and txn.guid not in cashflow_txn_guids:
+                    transfers_excluded.add(txn.guid)
+                    continue
                 amt = self._split_in_default_currency(
                     split, acct, factors.get(acct.guid)
                 )
@@ -856,7 +896,7 @@ class ReportingMixin:
             # Echo the canonical fullname rather than the raw input —
             # so callers passing %short or full-GUID input always see
             # a readable account name in the response.
-            return {
+            result = {
                 "account": (
                     target_account.fullname if account
                     else "All cash/bank accounts"
@@ -864,6 +904,44 @@ class ReportingMixin:
                 "inflows": str(inflows),
                 "outflows": str(outflows),
             }
+            if transfers_excluded:
+                result["transfers_excluded"] = len(transfers_excluded)
+            return result
+
+    def _cashflow_txn_guids(
+        self,
+        book: piecash.Book,
+        start_date: date,
+        end_date: date,
+    ) -> set[str]:
+        """Set of transaction GUIDs in the period that have at
+        least one INCOME or EXPENSE split.
+
+        Used by ``cash_flow`` to filter "internal transfer" noise
+        from the default report — see that method's docstring
+        for the rationale (SB-5).
+
+        Indexed SQL with the same date-upper-bound handling as
+        ``_query_filtered_splits`` (``post_date < end_date + 1 day``
+        to include the full inclusive end date past piecash's
+        neutral-time DateTime storage).
+        """
+        from piecash.core.account import Account
+        from piecash.core.transaction import Split, Transaction
+
+        q = (
+            book.session.query(Transaction.guid)
+            .join(Split, Split.transaction_guid == Transaction.guid)
+            .join(Account, Split.account_guid == Account.guid)
+            .filter(Transaction.post_date >= start_date)
+            .filter(Account.type.in_(("INCOME", "EXPENSE")))
+            .distinct()
+        )
+        if end_date < date.max:
+            q = q.filter(
+                Transaction.post_date < end_date + timedelta(days=1)
+            )
+        return {g for (g,) in q.all()}
 
     # ── Debt Payoff ───────────────────────────────────────────────
 

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -807,15 +807,24 @@ class ReportingMixin:
     ) -> dict:
         """Calculate cash flow (inflows and outflows) for a period.
 
-        By default, internal transfers between cash/bank/credit/
-        asset accounts are filtered out. A transaction with no
-        INCOME or EXPENSE leg is a pure rearrangement — transfer
-        to savings, credit-card payoff, currency wallet shuffle —
+        Scope: aggregates over BANK and CASH accounts only (the
+        ``_CASH_TYPES`` set). Credit-card movements are liability
+        changes, investment movements are asset rearrangements —
+        neither is "cash flow" in the bookkeeper's sense and they
+        belong on balance-sheet-style reports, not here. A caller
+        passing an explicit ``account=`` of any type still works
+        (that's their choice), but the default scope is intentionally
+        narrow.
+
+        By default, internal transfers between cash/bank accounts
+        are filtered out. A transaction with no INCOME or EXPENSE
+        leg is a pure rearrangement — transfer to savings, currency
+        wallet shuffle, paying down a credit card from checking —
         neither inflow nor outflow in cash-flow terms. Filtering
-        that noise is what makes the totals answer "where did
-        money come from and where did it go?" rather than "every
-        debit and credit that touched a cash account, including
-        same-pocket reshuffling." SB-5.
+        that noise is what makes the totals answer "where did money
+        come from and where did it go?" rather than "every debit
+        and credit that touched a cash account, including same-
+        pocket reshuffling." SB-5.
 
         Args:
             start_date: Start of period (inclusive).
@@ -830,10 +839,15 @@ class ReportingMixin:
 
         Returns:
             Dict with ``account``, ``inflows``, ``outflows``, and —
-            when any transfers were filtered — ``transfers_excluded``
-            (count of distinct transactions skipped, surfaced so the
+            when any transfers were filtered —
+            ``transfers_excluded``: the count of distinct
+            cash-touching transactions skipped as transfers (each
+            counted once regardless of how many cash-side splits it
+            has; pure-rearrangement transactions that don't touch a
+            BANK/CASH account aren't reachable from this report and
+            therefore can't appear in the count). Surfaced so the
             LLM can mention the ``include_transfers=true`` escape
-            hatch when relevant).
+            hatch when relevant.
         """
         with self.open(readonly=True) as book:
             # Two filter modes: a named account (one-GUID IN() clause)

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -21,12 +21,12 @@ Depends on shared helpers from BaseGnuCashBook:
   - self.open, self._find_account
 """
 
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal, InvalidOperation
 
 import piecash
 
-from gnucash_mcp.book._base import _to_decimal
+from gnucash_mcp.book._base import _is_voided, _to_decimal
 from gnucash_mcp._format import _format_number
 
 # Account-type groups used across the reports. Defined at module level
@@ -878,6 +878,15 @@ class ReportingMixin:
             outflows = Decimal("0")
             transfers_excluded: set[str] = set()
             for split, txn, acct in rows:
+                # Voided splits (state='v', value=quantity=0) are
+                # zombies, not active cash flow. Skip before the
+                # transfer-vs-real classification so they don't
+                # inflate ``transfers_excluded`` for voided-transfer
+                # txns or pollute the inflow/outflow accumulators
+                # for voided-income/expense txns — symmetric
+                # treatment regardless of which leg type was voided.
+                if _is_voided(split):
+                    continue
                 if cashflow_txn_guids is not None \
                         and txn.guid not in cashflow_txn_guids:
                     transfers_excluded.add(txn.guid)
@@ -915,33 +924,29 @@ class ReportingMixin:
         end_date: date,
     ) -> set[str]:
         """Set of transaction GUIDs in the period that have at
-        least one INCOME or EXPENSE split.
+        least one non-voided INCOME or EXPENSE split.
 
         Used by ``cash_flow`` to filter "internal transfer" noise
         from the default report — see that method's docstring
         for the rationale (SB-5).
 
-        Indexed SQL with the same date-upper-bound handling as
-        ``_query_filtered_splits`` (``post_date < end_date + 1 day``
-        to include the full inclusive end date past piecash's
-        neutral-time DateTime storage).
+        Routes through ``_query_filtered_splits`` to inherit the
+        date-bound fix, template-account exclusion, and null-
+        post_date filter — the chokepoint discipline this project
+        adopted in Branch 1. The voided-split filter is applied
+        Python-side so a voided salary or expense doesn't
+        rescue a zombie transaction from the transfer filter.
         """
-        from piecash.core.account import Account
-        from piecash.core.transaction import Split, Transaction
-
-        q = (
-            book.session.query(Transaction.guid)
-            .join(Split, Split.transaction_guid == Transaction.guid)
-            .join(Account, Split.account_guid == Account.guid)
-            .filter(Transaction.post_date >= start_date)
-            .filter(Account.type.in_(("INCOME", "EXPENSE")))
-            .distinct()
+        rows = self._query_filtered_splits(
+            book,
+            start_date=start_date,
+            end_date=end_date,
+            account_types=_NET_INCOME_TYPES,
         )
-        if end_date < date.max:
-            q = q.filter(
-                Transaction.post_date < end_date + timedelta(days=1)
-            )
-        return {g for (g,) in q.all()}
+        return {
+            txn.guid for split, txn, _acct in rows
+            if not _is_voided(split)
+        }
 
     # ── Debt Payoff ───────────────────────────────────────────────
 

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -138,9 +138,14 @@ def register(mcp, get_book) -> None:
     ) -> str:
         """Calculate cash flow (inflows and outflows) for a period.
 
-        By default, internal transfers between cash/bank/credit/asset
-        accounts are filtered out — a transaction with no INCOME or
-        EXPENSE leg is a pure rearrangement, not real cash flow. The
+        Scope is BANK and CASH accounts by default. Credit-card and
+        investment movements are not cash flow (they're liability /
+        asset changes — use balance_sheet). An explicit ``account=``
+        of any type works but the default scope is narrow.
+
+        Internal transfers (transactions with no INCOME or EXPENSE
+        leg — transfer to savings, currency wallet shuffle, paying
+        a credit card from checking) are filtered by default. The
         default totals answer "where did money come from and where
         did it go?" rather than "every debit and credit." Pass
         ``include_transfers=true`` for the gross flow (e.g. for

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -134,19 +134,33 @@ def register(mcp, get_book) -> None:
         start_date: str,
         end_date: str,
         account: str | None = None,
+        include_transfers: bool = False,
     ) -> str:
         """Calculate cash flow (inflows and outflows) for a period.
+
+        By default, internal transfers between cash/bank/credit/asset
+        accounts are filtered out — a transaction with no INCOME or
+        EXPENSE leg is a pure rearrangement, not real cash flow. The
+        default totals answer "where did money come from and where
+        did it go?" rather than "every debit and credit." Pass
+        ``include_transfers=true`` for the gross flow (e.g. for
+        reconciling against a bank statement).
 
         Args:
             start_date: Start of period (YYYY-MM-DD)
             end_date: End of period (YYYY-MM-DD)
-            account: Optional specific account to analyze (defaults to all cash/bank accounts)
+            account: Optional specific account to analyze (defaults
+                to all cash/bank accounts)
+            include_transfers: When False (default), filter internal
+                transfers. When True, include every cash/bank
+                movement regardless of category.
         """
         book = get_book()
         result = book.cash_flow(
             start_date=date.fromisoformat(start_date),
             end_date=date.fromisoformat(end_date),
             account=account,
+            include_transfers=include_transfers,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -354,6 +354,35 @@ class TestGetBookSummaryReconciliation:
                     s.reconcile_date = _dt.combine(on_date, _dt.min.time())
             book.save()
 
+    def _reconcile_all_unreconciled(
+        self,
+        gc: GnuCashBook,
+        account: str,
+        as_of: date | None = None,
+    ) -> None:
+        """Mark every currently-unreconciled split on the account as
+        reconciled. Used to clear the test_book fixture's pre-seeded
+        Jan 2024 activity so bucket-behavior tests exercise the
+        scenario their name describes — without the leftover
+        unreconciled clutter inflating the dashboard lag.
+
+        Under the post-self-review semantics (lag from OLDEST
+        unreconciled), the fixture's Jan 2024 splits would push
+        Checking permanently into the "stale" bucket regardless of
+        any later reconciliation — correct behavior in real life,
+        but it overrides what these tests are scoped to verify.
+        """
+        from datetime import datetime as _dt
+        anchor = as_of or date.today()
+        with gc.open(readonly=False) as book:
+            acct = gc._find_account(book, account)
+            assert acct is not None, account
+            for s in acct.splits:
+                if s.reconcile_state != "y":
+                    s.reconcile_state = "y"
+                    s.reconcile_date = _dt.combine(anchor, _dt.min.time())
+            book.save()
+
     def test_unreconciled_count_removed_from_transactions_line(
         self, test_book: Path,
     ):
@@ -392,6 +421,12 @@ class TestGetBookSummaryReconciliation:
         marker on that line; current accounts are by definition
         not behind."""
         gc = GnuCashBook(str(test_book))
+        # Clear the fixture's Jan 2024 unreconciled splits — under
+        # the post-self-review semantics they'd push Checking to
+        # stale via the oldest-unreconciled lag regardless of
+        # later activity. This test exercises bucket logic, not
+        # backlog reporting; we want a clean baseline.
+        self._reconcile_all_unreconciled(gc, "Assets:Checking")
         recent = date.today() - timedelta(days=10)
         with gc.open(readonly=False) as book:
             checking = gc._find_account(book, "Assets:Checking")
@@ -428,9 +463,20 @@ class TestGetBookSummaryReconciliation:
         self, test_book: Path,
     ):
         """Account whose last reconcile is well past 45 days shows
-        '(N months behind) ⚠'."""
+        '(N months behind) ⚠'. With no unreconciled work hanging,
+        the lag falls back to the latest_y_date — the original
+        pre-self-review semantics for the fully-caught-up case."""
         gc = GnuCashBook(str(test_book))
         old = date.today() - timedelta(days=120)
+        # Reconcile the fixture's Jan 2024 splits back-dated to the
+        # same OLD reference date so latest_y_date stays at ``old``
+        # and unreconciled_count = 0 (fully caught up). Without
+        # this, the new test transaction's reconciled split would
+        # NOT dominate latest_y_date over a fresher fixture state,
+        # and the Jan 2024 splits would push the lag to years.
+        self._reconcile_all_unreconciled(
+            gc, "Assets:Checking", as_of=old,
+        )
         with gc.open(readonly=False) as book:
             checking = gc._find_account(book, "Assets:Checking")
             opening = gc._find_account(book, "Equity:Opening Balance")
@@ -456,9 +502,15 @@ class TestGetBookSummaryReconciliation:
         self, test_book: Path,
     ):
         """The 45-59 day window uses days, not months — months
-        scale only kicks in at 60+."""
+        scale only kicks in at 60+. Tests the fully-caught-up-but-
+        stale-by-latest_y path."""
         gc = GnuCashBook(str(test_book))
         d50 = date.today() - timedelta(days=50)
+        # Reconcile fixture splits back-dated to d50 so unreconciled
+        # count is 0 and latest_y_date drives the lag (50 days).
+        self._reconcile_all_unreconciled(
+            gc, "Assets:Checking", as_of=d50,
+        )
         with gc.open(readonly=False) as book:
             checking = gc._find_account(book, "Assets:Checking")
             opening = gc._find_account(book, "Equity:Opening Balance")
@@ -549,6 +601,10 @@ class TestGetBookSummaryReconciliation:
         Per-account-distinct info stays per-account; identical-
         across-accounts info collapses to a count."""
         gc = GnuCashBook(str(test_book))
+        # Clear fixture's pre-seeded Jan 2024 unreconciled splits on
+        # Checking so the "Current bucket" assertion below holds —
+        # otherwise oldest-unreconciled lag pushes Checking to stale.
+        self._reconcile_all_unreconciled(gc, "Assets:Checking")
         # Never-reconciled bucket: add Visa with activity, no recon.
         gc.create_account(
             name="Visa", account_type="CREDIT", parent="Liabilities",
@@ -619,6 +675,10 @@ class TestGetBookSummaryReconciliation:
         plural 's'. Symmetric grammar with the never-reconciled
         bucket."""
         gc = GnuCashBook(str(test_book))
+        # Clear fixture's pre-seeded Jan 2024 unreconciled splits on
+        # Checking so it can land in the current bucket alongside
+        # the newly-added Savings account.
+        self._reconcile_all_unreconciled(gc, "Assets:Checking")
         # Add a second BANK account.
         gc.create_account(
             name="Savings", account_type="BANK", parent="Assets",
@@ -2919,13 +2979,19 @@ class TestGetBookSummaryUpcomingScheduled:
 
 
 class TestGetBookSummaryReconciliationSplitCount:
-    """Stale reconciliation lines carry "47 splits unreconciled,
-    last reconciled DATE" — the count tells the LLM the *scope* of
-    the work (12 splits is one sitting; 400 is "let's narrow by
-    month"), and the reconciled date provides supplementary context.
-    HP-8 reworded the line from "unreconciled since DATE" to "last
-    reconciled DATE" because the count is total outstanding (matches
-    ``get_unreconciled_splits``), not "splits after this date".
+    """Stale reconciliation lines carry "47 splits unreconciled
+    (4 months behind, oldest: 2020-03-15)" — the count tells the
+    LLM the *scope* of the work (12 splits is one sitting; 400 is
+    "let's narrow by month"), and the lag is computed from the
+    OLDEST unreconciled split so "behind" measures the true scope
+    of work, not just time-since-last-reconcile.
+
+    Pre-self-review the lag was computed from ``latest_y_date``,
+    which could understate scope by years: an account reconciled
+    through 2025-12-30 with 40 unreconciled splits from 2020
+    rendered as "(4 months behind)" — the bookkeeper would plan
+    for a one-session catch-up and discover they need six years of
+    statements.
     """
 
     def test_stale_account_shows_split_count(
@@ -2933,8 +2999,7 @@ class TestGetBookSummaryReconciliationSplitCount:
     ):
         """Reconcile a checking-account split partway, then add new
         unreconciled activity. The summary should show the count of
-        unreconciled splits with the new "last reconciled DATE"
-        phrasing."""
+        unreconciled splits with the "(lag, oldest: DATE)" suffix."""
         from datetime import date as _date, timedelta
         gc = GnuCashBook(str(multi_currency_book))
 
@@ -2973,19 +3038,104 @@ class TestGetBookSummaryReconciliationSplitCount:
         recon_line = next(
             (
                 l for l in result.splitlines()
-                if "Checking" in l and "last reconciled" in l
+                if "Checking" in l and "oldest:" in l
             ),
             None,
         )
         assert recon_line is not None, (
-            f"Expected 'last reconciled' line for Checking; "
+            f"Expected 'oldest:' line for Checking; "
             f"got summary:\n{result}"
         )
         # Count appears in the line.
         assert "splits unreconciled" in recon_line
-        assert "last reconciled" in recon_line
+        assert "oldest:" in recon_line
         # Warning marker still fires.
         assert "⚠" in recon_line
+
+
+class TestReconciliationLagFromOldestUnreconciled:
+    """The lag rendered for an account with pending reconciliation
+    work must reflect the OLDEST unreconciled split, not the
+    LATEST reconciled split. The bookkeeper plans against the
+    scope of work — "4 months behind" implies one sitting; "6
+    years behind" implies six years of statements. Misreporting
+    the lag costs a day of mismatched expectations.
+    """
+
+    def test_lag_reflects_oldest_unreconciled_not_latest_y(
+        self, test_book: Path,
+    ):
+        """Reconcile a RECENT split; leave an OLD split unreconciled.
+        The dashboard lag should describe the old gap, not the
+        recent reconciliation date.
+        """
+        from datetime import date as _date, timedelta, datetime as _dt
+        gc = GnuCashBook(str(test_book))
+
+        # Add an OLD unreconciled split (5 years ago).
+        old_date = _date.today() - timedelta(days=5 * 365)
+        with gc.open(readonly=False) as book:
+            checking = gc._find_account(book, "Assets:Checking")
+            opening = gc._find_account(book, "Equity:Opening Balance")
+            book.session.add(piecash.Transaction(
+                currency=book.default_currency,
+                description="Old skipped deposit",
+                post_date=old_date,
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("100")),
+                    piecash.Split(account=opening, value=Decimal("-100")),
+                ],
+            ))
+            book.save()
+
+        # Reconcile a RECENT split (10 days ago) on Checking.
+        recent_date = _date.today() - timedelta(days=10)
+        with gc.open(readonly=False) as book:
+            checking = gc._find_account(book, "Assets:Checking")
+            opening = gc._find_account(book, "Equity:Opening Balance")
+            book.session.add(piecash.Transaction(
+                currency=book.default_currency,
+                description="Recent reconciled deposit",
+                post_date=recent_date,
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("50")),
+                    piecash.Split(account=opening, value=Decimal("-50")),
+                ],
+            ))
+            book.save()
+            for s in checking.splits:
+                if s.transaction.post_date == recent_date:
+                    s.reconcile_state = "y"
+                    s.reconcile_date = _dt.combine(
+                        recent_date, _dt.min.time(),
+                    )
+            book.save()
+
+        result = gc.get_book_summary()
+        recon_line = next(
+            l for l in result.splitlines()
+            if "Checking" in l and "oldest:" in l
+        )
+        # Lag must NOT be "10 days behind" / "1 week behind" — that
+        # would describe the gap to ``latest_y_date``, not the real
+        # scope of work.
+        assert "10 days behind" not in recon_line, (
+            f"lag computed from latest_y_date instead of oldest "
+            f"unreconciled: {recon_line!r}"
+        )
+        # It should land in the "years" branch — 5 years ago.
+        assert (
+            "5 years behind" in recon_line
+            or "4 years behind" in recon_line
+        ), (
+            f"expected years-scale lag from oldest unreconciled; "
+            f"got: {recon_line!r}"
+        )
+        # And the oldest date itself appears in the line.
+        assert old_date.isoformat() in recon_line, (
+            f"oldest date {old_date} not surfaced in line: "
+            f"{recon_line!r}"
+        )
 
 
 class TestGetBookSummaryBusinessSignals:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8365,6 +8365,92 @@ class TestCashFlow:
             )
 
 
+class TestCashFlowInternalTransferFilter:
+    """SB-5: cash_flow's default report filters out internal
+    transfers — transactions with no INCOME or EXPENSE leg.
+
+    The multi_currency fixture is ideal: t1 (opening balance,
+    equity-side) and t3 (cross-currency wallet shuffle) are both
+    pure rearrangements; t2 (salary, INCOME leg) and t4 (groceries,
+    EXPENSE leg) are real cash flow events. Default = only t2 and
+    t4 counted; ``include_transfers=True`` = all four counted.
+    """
+
+    def test_default_filters_internal_transfers(
+        self, multi_currency_book: Path,
+    ):
+        """Default report excludes equity-side opening balance and
+        the cross-currency wallet shuffle. Inflows = salary only;
+        outflows = groceries only.
+        """
+        gc_book = GnuCashBook(str(multi_currency_book))
+        result = gc_book.cash_flow(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+        # Salary inflow only (t2): 3000. Opening (t1, equity) and
+        # cross-currency transfer (t3) filtered.
+        assert Decimal(result["inflows"]) == Decimal("3000")
+        # Groceries outflow only (t4): 200.
+        assert Decimal(result["outflows"]) == Decimal("200")
+        # Two transactions were filtered as transfers (t1 + t3).
+        assert result["transfers_excluded"] == 2
+
+    def test_include_transfers_restores_gross(
+        self, multi_currency_book: Path,
+    ):
+        """With ``include_transfers=True`` the totals match the
+        pre-SB-5 behavior — useful for bank statement reconciliation
+        where every debit/credit matters regardless of category.
+        """
+        gc_book = GnuCashBook(str(multi_currency_book))
+        result = gc_book.cash_flow(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            include_transfers=True,
+        )
+        assert Decimal(result["inflows"]) == Decimal("9100")
+        assert Decimal(result["outflows"]) == Decimal("1300")
+        # No transfers filtered → field omitted.
+        assert "transfers_excluded" not in result
+
+    def test_transfers_excluded_omitted_when_zero(
+        self, test_book: Path,
+    ):
+        """The ``transfers_excluded`` field only appears when at
+        least one transaction was filtered. Keeps the response
+        compact when there's nothing to surface.
+        """
+        gc_book = GnuCashBook(str(test_book))
+        # Empty range — no transactions touched, nothing filtered.
+        result = gc_book.cash_flow(
+            start_date=date(2030, 1, 1),
+            end_date=date(2030, 1, 31),
+        )
+        assert "transfers_excluded" not in result
+
+    def test_account_filter_with_transfer_filter(
+        self, multi_currency_book: Path,
+    ):
+        """When ``account`` is specified, transfer filtering still
+        applies. Running on Checking alone with the default: the
+        salary deposit counts (INCOME leg present), but the cross-
+        currency outflow to EUR Savings does not (no INCOME/EXPENSE
+        leg on that transaction).
+        """
+        gc_book = GnuCashBook(str(multi_currency_book))
+        result = gc_book.cash_flow(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+            account="Assets:Checking",
+        )
+        # Salary +3000 = inflow. Groceries -200 = outflow.
+        # Opening +5000 and cross-currency -1100 both filtered.
+        assert Decimal(result["inflows"]) == Decimal("3000")
+        assert Decimal(result["outflows"]) == Decimal("200")
+        assert result["transfers_excluded"] == 2
+
+
 class TestListCommodities:
     """Tests for list_commodities method."""
 
@@ -8706,11 +8792,16 @@ class TestMultiCurrencyBalances:
         """Cash flow aggregates USD-equivalent amounts across cash
         and bank accounts (using cost basis as fallback when no
         market rate is on file).
+
+        Asserts the gross numbers via ``include_transfers=True`` so
+        the test exercises the FX-conversion path without being
+        coupled to the default transfer-filter (SB-5).
         """
         gc_book = GnuCashBook(str(multi_currency_book))
         result = gc_book.cash_flow(
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
+            include_transfers=True,
         )
         inflows = Decimal(result["inflows"])
         outflows = Decimal(result["outflows"])

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -2919,18 +2919,22 @@ class TestGetBookSummaryUpcomingScheduled:
 
 
 class TestGetBookSummaryReconciliationSplitCount:
-    """Stale reconciliation lines now carry "47 splits unreconciled
-    since DATE" instead of just "through DATE". The split count
-    tells the LLM the *scope* of the work — 12 splits is one
-    sitting; 400 is "let's narrow by month."
+    """Stale reconciliation lines carry "47 splits unreconciled,
+    last reconciled DATE" — the count tells the LLM the *scope* of
+    the work (12 splits is one sitting; 400 is "let's narrow by
+    month"), and the reconciled date provides supplementary context.
+    HP-8 reworded the line from "unreconciled since DATE" to "last
+    reconciled DATE" because the count is total outstanding (matches
+    ``get_unreconciled_splits``), not "splits after this date".
     """
 
     def test_stale_account_shows_split_count(
         self, multi_currency_book: Path,
     ):
         """Reconcile a checking-account split partway, then add new
-        unreconciled activity in the future. The summary should
-        show the count of unreconciled splits."""
+        unreconciled activity. The summary should show the count of
+        unreconciled splits with the new "last reconciled DATE"
+        phrasing."""
         from datetime import date as _date, timedelta
         gc = GnuCashBook(str(multi_currency_book))
 
@@ -2969,16 +2973,17 @@ class TestGetBookSummaryReconciliationSplitCount:
         recon_line = next(
             (
                 l for l in result.splitlines()
-                if "Checking" in l and "unreconciled since" in l
+                if "Checking" in l and "last reconciled" in l
             ),
             None,
         )
         assert recon_line is not None, (
-            f"Expected 'unreconciled since' line for Checking; "
+            f"Expected 'last reconciled' line for Checking; "
             f"got summary:\n{result}"
         )
         # Count appears in the line.
-        assert "splits unreconciled since" in recon_line
+        assert "splits unreconciled" in recon_line
+        assert "last reconciled" in recon_line
         # Warning marker still fires.
         assert "⚠" in recon_line
 

--- a/tests/test_chokepoint_invariants.py
+++ b/tests/test_chokepoint_invariants.py
@@ -484,6 +484,78 @@ class TestIsVoidedConsistency:
             f"{checking_entry}"
         )
 
+    def test_reconciliation_backlog_counts_pre_latest_y_date(
+        self, test_book: Path,
+    ):
+        """HP-8: the dashboard's reconciliation backlog count must
+        include unreconciled splits that PREDATE the last
+        reconciled ('y') split — they're the ones most likely to
+        be problems (skipped during a partial reconciliation,
+        opening balances never stamped, edge cases that fell
+        through). Pre-fix the count was scoped to "splits after
+        latest_y_date" which silently dropped them, breaking the
+        invariant that the dashboard count equals
+        ``get_unreconciled_splits``'s count.
+        """
+        from datetime import datetime as _dt
+        gb = GnuCashBook(str(test_book))
+
+        # Fixture's Checking has opening + recent transactions, none
+        # reconciled. Reconcile a NEWER split, leaving the older one
+        # unreconciled — pre-fix this older split would be invisible
+        # to the dashboard count but visible to
+        # get_unreconciled_splits.
+        with gb.open(readonly=False) as book:
+            checking = gb._find_account(book, "Assets:Checking")
+            opening = gb._find_account(book, "Equity:Opening Balance")
+            recent_date = date.today() - timedelta(days=3)
+            book.session.add(piecash.Transaction(
+                currency=book.default_currency,
+                description="Recent reconciled deposit",
+                post_date=recent_date,
+                splits=[
+                    piecash.Split(account=checking, value=Decimal("100")),
+                    piecash.Split(account=opening, value=Decimal("-100")),
+                ],
+            ))
+            book.save()
+            # Mark only the recent Checking split as 'y'.
+            for s in checking.splits:
+                if s.transaction.post_date == recent_date:
+                    s.reconcile_state = "y"
+                    s.reconcile_date = _dt.combine(
+                        recent_date, _dt.min.time()
+                    )
+            book.save()
+
+        # Detail-tool ground truth.
+        detail = gb.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )
+        detail_count = detail["total"]
+
+        # Dashboard count from the same source.
+        with gb.open(readonly=True) as pb:
+            results = gb._account_reconciliation_status(
+                pb, list(pb.accounts),
+            )
+        checking_entry = next(
+            r for r in results if r["account"] == "Assets:Checking"
+        )
+
+        assert checking_entry["unreconciled_count"] == detail_count, (
+            f"dashboard ({checking_entry['unreconciled_count']}) "
+            f"disagrees with get_unreconciled_splits ({detail_count}) "
+            f"— bookkeeper's first instinct will be 'the book is "
+            f"wrong'"
+        )
+        # And confirm the pre-fix bug-shape: at least one
+        # unreconciled split predates ``latest_y_date``.
+        assert detail_count >= 1, (
+            "fixture didn't produce the pre-latest_y_date "
+            "unreconciled scenario this test is meant to lock"
+        )
+
     def test_assign_split_to_lot_rejects_voided(
         self, investment_book: Path,
     ):

--- a/tests/test_chokepoint_invariants.py
+++ b/tests/test_chokepoint_invariants.py
@@ -25,7 +25,7 @@ import piecash
 import pytest
 
 from gnucash_mcp.book import GnuCashBook
-from gnucash_mcp.book._base import _is_voided
+from gnucash_mcp.book._base import _is_unreconciled, _is_voided
 
 
 class TestResolveAccountTemplateFilter:
@@ -554,6 +554,114 @@ class TestIsVoidedConsistency:
         assert detail_count >= 1, (
             "fixture didn't produce the pre-latest_y_date "
             "unreconciled scenario this test is meant to lock"
+        )
+
+    def test_is_unreconciled_chokepoint_at_both_count_sites(
+        self, test_book: Path,
+    ):
+        """HP-8 chokepoint: the predicate that determines whether a
+        split counts as pending bookkeeping work must live in ONE
+        place (``_is_unreconciled`` in ``_base.py``) — not duplicated
+        at the dashboard count site and the detail-tool site.
+
+        This test enforces structural identity, not just behavioral
+        equality: if a future change adds a state guard at only one
+        of the two predicate sites, the chokepoint discipline broke
+        and the dashboard-vs-detail divergence bug class HP-8 closed
+        can reopen in a new shape.
+
+        We probe via inputs hand-picked to exercise each state value
+        the predicate cares about: 'y' (skip), 'c' (count), 'n'
+        (count), 'v' (skip). Both surfaces must agree on each.
+        """
+        # Sanity: helper returns the right answer for each state.
+        class _FakeSplit:
+            def __init__(self, state):
+                self.reconcile_state = state
+
+        assert _is_unreconciled(_FakeSplit("n")) is True
+        assert _is_unreconciled(_FakeSplit("c")) is True
+        assert _is_unreconciled(_FakeSplit("y")) is False
+        assert _is_unreconciled(_FakeSplit("v")) is False
+
+        # Structural lock: both call sites must call the helper.
+        # Reading the source is the right test here — a future
+        # contributor inlining ``s.reconcile_state != "y" and not
+        # _is_voided(s)`` at either site would silently undo the
+        # chokepoint. Searching for the helper at each site catches
+        # the regression without depending on book state.
+        import inspect
+        from gnucash_mcp.book import core, reconciliation
+
+        dashboard_src = inspect.getsource(
+            core.CoreMixin._account_reconciliation_status
+        )
+        detail_src = inspect.getsource(
+            reconciliation.ReconciliationMixin.get_unreconciled_splits
+        )
+        assert "_is_unreconciled" in dashboard_src, (
+            "_account_reconciliation_status doesn't route through "
+            "_is_unreconciled — HP-8 chokepoint broken"
+        )
+        assert "_is_unreconciled" in detail_src, (
+            "get_unreconciled_splits doesn't route through "
+            "_is_unreconciled — HP-8 chokepoint broken"
+        )
+
+    def test_cash_flow_voided_transactions_treated_symmetrically(
+        self, multi_currency_book: Path,
+    ):
+        """SB-5 follow-up: a voided transaction should be skipped
+        entirely in cash_flow — neither contributing to inflows/
+        outflows nor inflating transfers_excluded — regardless of
+        whether its legs are INCOME/EXPENSE or pure cash/bank.
+
+        Pre-fix asymmetry: a voided INCOME/EXPENSE txn was
+        classified as a 'real cash event' (its INCOME split was
+        found by the type-only filter) while a voided pure-transfer
+        was counted in ``transfers_excluded``. The fix added an
+        early ``_is_voided`` filter at both the helper site and
+        the row loop.
+        """
+        from datetime import date as _date
+        gc = GnuCashBook(str(multi_currency_book))
+
+        # Void the salary transaction (Income split) AND the
+        # cross-currency transfer (pure cash). After voiding both,
+        # the resulting cash_flow should treat each symmetrically:
+        # neither contributes to the inflows/outflows totals, and
+        # neither is counted in transfers_excluded.
+        with gc.open(readonly=False) as book:
+            for txn in list(book.transactions):
+                if txn.description in (
+                    "Salary",
+                    "Transfer to EUR savings",
+                ):
+                    for s in txn.splits:
+                        s.reconcile_state = "v"
+                        s.value = Decimal("0")
+                        s.quantity = Decimal("0")
+            book.save()
+
+        result = gc.cash_flow(
+            start_date=_date(2024, 1, 1),
+            end_date=_date(2024, 12, 31),
+        )
+        # Remaining real activity: opening balance (equity-side,
+        # filtered as transfer) + groceries (real expense).
+        assert Decimal(result["outflows"]) == Decimal("200"), (
+            "groceries should still contribute its $200 outflow"
+        )
+        assert Decimal(result["inflows"]) == Decimal("0"), (
+            "voided salary should NOT contribute to inflows"
+        )
+        # transfers_excluded counts only LIVE rearrangement txns —
+        # the voided cross-currency transfer must not be counted.
+        # Only the opening balance (equity-side, no INCOME/EXPENSE
+        # leg, not voided) should remain.
+        assert result["transfers_excluded"] == 1, (
+            f"voided pure-transfer should not be in transfers_excluded; "
+            f"got {result.get('transfers_excluded')}"
         )
 
     def test_assign_split_to_lot_rejects_voided(


### PR DESCRIPTION
## Summary

The two deferred design calls from the v1.3 review, resolved per Stephen's calls and validated on Alex (USD) and Lin Wei (CNY).

- **SB-5 — filter internal transfers in `cash_flow` by default.** A transaction with no INCOME or EXPENSE leg is a pure rearrangement between cash/bank/credit/asset accounts (transfer to savings, credit-card payoff, currency wallet shuffle) — neither inflow nor outflow in cash-flow terms. Counting them inflates the report by every funding hop. Cash flow answers "where did money come from and where did it go?", not "every debit and credit that touched a cash account." New `include_transfers: bool = False` param restores the gross flow for bank-statement reconciliation. Response gains `transfers_excluded` count (only when > 0) so the LLM can surface the escape hatch.
- **HP-8 — unify reconciliation backlog count on the `get_unreconciled_splits` rule.** The dashboard count must equal the detail-tool count for the same account. Pre-fix the dashboard scoped to "splits after `latest_y_date`" while `get_unreconciled_splits` returned all non-y non-voided splits — and the pre-`latest_y_date` ones (skipped during partial passes, opening balances never stamped) are exactly the ones that tend to be problems. Renderer line reworded "unreconciled since DATE" → "unreconciled, last reconciled DATE" because the count is no longer "splits after this date."
- **Arc doc updated.** `specs/REMAINING_ARC.md` now records the resolutions and the reasoning that led to each (Stephen's home-book example for SB-5, the bookkeeper's "first instinct will be 'the book is wrong'" framing for HP-8). 26 of 27 substantive review items closed; only MP-1 remains as an open design call.

## Test plan

- [x] Full suite passes: 1481/1481.
- [x] 4 new tests in `TestCashFlowInternalTransferFilter` exercise default-filtered, gross-via-flag, omitted-when-zero, and account-scoped-with-filter.
- [x] Existing `test_cash_flow_converts_foreign_currency` pinned with `include_transfers=True` so the FX-conversion path is exercised without coupling to the new default.
- [x] New regression `test_reconciliation_backlog_counts_pre_latest_y_date` locks the dashboard==detail-tool count invariant on a setup with an unreconciled split predating `latest_y_date`.
- [x] Existing `TestGetBookSummaryReconciliationSplitCount` updated to assert the reworded "last reconciled DATE" line.
- [x] Bookkeeper validation on Alex + Lin Wei:
  - SB-5: `cash_flow` filtered → 28 transfers excluded with `transfers_excluded` surfaced.
  - SB-5: `cash_flow(include_transfers=true)` → gross flow restored, no exclusion field.
  - HP-8: Checking dashboard count 1,484 == detail-tool count 1,484.
  - HP-8: Savings dashboard count 1 == detail-tool count 1.