### PR TITLE
feat(core): batch transaction entry — create_transactions

### DIFF
--- a/specs/BATCH_TRANSACTION_ENTRY_SPEC.md
+++ b/specs/BATCH_TRANSACTION_ENTRY_SPEC.md
@@ -1,0 +1,427 @@
+# Batch Transaction Entry Specification
+
+## GnuCash MCP Server — Post-v1.3.1 Feature
+
+Status: **Draft** (design agreed; pending implementation)
+Author: design session 2026-06-13
+Supersedes nothing; extends the existing `create_transaction` write path.
+
+---
+
+## Executive Summary
+
+A new tool, **`create_transactions`** (plural), lets a caller submit
+**multiple transactions in one command** and receive a per-transaction
+result it can correlate back to its input.
+
+This is the largest change to the app's write workflow since the
+ledger primitives were built. Today every transaction is a separate
+`create_transaction` call — one book open, one save, one round-trip
+each. Batch entry amortizes that: **one book open and one atomic save
+for N transactions**, which is the v1.0.2 output-efficiency instinct
+finally applied to the *write* path.
+
+The hard problem batch entry introduces is not the writing — it is the
+**response**: how to return N independent results (created / rejected /
+duplicate-flagged), each carrying its own list of potential-duplicate
+matches, in a shape the calling LLM can correlate to what it sent. This
+spec fixes that shape.
+
+---
+
+## Background: Why This Matters
+
+- **Per-call overhead, amortized.** A book open is the hot path
+  (20–50 ms each, logged as "Book opened in X ms"). Entering a month of
+  activity one transaction at a time pays that cost N times. Batch pays
+  it once.
+- **Bookkeeper ergonomics.** The live tester routinely enters many
+  transactions in a sitting — a statement's worth, a month of receipts.
+  "Here are 40 entries" in one call beats 40 calls, both in wall-clock
+  and in the caller's context budget.
+- **It continues the efficiency lineage, not breaks from it.** v1.0.2
+  minified the *output*; short-GUIDs trimmed the *handles*; this trims
+  the *write round-trips*. Same principle: every byte and every
+  round-trip either helps the caller or is waste.
+
+---
+
+## Tool Surface
+
+```
+create_transactions(
+    transactions: str,          # TSV block (header + N rows). Required.
+    force: bool = False,        # batch-level duplicate override (see D7)
+    dry_run: bool = False,      # validate + screen, write nothing
+    on_error: str = "abort",    # "abort" | "skip"  (structural errors; see D6)
+) -> dict                       # thin JSON envelope (see Output Format)
+```
+
+Module placement: `transactions` sub-module (alongside
+`create_transaction`), `core` group. The book method
+`create_transactions` lives on `CoreMixin`; the tool wrapper in
+`tools/core.py` registers it and is added to
+`TOOL_MODULES["transactions"]`.
+
+---
+
+## Input Format
+
+A single TSV string: **one header row, then one row per transaction.**
+Splits are encoded as repeated `(amount, account)` column pairs,
+widening rightward as far as the widest transaction requires.
+
+```
+ref	date	description	amt1	acct1	amt2	acct2	amt3	acct3
+1	2026-05-21	Capital One CC Payment	-500	Assets:Current Assets:Checking Account	500	Liabilities:Credit Card:Capital One
+2	2026-05-21	Northgate 76 Gas	-54.19	Assets:Current Assets:Checking Account	54.19	Expenses:Auto:Fuel
+```
+
+### Columns
+
+| Column        | Meaning                                                      |
+|---------------|-------------------------------------------------------------|
+| `ref`         | Caller-assigned correlation key (see D1). Required, unique within the batch. |
+| `date`        | ISO `YYYY-MM-DD`.                                            |
+| `description` | Transaction description.                                     |
+| `amtN` `acctN`| Split amount + account, repeated. Amount is a string Decimal; account is a path, `%short`, or full GUID. |
+
+### Parse contract
+
+- First three fields are fixed: `ref`, `date`, `description`.
+- **Everything after `description` is read in `(amount, account)`
+  pairs to end of row** — the server is a pair-reader, not a
+  fixed-column reader, so rows may be **ragged** (transaction 1 with
+  two splits, transaction 2 with three). The header is sized to the
+  widest row; narrower rows simply end earlier.
+- Per-row validation (structural — see D6): even trailing-field count,
+  **≥ 2 splits**, splits **balance to zero** in transaction currency,
+  every account resolves, date parses.
+- Batch validation: every `ref` is **non-empty and unique**; a
+  collision fails the whole submission as a caller bug.
+
+Splits are denormalized (wide) deliberately — see D2. Per-split memo,
+per-transaction currency/notes: see Open Questions.
+
+---
+
+## Output Format
+
+A **thin JSON envelope** whose values are **TSV strings, each with a
+header row.** Never a single TSV blob with embedded section markers
+(see D3).
+
+```json
+{
+  "results": "ref\tstatus\ttxn_guid\tdup_count\treason\n1\tcreated\ta1f3\t0\t\n2\tcreated\t77bd\t2\t\n3\trejected\t\t1\tduplicate_detected",
+  "duplicates": "ref\tconfidence\tguid\tdate\tamount\tdescription\tsignals\n3\tHIGH\t4b91\t2026-05-21\t-500\tCapital One CC Payment\tamt,desc,date"
+}
+```
+
+### `results` table — always present, one row per input transaction
+
+| Column     | Created row            | Rejected row                         |
+|------------|------------------------|--------------------------------------|
+| `ref`      | echoed verbatim        | echoed verbatim                      |
+| `status`   | `created`              | `rejected`                           |
+| `txn_guid` | short transaction GUID | blank                                |
+| `dup_count`| advisory matches (≥0)  | matches that caused/accompanied it   |
+| `reason`   | blank                  | machine code (e.g. `duplicate_detected`, or the structural validation message) |
+
+- **`txn_guid` is the transaction handle, not split GUIDs** (D5).
+  Callers wanting splits call `get_transaction(guid)`.
+- **`reason` reuses single-entry's exact value** for duplicates —
+  `duplicate_detected` — so a caller that learned single-entry reads a
+  batch rejection identically. The "retry with force=true" hint is
+  **not** repeated per row; it lives once in the tool docstring (D8).
+
+### `duplicates` table — sparse; present only when matches exist
+
+Reuses single-entry's `_duplicates_to_tsv` field order **with `ref`
+prepended** as the foreign key:
+
+```
+ref   confidence   guid   date   amount   description   signals
+```
+
+- When no transaction has any potential-duplicate match, the field is
+  emitted as `""` and dropped by `_strip_noise` — so **absence of the
+  `duplicates` key means "no duplicates anywhere."**
+- It carries both **blocking** matches (HIGH, which rejected a row) and
+  **advisory** matches (MED, which merely annotated a created row).
+  `status` + `reason` on the parent `results` row say which.
+
+### `dup_count` is a pointer *and* a checksum
+
+It points the caller from a `results` row into the `duplicates` table
+by `ref`. It is also a self-check: **Σ `dup_count` over `results` must
+equal the data-row count of `duplicates`.** A caller can verify it
+parsed both tables consistently.
+
+---
+
+## Behavior
+
+A **three-phase** model. The phases give a clean, defensible answer to
+the two questions that haunt batch writes — atomicity, and what
+"rejected" means.
+
+### Phase 1 — Validate all (structural; atomic gate)
+
+Parse and structurally validate every row via the existing
+`_validate_transaction_splits` chokepoint (balance, account
+resolution, currency, sign). **Structural failures are fatal to the
+batch** under the default `on_error="abort"`: nothing is written, and
+`results` reports each row — failed rows with their reason, valid rows
+with `status=rejected`, `reason=batch_aborted`. Rationale in D6.
+
+### Phase 2 — Duplicate screen (per-row)
+
+All surviving rows are structurally valid. Run the existing
+duplicate-detection signals per row. A **blocking** (HIGH) match with
+`force=False` marks that row `rejected` / `duplicate_detected` and
+**removes it from the write set** — but does **not** abort the batch.
+Other rows proceed. **Duplicates are fatal only to the row.** MED
+matches are advisory: the row stays in the write set and its
+`dup_count` reflects the matches.
+
+### Phase 3 — Commit the accepted set (one atomic save)
+
+The write set = structurally-valid rows minus blocked duplicates. They
+are built and committed in **one `book.save()`** — the per-write
+overhead amortized. Each committed transaction gets its **own audit-log
+entry** (see Open Questions on batch audit shape).
+
+### The rule, in one sentence
+
+> **Structural errors are fatal to the batch; duplicates are fatal only
+> to the row.**
+
+Because the two mean different things: a structural error means *the
+request is malformed* (likely a systematic caller mistake — wrong
+column mapping, off-by-one in the split pairs), so writing the "good"
+rows risks landing subtly-wrong financial data; a duplicate means *the
+request is valid* and you are merely flagging that an entry may already
+exist, which the caller reviews per-row.
+
+### `dry_run`
+
+Runs Phases 1–2 and returns the full `results` + `duplicates`
+envelope **without writing.** This is the clean "review before commit"
+workflow: submit → see what would be created and what looks like a
+duplicate → prune or force → resubmit. Mirrors single-entry's existing
+`dry_run`.
+
+---
+
+## Design Decisions
+
+### D1: Correlation via caller-supplied `ref` (ordinal-as-data)
+
+Positional pairing (result[i] ↔ input[i]) is rejected: any reorder,
+drop, or pre-validation skip shifts indices and silently misaligns
+everything after the divergence. Instead the caller stamps each row
+with a `ref` the server **echoes verbatim and never interprets**.
+
+The `ref` is required (not optional-with-index-fallback — an optional
+key means two code paths and the fragile one gets used), validated
+unique-within-batch, and treated as opaque. **It may simply be the row
+ordinal (`1..N`)** — "position carried as *data*, not as an
+*invariant*." That gives positional simplicity with explicit
+robustness: a server reorder or a dropped row can't cause the silent
+cascade, because the pairing is written down in both tables.
+
+This is *independently required* by the two-table output: the
+`duplicates` table needs an explicit foreign key back to its parent
+transaction regardless of atomicity, and once you need it there, using
+the same key for top-level correlation is one mechanism instead of two.
+
+### D2: Splits denormalized on input (wide), duplicates normalized on output (tall)
+
+These look inconsistent but answer two different cardinality regimes:
+
+- **Splits: known and bounded.** The *caller* knows the split count and
+  it is small. Known-and-bounded → widen (repeat columns, one row).
+- **Duplicates: discovered and unbounded.** The *server* finds them;
+  the count is unknown ahead of time and varies per row. → separate
+  table with an FK. You cannot widen what you cannot count.
+
+The same test says when escaped-JSON-in-a-cell is appropriate (ragged,
+*heterogeneous* nested data) versus a flat sub-table (*uniform* nested
+data). Duplicate rows are uniform → flat table, not a JSON cell.
+
+### D3: Two named TSV fields in a JSON envelope, not section markers in one TSV
+
+The two tables are *heterogeneous* (different schemas). JSON is good at
+a small set of named, differently-shaped fields; TSV is good at
+homogeneous rows. Let the envelope do the outer split, TSV the inner
+rows. Embedding `## RESULTS` / `## DUPLICATES` markers in one string
+re-creates, by fragile textual convention, the structure the envelope
+gives for free — and risks colliding with a transaction description
+that contains the marker text. This is also **already the app's
+convention**: single-entry returns a dict with
+`result["duplicates"] = <tsv>`; batch is that pattern plus a `results`
+field.
+
+### D4: Headers on every TSV — reversing the house default
+
+Historically TSV emitters omit the header and document the shape in the
+docstring. That was a false economy the moment there was more than one
+TSV shape to remember, and it is untenable when the caller must *join
+two tables*. Batch emits headers on both tables. (Related: a small
+app-wide pass to add headers to the existing `_*_to_tsv` emitters —
+tracked separately, may ride this sprint.)
+
+Interaction with D3's sparse handling: a header-only string is
+non-empty, so it would defeat `_strip_noise`'s absence-as-signal.
+Resolution: sparse tables emit **header+rows when there is data, `""`
+when there is none** — never a lonely header.
+
+### D5: Return the transaction handle, not split GUIDs
+
+`create_transaction` today returns `{guid, status}` — the *transaction*
+short-GUID, no split GUIDs. Batch matches it. Emitting split GUIDs would
+introduce a *second* one-to-many (txn → splits) and drag the response
+back toward the 3-D shape the two-table design exists to avoid. The
+transaction handle is sufficient; `get_transaction(guid)` yields splits
+on demand.
+
+### D6: Structural errors abort the batch by default (`on_error="abort"`)
+
+A malformed batch usually signals a *systematic* caller error (wrong
+column mapping, off-by-one split pairs), and writing the rows that
+happened to parse risks landing subtly-wrong financial data. Abort-all
+forces a look before anything commits — consistent with the project's
+"never write wrong data" posture and its existing validate-everything-
+up-front-then-mutate pattern. `on_error="skip"` is offered as an opt-in
+for callers who genuinely want skip-bad-keep-good.
+
+### D7: Duplicate override — `force` semantics
+
+Single-entry uses a per-call `force=true`. For batch, the v1 surface is
+a **batch-level `force`** (override *all* blocking duplicates this
+submission). A per-row `force` column is the more granular alternative
+and is the recommended pairing with the `dry_run` → review → resubmit
+flow, but it widens the input contract. See Open Questions.
+
+### D8: The hint is not per-row
+
+Single-entry pairs its duplicate rejection with a `hint` ("retry with
+force=true"). Identical on every `duplicate_detected` row, so N copies
+is waste. `reason` stays a terse machine code; the hint lives once in
+the tool docstring.
+
+---
+
+## Consistency With Single-Entry (`create_transaction`)
+
+| Concern             | Single-entry                          | Batch — same?                          |
+|---------------------|---------------------------------------|----------------------------------------|
+| Returned handle     | `{guid, status}` (txn short-GUID)     | ✅ `txn_guid` per row                   |
+| Duplicate reject    | `reason="duplicate_detected"` + hint  | ✅ same `reason`; hint in docstring     |
+| Duplicate render    | `_duplicates_to_tsv` (6 cols, no hdr) | ✅ same 6 cols + `ref` FK + header      |
+| Override            | `force=True`                          | ✅ `force` (batch-level in v1)          |
+| Dry run             | `dry_run`                             | ✅ `dry_run`                            |
+| GUID prefixes       | short, `_unique_prefix`               | ✅ short                                |
+| Validation          | `_validate_transaction_splits`        | ✅ reused per row                       |
+
+The guiding principle: a caller that has learned single-entry should
+read batch with *no new parsing rules* — only "there are N of them, and
+they're keyed by `ref`."
+
+---
+
+## Testing Strategy
+
+- **Unit (book method):** all-valid batch (atomic create, N audit
+  entries); structural failure aborts under `abort` and skips under
+  `skip`; blocking duplicate rejects its row but commits the rest;
+  advisory (MED) duplicate creates with `dup_count>0`; `dry_run` writes
+  nothing; ragged split widths; `ref` collision rejected; cross-batch
+  duplicate (two identical rows in one submission — second flags the
+  first).
+- **Output contract:** `results` always present with header; `duplicates`
+  absent when none, present-with-header when some; Σ `dup_count` ==
+  `duplicates` row count (the checksum); every `ref` echoed verbatim.
+- **Atomicity:** a Phase-3 failure (forced past a real problem) rolls
+  back the whole save — no partial batch lands.
+- **Persona integration:** a realistic month-of-activity batch against
+  Alex (USD) and Lin Wei (CNY), including a multi-currency row, with
+  cross-tool agreement (`get_book_summary` / `balance_sheet`) holding
+  after the batch.
+- **Regression:** single-entry `create_transaction` output unchanged.
+
+---
+
+## Implementation Plan
+
+1. `CoreMixin.create_transactions(transactions, force, dry_run,
+   on_error)` — parse TSV, Phase 1 (reuse `_validate_transaction_splits`
+   per row), Phase 2 (reuse duplicate signals), Phase 3 (build all,
+   one `book.save()`), assemble the envelope.
+2. `_results_to_tsv(rows)` and a `ref`-prefixed variant of
+   `_duplicates_to_tsv` — both with headers.
+3. Tool wrapper in `tools/core.py`; add `create_transactions` to
+   `TOOL_MODULES["transactions"]`.
+4. Audit-log dispatch: decide batch shape (Open Questions) and add the
+   formatter(s) to `logging_config.py`.
+5. Tests per the strategy above.
+6. Live bookkeeper validation on Alex + Lin Wei before any PR.
+
+---
+
+## Decisions (resolved 2026-06-13)
+
+1. **`on_error` default = `abort`.** A structurally-malformed batch
+   aborts entirely; nothing is written. Financial-data caution wins.
+   `skip` (skip-bad-keep-good) remains an opt-in argument value.
+2. **`force` = batch-level flag (v1).** A single `force=True` overrides
+   all blocking duplicates this submission, matching single-entry's
+   per-call force. A per-row force column is deferred.
+3. **Per-split memo and per-transaction currency = omitted in v1.** The
+   input stays `(amt, acct)` pairs only; memo-bearing or
+   unusual-currency transactions use single-entry. Documented
+   limitation, not a gap to apologize for.
+4. **Audit-log shape = N individual entries.** Each committed
+   transaction logs identically to a single-entry create — no new audit
+   shape for the dispatcher or a human reader to learn.
+
+## Open Questions (remaining — minor, may default during implementation)
+
+5. **Batch size cap.** The app caps listings at 250. A submission cap
+   (and its error message) needs a number — proposed default **100**;
+   confirm during implementation.
+6. **Codifying validation reasons.** Structural `reason` values are
+   currently the validation message text. Whether to normalize them to
+   short codes (like `duplicate_detected`) is a smaller follow-on.
+
+---
+
+## v1 Limitations (the wide format trades expressiveness for throughput)
+
+Reading the real `create_transaction` confirmed the wide TSV implies a
+deliberately narrow v1. Each case below falls back to single-entry
+`create_transaction`:
+
+- **Same-currency only** (book default). The `(amt, acct)` format has
+  no `quantity` slot, so cross-currency / cross-commodity (investment)
+  splits aren't expressible. Single-currency splits need no quantity
+  (`value == quantity`), so this is clean, not a workaround.
+- **No per-split memo, no per-transaction notes.**
+- **No auto-fill** — every row supplies explicit splits.
+- **No intra-batch duplicate detection.** Duplicates are detected
+  against *existing* book data via `_collect_create_signals`. Two
+  identical new rows in one batch both commit: the "don't flush
+  mid-build" rule means an unsaved sibling has no GUID, and the
+  DUPLICATES `guid` column assumes a persisted match. Deferred to v2.
+- **No per-row advisory warnings** (e.g. split-consistency). RESULTS is
+  status-focused; single-entry surfaces these.
+
+## Out of Scope (this feature)
+
+- Batch *update* / *delete* / *void* — this spec is create-only.
+- Batch scheduled-transaction instantiation.
+- Streaming / chunked responses for very large batches (the size cap
+  in Open Q5 bounds this instead).
+- Cross-transaction balancing (each row balances independently; the
+  batch is not one super-transaction).

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3032,6 +3032,188 @@ class CoreMixin:
                 result["auto_filled_from"] = auto_filled_from
             return result
 
+    def create_transactions(
+        self,
+        transactions: list[dict],
+        force: bool = False,
+        dry_run: bool = False,
+        on_error: str = "abort",
+    ) -> dict:
+        """Create multiple transactions in one atomic save.
+
+        Spec: specs/BATCH_TRANSACTION_ENTRY_SPEC.md. Each entry is
+        ``{ref, date (date), description, splits: [{account, amount}]}``.
+
+        Three phases under one book-open: validate all structurally,
+        screen each against existing-book duplicates, then build every
+        accepted transaction and ``save()`` once. ``on_error="abort"``
+        (default) sinks the whole batch on any structural failure;
+        ``"skip"`` keeps the good rows. A HIGH duplicate rejects only
+        its own row (``force=True`` overrides).
+
+        Returns a thin envelope: ``results`` TSV (always) and
+        ``duplicates`` TSV (only when a match exists; otherwise empty,
+        which ``_strip_noise`` drops). v1 is same-currency (book
+        default), no per-split memo, no intra-batch dedup — exotic cases
+        use ``create_transaction``.
+        """
+        if on_error not in ("abort", "skip"):
+            raise ValueError("on_error must be 'abort' or 'skip'")
+        refs = [t["ref"] for t in transactions]
+        if len(set(refs)) != len(refs):
+            raise ValueError(
+                "duplicate ref in batch — each ref must be unique"
+            )
+        readonly = dry_run
+        by_ref: dict = {}        # ref -> final result row
+        dup_rows: list = []      # (ref, candidate-dict) for the FK table
+
+        with self.open(readonly=readonly) as book:
+            default_currency = self._require_default_currency(book)
+
+            # --- Phase 1: structural validation (every row) ---
+            prepared = []
+            for txn in transactions:
+                ref = txn["ref"]
+                try:
+                    splits = txn["splits"]
+                    if len(splits) < 2:
+                        raise ValueError("at least 2 splits required")
+                    validated = self._validate_transaction_splits(
+                        book, splits, default_currency,
+                    )
+                    for v in validated:
+                        if v["account"].placeholder:
+                            raise ValueError(
+                                f"account '{v['account'].fullname}' is a "
+                                f"placeholder and cannot receive splits"
+                            )
+                    prepared.append({
+                        "ref": ref,
+                        "description": txn["description"],
+                        "trans_date": txn["date"],
+                        "validated": validated,
+                        "proposed_amounts": [
+                            abs(_to_decimal(s["amount"])) for s in splits
+                        ],
+                    })
+                except (ValueError, KeyError) as e:
+                    by_ref[ref] = {
+                        "ref": ref, "status": "rejected", "reason": str(e),
+                    }
+
+            # abort: any structural failure sinks the batch — the valid
+            # rows report batch_aborted, nothing is written.
+            if by_ref and on_error == "abort":
+                for p in prepared:
+                    by_ref[p["ref"]] = {
+                        "ref": p["ref"], "status": "rejected",
+                        "reason": "batch_aborted",
+                    }
+                return self._batch_envelope(transactions, by_ref, [])
+
+            # --- Phase 2: duplicate screen (against existing book) ---
+            accepted = []
+            for p in prepared:
+                signals = self._collect_create_signals(
+                    book, p["description"], p["trans_date"],
+                    p["proposed_amounts"],
+                    want_auto_fill=False, want_stability=False,
+                    want_duplicates=True, want_recent=False,
+                )
+                dups = signals.duplicates
+                for d in dups:
+                    dup_rows.append((p["ref"], d))
+                if signals.has_high_duplicate and not force:
+                    by_ref[p["ref"]] = {
+                        "ref": p["ref"], "status": "rejected",
+                        "reason": "duplicate_detected", "dup_count": len(dups),
+                    }
+                else:
+                    accepted.append((p, len(dups)))
+
+            # --- Phase 3: build all accepted rows, one save ---
+            if dry_run:
+                for p, dup_count in accepted:
+                    by_ref[p["ref"]] = {
+                        "ref": p["ref"], "status": "would_create",
+                        "dup_count": dup_count,
+                    }
+                return self._batch_envelope(transactions, by_ref, dup_rows)
+
+            built = []
+            for p, dup_count in accepted:
+                piecash_splits = [
+                    piecash.Split(
+                        account=v["account"], value=v["value"],
+                        quantity=v["quantity"], memo=v["memo"] or "",
+                    )
+                    for v in p["validated"]
+                ]
+                txn_obj = piecash.Transaction(
+                    currency=default_currency,
+                    description=p["description"],
+                    post_date=p["trans_date"],
+                    splits=piecash_splits,
+                )
+                built.append((p["ref"], txn_obj, dup_count))
+
+            # Single flush for the whole batch — per the "don't flush
+            # mid-build" rule, every Transaction is fully constructed
+            # before the one save.
+            book.save()
+
+            all_guids = [t.guid for t in book.transactions]
+            for ref, txn_obj, dup_count in built:
+                by_ref[ref] = {
+                    "ref": ref, "status": "created",
+                    "txn_guid": _unique_prefix(txn_obj.guid, all_guids),
+                    "dup_count": dup_count,
+                }
+
+            return self._batch_envelope(transactions, by_ref, dup_rows)
+
+    def _batch_envelope(
+        self, transactions: list[dict], by_ref: dict, dup_rows: list,
+    ) -> dict:
+        """Assemble the {results, duplicates} TSV envelope in input
+        order. Empty ``duplicates`` renders as "" so _strip_noise drops
+        it — absence of the key means no duplicates anywhere."""
+        rows = [by_ref[t["ref"]] for t in transactions]
+        return {
+            "results": self._batch_results_to_tsv(rows),
+            "duplicates": self._batch_duplicates_to_tsv(dup_rows),
+        }
+
+    @staticmethod
+    def _batch_results_to_tsv(rows: list[dict]) -> str:
+        """RESULTS table: header + one row per input transaction.
+        Blank cells for fields a given status doesn't carry; ``dup_count``
+        of 0 renders as "0", absent renders blank."""
+        header = "ref\tstatus\ttxn_guid\tdup_count\treason"
+        lines = [header]
+        for r in rows:
+            dup = r["dup_count"] if "dup_count" in r else ""
+            lines.append(
+                f"{r['ref']}\t{r['status']}\t{r.get('txn_guid', '')}\t"
+                f"{dup}\t{r.get('reason', '')}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _batch_duplicates_to_tsv(dup_rows: list) -> str:
+        """DUPLICATES table: single-entry's column order with ``ref``
+        prepended as the FK. Empty string when no row has a match."""
+        if not dup_rows:
+            return ""
+        lines = ["ref\tconfidence\tguid\tdate\tamount\tdescription\tsignals"]
+        for ref, d in dup_rows:
+            lines.append(
+                f"{ref}\t{d['confidence']}\t{d['guid']}\t{d['date']}\t"
+                f"{d['amount']}\t{d['description']}\t{d['signals']}"
+            )
+        return "\n".join(lines)
+
     def search_transactions(
         self,
         query: str,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -509,6 +509,69 @@ def _fmt_transaction_create(entry: dict) -> list[str]:
     return lines
 
 
+def _parse_audit_tsv_rows(tsv: str) -> list[dict]:
+    """Header-bearing TSV string -> row dicts (display-only)."""
+    if not tsv:
+        return []
+    rows = tsv.split("\n")
+    header = rows[0].split("\t")
+    return [dict(zip(header, r.split("\t"))) for r in rows[1:] if r]
+
+
+def _parse_batch_submission(tsv: str) -> dict:
+    """ref -> {description, date, splits} from the submitted batch TSV.
+    Positional parse mirroring the tool layer; tolerant of ragged rows
+    since this is display-only."""
+    out: dict = {}
+    for ln in (tsv.split("\n")[1:] if tsv else []):
+        if not ln.strip():
+            continue
+        f = ln.split("\t")
+        if len(f) < 3:
+            continue
+        rest = f[3:]
+        splits = [
+            {"account": rest[j + 1], "amount": rest[j]}
+            for j in range(0, len(rest) - 1, 2)
+        ]
+        out[f[0].strip()] = {
+            "description": f[2], "date": f[1].strip(), "splits": splits,
+        }
+    return out
+
+
+def _fmt_transaction_create_batch(entry: dict) -> list[str]:
+    """Batch create audits as N individual create blocks — one per
+    committed transaction, each rendered like a single-entry create.
+    Joins the submitted TSV (params) with the results TSV (after_state)
+    by ref. Account refs render as the caller supplied them (the TSV
+    isn't run through the audit ref-normalizer)."""
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    submitted = _parse_batch_submission(params.get("transactions") or "")
+    results = _parse_audit_tsv_rows(after.get("results") or "")
+    created = [r for r in results if r.get("status") == "created"]
+    rejected = [r for r in results if r.get("status") == "rejected"]
+
+    lines = [
+        f"{time_part}  CREATE TRANSACTIONS (batch)  "
+        f"{len(created)} created, {len(rejected)} rejected"
+    ]
+    for r in created:
+        src = submitted.get(r.get("ref", ""), {})
+        guid = r.get("txn_guid", "")
+        desc = src.get("description", "")
+        date_str = src.get("date", "")
+        lines.append(
+            f'{_INDENT}CREATE  guid:{guid}  "{desc}" ({date_str})'
+        )
+        splits = src.get("splits") or []
+        if splits:
+            lines.append(_format_splits_text(splits, _INDENT_SPLITS))
+    return lines
+
+
 def _fmt_transaction_update(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     before = entry.get("before_state")
@@ -1680,6 +1743,7 @@ def _fmt_scheduled_transaction_delete(entry: dict) -> list[str]:
 
 _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("transaction", "CREATE"): _fmt_transaction_create,
+    ("transaction", "CREATE_BATCH"): _fmt_transaction_create_batch,
     ("transaction", "UPDATE"): _fmt_transaction_update,
     ("transaction", "VOID"): _fmt_transaction_void,
     ("transaction", "UNVOID"): _fmt_transaction_unvoid,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -144,6 +144,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "list_transactions",
         "get_transaction",
         "create_transaction",
+        "create_transactions",
         "update_transaction",
         "delete_transaction",
         "replace_splits",
@@ -651,13 +652,13 @@ Usage: gnucash-mcp [OPTIONS]
 
 Options:
   --modules=MODULES    Tool modules to load (comma-separated).
-                       Default: core (29 tools, always-on). Use "all"
-                       for every module (106 tools).
+                       Default: core (30 tools, always-on). Use "all"
+                       for every module (107 tools).
 
                        Role-based selections (group aliases that
                        expand to underlying modules — start here):
                          core         Ledger primitives + reconciliation.
-                                      Always on regardless. 29 tools.
+                                      Always on regardless. 30 tools.
                          bookkeeper   Reporting + budgets + scheduling.
                                       17 tools.
                          investor     tax_lots + portfolio (cost basis

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -19,6 +19,49 @@ from gnucash_mcp.tools._helpers import (
 )
 
 
+def _parse_transactions_tsv(tsv: str) -> list[dict]:
+    """Parse the batch-entry TSV into structured transactions.
+
+    Header row + one row per transaction; positional parse so rows may
+    be ragged. First three fields are ref / date / description; the rest
+    are ``(amount, account)`` pairs. Raises ValueError on a missing
+    header, too-few columns, or an odd trailing count.
+    """
+    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        raise ValueError(
+            "transactions TSV needs a header row and at least one data row"
+        )
+    out: list[dict] = []
+    for i, ln in enumerate(lines[1:], start=1):
+        fields = ln.split("\t")
+        if len(fields) < 5:
+            raise ValueError(
+                f"row {i}: expected ref, date, description, and at least "
+                f"one (amount, account) pair"
+            )
+        ref, dt, desc = fields[0].strip(), fields[1].strip(), fields[2]
+        if not ref:
+            raise ValueError(f"row {i}: empty ref (each row needs a key)")
+        rest = fields[3:]
+        if len(rest) % 2 != 0:
+            raise ValueError(
+                f"row {i} (ref {ref!r}): trailing fields must be "
+                f"(amount, account) pairs — got an odd count"
+            )
+        splits = [
+            {"account": rest[j + 1], "amount": rest[j]}
+            for j in range(0, len(rest), 2)
+        ]
+        out.append({
+            "ref": ref,
+            "date": _parse_iso_date(dt) or date.today(),
+            "description": desc,
+            "splits": splits,
+        })
+    return out
+
+
 def register(mcp, get_book) -> None:
     """Attach core tools to the FastMCP server."""
 
@@ -217,6 +260,69 @@ def register(mcp, get_book) -> None:
             check_duplicates=check_duplicates,
             force_create=force_create,
             dry_run=dry_run,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(
+        classification="write", operation="create_batch",
+        entity_type="transaction",
+    )
+    def create_transactions(
+        transactions: str,
+        force: bool = False,
+        dry_run: bool = False,
+        on_error: str = "abort",
+    ) -> str:
+        """Create MANY transactions in one atomic command (bulk entry).
+
+        INPUT — ``transactions`` is a TSV block: a header row, then one
+        row per transaction. Splits are ``(amount, account)`` column
+        PAIRS, repeated as wide as a transaction needs::
+
+            ref<TAB>date<TAB>description<TAB>amt1<TAB>acct1<TAB>amt2<TAB>acct2...
+            1<TAB>2026-05-21<TAB>Gas<TAB>-54.19<TAB>Assets:Checking<TAB>54.19<TAB>Expenses:Auto:Fuel
+
+        - ``ref``: YOUR correlation key per row (e.g. 1, 2, 3), unique
+          within the batch. It is echoed back so you can match results
+          to what you sent; the server never reuses or interprets it.
+        - ``date``: ISO YYYY-MM-DD. ``amount``: decimal STRING (never a
+          raw JSON number). Each transaction needs >=2 splits balancing
+          to zero. Rows may differ in width (2 splits vs 3).
+        - v1 is same-currency (book default) with no per-split memo —
+          use ``create_transaction`` for cross-currency, investment, or
+          memo-bearing entries.
+
+        BEHAVIOR — one book-open, one atomic save:
+        - A STRUCTURAL error (unbalanced, unknown account, bad pairs)
+          aborts the WHOLE batch by default; nothing is written. Pass
+          ``on_error="skip"`` to write the good rows and reject only the
+          bad ones.
+        - A duplicate rejects ONLY its row; ``force=True`` overrides all
+          blocking duplicates (as in ``create_transaction``).
+          ``dry_run=True`` validates + screens without writing.
+
+        OUTPUT — a JSON envelope of two TSV tables joined by ``ref``:
+        - ``results`` (always): ``ref, status, txn_guid, dup_count,
+          reason``. status is ``created`` | ``rejected`` |
+          ``would_create`` (dry_run); reason is a code like
+          ``duplicate_detected`` or the validation message.
+        - ``duplicates`` (only when matches exist): ``ref, confidence,
+          guid, date, amount, description, signals`` — the columns
+          ``create_transaction`` emits, keyed back to the offending
+          ``ref``. Σ(dup_count) equals the duplicates row count.
+
+        Args:
+            transactions: The TSV block described above.
+            force: Override ALL blocking (HIGH) duplicates this batch.
+            dry_run: Validate + screen, write nothing.
+            on_error: "abort" (default) or "skip" for structural errors.
+        """
+        book = get_book()
+        parsed = _parse_transactions_tsv(transactions)
+        result = book.create_transactions(
+            parsed, force=force, dry_run=dry_run, on_error=on_error,
         )
         return _json(result)
 

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -1,0 +1,134 @@
+"""Behavior tests for batch transaction entry (create_transactions).
+
+Spec: specs/BATCH_TRANSACTION_ENTRY_SPEC.md. These exercise the book
+method directly (the tool wrapper + audit are tested separately).
+"""
+
+from datetime import date
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+
+
+def _parse(tsv: str) -> list[dict]:
+    """Parse a header-bearing TSV string into a list of dicts."""
+    if not tsv:
+        return []
+    lines = tsv.split("\n")
+    header = lines[0].split("\t")
+    return [dict(zip(header, ln.split("\t"))) for ln in lines[1:]]
+
+
+def _txn(ref, desc, amt, d=date(2026, 5, 21),
+         acct_from="Assets:Checking", acct_to="Expenses:Groceries"):
+    return {
+        "ref": str(ref),
+        "date": d,
+        "description": desc,
+        "splits": [
+            {"account": acct_from, "amount": f"-{amt}"},
+            {"account": acct_to, "amount": str(amt)},
+        ],
+    }
+
+
+def _seed_rent(gc):
+    gc.create_transaction(
+        description="Rent",
+        splits=[
+            {"account": "Assets:Checking", "amount": "-1800"},
+            {"account": "Expenses:Groceries", "amount": "1800"},
+        ],
+        trans_date=date(2026, 5, 20),
+    )
+
+
+def _descriptions(gc):
+    return {t["description"] for t in gc.list_transactions(compact=False)}
+
+
+class TestBatchCreate:
+    def test_all_valid_atomic_create(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([
+            _txn(1, "Groceries A", "50.00"),
+            _txn(2, "Groceries B", "25.00"),
+        ])
+        rows = _parse(env["results"])
+        assert len(rows) == 2
+        assert all(r["status"] == "created" for r in rows)
+        assert all(r["txn_guid"] for r in rows)
+        assert env["duplicates"] == ""
+        assert {"Groceries A", "Groceries B"} <= _descriptions(gc)
+
+    def test_structural_failure_aborts(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        bad = _txn(2, "Unbalanced", "10.00")
+        bad["splits"][1]["amount"] = "999"  # breaks sum-to-zero
+        env = gc.create_transactions([_txn(1, "Good one", "50.00"), bad])
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["2"]["status"] == "rejected"
+        assert rows["1"]["status"] == "rejected"
+        assert rows["1"]["reason"] == "batch_aborted"
+        assert "Good one" not in _descriptions(gc)  # nothing written
+
+    def test_on_error_skip_keeps_good(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        bad = _txn(2, "Unbalanced", "10.00")
+        bad["splits"][1]["amount"] = "999"
+        env = gc.create_transactions(
+            [_txn(1, "Good one", "50.00"), bad], on_error="skip",
+        )
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["1"]["status"] == "created"
+        assert rows["2"]["status"] == "rejected"
+        assert "Good one" in _descriptions(gc)
+
+    def test_duplicate_rejects_only_its_row(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions([
+            _txn(1, "Rent", "1800", d=date(2026, 5, 20)),  # HIGH dup
+            _txn(2, "Fresh", "30.00"),
+        ])
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["1"]["status"] == "rejected"
+        assert rows["1"]["reason"] == "duplicate_detected"
+        assert rows["2"]["status"] == "created"
+        dup_rows = _parse(env["duplicates"])
+        assert dup_rows and all(d["ref"] == "1" for d in dup_rows)
+
+    def test_force_overrides_duplicate(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1800", d=date(2026, 5, 20))], force=True,
+        )
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+
+    def test_dry_run_writes_nothing(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions(
+            [_txn(1, "Preview", "50.00")], dry_run=True,
+        )
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "would_create"
+        assert "Preview" not in _descriptions(gc)
+
+    def test_checksum_dupcount_equals_table_rows(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions([
+            _txn(1, "Rent", "1800", d=date(2026, 5, 20)),
+            _txn(2, "Fresh", "30.00"),
+        ], force=True)
+        results = _parse(env["results"])
+        dup_total = sum(int(r["dup_count"]) for r in results if r["dup_count"])
+        assert dup_total == len(_parse(env["duplicates"]))
+
+    def test_bad_on_error_raises(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError):
+            gc.create_transactions([_txn(1, "x", "1")], on_error="bad")

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -78,22 +78,22 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_group_resolves_to_29_tools(self):
-        """The ``core`` group expands to 29 tools across its nine
+        """The ``core`` group expands to 30 tools across its nine
         sub-modules (summary 1 + accounts 7 + transactions 9 + slots
         3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
         reconciliation 3). Reconciliation joined core in v1.3.1
         per the bookkeeper-driven principle that any configuration
         which handles money must include reconciliation.
         """
-        assert len(_core_tool_names()) == 29
+        assert len(_core_tool_names()) == 30
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 106 —
+        """Total tools across all sub-modules should be 107 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
         1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 106
+        assert total == 107
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -157,7 +157,7 @@ class TestToolFileVsModulesMapping:
 
     Pre-restructure this was a per-module 1:1 check (each
     ``tools/<X>.py`` matched ``TOOL_MODULES[X]`` exactly). The Core
-    restructure broke that bijection — Core's 29 tools span
+    restructure broke that bijection — Core's 30 tools span
     ``tools/core.py`` + ``tools/reconciliation.py`` +
     ``tools/admin.py`` + ``tools/backup.py``. The contract is now
     bidirectional-totality: every decorated tool maps to some
@@ -257,9 +257,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 106 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables)."""
+        """--modules=all should keep all 107 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 106
+        assert len(self._tool_names()) == 107
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -291,12 +291,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 106
+        assert len(self._tool_names()) == 107
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 106 tools."""
+        """'all' mixed with other modules should keep all 107 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 106
+        assert len(self._tool_names()) == 107
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.


### PR DESCRIPTION
## Summary

Adds **`create_transactions`** — submit many transactions in one TSV command, with **one book-open and one atomic save for N** (the v1.0.2 output-efficiency instinct applied to the write path).

- **Input** — a TSV block: header + one row per transaction, splits as `(amount, account)` pairs widening rightward. Each row carries a caller-supplied `ref` (its correlation key, echoed back verbatim).
- **Behavior** — three phases under one book-open: validate all (structural errors abort the batch by default; `on_error="skip"` keeps the good rows), screen each row against existing-book duplicates (a HIGH match rejects only its row; `force=true` overrides), then commit the accepted set in one save. `dry_run=true` validates + screens without writing.
- **Output** — a two-table TSV envelope joined by `ref`: `results` (always: `ref, status, txn_guid, dup_count, reason`) and `duplicates` (only when matches exist — the columns single-entry emits, keyed back to `ref`). `Σ dup_count` equals the duplicates row count.
- **Audit** — N individual entries, one per committed transaction, each rendered like a single-entry create.
- **Consistency** — reuses `_validate_transaction_splits`, `_collect_create_signals`, the duplicate-TSV shape, short GUIDs, and `force` semantics; a caller that knows `create_transaction` reads this with no new rules.

Design + rationale: `specs/BATCH_TRANSACTION_ENTRY_SPEC.md`.

**v1 limitations** (documented; exotic cases use `create_transaction`): same-currency only (the wide format has no `quantity` slot), no per-split memo, no auto-fill, no intra-batch duplicate detection (the "don't flush mid-build" rule means an unsaved sibling has no GUID to match against).

## Test plan

- [x] 8 behavior tests (`tests/test_batch_transactions.py`): atomic all-valid create; structural failure aborts, and `on_error="skip"` keeps the good rows; duplicate rejects only its row; `force` overrides; `dry_run` writes nothing; `Σ dup_count == duplicates rows` checksum; bad `on_error` raises
- [x] Audit handler renders N individual create blocks (formatter smoke + contract test `test_every_write_decorator_has_a_dispatcher_entry`)
- [x] Tool registered and in `TOOL_MODULES`; module-mapping + tool-count contracts updated (core 30, total 107)
- [x] **Full suite green — 1592 passed, 0 failed**
- [x] **Bookkeeper live signoff** on a test book: validated the happy path, duplicate detection, and malformed/unbalanced-row rejection
