### PR TITLE
Pagination: offset + Showing X-Y of Z indicator across all list tools

### DIFF
--- a/specs/PAGINATION.md
+++ b/specs/PAGINATION.md
@@ -1,0 +1,150 @@
+# Pagination: offset + limit + result count indicator
+
+## Implementation status — shipped
+
+Implemented on `feat/pagination`. The chokepoint is
+`_paginate(items, offset, limit, default=50, max_cap=250,
+entity_name, date_range)` in `gnucash_mcp/_format.py`, which retired
+both prior truncation mechanisms (`_apply_limit` and the bespoke
+`_truncation_notice`). Date helpers `_iso_date` / `_date_range` live
+in `book/_base.py`.
+
+Scope landed broader than the named subset below: **all 20
+list-returning tools** carry the indicator + `offset`, not just the
+"must / should have" lists. Dated tools (`list_transactions`,
+`search_transactions`, `get_unreconciled_splits`, `list_invoices`,
+`get_outstanding_invoices`, `get_prices`, `get_upcoming_transactions`,
+`list_backups`) render the `(earliest to latest)` range; undated ones
+omit the parens. Verbose mode returns a uniform envelope
+`{<entity>, showing, total, offset, count}` everywhere.
+
+Two tools deviate by necessity, both documented in code:
+`list_backups` paginates at the tool layer (its book method stays a
+full list for internal callers), and `get_audit_log` uses a
+recency-anchored window (offset pages *backward* from the newest
+entry) since a log is read newest-first. The contract is locked by
+`tests/test_tools.py::TestPaginationCoverage`.
+
+## Problem
+
+List tools (`list_transactions`, `search_transactions`, `get_unreconciled_splits`, etc.) silently truncate results at a default limit. The LLM has no way to know it's looking at a partial view. This caused a real miss: 93 of 109 checking transactions were returned, the LLM assumed completeness, and 16 missing entries went undetected for an entire reconciliation session.
+
+## Solution
+
+Add `offset` parameter and a "Showing X-Y of Z" indicator to every tool that returns a list of results.
+
+## Indicator format
+
+First line of the response, before any TSV data:
+
+```
+Showing 1-50 of 109 transactions (2026-05-01 to 2026-06-12)
+```
+
+Components:
+- `1-50`: the row range in this response (1-indexed for readability)
+- `of 109`: total matching rows (the number the LLM needs to decide whether to paginate)
+- `transactions`: the entity type (transactions, splits, accounts, etc.)
+- `(2026-05-01 to 2026-06-12)`: date range of the FULL result set, not just this page — tells the LLM the time window without parsing rows
+
+When all results fit in one page:
+```
+Showing 1-23 of 23 transactions (2026-06-01 to 2026-06-18)
+```
+
+The LLM sees `1-23 of 23` and knows the set is complete. No pagination needed.
+
+## Parameters
+
+Add to every listing tool:
+
+```python
+offset: int = 0    # 0-indexed starting row. Default 0 (first page).
+limit: int = 50    # Maximum rows to return. Existing parameter, already present on most tools.
+```
+
+Behavior:
+- `offset=0, limit=50` → rows 0-49 (first page, default)
+- `offset=50, limit=50` → rows 50-99 (second page)
+- `offset=100, limit=50` → rows 100-108 (last page, partial)
+- `offset=0, limit=200` → rows 0-108 (all results in one call if under limit)
+
+The total count `Z` in the indicator is ALWAYS the full result count regardless of offset/limit. This is computed once via `COUNT(*)` or `len()` on the full query, before slicing.
+
+## Tools to update
+
+### Must have (high-volume listing tools)
+1. **list_transactions** — the primary surface. Most likely to truncate silently on active accounts.
+2. **search_transactions** — same result format, same truncation risk.
+3. **get_unreconciled_splits** — used for reconciliation. Missing splits = missed reconciliation items.
+
+### Should have (lower volume but same pattern)
+4. **list_accounts** — usually small enough to fit, but placeholder-heavy books could exceed limits.
+5. **list_invoices** — a business with 100+ invoices needs pagination.
+6. **list_customers / list_vendors / list_employees** — unlikely to exceed limits but should be consistent.
+
+### Don't need
+- `get_book_summary`, `balance_sheet`, `net_worth` — single-result tools, not lists.
+- `get_transaction`, `get_invoice`, `get_account` — single-entity lookups.
+- `spending_by_category`, `income_by_source` — aggregated reports, not row listings.
+
+## Implementation notes
+
+### Count query
+The total count must be computed from the SAME filter as the data query — same account, same date range, same search term. Don't count all transactions when the user asked for a specific account's transactions.
+
+```python
+# Pseudocode
+total = query.count()  # or len(results) before slicing
+page = results[offset:offset+limit]
+indicator = f"Showing {offset+1}-{offset+len(page)} of {total} transactions"
+```
+
+### Performance
+For SQLAlchemy/piecash: `query.count()` is a separate SQL query but it's fast (index scan). The cost is one extra query per call, not per row. On a 50,000-transaction book, this adds ~1ms.
+
+For very large result sets, the offset-based approach may slow down at high offsets (SQL has to skip N rows). This is acceptable for MCP usage — an LLM isn't going to page through 10,000 transactions one page at a time. If it needs that many, it should use a tighter date range or search filter.
+
+### Existing limit parameter
+Most listing tools already have a `limit` parameter. Add `offset` alongside it. Default offset to 0. Default limit stays at its current value (usually 50).
+
+### Backward compatibility
+The indicator line is PREPENDED to the response. Existing consumers that parse TSV starting from line 1 (the header) would need to adjust to start from line 2. Since the consumers are LLMs (not rigid parsers), this is a non-issue — the LLM reads the indicator naturally.
+
+If strict backward compatibility is needed, the indicator could go AFTER the TSV data as a footer. But header position is better — the LLM reads it first and knows whether to ask for more before processing the rows.
+
+## Edge cases
+
+### Zero results
+```
+Showing 0 of 0 transactions
+```
+No TSV data follows. The LLM knows the query returned nothing.
+
+### Offset beyond total
+```
+Showing 0 of 109 transactions (offset 200 exceeds result count)
+```
+Empty page with the total count visible. The LLM knows it overshot and can adjust.
+
+### limit=0 (count-only mode)
+Optional but useful: if `limit=0`, return ONLY the indicator line with no data. Lets the LLM check how many results exist before deciding how to page.
+
+```
+list_transactions(account="Checking", start_date="2026-01-01", limit=0)
+→ "Showing 0 of 245 transactions (2026-01-01 to 2026-06-18)"
+```
+
+One call to know the size, then a targeted `limit=245` call to get everything. Cheaper than discovering truncation after processing 50 rows.
+
+## Tests
+1. Default call returns indicator showing `1-50 of N` when N > 50
+2. `offset=50` returns `51-100 of N` with correct rows
+3. Last page shows partial range: `101-109 of 109`
+4. Full result set (N ≤ limit) shows `1-N of N`
+5. Zero results shows `0 of 0`
+6. Offset beyond total shows error/empty with count
+7. `limit=0` returns count-only indicator (if implemented)
+8. Total count matches actual query filter (not all-transactions count)
+9. Date range in indicator reflects full result set, not current page
+10. Indicator is first line, TSV header is second line, data follows

--- a/specs/PAGINATION.md
+++ b/specs/PAGINATION.md
@@ -4,10 +4,13 @@
 
 Implemented on `feat/pagination`. The chokepoint is
 `_paginate(items, offset, limit, default=50, max_cap=250,
-entity_name, date_range)` in `gnucash_mcp/_format.py`, which retired
+entity_name, date_key)` in `gnucash_mcp/_format.py`, which retired
 both prior truncation mechanisms (`_apply_limit` and the bespoke
-`_truncation_notice`). Date helpers `_iso_date` / `_date_range` live
-in `book/_base.py`.
+`_truncation_notice`). Dated callers pass a `date_key` callable
+(`row -> date/datetime/ISO-string`); `_paginate` computes the range
+itself — over the **current page** for paged calls, over the full set
+for count-only/overshoot. The `_iso_date` normalizer lives in
+`_format.py` (layer-neutral, so the book layer doesn't reach upward).
 
 Scope landed broader than the named subset below: **all 20
 list-returning tools** carry the indicator + `offset`, not just the
@@ -45,7 +48,13 @@ Components:
 - `1-50`: the row range in this response (1-indexed for readability)
 - `of 109`: total matching rows (the number the LLM needs to decide whether to paginate)
 - `transactions`: the entity type (transactions, splits, accounts, etc.)
-- `(2026-05-01 to 2026-06-12)`: date range of the FULL result set, not just this page — tells the LLM the time window without parsing rows
+- `(2026-05-01 to 2026-06-12)`: date range of **this page** — on a
+  chronological list it's the actionable navigation signal ("rows
+  251-500 cover Oct–Dec; I need May, jump ahead"). The exception is
+  count-only mode (`limit=0`), which has no page and so spans the FULL
+  result set — the "what's the scope?" query. (Design refined from
+  full-set-everywhere after the bookkeeper pointed out the page range
+  is what enables offset arithmetic.)
 
 When all results fit in one page:
 ```

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -17,6 +17,7 @@ Two pieces:
 """
 
 import os
+from datetime import datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import TypeVar
 
@@ -156,6 +157,41 @@ def _apply_limit(
 # ── Pagination ─────────────────────────────────────────────────────
 
 
+def _iso_date(value) -> str | None:
+    """Normalize a ``date`` / ``datetime`` / ISO-string to ``YYYY-MM-DD``.
+
+    The pagination indicator's date range needs day precision only.
+    piecash hands back ``datetime`` for some columns (``post_date``) and
+    ``date`` for others, and several callers already carry ISO strings
+    (split dicts, backup timestamps) — all normalize here. ``None``
+    passes through so absent dates drop out of a range.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        # Already ISO (possibly with a time component) — keep the date.
+        return value[:10]
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return value.isoformat()
+
+
+def _range_suffix(rows, date_key) -> str:
+    """Build the `` (earliest to latest)`` parenthetical over ``rows``.
+
+    Empty when ``date_key`` is None (undated entity) or no row carries a
+    date. The caller decides which rows to span — the current page (for
+    navigation) or the full set (for the count-only "scope" query).
+    """
+    if date_key is None:
+        return ""
+    isos = [_iso_date(date_key(r)) for r in rows]
+    isos = [d for d in isos if d]
+    if not isos:
+        return ""
+    return f" ({min(isos)} to {max(isos)})"
+
+
 def _paginate(
     items: list[T],
     offset: int = 0,
@@ -163,7 +199,7 @@ def _paginate(
     default: int = 50,
     max_cap: int = 250,
     entity_name: str = "items",
-    date_range: tuple[str | None, str | None] | None = None,
+    date_key=None,
 ) -> tuple[list[T], str]:
     """Slice ``items`` to one page and build a ``Showing X-Y of Z`` line.
 
@@ -172,6 +208,12 @@ def _paginate(
     LLM learns the view is partial *before* reading any rows. A silent
     truncation is exactly the failure this prevents (a reconciliation
     session once missed 16 of 109 transactions to a hidden cap).
+
+    The date range spans the **current page**, not the full set: on a
+    chronological list it's the actionable navigation signal ("rows
+    251-500 cover Nov–Dec; I need May, so jump ahead"). The exception is
+    count-only / overshoot mode, where there is no page and the range
+    spans the full set — the "what's the scope?" query.
 
     Args:
         items: The FULL filtered, sorted result set. Slicing happens
@@ -184,10 +226,10 @@ def _paginate(
             ``limit capped at N`` note appended to the indicator.
         entity_name: Plural noun for the indicator ("transactions",
             "accounts", "splits").
-        date_range: ``(earliest, latest)`` ISO strings spanning the
-            FULL result set — not just this page — rendered in parens
-            so the LLM sees the time window without parsing rows. Omit
-            (or pass None/empty members) for undated entities.
+        date_key: Optional ``row -> date/datetime/ISO-string`` callable.
+            Provided for dated entities so the indicator carries the
+            range; omit for undated ones (no parens). The range is
+            computed from the page (or the full set in count-only mode).
 
     Returns:
         ``(page, indicator)``. ``page`` is the sliced rows; ``indicator``
@@ -195,15 +237,13 @@ def _paginate(
     """
     total = len(items)
 
-    suffix = ""
-    if date_range:
-        lo, hi = date_range
-        if lo and hi:
-            suffix = f" ({lo} to {hi})"
-
     # Count-only mode — one cheap call to learn the size before paging.
+    # No page, so the range spans the full set (the scope question).
     if limit == 0:
-        return [], f"Showing 0 of {total} {entity_name}{suffix}"
+        return [], (
+            f"Showing 0 of {total} {entity_name}"
+            f"{_range_suffix(items, date_key)}"
+        )
 
     if not limit or limit < 1:
         limit = default
@@ -216,17 +256,19 @@ def _paginate(
     if total == 0:
         return [], f"Showing 0 of 0 {entity_name}"
 
-    # Overshot the end — surface the total so the LLM can correct.
+    # Overshot the end — surface the total (and full-set scope) so the
+    # LLM can correct.
     if offset >= total:
         return [], (
             f"Showing 0 of {total} {entity_name} "
-            f"(offset {offset} exceeds result count){suffix}"
+            f"(offset {offset} exceeds result count)"
+            f"{_range_suffix(items, date_key)}"
         )
 
     page = items[offset:offset + effective]
     cap_note = f"; limit capped at {effective}" if capped else ""
     indicator = (
         f"Showing {offset + 1}-{offset + len(page)} of {total} "
-        f"{entity_name}{cap_note}{suffix}"
+        f"{entity_name}{cap_note}{_range_suffix(page, date_key)}"
     )
     return page, indicator

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -151,3 +151,82 @@ def _apply_limit(
         return items, f"[Limit capped at {effective}]"
 
     return items, None
+
+
+# ── Pagination ─────────────────────────────────────────────────────
+
+
+def _paginate(
+    items: list[T],
+    offset: int = 0,
+    limit: int | None = None,
+    default: int = 50,
+    max_cap: int = 250,
+    entity_name: str = "items",
+    date_range: tuple[str | None, str | None] | None = None,
+) -> tuple[list[T], str]:
+    """Slice ``items`` to one page and build a ``Showing X-Y of Z`` line.
+
+    Unlike :func:`_apply_limit`, the indicator is **always** returned
+    (never None) and is meant to be the FIRST line of the response — the
+    LLM learns the view is partial *before* reading any rows. A silent
+    truncation is exactly the failure this prevents (a reconciliation
+    session once missed 16 of 109 transactions to a hidden cap).
+
+    Args:
+        items: The FULL filtered, sorted result set. Slicing happens
+            here; ``len(items)`` is the authoritative total — count
+            before paginating, never after.
+        offset: 0-indexed first row. Negative clamps to 0.
+        limit: Page size. Falsy/None falls back to ``default`` (50);
+            ``limit == 0`` is count-only mode (empty page, total still
+            reported); values above ``max_cap`` (250) clamp with a
+            ``limit capped at N`` note appended to the indicator.
+        entity_name: Plural noun for the indicator ("transactions",
+            "accounts", "splits").
+        date_range: ``(earliest, latest)`` ISO strings spanning the
+            FULL result set — not just this page — rendered in parens
+            so the LLM sees the time window without parsing rows. Omit
+            (or pass None/empty members) for undated entities.
+
+    Returns:
+        ``(page, indicator)``. ``page`` is the sliced rows; ``indicator``
+        is the always-present header line.
+    """
+    total = len(items)
+
+    suffix = ""
+    if date_range:
+        lo, hi = date_range
+        if lo and hi:
+            suffix = f" ({lo} to {hi})"
+
+    # Count-only mode — one cheap call to learn the size before paging.
+    if limit == 0:
+        return [], f"Showing 0 of {total} {entity_name}{suffix}"
+
+    if not limit or limit < 1:
+        limit = default
+    capped = limit > max_cap
+    effective = min(limit, max_cap)
+
+    if offset < 0:
+        offset = 0
+
+    if total == 0:
+        return [], f"Showing 0 of 0 {entity_name}"
+
+    # Overshot the end — surface the total so the LLM can correct.
+    if offset >= total:
+        return [], (
+            f"Showing 0 of {total} {entity_name} "
+            f"(offset {offset} exceeds result count){suffix}"
+        )
+
+    page = items[offset:offset + effective]
+    cap_note = f"; limit capped at {effective}" if capped else ""
+    indicator = (
+        f"Showing {offset + 1}-{offset + len(page)} of {total} "
+        f"{entity_name}{cap_note}{suffix}"
+    )
+    return page, indicator

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -62,6 +62,34 @@ def _slot_value_str(value) -> str:
     return str(value)
 
 
+def _iso_date(value) -> str | None:
+    """Render a ``date`` / ``datetime`` as a bare ``YYYY-MM-DD`` string.
+
+    The pagination indicator's date-range needs day precision only,
+    and piecash hands back ``datetime`` for some columns (``post_date``)
+    and ``date`` for others. ``None`` passes through so callers can
+    skip absent dates when computing a range.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return value.isoformat()
+
+
+def _date_range(values) -> tuple[str | None, str | None] | None:
+    """Min/max ISO date over an iterable of ``date``/``datetime``/None.
+
+    Returns ``(earliest, latest)`` for the pagination indicator, or
+    ``None`` when nothing dated is present — passing that straight to
+    :func:`gnucash_mcp._format._paginate` omits the parenthetical.
+    """
+    present = [v for v in values if v is not None]
+    if not present:
+        return None
+    return _iso_date(min(present)), _iso_date(max(present))
+
+
 def _is_voided(split) -> bool:
     """True iff ``split`` carries GnuCash's voided marker.
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -17,7 +17,7 @@ import sqlite3
 import threading
 import time
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from typing import Generator, Iterable
@@ -60,34 +60,6 @@ def _slot_value_str(value) -> str:
     if hasattr(value, "value"):
         return str(value.value)
     return str(value)
-
-
-def _iso_date(value) -> str | None:
-    """Render a ``date`` / ``datetime`` as a bare ``YYYY-MM-DD`` string.
-
-    The pagination indicator's date-range needs day precision only,
-    and piecash hands back ``datetime`` for some columns (``post_date``)
-    and ``date`` for others. ``None`` passes through so callers can
-    skip absent dates when computing a range.
-    """
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date().isoformat()
-    return value.isoformat()
-
-
-def _date_range(values) -> tuple[str | None, str | None] | None:
-    """Min/max ISO date over an iterable of ``date``/``datetime``/None.
-
-    Returns ``(earliest, latest)`` for the pagination indicator, or
-    ``None`` when nothing dated is present — passing that straight to
-    :func:`gnucash_mcp._format._paginate` omits the parenthetical.
-    """
-    present = [v for v in values if v is not None]
-    if not present:
-        return None
-    return _iso_date(min(present)), _iso_date(max(present))
 
 
 def _is_voided(split) -> bool:

--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -23,6 +23,7 @@ from gnucash_mcp.book._base import (
     _verify_composite_write,
     _verify_write,
 )
+from gnucash_mcp._format import _paginate
 
 
 def _collapse_period_runs(
@@ -378,31 +379,49 @@ class BudgetsMixin:
 
     # ── CRUD ──────────────────────────────────────────────────────
 
-    def list_budgets(self, compact: bool = True) -> list[dict] | str:
+    def list_budgets(
+        self, compact: bool = True, limit: int = 50, offset: int = 0,
+    ) -> dict | str:
         """List all budgets in the book.
 
+        Leads with a ``Showing X-Y of Z budgets`` indicator; page with
+        ``offset``.
+
         Args:
-            compact: If True (default), return a compact one-line-per-
-                     budget string. Verbose mode returns the structured
-                     dict list.
+            compact: If True (default), return the indicator + a compact
+                     one-line-per-budget string. Verbose mode returns the
+                     envelope.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            If compact: newline-separated lines of the form
+            If compact: indicator + newline-separated lines of the form
                 ``"<name>  <num_periods> periods (<period_type>)  starts:<YYYY-MM-DD>"``.
-            If not compact: list of budget dicts.
+            If not compact: envelope ``{showing, total, offset, count,
+            budgets}``.
         """
 
         with self.open(readonly=True) as book:
             budgets = book.session.query(Budget).all()
             dicts = [self._budget_to_dict(b) for b in budgets]
-            if not compact:
-                return dicts
 
-            if not dicts:
-                return ""
-            name_width = max(len(d["name"]) for d in dicts)
-            lines = []
-            for d in dicts:
+            page, indicator = _paginate(
+                dicts, offset=offset, limit=limit, entity_name="budgets",
+            )
+            if not compact:
+                return {
+                    "showing": indicator,
+                    "total": len(dicts),
+                    "offset": offset,
+                    "count": len(page),
+                    "budgets": page,
+                }
+
+            if not page:
+                return indicator
+            name_width = max(len(d["name"]) for d in page)
+            lines = [indicator]
+            for d in page:
                 periods = d.get("num_periods", "?")
                 ptype = d.get("period_type", "")
                 start = d.get("start_date", "?")

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -27,7 +27,6 @@ from gnucash_mcp.book._base import (
     _verify_write,
 )
 from gnucash_mcp._format import _paginate
-from gnucash_mcp.book._base import _date_range
 
 
 def _commodity_quantum(commodity) -> Decimal:
@@ -4414,7 +4413,7 @@ class BusinessMixin:
                 offset=offset,
                 limit=limit,
                 entity_name="invoices",
-                date_range=_date_range(i.date_opened for i in invoices),
+                date_key=lambda i: i.date_opened,
             )
             invoices = page
 
@@ -6893,16 +6892,12 @@ class BusinessMixin:
                 key=lambda r: -(r["days_past_due"] or 0),
             )
 
-            # date_posted is already an ISO string; min/max of ISO
-            # dates is chronological order.
-            posted = [r["date_posted"] for r in results if r["date_posted"]]
-            dr = (min(posted), max(posted)) if posted else None
             page, indicator = _paginate(
                 results,
                 offset=offset,
                 limit=limit,
                 entity_name="invoices",
-                date_range=dr,
+                date_key=lambda r: r["date_posted"],
             )
             if compact:
                 body = _format_outstanding_invoices_compact(page)

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -26,7 +26,8 @@ from gnucash_mcp.book._base import (
     _verify_composite_write,
     _verify_write,
 )
-from gnucash_mcp._format import _apply_limit
+from gnucash_mcp._format import _paginate
+from gnucash_mcp.book._base import _date_range
 
 
 def _commodity_quantum(commodity) -> Decimal:
@@ -2086,26 +2087,44 @@ class BusinessMixin:
         self,
         active_only: bool = True,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all customers.
+
+        Leads with a ``Showing X-Y of Z customers`` indicator; page
+        with ``offset``.
 
         Args:
             active_only: If True, only return active customers.
             compact: If True, return compact one-line-per-customer string.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Compact string or list of dicts.
+            Compact string or verbose envelope.
         """
         with self.open() as book:
             customers = sorted(book.customers, key=lambda c: c.name)
             if active_only:
                 customers = [c for c in customers if c.active]
 
+            page, indicator = _paginate(
+                customers, offset=offset, limit=limit,
+                entity_name="customers",
+            )
             if compact:
-                lines = [self._customer_to_compact_line(c) for c in customers]
+                lines = [indicator]
+                lines += [self._customer_to_compact_line(c) for c in page]
                 return "\n".join(lines)
             else:
-                return [self._customer_to_dict(c) for c in customers]
+                return {
+                    "showing": indicator,
+                    "total": len(customers),
+                    "offset": offset,
+                    "count": len(page),
+                    "customers": [self._customer_to_dict(c) for c in page],
+                }
 
     def get_customer(self, customer_id: str) -> dict:
         """Get customer details by ID.
@@ -2156,26 +2175,43 @@ class BusinessMixin:
         self,
         active_only: bool = True,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all vendors.
+
+        Leads with a ``Showing X-Y of Z vendors`` indicator; page with
+        ``offset``.
 
         Args:
             active_only: If True, only return active vendors.
             compact: If True, return compact one-line-per-vendor string.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Compact string or list of dicts.
+            Compact string or verbose envelope.
         """
         with self.open() as book:
             vendors = sorted(book.vendors, key=lambda v: v.name)
             if active_only:
                 vendors = [v for v in vendors if v.active]
 
+            page, indicator = _paginate(
+                vendors, offset=offset, limit=limit, entity_name="vendors",
+            )
             if compact:
-                lines = [self._vendor_to_compact_line(v) for v in vendors]
+                lines = [indicator]
+                lines += [self._vendor_to_compact_line(v) for v in page]
                 return "\n".join(lines)
             else:
-                return [self._vendor_to_dict(v) for v in vendors]
+                return {
+                    "showing": indicator,
+                    "total": len(vendors),
+                    "offset": offset,
+                    "count": len(page),
+                    "vendors": [self._vendor_to_dict(v) for v in page],
+                }
 
     def get_vendor(self, vendor_id: str) -> dict:
         """Get vendor details by ID.
@@ -2227,26 +2263,44 @@ class BusinessMixin:
         self,
         active_only: bool = True,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all employees.
+
+        Leads with a ``Showing X-Y of Z employees`` indicator; page
+        with ``offset``.
 
         Args:
             active_only: If True, only return active employees.
             compact: If True, return compact one-line-per-employee string.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Compact string or list of dicts.
+            Compact string or verbose envelope.
         """
         with self.open() as book:
             employees = sorted(book.employees, key=lambda e: e.name)
             if active_only:
                 employees = [e for e in employees if e.active]
 
+            page, indicator = _paginate(
+                employees, offset=offset, limit=limit,
+                entity_name="employees",
+            )
             if compact:
-                lines = [self._employee_to_compact_line(e) for e in employees]
+                lines = [indicator]
+                lines += [self._employee_to_compact_line(e) for e in page]
                 return "\n".join(lines)
             else:
-                return [self._employee_to_dict(e) for e in employees]
+                return {
+                    "showing": indicator,
+                    "total": len(employees),
+                    "offset": offset,
+                    "count": len(page),
+                    "employees": [self._employee_to_dict(e) for e in page],
+                }
 
     def get_employee(self, employee_id: str) -> dict:
         """Get employee details by ID.
@@ -2405,14 +2459,21 @@ class BusinessMixin:
                 "status": "created",
             }
 
-    def list_billterms(self, compact: bool = True) -> list[dict] | str:
+    def list_billterms(
+        self, compact: bool = True, limit: int = 50, offset: int = 0,
+    ) -> dict | str:
         """List all billing terms.
+
+        Leads with a ``Showing X-Y of Z billterms`` indicator; page
+        with ``offset``.
 
         Args:
             compact: If True, return compact one-line-per-term string.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Compact string or list of dicts.
+            Compact string or verbose envelope.
         """
         from piecash.business.invoice import Billterm
 
@@ -2421,13 +2482,21 @@ class BusinessMixin:
                 Billterm.invisible == 0
             ).order_by(Billterm.name).all()
 
+            page, indicator = _paginate(
+                terms, offset=offset, limit=limit, entity_name="billterms",
+            )
             if compact:
-                lines = []
-                for t in terms:
-                    lines.append(f"{t.name}\t{t.duedays} days")
+                lines = [indicator]
+                lines += [f"{t.name}\t{t.duedays} days" for t in page]
                 return "\n".join(lines)
             else:
-                return [self._billterm_to_dict(t) for t in terms]
+                return {
+                    "showing": indicator,
+                    "total": len(terms),
+                    "offset": offset,
+                    "count": len(page),
+                    "billterms": [self._billterm_to_dict(t) for t in page],
+                }
 
     # ── Taxtable CRUD ─────────────────────────────────────────────
     #
@@ -2812,14 +2881,15 @@ class BusinessMixin:
             }
 
     def list_taxtables(
-        self, compact: bool = True,
-    ) -> list[dict] | str:
+        self, compact: bool = True, limit: int = 50, offset: int = 0,
+    ) -> dict | str:
         """List all tax tables.
 
-        Compact (default): one line per taxtable,
+        Leads with a ``Showing X-Y of Z taxtables`` indicator; page
+        with ``offset``. Compact (default): one line per taxtable,
         ``name<TAB>N entries: 5%→GST Payable, 7%→PST Payable``.
-        Verbose: list of full dicts with resolved account paths and
-        computed refcount. Empty book → empty string / empty list.
+        Verbose: envelope of full dicts with resolved account paths
+        and computed refcount.
         """
         from piecash.business.tax import Taxtable
 
@@ -2828,9 +2898,13 @@ class BusinessMixin:
                 Taxtable.name,
             ).all()
 
+            page, indicator = _paginate(
+                tables, offset=offset, limit=limit,
+                entity_name="taxtables",
+            )
             if compact:
-                lines = []
-                for tt in tables:
+                lines = [indicator]
+                for tt in page:
                     summary = ", ".join(
                         self._taxtable_entry_summary(e)
                         for e in tt.entries
@@ -2842,19 +2916,25 @@ class BusinessMixin:
                     )
                 return "\n".join(lines)
 
-            return [
-                self._taxtable_to_dict(
-                    tt,
-                    account_paths={
-                        e.account_guid: e.account.fullname
-                        for e in tt.entries
-                    },
-                    refcount=self._compute_taxtable_refcount(
-                        book, tt.guid,
-                    ),
-                )
-                for tt in tables
-            ]
+            return {
+                "showing": indicator,
+                "total": len(tables),
+                "offset": offset,
+                "count": len(page),
+                "taxtables": [
+                    self._taxtable_to_dict(
+                        tt,
+                        account_paths={
+                            e.account_guid: e.account.fullname
+                            for e in tt.entries
+                        },
+                        refcount=self._compute_taxtable_refcount(
+                            book, tt.guid,
+                        ),
+                    )
+                    for tt in page
+                ],
+            }
 
     def get_taxtable(self, name: str) -> dict:
         """Full details for a tax table.
@@ -4271,19 +4351,24 @@ class BusinessMixin:
         compact: bool = True,
         limit: int | None = None,
         job_id: str | None = None,
-    ) -> list[dict] | str:
+        offset: int = 0,
+    ) -> dict | str:
         """List invoices and/or bills.
+
+        Leads with a ``Showing X-Y of Z invoices (date range)``
+        indicator over the full filter set; page with ``offset``.
 
         Args:
             owner_type: 'customer', 'vendor', or None for all.
             status: 'posted', 'open', or None for all.
             compact: If True, one line per invoice.
-            limit: Defaults to 50, capped at 250 server-side.
+            limit: Page size (default 50, max 250). 0 = count only.
             job_id: Filter to invoices grouped under a specific job.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Compact string (with optional truncation notice) or the
-            verbose envelope ``{invoices, count, total, notice}``.
+            Compact string (indicator + rows) or the verbose envelope
+            ``{invoices, showing, total, offset, count}``.
         """
         from piecash.business.invoice import Invoice
 
@@ -4324,17 +4409,18 @@ class BusinessMixin:
                 invoices = [i for i in invoices if not _is_invoice_posted(i)]
 
             total = len(invoices)
-            invoices, notice = _apply_limit(
+            page, indicator = _paginate(
                 invoices,
+                offset=offset,
                 limit=limit,
                 entity_name="invoices",
-                suggest_narrow=True,
+                date_range=_date_range(i.date_opened for i in invoices),
             )
+            invoices = page
 
             if compact:
-                lines = [self._invoice_to_compact_line(book, i) for i in invoices]
-                if notice:
-                    lines.append(notice)
+                lines = [indicator]
+                lines += [self._invoice_to_compact_line(book, i) for i in invoices]
                 return "\n".join(lines)
             else:
                 # Verbose path resolves owner names per invoice.
@@ -4369,15 +4455,15 @@ class BusinessMixin:
                             job=j_dict,
                         )
                     )
-                # Envelope matches get_unreconciled_splits /
-                # get_prices: ``count`` = truncated length,
-                # ``total`` = full filter-set size, ``notice`` = the
-                # same string compact appends (or None).
+                # Envelope matches the other list tools: ``count`` =
+                # page length, ``total`` = full filter-set size,
+                # ``showing`` = the indicator compact leads with.
                 return {
-                    "invoices": results,
-                    "count": len(results),
+                    "showing": indicator,
                     "total": total,
-                    "notice": notice,
+                    "offset": offset,
+                    "count": len(results),
+                    "invoices": results,
                 }
 
     def get_invoice(self, invoice_id: str, owner_type: str | None = None) -> dict:
@@ -6377,16 +6463,23 @@ class BusinessMixin:
         owner_id: str | None = None,
         active_only: bool = True,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List jobs, optionally filtered by owner_type and/or
         owner_id.
+
+        Leads with a ``Showing X-Y of Z jobs`` indicator; page with
+        ``offset``.
 
         Args:
             owner_type: 'customer' or 'vendor'; omit for all.
             owner_id: Requires owner_type (customer and vendor IDs
                 share a sequence space).
             active_only: If True (default), exclude inactive jobs.
-            compact: One line per job (default) or list of dicts.
+            compact: One line per job (default) or verbose envelope.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
         """
         from piecash.business.invoice import Job
 
@@ -6433,9 +6526,12 @@ class BusinessMixin:
 
             jobs = sorted(query.all(), key=lambda j: j.id)
 
+            page, indicator = _paginate(
+                jobs, offset=offset, limit=limit, entity_name="jobs",
+            )
             if compact:
-                lines = []
-                for job in jobs:
+                lines = [indicator]
+                for job in page:
                     owner = self._find_invoice_owner_by_guid(
                         book, job.owner_type, job.owner_guid,
                     )
@@ -6449,7 +6545,7 @@ class BusinessMixin:
                 return "\n".join(lines)
 
             results = []
-            for job in jobs:
+            for job in page:
                 owner = self._find_invoice_owner_by_guid(
                     book, job.owner_type, job.owner_guid,
                 )
@@ -6459,7 +6555,13 @@ class BusinessMixin:
                         owner_name=owner.name if owner else None,
                     )
                 )
-            return results
+            return {
+                "showing": indicator,
+                "total": len(jobs),
+                "offset": offset,
+                "count": len(page),
+                "jobs": results,
+            }
 
     def get_job(self, job_id: str) -> dict:
         """Get a job's details by ID.
@@ -6623,8 +6725,13 @@ class BusinessMixin:
         customer_id: str | None = None,
         vendor_id: str | None = None,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """Get all posted invoices/bills with outstanding balances.
+
+        Leads with a ``Showing X-Y of Z invoices (date range)``
+        indicator, most-overdue first; page with ``offset``.
 
         Args:
             owner_type: 'customer' or 'vendor'; omit for all.
@@ -6632,10 +6739,11 @@ class BusinessMixin:
             vendor_id: Filter by specific vendor ID.
             compact: One line per doc with action columns (due
                 date, days past due, (BILL)/(CN) tags),
-                most-overdue first; empty string when nothing is
-                outstanding. Verbose returns dicts with the full
-                original_amount / amount_paid / amount_due
-                breakdown.
+                most-overdue first. Verbose returns the envelope
+                with the full original_amount / amount_paid /
+                amount_due breakdown per doc.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
         """
         from piecash.business.invoice import Invoice
 
@@ -6785,9 +6893,27 @@ class BusinessMixin:
                 key=lambda r: -(r["days_past_due"] or 0),
             )
 
+            # date_posted is already an ISO string; min/max of ISO
+            # dates is chronological order.
+            posted = [r["date_posted"] for r in results if r["date_posted"]]
+            dr = (min(posted), max(posted)) if posted else None
+            page, indicator = _paginate(
+                results,
+                offset=offset,
+                limit=limit,
+                entity_name="invoices",
+                date_range=dr,
+            )
             if compact:
-                return _format_outstanding_invoices_compact(results)
-            return results
+                body = _format_outstanding_invoices_compact(page)
+                return f"{indicator}\n{body}" if body else indicator
+            return {
+                "showing": indicator,
+                "total": len(results),
+                "offset": offset,
+                "count": len(page),
+                "invoices": page,
+            }
 
     def get_job_report(self, job_id: str) -> dict:
         """Per-job summary: billed / paid / outstanding totals

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -28,7 +28,6 @@ _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
 from gnucash_mcp.book._base import (
     _account_to_compact_line,
     _account_to_dict,
-    _date_range,
     _guid_prefix_map,
     _is_market_price,
     _is_unreconciled,
@@ -2316,17 +2315,13 @@ class CoreMixin:
                 key=lambda t: t.post_date or date.min, reverse=True
             )
 
-            # Date range spans the FULL filtered set (real post_dates
-            # only — null-date artifacts contribute nothing to the
-            # window). Computed before slicing, per the indicator's
-            # full-set contract.
             page, indicator = _paginate(
                 filtered,
                 offset=offset,
                 limit=limit,
                 max_cap=self.MAX_LIST_LIMIT,
                 entity_name="transactions",
-                date_range=_date_range(t.post_date for t in filtered),
+                date_key=lambda t: t.post_date,
             )
 
             if compact:
@@ -3277,7 +3272,7 @@ class CoreMixin:
                 limit=limit,
                 max_cap=self.MAX_LIST_LIMIT,
                 entity_name="transactions",
-                date_range=_date_range(t.post_date for t in matched),
+                date_key=lambda t: t.post_date,
             )
 
             if compact:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2121,17 +2121,23 @@ class CoreMixin:
         self,
         root: str | None = None,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all accounts in the chart of accounts.
 
-        Compact output emits one ``%shortguid<TAB>fullname [ANNOTATION]``
-        line per account; the short GUID is the cheap handle for
-        subsequent calls (tools resolve ``%xxxxxxx``, full GUIDs, and
-        paths interchangeably via ``_resolve_account``).
+        Leads with a ``Showing X-Y of Z accounts`` indicator (accounts
+        are undated, so no date range). Compact output then emits one
+        ``%shortguid<TAB>fullname [ANNOTATION]`` line per account; the
+        short GUID is the cheap handle for subsequent calls (tools
+        resolve ``%xxxxxxx``, full GUIDs, and paths interchangeably via
+        ``_resolve_account``).
 
         Args:
             root: Optional subtree filter (path, ``%short``, or GUID).
-            compact: If False, return full account dicts instead.
+            compact: If False, return a verbose envelope instead.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
         """
         with self.open(readonly=True) as book:
             # Template accounts are GnuCash internals, not part of
@@ -2160,17 +2166,32 @@ class CoreMixin:
 
             filtered.sort(key=lambda a: a.fullname)
 
+            page, indicator = _paginate(
+                filtered,
+                offset=offset,
+                limit=limit,
+                max_cap=self.MAX_LIST_LIMIT,
+                entity_name="accounts",
+            )
+
             if compact:
                 # Short-guid map spans the whole book so prefixes
                 # stay unambiguous against every resolvable account.
                 short_map = self._account_short_guid_map(book)
-                lines = [
+                lines = [indicator]
+                lines += [
                     f"{short_map[a.guid]}\t{_account_to_compact_line(a)}"
-                    for a in filtered
+                    for a in page
                 ]
                 return "\n".join(lines)
             else:
-                return [_account_to_dict(a) for a in filtered]
+                return {
+                    "showing": indicator,
+                    "total": len(filtered),
+                    "offset": offset,
+                    "count": len(page),
+                    "accounts": [_account_to_dict(a) for a in page],
+                }
 
     def get_account(self, name: str) -> dict | None:
         """Get details for a specific account by full name.

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -21,12 +21,14 @@ from decimal import Decimal, InvalidOperation
 import piecash
 
 from gnucash_mcp.logging_config import DEBUG_LOGGER_NAME
+from gnucash_mcp._format import _paginate
 
 _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
 
 from gnucash_mcp.book._base import (
     _account_to_compact_line,
     _account_to_dict,
+    _date_range,
     _guid_prefix_map,
     _is_market_price,
     _is_unreconciled,
@@ -2225,28 +2227,27 @@ class CoreMixin:
         start_date: date | None = None,
         end_date: date | None = None,
         limit: int = 50,
+        offset: int = 0,
         compact: bool = True,
-    ) -> list[dict] | str:
+    ) -> dict | str:
         """List transactions with optional filters.
 
-        Compact output appends a ``[Showing N of M ...]`` truncation
-        notice when the result set exceeds ``limit``; limits above
-        ``MAX_LIST_LIMIT`` (250) are clamped server-side and flagged.
-        Verbose mode truncates silently (callers have the length).
+        Both modes lead with a ``Showing X-Y of Z transactions`` line
+        spanning the full filtered set's date range, so a partial view
+        is never silent. ``offset`` pages through; limits above
+        ``MAX_LIST_LIMIT`` (250) clamp server-side and flag it.
 
         Args:
             account: Filter by account ref.
             start_date / end_date: Inclusive date bounds.
-            limit: Maximum to return. Capped at 250.
-            compact: One line per transaction (default) or dicts,
-                most recent first.
+            limit: Page size. Capped at 250. ``0`` = count only.
+            offset: 0-indexed first row to return.
+            compact: One line per transaction (default) or a verbose
+                envelope, most recent first.
 
         Raises:
             ValueError: If specified account not found.
         """
-        capped = limit > self.MAX_LIST_LIMIT
-        effective_limit = min(limit, self.MAX_LIST_LIMIT)
-
         with self.open(readonly=True) as book:
             # If filtering by account, get transactions through that account's splits
             focus_fullname: str | None = None
@@ -2294,30 +2295,31 @@ class CoreMixin:
                 key=lambda t: t.post_date or date.min, reverse=True
             )
 
-            total_matched = len(filtered)
-            # Apply limit
-            filtered = filtered[:effective_limit]
+            # Date range spans the FULL filtered set (real post_dates
+            # only — null-date artifacts contribute nothing to the
+            # window). Computed before slicing, per the indicator's
+            # full-set contract.
+            page, indicator = _paginate(
+                filtered,
+                offset=offset,
+                limit=limit,
+                max_cap=self.MAX_LIST_LIMIT,
+                entity_name="transactions",
+                date_range=_date_range(t.post_date for t in filtered),
+            )
 
             if compact:
                 # Prefix map spans ALL transactions so emitted
                 # prefixes stay valid _resolve_guid keys; cached by
                 # book mtime.
                 prefixes = self._transaction_prefix_map(book)
-                lines = [
+                lines = [indicator]
+                lines += [
                     _transaction_to_compact_line(
                         t, focus_account=focus_fullname, prefixes=prefixes
                     )
-                    for t in filtered
+                    for t in page
                 ]
-                notice = self._truncation_notice(
-                    total=total_matched,
-                    shown=len(filtered),
-                    effective_limit=effective_limit,
-                    capped=capped,
-                    suggest_narrow=True,
-                )
-                if notice:
-                    lines.append(notice)
                 return "\n".join(lines)
             else:
                 # Verbose also emits short prefixes — every
@@ -2325,51 +2327,21 @@ class CoreMixin:
                 txn_prefixes = self._transaction_prefix_map(book)
                 split_prefixes = self._split_prefix_map(book)
                 lot_prefixes = self._lot_prefix_map(book)
-                return [
-                    _transaction_to_dict(
-                        t,
-                        txn_prefixes=txn_prefixes,
-                        split_prefixes=split_prefixes,
-                        lot_prefixes=lot_prefixes,
-                    )
-                    for t in filtered
-                ]
-
-    @staticmethod
-    def _truncation_notice(
-        total: int,
-        shown: int,
-        effective_limit: int,
-        capped: bool,
-        suggest_narrow: bool = True,
-    ) -> str | None:
-        """Build a truncation-notice line, or return None if no notice needed.
-
-        Emits one of:
-          - "[Limit capped at 250 — narrow your criteria for larger datasets]"
-            when the caller's limit exceeded MAX_LIST_LIMIT AND results fit.
-          - "[Showing N of M transactions — use start_date/end_date to narrow,
-             or set limit= higher]" when results were truncated (capped or not).
-          - None when total <= shown (everything fit).
-        """
-        if total <= shown:
-            if capped:
-                return (
-                    f"[Limit capped at {effective_limit} — results fit under "
-                    f"the cap]"
-                )
-            return None
-        if capped:
-            return (
-                f"[Showing {shown} of {total} transactions — limit was capped "
-                f"at {effective_limit}; narrow your criteria for complete "
-                f"results]"
-            )
-        hint = (
-            "use start_date/end_date to narrow, or set limit= higher"
-            if suggest_narrow else "set limit= higher"
-        )
-        return f"[Showing {shown} of {total} transactions — {hint}]"
+                return {
+                    "showing": indicator,
+                    "total": len(filtered),
+                    "offset": offset,
+                    "count": len(page),
+                    "transactions": [
+                        _transaction_to_dict(
+                            t,
+                            txn_prefixes=txn_prefixes,
+                            split_prefixes=split_prefixes,
+                            lot_prefixes=lot_prefixes,
+                        )
+                        for t in page
+                    ],
+                }
 
     def get_transaction(self, guid: str) -> dict | None:
         """Get details for a specific transaction by GUID.
@@ -3219,27 +3191,28 @@ class CoreMixin:
         query: str,
         field: str = "description",
         limit: int = 50,
+        offset: int = 0,
         compact: bool = True,
-    ) -> list[dict] | str:
+    ) -> dict | str:
         """Search transactions by field.
 
-        Truncation mirrors ``list_transactions`` (notice + 250 cap).
+        Pagination mirrors ``list_transactions`` (``Showing X-Y of Z``
+        indicator + offset + 250 cap).
 
         Args:
             query: Search string. For 'amount': exact ("100.00"),
                 ">100", "<100", or range "100-200".
             field: 'description', 'memo', 'notes', or 'amount'.
-            limit: Maximum to return. Capped at 250.
-            compact: One line per transaction (default) or dicts.
+            limit: Page size. Capped at 250. ``0`` = count only.
+            offset: 0-indexed first row to return.
+            compact: One line per transaction (default) or a verbose
+                envelope.
 
         Raises:
             ValueError: If field is not valid.
         """
         if field not in ("description", "memo", "notes", "amount"):
             raise ValueError(f"Invalid search field: {field}")
-
-        capped = limit > self.MAX_LIST_LIMIT
-        effective_limit = min(limit, self.MAX_LIST_LIMIT)
 
         with self.open(readonly=True) as book:
             matched = []
@@ -3277,28 +3250,34 @@ class CoreMixin:
                 key=lambda t: t.post_date or date.min, reverse=True
             )
 
-            total_matched = len(matched)
-            matched = matched[:effective_limit]
+            page, indicator = _paginate(
+                matched,
+                offset=offset,
+                limit=limit,
+                max_cap=self.MAX_LIST_LIMIT,
+                entity_name="transactions",
+                date_range=_date_range(t.post_date for t in matched),
+            )
 
             if compact:
                 # Prefix map cached by book mtime.
                 prefixes = self._transaction_prefix_map(book)
-                lines = [
+                lines = [indicator]
+                lines += [
                     _transaction_to_compact_line(t, prefixes=prefixes)
-                    for t in matched
+                    for t in page
                 ]
-                notice = self._truncation_notice(
-                    total=total_matched,
-                    shown=len(matched),
-                    effective_limit=effective_limit,
-                    capped=capped,
-                    suggest_narrow=False,  # no date-range hint on search
-                )
-                if notice:
-                    lines.append(notice)
                 return "\n".join(lines)
             else:
-                return [_transaction_to_dict(t) for t in matched]
+                return {
+                    "showing": indicator,
+                    "total": len(matched),
+                    "offset": offset,
+                    "count": len(page),
+                    "transactions": [
+                        _transaction_to_dict(t) for t in page
+                    ],
+                }
 
     def _match_amount(self, transaction: piecash.Transaction, query: str) -> bool:
         """Check if any split amount matches the query.

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -30,7 +30,6 @@ from gnucash_mcp.book._base import (
     _unique_prefix,
 )
 from gnucash_mcp._format import _format_number, _paginate
-from gnucash_mcp.book._base import _date_range
 
 
 class InvestmentsMixin:
@@ -468,15 +467,12 @@ class InvestmentsMixin:
 
             prices.sort(key=lambda x: x["date"], reverse=True)
             total = len(prices)
-            # ISO date strings; min/max is chronological.
-            all_dates = [p["date"] for p in prices]
-            dr = (min(all_dates), max(all_dates)) if all_dates else None
             page, indicator = _paginate(
                 prices,
                 offset=offset,
                 limit=limit,
                 entity_name="prices",
-                date_range=dr,
+                date_key=lambda p: p["date"],
             )
 
             if not compact:

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -29,7 +29,8 @@ from gnucash_mcp.book._base import (
     _to_decimal,
     _unique_prefix,
 )
-from gnucash_mcp._format import _apply_limit, _format_number
+from gnucash_mcp._format import _format_number, _paginate
+from gnucash_mcp.book._base import _date_range
 
 
 class InvestmentsMixin:
@@ -37,16 +38,26 @@ class InvestmentsMixin:
 
     # ── Commodities and prices ────────────────────────────────────
 
-    def list_commodities(self, compact: bool = True) -> dict | str:
+    def list_commodities(
+        self, compact: bool = True, limit: int = 50, offset: int = 0,
+    ) -> dict | str:
         """List all commodities in the book with latest prices.
+
+        Leads with a ``Showing X-Y of Z commodities`` indicator; page
+        with ``offset``.
 
         Args:
             compact: If True (default), return compact one-line-per-commodity
-                     string. If False, return full dict grouped by namespace.
+                     string. If False, return the verbose envelope with
+                     commodities grouped by namespace.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            If compact: newline-separated string of commodity lines.
-            If not compact: dict with commodities grouped by namespace.
+            If compact: indicator + newline-separated commodity lines.
+            If not compact: envelope ``{showing, total, offset, count,
+            default_currency, commodities}`` (commodities grouped by
+            namespace, limited to the page).
         """
         with self.open(readonly=True) as book:
             by_namespace: dict[str, list[dict]] = {}
@@ -92,19 +103,40 @@ class InvestmentsMixin:
             for ns in by_namespace:
                 by_namespace[ns].sort(key=lambda c: c["mnemonic"])
 
-            result = {
-                "default_currency": self._require_default_currency(book).mnemonic,
-                "commodities": by_namespace,
-            }
+            default_currency = self._require_default_currency(book).mnemonic
+
+            # Flatten to one ordered list (namespace, then mnemonic —
+            # the compact render order) so pagination has a flat
+            # sequence to slice; the verbose path re-groups the page.
+            flat = [
+                (ns, entry)
+                for ns, entries in sorted(by_namespace.items())
+                for entry in entries
+            ]
+            page, indicator = _paginate(
+                flat, offset=offset, limit=limit,
+                entity_name="commodities",
+            )
 
             if compact:
-                lines = []
-                for ns, entries in sorted(by_namespace.items()):
-                    for entry in entries:
-                        lines.append(_commodity_to_compact_line(ns, entry))
+                lines = [indicator]
+                lines += [
+                    _commodity_to_compact_line(ns, entry)
+                    for ns, entry in page
+                ]
                 return "\n".join(lines)
             else:
-                return result
+                paged_by_ns: dict[str, list[dict]] = {}
+                for ns, entry in page:
+                    paged_by_ns.setdefault(ns, []).append(entry)
+                return {
+                    "showing": indicator,
+                    "total": len(flat),
+                    "offset": offset,
+                    "count": len(page),
+                    "default_currency": default_currency,
+                    "commodities": paged_by_ns,
+                }
 
     def create_commodity(
         self,
@@ -380,8 +412,13 @@ class InvestmentsMixin:
         currency: str | None = None,
         limit: int | None = None,
         compact: bool = True,
+        offset: int = 0,
     ) -> dict | str:
         """Get price history for a commodity.
+
+        Leads with a ``Showing X-Y of Z prices (date range)`` indicator;
+        page with ``offset``. Sorted by date descending — most recent
+        first, so a small ``limit`` still surfaces the freshest data.
 
         Args:
             commodity: Symbol of the commodity (e.g., "VTSAX").
@@ -389,15 +426,12 @@ class InvestmentsMixin:
             start_date: Optional start date filter.
             end_date: Optional end date filter.
             currency: Optional currency filter (e.g., "USD").
-            limit: Maximum prices to return. Defaults to 50, capped at
-                   250 server-side.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            Dict with ``prices`` (list, possibly truncated), ``count``
-            (truncated length), ``total`` (untruncated), and ``notice``
-            (truncation message or None). Sorted by date descending —
-            most recent first, so a small ``limit`` still surfaces the
-            freshest data.
+            Verbose envelope ``{prices, showing, total, offset, count}``;
+            compact leads with the indicator.
 
         Raises:
             ValueError: If commodity not found.
@@ -434,31 +468,35 @@ class InvestmentsMixin:
 
             prices.sort(key=lambda x: x["date"], reverse=True)
             total = len(prices)
-            prices, notice = _apply_limit(
+            # ISO date strings; min/max is chronological.
+            all_dates = [p["date"] for p in prices]
+            dr = (min(all_dates), max(all_dates)) if all_dates else None
+            page, indicator = _paginate(
                 prices,
+                offset=offset,
                 limit=limit,
                 entity_name="prices",
-                suggest_narrow=True,
+                date_range=dr,
             )
 
-            full = {
-                "prices": prices,
-                "count": len(prices),
-                "total": total,
-                "notice": notice,
-            }
             if not compact:
-                return full
+                return {
+                    "showing": indicator,
+                    "total": total,
+                    "offset": offset,
+                    "count": len(page),
+                    "prices": page,
+                }
 
             # Compact: "2026-04-30  273.43  USD  last  yfinance",
-            # columns aligned.
-            if not prices:
-                return notice or "No prices found."
-            value_w = max(len(p["value"]) for p in prices)
-            type_w = max(len(p.get("type") or "") for p in prices)
-            ccy_w = max(len(p["currency"]) for p in prices)
-            lines = []
-            for p in prices:
+            # columns aligned, under the indicator.
+            if not page:
+                return indicator
+            value_w = max(len(p["value"]) for p in page)
+            type_w = max(len(p.get("type") or "") for p in page)
+            ccy_w = max(len(p["currency"]) for p in page)
+            lines = [indicator]
+            for p in page:
                 lines.append(
                     f"{p['date']}  "
                     f"{p['value']:>{value_w}}  "
@@ -466,8 +504,6 @@ class InvestmentsMixin:
                     f"{(p.get('type') or ''):<{type_w}}  "
                     f"{p.get('source') or ''}"
                 )
-            if notice:
-                lines.append(notice)
             return "\n".join(lines)
 
     def get_latest_price(
@@ -695,18 +731,26 @@ class InvestmentsMixin:
         account: str,
         include_closed: bool = False,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all lots for an investment account.
+
+        Leads with a ``Showing X-Y of Z lots`` indicator; page with
+        ``offset``.
 
         Args:
             account: Full path of investment account.
             include_closed: If True, include fully-sold lots. Default False.
-            compact: If True (default), return a compact newline-separated
-                     string with one line per lot.
+            compact: If True (default), return the indicator + a compact
+                     newline-separated string with one line per lot.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            If compact: newline-separated string of lot lines.
-            If not compact: list of lot dicts.
+            If compact: indicator + newline-separated lot lines.
+            If not compact: envelope ``{showing, total, offset, count,
+            lots}``.
 
         Raises:
             ValueError: If account not found.
@@ -737,6 +781,9 @@ class InvestmentsMixin:
                     **summary,
                 })
 
+            page, indicator = _paginate(
+                results, offset=offset, limit=limit, entity_name="lots",
+            )
             if compact:
                 # Prefix map spans every lot in the book —
                 # _resolve_guid searches table-wide.
@@ -745,12 +792,19 @@ class InvestmentsMixin:
                     for row in book.session.query(Lot.guid).all()
                 ]
                 prefixes = _guid_prefix_map(all_lot_guids)
-                lines = [
-                    _lot_to_compact_line(d, prefixes=prefixes) for d in results
+                lines = [indicator]
+                lines += [
+                    _lot_to_compact_line(d, prefixes=prefixes) for d in page
                 ]
                 return "\n".join(lines)
             else:
-                return results
+                return {
+                    "showing": indicator,
+                    "total": len(results),
+                    "offset": offset,
+                    "count": len(page),
+                    "lots": page,
+                }
 
     def get_lot(self, guid: str) -> dict:
         """Get detailed information about a lot.

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -23,7 +23,7 @@ from gnucash_mcp.book._base import (
     _unique_prefix,
     _unreconciled_split_to_compact_line,
 )
-from gnucash_mcp._format import _apply_limit
+from gnucash_mcp._format import _paginate
 
 
 def _split_state_dict(split) -> dict:
@@ -133,13 +133,14 @@ class ReconciliationMixin:
         as_of_date: date | None = None,
         compact: bool = True,
         limit: int | None = None,
+        offset: int = 0,
     ) -> dict | str:
         """Get unreconciled splits for an account.
 
-        Returns up to ``limit`` splits (default 50, capped 250),
-        post-date ascending. The cleared/uncleared totals always
-        reflect the **full** unreconciled set, not the truncated
-        slice.
+        Leads with a ``Showing X-Y of Z splits`` indicator, post-date
+        ascending; page with ``offset``. The cleared/uncleared totals
+        always reflect the **full** unreconciled set, not the page —
+        truncation hides line items, never the headline summary.
 
         **Currency unit:** the totals are in the **account's
         commodity** (sum of ``split.quantity``, not ``split.value``)
@@ -149,9 +150,11 @@ class ReconciliationMixin:
         Args:
             account_name: Account ref.
             as_of_date: Only include splits on or before this date.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
             compact: One line per split + summary footer (default),
                 or the dict envelope {account, splits, totals,
-                count, total, notice}.
+                count, total, showing}.
 
         Raises:
             ValueError: If account not found.
@@ -194,25 +197,31 @@ class ReconciliationMixin:
                 else:
                     uncleared_total += split.quantity
 
-            unreconciled, notice = _apply_limit(
+            # Splits are sorted post-date ascending, so the full set's
+            # date window is its first and last rows.
+            dates = [s["date"] for s in all_unreconciled]
+            date_range = (dates[0], dates[-1]) if dates else None
+            unreconciled, indicator = _paginate(
                 all_unreconciled,
+                offset=offset,
                 limit=limit,
                 entity_name="splits",
-                suggest_narrow=True,
+                date_range=date_range,
             )
             total_count = len(all_unreconciled)
 
             result = {
                 "account": account.fullname,
                 "as_of_date": as_of_date.isoformat() if as_of_date else None,
+                "showing": indicator,
                 "splits": unreconciled,
                 # Totals always reflect the full unreconciled set —
                 # truncation hides line items, never the headline summary.
                 "cleared_total": str(cleared_total),
                 "uncleared_total": str(uncleared_total),
+                "offset": offset,
                 "count": len(unreconciled),
                 "total": total_count,
-                "notice": notice,
             }
 
             if compact:
@@ -222,7 +231,8 @@ class ReconciliationMixin:
                     s.guid for txn in book.transactions for s in txn.splits
                 )
                 prefixes = _guid_prefix_map(all_split_guids)
-                lines = [
+                lines = [indicator]
+                lines += [
                     _unreconciled_split_to_compact_line(s, prefixes=prefixes)
                     for s in unreconciled
                 ]
@@ -231,8 +241,6 @@ class ReconciliationMixin:
                     f"uncleared:{uncleared_total}"
                 )
                 lines.append(footer)
-                if notice:
-                    lines.append(notice)
                 return "\n".join(lines)
             else:
                 return result

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -197,16 +197,12 @@ class ReconciliationMixin:
                 else:
                     uncleared_total += split.quantity
 
-            # Splits are sorted post-date ascending, so the full set's
-            # date window is its first and last rows.
-            dates = [s["date"] for s in all_unreconciled]
-            date_range = (dates[0], dates[-1]) if dates else None
             unreconciled, indicator = _paginate(
                 all_unreconciled,
                 offset=offset,
                 limit=limit,
                 entity_name="splits",
-                date_range=date_range,
+                date_key=lambda s: s["date"],
             )
             total_count = len(all_unreconciled)
 

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -597,12 +597,10 @@ class SchedulingMixin:
 
             upcoming.sort(key=lambda x: x["occurrence_date"])
 
-            # Sorted ascending by occurrence_date (ISO strings).
-            dates = [e["occurrence_date"] for e in upcoming]
-            dr = (dates[0], dates[-1]) if dates else None
             page, indicator = _paginate(
                 upcoming, offset=offset, limit=limit,
-                entity_name="upcoming transactions", date_range=dr,
+                entity_name="upcoming transactions",
+                date_key=lambda e: e["occurrence_date"],
             )
             if compact:
                 # Prefix uniqueness across all scheduled transactions

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -34,6 +34,7 @@ from gnucash_mcp.book._base import (
     _verify_delete,
     _verify_write,
 )
+from gnucash_mcp._format import _paginate
 
 
 class SchedulingMixin:
@@ -393,17 +394,25 @@ class SchedulingMixin:
         self,
         enabled_only: bool = True,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """List all scheduled transactions.
+
+        Leads with a ``Showing X-Y of Z scheduled transactions``
+        indicator; page with ``offset``.
 
         Args:
             enabled_only: If True, only show enabled schedules. Default True.
-            compact: If True (default), return a compact newline-separated
-                     string with one line per scheduled transaction.
+            compact: If True (default), return the indicator + a compact
+                     newline-separated string with one line per schedule.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
 
         Returns:
-            If compact: newline-separated string of scheduled transaction lines.
-            If not compact: list of scheduled transaction dicts.
+            If compact: indicator + newline-separated lines.
+            If not compact: envelope ``{showing, total, offset, count,
+            scheduled_transactions}``.
         """
 
         with self.open(readonly=True) as book:
@@ -420,15 +429,26 @@ class SchedulingMixin:
                     d["splits"] = self._get_sx_splits(book, sx)
                 results.append(d)
 
+            page, indicator = _paginate(
+                results, offset=offset, limit=limit,
+                entity_name="scheduled transactions",
+            )
             if compact:
                 # Prefix uniqueness across all scheduled transactions
                 prefixes = _guid_prefix_map(sx.guid for sx in all_sx)
-                lines = [
-                    _sx_to_compact_line(d, prefixes=prefixes) for d in results
+                lines = [indicator]
+                lines += [
+                    _sx_to_compact_line(d, prefixes=prefixes) for d in page
                 ]
                 return "\n".join(lines)
             else:
-                return results
+                return {
+                    "showing": indicator,
+                    "total": len(results),
+                    "offset": offset,
+                    "count": len(page),
+                    "scheduled_transactions": page,
+                }
 
     def _upcoming_within_days(
         self, book, days: int = 7,
@@ -494,12 +514,20 @@ class SchedulingMixin:
         self,
         days: int = 14,
         compact: bool = True,
-    ) -> list[dict] | str:
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict | str:
         """Get scheduled transactions due within a time window.
+
+        Leads with a ``Showing X-Y of Z upcoming transactions (date
+        range)`` indicator, soonest first; page with ``offset``.
 
         Args:
             days: Look ahead window in days. Default 14.
-            compact: If True, return compact one-line format.
+            compact: If True, return the indicator + compact one-line
+                format; otherwise the verbose envelope.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
         """
 
         today = date.today()
@@ -569,16 +597,30 @@ class SchedulingMixin:
 
             upcoming.sort(key=lambda x: x["occurrence_date"])
 
+            # Sorted ascending by occurrence_date (ISO strings).
+            dates = [e["occurrence_date"] for e in upcoming]
+            dr = (dates[0], dates[-1]) if dates else None
+            page, indicator = _paginate(
+                upcoming, offset=offset, limit=limit,
+                entity_name="upcoming transactions", date_range=dr,
+            )
             if compact:
                 # Prefix uniqueness across all scheduled transactions
                 prefixes = _guid_prefix_map(sx.guid for sx in all_sx)
-                lines = [
+                lines = [indicator]
+                lines += [
                     _upcoming_to_compact_line(e, prefixes=prefixes)
-                    for e in upcoming
+                    for e in page
                 ]
                 return "\n".join(lines)
             else:
-                return upcoming
+                return {
+                    "showing": indicator,
+                    "total": len(upcoming),
+                    "offset": offset,
+                    "count": len(page),
+                    "upcoming_transactions": page,
+                }
 
     def create_transaction_from_scheduled(
         self,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -586,10 +586,14 @@ if _book_path and (_audit_mode or _debug_mode):
 
 @mcp.resource("gnucash://accounts")
 def accounts_resource() -> str:
-    """Full chart of accounts from the GnuCash book."""
+    """Full chart of accounts from the GnuCash book.
+
+    Resources are whole-snapshot reads, so this unwraps the paginated
+    envelope and returns the bare account list (up to the server cap).
+    """
     book = get_book()
-    accounts = book.list_accounts(compact=False)
-    return _json(accounts)
+    envelope = book.list_accounts(compact=False, limit=book.MAX_LIST_LIMIT)
+    return _json(envelope["accounts"])
 
 
 # ============== Server Diagnostic Tool ==============

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -39,7 +39,11 @@ def _parse_iso_date(s: str | None) -> date | None:
 # concern for which file the implementation lives in. Book-layer code
 # imports directly from ``gnucash_mcp._format`` to preserve the
 # one-way ``tools → book`` dependency.
-from gnucash_mcp._format import _apply_limit, _format_number  # noqa: F401
+from gnucash_mcp._format import (  # noqa: F401
+    _apply_limit,
+    _format_number,
+    _paginate,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/gnucash_mcp/tools/admin.py
+++ b/src/gnucash_mcp/tools/admin.py
@@ -103,16 +103,24 @@ def register(mcp, get_book) -> None:
     def get_audit_log(
         log_date: str | None = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """Read audit log entries for a date.
 
-        Returns the human-readable text audit log. Each write operation
-        (CREATE, UPDATE, DELETE, VOID, RECONCILE, etc.) is one entry
-        separated by a blank line. Reads are not logged.
+        Returns the human-readable text audit log, led by a
+        ``Showing X-Y of Z audit entries (date)`` indicator. Each write
+        operation (CREATE, UPDATE, DELETE, VOID, RECONCILE, etc.) is one
+        entry separated by a blank line. Reads are not logged.
+
+        Unlike the row-list tools, the window is anchored to the most
+        recent entry: ``offset`` pages *backward* into history (offset=0
+        is the newest page), since "what happened lately" is the usual
+        question. ``limit=0`` returns the count only.
 
         Args:
             log_date: Date to read (YYYY-MM-DD). Defaults to today.
-            limit: Maximum entries to return (default 50). Most recent last.
+            limit: Page size (default 50). 0 = count only.
+            offset: Entries to skip back from the most recent (default 0).
         """
         log_dir = get_log_dir()
         if not log_dir:
@@ -163,14 +171,37 @@ def register(mcp, get_book) -> None:
 
         # Entries are separated by blank lines. The first block is the
         # day's header (box-drawing banner) — preserve it regardless of
-        # limit so the reader knows date/timezone/book context.
+        # paging so the reader knows date/timezone/book context.
         blocks = content.split("\n\n")
         header = None
         if blocks and "═" in blocks[0]:
             header, blocks = blocks[0], blocks[1:]
 
-        if len(blocks) > limit:
-            blocks = blocks[-limit:]
+        total = len(blocks)
+        # Recency-anchored window: offset counts back from the newest
+        # entry, so offset=0 is the most recent page. This inverts the
+        # row-list tools' offset-from-start, matching how an audit log
+        # is actually read. Indicator positions are 1-indexed in
+        # chronological (oldest-first) order so they stay monotonic.
+        if offset < 0:
+            offset = 0
+        if limit == 0:
+            page = []
+            indicator = f"Showing 0 of {total} audit entries ({target_date})"
+        else:
+            page_limit = limit if limit > 0 else 50
+            end_idx = max(0, total - offset)
+            start_idx = max(0, end_idx - page_limit)
+            page = blocks[start_idx:end_idx]
+            if page:
+                indicator = (
+                    f"Showing {start_idx + 1}-{end_idx} of {total} "
+                    f"audit entries ({target_date})"
+                )
+            else:
+                indicator = (
+                    f"Showing 0 of {total} audit entries ({target_date})"
+                )
 
-        parts = ([header] if header else []) + blocks
+        parts = [indicator] + ([header] if header else []) + page
         return "\n\n".join(parts)

--- a/src/gnucash_mcp/tools/backup.py
+++ b/src/gnucash_mcp/tools/backup.py
@@ -80,15 +80,9 @@ def register(mcp, get_book) -> None:
         """
         book = get_book()
         entries = book.list_backups()
-        # Entries are newest-first; ISO timestamps, so the full set's
-        # window is its last and first rows (date portion only).
-        dr = (
-            (entries[-1]["timestamp"][:10], entries[0]["timestamp"][:10])
-            if entries else None
-        )
         page, indicator = _paginate(
             entries, offset=offset, limit=limit,
-            entity_name="backups", date_range=dr,
+            entity_name="backups", date_key=lambda e: e["timestamp"],
         )
         if not page:
             return indicator

--- a/src/gnucash_mcp/tools/backup.py
+++ b/src/gnucash_mcp/tools/backup.py
@@ -12,7 +12,7 @@ procedure performed with the server stopped. See
 """
 
 from gnucash_mcp.logging_config import audit_log
-from gnucash_mcp.tools._helpers import _json, safe_tool
+from gnucash_mcp.tools._helpers import _json, _paginate, safe_tool
 
 
 def register(mcp, get_book) -> None:
@@ -63,24 +63,40 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def list_backups() -> str:
+    def list_backups(limit: int = 50, offset: int = 0) -> str:
         """List all available backups, newest first.
 
-        Returns a compact tab-separated table with one row per backup:
+        Leads with a ``Showing X-Y of Z backups (date range)`` line,
+        then a compact tab-separated table with one row per backup:
         ``stage``, ``timestamp`` (ISO UTC), ``age``, ``size`` (MB),
         and ``label`` (if any). Stages are ``session`` / ``weekly`` /
         ``monthly`` (automatic retention tiers) and ``manual`` (user-
-        invoked, unlimited retention).
+        invoked, unlimited retention). Page with ``offset``; ``limit=0``
+        returns the count only.
+
+        Args:
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
         entries = book.list_backups()
-        if not entries:
-            return "No backups found."
+        # Entries are newest-first; ISO timestamps, so the full set's
+        # window is its last and first rows (date portion only).
+        dr = (
+            (entries[-1]["timestamp"][:10], entries[0]["timestamp"][:10])
+            if entries else None
+        )
+        page, indicator = _paginate(
+            entries, offset=offset, limit=limit,
+            entity_name="backups", date_range=dr,
+        )
+        if not page:
+            return indicator
 
-        # Header + rows. TSV is compact and the LLM can parse it
-        # without a schema reminder.
-        lines = ["stage\ttimestamp\tage\tsize_mb\tlabel"]
-        for e in entries:
+        # Indicator + header + rows. TSV is compact and the LLM can
+        # parse it without a schema reminder.
+        lines = [indicator, "stage\ttimestamp\tage\tsize_mb\tlabel"]
+        for e in page:
             size_mb = f"{e['size_bytes'] / (1024 * 1024):.1f}"
             label = e.get("label") or ""
             lines.append(

--- a/src/gnucash_mcp/tools/budgets.py
+++ b/src/gnucash_mcp/tools/budgets.py
@@ -10,17 +10,27 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def list_budgets(verbose: bool = False) -> str:
+    def list_budgets(
+        verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> str:
         """List all budgets in the book.
 
-        Returns a compact one-line-per-budget format by default. Use
-        verbose=true for the full JSON list.
+        Leads with a ``Showing X-Y of Z budgets`` line, then a compact
+        one-line-per-budget format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for the full
+        JSON envelope.
 
         Args:
-            verbose: If true, return the full JSON list.
+            verbose: If true, return the full JSON envelope.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_budgets(compact=not verbose)
+        result = book.list_budgets(
+            compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -51,18 +51,27 @@ def register(mcp, get_book) -> None:
     def list_customers(
         active_only: bool = True,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all customers.
 
-        Returns a compact one-line-per-customer format by default.
-        Use verbose=true for full JSON with guid, address, notes, etc.
+        Leads with a ``Showing X-Y of Z customers`` line, then a compact
+        one-line-per-customer format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, address, notes, etc.
 
         Args:
             active_only: If True, only show active customers. Default True.
             verbose: If true, return full JSON details for each customer.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_customers(active_only=active_only, compact=not verbose)
+        result = book.list_customers(
+            active_only=active_only, compact=not verbose,
+            limit=limit, offset=offset,
+        )
         if verbose:
             return _json(result)
         return result
@@ -116,18 +125,27 @@ def register(mcp, get_book) -> None:
     def list_vendors(
         active_only: bool = True,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all vendors.
 
-        Returns a compact one-line-per-vendor format by default.
-        Use verbose=true for full JSON with guid, address, notes, etc.
+        Leads with a ``Showing X-Y of Z vendors`` line, then a compact
+        one-line-per-vendor format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, address, notes, etc.
 
         Args:
             active_only: If True, only show active vendors. Default True.
             verbose: If true, return full JSON details for each vendor.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_vendors(active_only=active_only, compact=not verbose)
+        result = book.list_vendors(
+            active_only=active_only, compact=not verbose,
+            limit=limit, offset=offset,
+        )
         if verbose:
             return _json(result)
         return result
@@ -182,18 +200,27 @@ def register(mcp, get_book) -> None:
     def list_employees(
         active_only: bool = True,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all employees.
 
-        Returns a compact one-line-per-employee format by default.
-        Use verbose=true for full JSON with guid, address, etc.
+        Leads with a ``Showing X-Y of Z employees`` line, then a compact
+        one-line-per-employee format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, address, etc.
 
         Args:
             active_only: If True, only show active employees. Default True.
             verbose: If true, return full JSON details for each employee.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_employees(active_only=active_only, compact=not verbose)
+        result = book.list_employees(
+            active_only=active_only, compact=not verbose,
+            limit=limit, offset=offset,
+        )
         if verbose:
             return _json(result)
         return result
@@ -345,17 +372,25 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="read")
     def list_billterms(
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all billing terms.
 
-        Returns a compact one-line-per-term format by default.
-        Use verbose=true for full JSON with guid, discount details, etc.
+        Leads with a ``Showing X-Y of Z billterms`` line, then a compact
+        one-line-per-term format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, discount details, etc.
 
         Args:
             verbose: If true, return full JSON details for each billing term.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_billterms(compact=not verbose)
+        result = book.list_billterms(
+            compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result
@@ -408,18 +443,26 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="read")
     def list_taxtables(
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all sales-tax tables.
 
-        Compact format (default): one line per taxtable with name,
-        entry count, and per-entry rate→account routing. Verbose:
-        full JSON with resolved account paths and refcount.
+        Leads with a ``Showing X-Y of Z taxtables`` line. Compact format
+        (default): one line per taxtable with name, entry count, and
+        per-entry rate→account routing. Page with ``offset``; ``limit=0``
+        returns the count only. Verbose: full JSON with resolved account
+        paths and refcount.
 
         Args:
             verbose: If true, return full JSON for each taxtable.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_taxtables(compact=not verbose)
+        result = book.list_taxtables(
+            compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result
@@ -954,23 +997,25 @@ def register(mcp, get_book) -> None:
         verbose: bool = False,
         limit: int = 50,
         job_id: str | None = None,
+        offset: int = 0,
     ) -> str:
         """List invoices and/or vendor bills.
 
-        Returns a compact one-line-per-invoice format by default.
-        Use verbose=true for full JSON with GUIDs, dates, notes, etc.
+        Leads with a ``Showing X-Y of Z invoices (date range)`` line,
+        then a compact one-line-per-invoice format by default. Page with
+        ``offset``; ``limit=0`` returns the count only. Use verbose=true
+        for full JSON with GUIDs, dates, notes, etc.
 
         Args:
             owner_type: Filter by type: "customer" for invoices,
                         "vendor" for bills, or omit for all.
             status: Filter by status: "posted" or "open", or omit for all.
             verbose: If true, return full JSON details.
-            limit: Maximum invoices to return. Defaults to 50, capped
-                   at 250. Compact output appends a truncation notice
-                   when results are clipped.
+            limit: Page size (default 50, max 250). 0 = count only.
             job_id: Filter to invoices grouped under a specific
                 job — useful for the "what's part of this
                 engagement?" listing pattern.
+            offset: 0-indexed first row to return (default 0).
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -980,6 +1025,7 @@ def register(mcp, get_book) -> None:
             compact=not verbose,
             limit=limit,
             job_id=job_id,
+            offset=offset,
         )
         if verbose:
             return _json(result)
@@ -1324,8 +1370,13 @@ def register(mcp, get_book) -> None:
         owner_id: str | None = None,
         active_only: bool = True,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List jobs, optionally filtered.
+
+        Leads with a ``Showing X-Y of Z jobs`` line; page with
+        ``offset``, or pass ``limit=0`` for the count only.
 
         Args:
             owner_type: Filter by "customer" or "vendor". Omit
@@ -1335,6 +1386,8 @@ def register(mcp, get_book) -> None:
             active_only: If True (default), exclude inactive jobs.
             verbose: If True, return full JSON dicts; otherwise
                 compact tab-separated rows.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -1343,6 +1396,8 @@ def register(mcp, get_book) -> None:
             owner_id=owner_id,
             active_only=active_only,
             compact=not verbose,
+            limit=limit,
+            offset=offset,
         )
         # Match the other list_* tools' verbose pattern: all
         # list_* verbose returns route through
@@ -1453,13 +1508,17 @@ def register(mcp, get_book) -> None:
         customer_id: str | None = None,
         vendor_id: str | None = None,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """Get all posted invoices/bills with outstanding balances.
 
-        Returns a compact one-line-per-doc format by default with action
+        Leads with a ``Showing X-Y of Z invoices (date range)`` line,
+        then a compact one-line-per-doc format by default with action
         columns (due date, days past due, currency, BILL tag, owner).
         Sorted most-overdue-first so the bookkeeper sees the urgent
-        items at the top.
+        items at the top. Page with ``offset``; ``limit=0`` returns the
+        count only.
 
         Use verbose=true for full JSON with ``original_amount`` /
         ``amount_paid`` / ``amount_due`` breakdown — the shape
@@ -1470,6 +1529,8 @@ def register(mcp, get_book) -> None:
             customer_id: Filter by specific customer ID.
             vendor_id: Filter by specific vendor ID.
             verbose: If true, return full JSON details.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         owner_type = _gate_owner_type(owner_type)
         # When Business isn't loaded, vendor_id is also a vendor-only
@@ -1495,6 +1556,8 @@ def register(mcp, get_book) -> None:
             customer_id=customer_id,
             vendor_id=vendor_id,
             compact=not verbose,
+            limit=limit,
+            offset=offset,
         )
         if verbose:
             return _json(result)

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -84,18 +84,26 @@ def register(mcp, get_book) -> None:
     def list_accounts(
         root: str | None = None,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all accounts in the GnuCash chart of accounts.
 
-        Returns a compact one-line-per-account format by default.
-        Use verbose=true for full JSON with guid, type, commodity, etc.
+        Leads with a ``Showing X-Y of Z accounts`` line, then a compact
+        one-line-per-account format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, type, commodity, etc.
 
         Args:
             root: Filter to a subtree (e.g., "Expenses" for expense accounts only).
             verbose: If true, return full JSON details for each account.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_accounts(root=root, compact=not verbose)
+        result = book.list_accounts(
+            root=root, compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -157,9 +157,14 @@ def register(mcp, get_book) -> None:
         start_date: str | None = None,
         end_date: str | None = None,
         limit: int = 50,
+        offset: int = 0,
         verbose: bool = False,
     ) -> str:
         """List transactions with optional filters.
+
+        Leads with a ``Showing X-Y of Z transactions (date range)``
+        line so a truncated view is never mistaken for the whole set.
+        Page with ``offset``; ``limit=0`` returns the count only.
 
         Compact format (default):
         - Unfiltered: ``DATE<TAB>guid<TAB>Description<TAB>splits``
@@ -176,13 +181,16 @@ def register(mcp, get_book) -> None:
             account: Filter by account name (switches output to register form)
             start_date: Start date in ISO format (YYYY-MM-DD)
             end_date: End date in ISO format (YYYY-MM-DD)
-            limit: Maximum number of transactions to return (default 50)
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
             verbose: If true, return full JSON details for each transaction.
         """
         book = get_book()
         start = _parse_iso_date(start_date)
         end = _parse_iso_date(end_date)
-        result = book.list_transactions(account, start, end, limit, compact=not verbose)
+        result = book.list_transactions(
+            account, start, end, limit, offset, compact=not verbose
+        )
         if verbose:
             return _json(result)
         return result
@@ -333,6 +341,7 @@ def register(mcp, get_book) -> None:
         query: str,
         field: str = "description",
         limit: int = 50,
+        offset: int = 0,
         verbose: bool = False,
     ) -> str:
         """Search transactions by description, memo, notes, or amount.
@@ -341,17 +350,20 @@ def register(mcp, get_book) -> None:
         ``DATE<TAB>guid<TAB>Description<TAB>splits``
         Transactions with more than 4 splits collapse to the top 3 by
         |value| plus ``+N more`` — call ``get_transaction`` for the
-        full breakdown. When matches exceed ``limit``, a
-        ``[Showing N of M ...]`` notice is appended.
+        full breakdown. Leads with a ``Showing X-Y of Z transactions``
+        line; page with ``offset``, or pass ``limit=0`` for the count.
 
         Args:
             query: Search query string. For amount, supports: exact ("100"), greater (">100"), less ("<100"), range ("100-200")
             field: Field to search: 'description', 'memo', 'notes', or 'amount'
-            limit: Maximum number of matches to return (default 50, server cap 250).
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
             verbose: If true, return full JSON details for each transaction.
         """
         book = get_book()
-        result = book.search_transactions(query, field, limit=limit, compact=not verbose)
+        result = book.search_transactions(
+            query, field, limit=limit, offset=offset, compact=not verbose
+        )
         if verbose:
             return _json(result)
         return result

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -17,17 +17,27 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
-    def list_commodities(verbose: bool = False) -> str:
+    def list_commodities(
+        verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> str:
         """List all commodities (currencies, stocks, etc.) in the book.
 
-        Returns a compact one-line-per-commodity format by default.
-        Use verbose=true for full JSON with fraction, latest prices, etc.
+        Leads with a ``Showing X-Y of Z commodities`` line, then a
+        compact one-line-per-commodity format by default. Page with
+        ``offset``; ``limit=0`` returns the count only. Use verbose=true
+        for full JSON with fraction, latest prices, etc.
 
         Args:
             verbose: If true, return full JSON details for each commodity.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_commodities(compact=not verbose)
+        result = book.list_commodities(
+            compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result
@@ -153,12 +163,15 @@ def register(mcp, get_book) -> None:
         currency: str | None = None,
         limit: int = 50,
         verbose: bool = False,
+        offset: int = 0,
     ) -> str:
         """Get price history for a commodity.
 
-        Returns a compact aligned text table by default. Use
-        verbose=true for the full structured envelope (``prices`` list,
-        ``count``, ``total``, ``notice``).
+        Leads with a ``Showing X-Y of Z prices (date range)`` line, then
+        a compact aligned text table by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for the full
+        structured envelope (``prices`` list, ``showing``, ``total``,
+        ``offset``, ``count``).
 
         Args:
             commodity: Symbol of the commodity (e.g., "VTSAX").
@@ -166,8 +179,9 @@ def register(mcp, get_book) -> None:
             start_date: Optional start date filter (YYYY-MM-DD).
             end_date: Optional end date filter (YYYY-MM-DD).
             currency: Optional currency filter (e.g., "USD").
-            limit: Maximum prices to return. Defaults to 50, capped at 250.
+            limit: Page size (default 50, max 250). 0 = count only.
             verbose: If true, return the structured dict.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
         start = date_type.fromisoformat(start_date) if start_date else None
@@ -181,6 +195,7 @@ def register(mcp, get_book) -> None:
             currency=currency,
             limit=limit,
             compact=not verbose,
+            offset=offset,
         )
         if verbose:
             return _json(result)
@@ -244,19 +259,28 @@ def register(mcp, get_book) -> None:
         account: str,
         include_closed: bool = False,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all lots for an investment account.
 
-        Returns a compact one-line-per-lot format by default.
-        Use verbose=true for full JSON with guid, title, notes, etc.
+        Leads with a ``Showing X-Y of Z lots`` line, then a compact
+        one-line-per-lot format by default. Page with ``offset``;
+        ``limit=0`` returns the count only. Use verbose=true for full
+        JSON with guid, title, notes, etc.
 
         Args:
             account: Account ref (full path, %short GUID, or full 32-char GUID).
             include_closed: If True, include fully-sold lots. Default False.
             verbose: If true, return full JSON details for each lot.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.list_lots(account=account, include_closed=include_closed, compact=not verbose)
+        result = book.list_lots(
+            account=account, include_closed=include_closed,
+            compact=not verbose, limit=limit, offset=offset,
+        )
         if verbose:
             return _json(result)
         return result

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -50,22 +50,25 @@ def register(mcp, get_book) -> None:
         as_of_date: str | None = None,
         verbose: bool = False,
         limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """Get unreconciled splits for an account.
 
-        Returns up to ``limit`` splits in a compact one-line-per-split
-        format by default with a summary footer reflecting the **full**
+        Leads with a ``Showing X-Y of Z splits`` indicator, then one
+        line per split, then a summary footer reflecting the **full**
         unreconciled set (so the headline is honest even when individual
-        lines are clipped).
+        lines are clipped). Page with ``offset``; ``limit=0`` returns
+        the count only.
 
         Use verbose=true for full JSON with split GUIDs, amounts, totals,
-        and the truncation notice as a structured field.
+        and the ``showing`` indicator as a structured field.
 
         Args:
             account: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID
             as_of_date: Only include splits on or before this date (YYYY-MM-DD)
             verbose: If true, return full JSON details. Default compact one-line format.
-            limit: Maximum splits to return. Defaults to 50, capped at 250.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
         date_obj = _parse_iso_date(as_of_date)
@@ -74,6 +77,7 @@ def register(mcp, get_book) -> None:
             as_of_date=date_obj,
             compact=not verbose,
             limit=limit,
+            offset=offset,
         )
         if verbose:
             return _json(result)

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -57,20 +57,28 @@ def register(mcp, get_book) -> None:
     def list_scheduled_transactions(
         enabled_only: bool = True,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """List all scheduled transactions.
 
-        Returns a compact one-line-per-schedule format by default.
-        Use verbose=true for full JSON with GUIDs, splits, dates, etc.
+        Leads with a ``Showing X-Y of Z scheduled transactions`` line,
+        then a compact one-line-per-schedule format by default. Page with
+        ``offset``; ``limit=0`` returns the count only. Use verbose=true
+        for full JSON with GUIDs, splits, dates, etc.
 
         Args:
             enabled_only: If True, only show enabled schedules. Default True.
             verbose: If true, return full JSON details for each scheduled transaction.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
         result = book.list_scheduled_transactions(
             enabled_only=enabled_only,
             compact=not verbose,
+            limit=limit,
+            offset=offset,
         )
         if verbose:
             return _json(result)
@@ -82,17 +90,26 @@ def register(mcp, get_book) -> None:
     def get_upcoming_transactions(
         days: int = 14,
         verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
     ) -> str:
         """Get scheduled transactions due within a time window.
 
-        This is the "what bills are coming up?" query.
+        This is the "what bills are coming up?" query. Leads with a
+        ``Showing X-Y of Z upcoming transactions (date range)`` line,
+        soonest first. Page with ``offset``; ``limit=0`` returns the
+        count only.
 
         Args:
             days: Look ahead window in days. Default 14.
             verbose: If true, return full JSON with splits. Default compact one-line format.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
-        result = book.get_upcoming_transactions(days=days, compact=not verbose)
+        result = book.get_upcoming_transactions(
+            days=days, compact=not verbose, limit=limit, offset=offset
+        )
         if verbose:
             return _json(result)
         return result

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -45,7 +45,7 @@ def _seed_rent(gc):
 
 
 def _descriptions(gc):
-    return {t["description"] for t in gc.list_transactions(compact=False)}
+    return {t["description"] for t in gc.list_transactions(compact=False)["transactions"]}
 
 
 class TestBatchCreate:

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3367,7 +3367,8 @@ class TestListAccounts:
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts()
 
-        lines = result.strip().split("\n")
+        # Line 0 is the "Showing X-Y of Z accounts" indicator.
+        lines = result.strip().split("\n")[1:]
         # Extract fullname (before any annotation bracket); skip past
         # the '%shortguid<TAB>' prefix introduced by short GUIDs.
         names = [
@@ -3379,7 +3380,7 @@ class TestListAccounts:
     def test_list_accounts_structure_verbose(self, test_book: Path):
         """compact=False should return proper account dict structure."""
         gc_book = GnuCashBook(str(test_book))
-        accounts = gc_book.list_accounts(compact=False)
+        accounts = gc_book.list_accounts(compact=False)["accounts"]
 
         assert isinstance(accounts, list)
         account = accounts[0]
@@ -3426,7 +3427,7 @@ class TestListAccounts:
     def test_verbose_mode(self, test_book: Path):
         """compact=False should return list of dicts (old behavior)."""
         gc_book = GnuCashBook(str(test_book))
-        result = gc_book.list_accounts(compact=False)
+        result = gc_book.list_accounts(compact=False)["accounts"]
 
         assert isinstance(result, list)
         assert all(isinstance(a, dict) for a in result)
@@ -3438,7 +3439,8 @@ class TestListAccounts:
         """root parameter should filter to a subtree."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts(root="Expenses")
-        paths = [_path_from_compact_line(l) for l in result.strip().split("\n")]
+        # Skip the leading "Showing X-Y of Z accounts" indicator.
+        paths = [_path_from_compact_line(l) for l in result.strip().split("\n")[1:]]
 
         for path in paths:
             assert path.startswith("Expenses")
@@ -3447,7 +3449,7 @@ class TestListAccounts:
     def test_root_filter_verbose(self, test_book: Path):
         """root + compact=False should return filtered dicts."""
         gc_book = GnuCashBook(str(test_book))
-        result = gc_book.list_accounts(root="Assets", compact=False)
+        result = gc_book.list_accounts(root="Assets", compact=False)["accounts"]
 
         assert isinstance(result, list)
         for a in result:
@@ -3457,13 +3459,13 @@ class TestListAccounts:
         """root filter should not partially match account names."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts(root="Exp")
-        assert result == ""
+        assert result == "Showing 0 of 0 accounts"
 
     def test_root_nonexistent(self, test_book: Path):
         """root filter for nonexistent account returns empty."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts(root="Nonexistent")
-        assert result == ""
+        assert result == "Showing 0 of 0 accounts"
 
     def test_root_includes_self(self, test_book: Path):
         """root account itself should be included in results."""
@@ -3617,7 +3619,7 @@ class TestResolveAccount:
         import re
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts()
-        for line in result.strip().split("\n"):
+        for line in result.strip().split("\n")[1:]:  # skip indicator
             # '%' + 7+ hex + TAB + non-empty path
             assert re.match(r"^%[0-9a-f]{7,32}\t\S", line), (
                 f"unexpected line shape: {line!r}"
@@ -3632,7 +3634,7 @@ class TestResolveAccount:
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_accounts()
         with gc_book.open(readonly=True) as book:
-            for line in result.strip().split("\n"):
+            for line in result.strip().split("\n")[1:]:  # skip indicator
                 short, rest = line.split("\t", 1)
                 # Path is everything before the optional " [ANN]" suffix.
                 path = rest.split(" [", 1)[0]
@@ -3836,7 +3838,7 @@ class TestTemplateAccountsHidden:
         compact = gc.list_accounts()
         assert "MonthlyRentTemplate" not in compact
 
-        verbose = gc.list_accounts(compact=False)
+        verbose = gc.list_accounts(compact=False)["accounts"]
         names = {a["fullname"] for a in verbose}
         assert not any("MonthlyRentTemplate" in n for n in names)
         # User's chart of accounts still appears normally.
@@ -6721,7 +6723,7 @@ class TestReplaceSplits:
         # emits and the LLM passes back. ``list_accounts`` returns
         # the full 32-char GUID; the shortcut is "%" + the first 7
         # chars (the bookkeeper's exact failing input format).
-        accounts_list = gc_book.list_accounts(compact=False)
+        accounts_list = gc_book.list_accounts(compact=False)["accounts"]
         groceries_full = next(
             a["guid"] for a in accounts_list
             if a["fullname"] == "Expenses:Groceries"
@@ -6767,7 +6769,7 @@ class TestReplaceSplits:
         )["transactions"]
         guid = transactions[0]["guid"]
 
-        accounts_list = gc_book.list_accounts(compact=False)
+        accounts_list = gc_book.list_accounts(compact=False)["accounts"]
         groceries_full = next(
             a["guid"] for a in accounts_list
             if a["fullname"] == "Expenses:Groceries"
@@ -10866,8 +10868,9 @@ class TestShortGuidRoundTripClosure:
     def test_account_short_guid_round_trip(self, test_book: Path):
         gc_book = GnuCashBook(str(test_book))
         # list_accounts compact emits "%shortguid<TAB>fullname [ANN]".
+        # Line 0 is the pagination indicator; first account is line 1.
         compact = gc_book.list_accounts()
-        line = compact.strip().split("\n")[0]
+        line = compact.strip().split("\n")[1]
         short_acct, _rest = line.split("\t", 1)
         assert short_acct.startswith("%")
         # Feed it back into get_account — accepts %short, full path,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3980,7 +3980,7 @@ class TestListTransactions:
     def test_list_all_transactions(self, test_book: Path):
         """Should return all transactions."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
 
         assert len(transactions) == 3
         descriptions = {t["description"] for t in transactions}
@@ -3993,7 +3993,7 @@ class TestListTransactions:
         gc_book = GnuCashBook(str(test_book))
 
         # Groceries account only has one transaction
-        transactions = gc_book.list_transactions(account="Expenses:Groceries", compact=False)
+        transactions = gc_book.list_transactions(account="Expenses:Groceries", compact=False)["transactions"]
         assert len(transactions) == 1
         assert transactions[0]["description"] == "Weekly Groceries"
 
@@ -4006,21 +4006,21 @@ class TestListTransactions:
             start_date=date(2024, 1, 10),
             end_date=date(2024, 1, 18),
             compact=False,
-        )
+        )["transactions"]
         assert len(transactions) == 1
         assert transactions[0]["description"] == "Salary Deposit"
 
     def test_list_transactions_limit(self, test_book: Path):
         """Should respect limit parameter."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(limit=2, compact=False)
+        transactions = gc_book.list_transactions(limit=2, compact=False)["transactions"]
 
         assert len(transactions) == 2
 
     def test_list_transactions_sorted_descending(self, test_book: Path):
         """Should return transactions sorted by date descending."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
 
         dates = [t["date"] for t in transactions]
         assert dates == sorted(dates, reverse=True)
@@ -4032,33 +4032,32 @@ class TestListTransactions:
         with pytest.raises(ValueError, match="Account not found"):
             gc_book.list_transactions(account="Nonexistent:Account")
 
-    def test_compact_truncation_notice_when_over_limit(self, test_book: Path):
-        """Compact mode appends [Showing N of M ...] when results truncate."""
+    def test_compact_indicator_when_over_limit(self, test_book: Path):
+        """Compact mode leads with ``Showing 1-N of M`` when truncated."""
         gc_book = GnuCashBook(str(test_book))
-        # test_book has 3 transactions; limit=2 triggers truncation.
+        # test_book has 3 transactions; limit=2 shows a partial page.
         result = gc_book.list_transactions(limit=2, compact=True)
-        assert "[Showing 2 of 3 transactions" in result
-        assert "start_date/end_date" in result
+        assert result.split("\n")[0].startswith("Showing 1-2 of 3 transactions")
 
-    def test_compact_no_notice_when_under_limit(self, test_book: Path):
-        """No notice when results fit under the limit."""
+    def test_compact_indicator_always_present_when_under_limit(self, test_book: Path):
+        """The indicator is the first line even when everything fits —
+        ``1-3 of 3`` tells the LLM the set is complete."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_transactions(limit=50, compact=True)
-        assert "Showing" not in result
+        assert result.split("\n")[0].startswith("Showing 1-3 of 3 transactions")
 
     def test_compact_cap_note_when_limit_over_max(self, test_book: Path):
-        """Limit above MAX_LIST_LIMIT (250) gets clamped with a note when
-        results fit, or included in the truncation message when they don't."""
+        """Limit above MAX_LIST_LIMIT (250) is flagged in the indicator."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.list_transactions(limit=10000, compact=True)
-        # test_book has only 3, fits under the cap
-        assert "Limit capped at 250" in result
-        assert "results fit under the cap" in result
+        # test_book has only 3, fits under the cap, but the over-limit
+        # is still surfaced.
+        assert "limit capped at 250" in result.split("\n")[0]
 
     def test_verbose_mode_no_notice(self, test_book: Path):
         """Non-compact (dict) mode returns list silently — no notice field."""
         gc_book = GnuCashBook(str(test_book))
-        result = gc_book.list_transactions(limit=2, compact=False)
+        result = gc_book.list_transactions(limit=2, compact=False)["transactions"]
         assert isinstance(result, list)
         assert len(result) == 2
 
@@ -4129,7 +4128,12 @@ class TestCompactTransactionFormat:
     def test_search_output_matches_unfiltered_list_shape(self, test_book: Path):
         """search_transactions's compact shape is identical to unfiltered list."""
         gc_book = GnuCashBook(str(test_book))
-        search_line = gc_book.search_transactions("Groceries").strip().split("\n")[0]
+        # Both outputs lead with a pagination indicator; compare the
+        # Groceries data row, which is identical across the two surfaces.
+        search_line = next(
+            l for l in gc_book.search_transactions("Groceries").strip().split("\n")
+            if "Weekly Groceries" in l
+        )
         list_line = next(
             l for l in gc_book.list_transactions().strip().split("\n")
             if "Weekly Groceries" in l
@@ -4169,7 +4173,10 @@ class TestCompactTransactionFormat:
         the description.
         """
         gc_book = GnuCashBook(str(test_book))
-        lines = gc_book.list_transactions(account="Assets:Checking").strip().split("\n")
+        # Skip the leading "Showing X-Y of Z" pagination indicator.
+        lines = gc_book.list_transactions(
+            account="Assets:Checking"
+        ).strip().split("\n")[1:]
         for line in lines:
             cols = line.split("\t")
             # 5 or 6 cols (6 if the transaction has notes)
@@ -4257,7 +4264,7 @@ class TestGetTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # First get a valid GUID
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Then fetch by GUID
@@ -5093,7 +5100,7 @@ class TestDryRun:
     def test_dry_run_no_write(self, test_book: Path):
         """Dry run should not create a transaction in the book."""
         gc_book = GnuCashBook(str(test_book))
-        before = gc_book.list_transactions(compact=False)
+        before = gc_book.list_transactions(compact=False)["transactions"]
         gc_book.create_transaction(
             description="Ghost Transaction",
             splits=[
@@ -5102,7 +5109,7 @@ class TestDryRun:
             ],
             dry_run=True,
         )
-        after = gc_book.list_transactions(compact=False)
+        after = gc_book.list_transactions(compact=False)["transactions"]
         assert len(after) == len(before)
 
     def test_dry_run_includes_warnings(self, test_book: Path):
@@ -5250,7 +5257,7 @@ class TestAutoFillTransaction:
         phantom = gc_book.search_transactions(
             query="Never Seen Before XYZ123", field="description",
             compact=False,
-        )
+        )["transactions"]
         assert phantom == []
 
     def test_real_match_beats_empty_description_txn(
@@ -5687,7 +5694,7 @@ class TestSearchTransactions:
         """Should find transactions by description."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("Salary", field="description", compact=False)
+        results = gc_book.search_transactions("Salary", field="description", compact=False)["transactions"]
         assert len(results) == 1
         assert results[0]["description"] == "Salary Deposit"
 
@@ -5695,14 +5702,14 @@ class TestSearchTransactions:
         """Should search case-insensitively."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("salary", field="description", compact=False)
+        results = gc_book.search_transactions("salary", field="description", compact=False)["transactions"]
         assert len(results) == 1
 
     def test_search_by_amount_exact(self, test_book: Path):
         """Should find transactions by exact amount."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("150", field="amount", compact=False)
+        results = gc_book.search_transactions("150", field="amount", compact=False)["transactions"]
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -5710,7 +5717,7 @@ class TestSearchTransactions:
         """Should find transactions with amount greater than threshold."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions(">500", field="amount", compact=False)
+        results = gc_book.search_transactions(">500", field="amount", compact=False)["transactions"]
         # Opening (1000) and Salary (2000) transactions
         assert len(results) == 2
 
@@ -5718,7 +5725,7 @@ class TestSearchTransactions:
         """Should find transactions with amount less than threshold."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("<200", field="amount", compact=False)
+        results = gc_book.search_transactions("<200", field="amount", compact=False)["transactions"]
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -5726,7 +5733,7 @@ class TestSearchTransactions:
         """Should find transactions with amount in range."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("100-500", field="amount", compact=False)
+        results = gc_book.search_transactions("100-500", field="amount", compact=False)["transactions"]
         assert len(results) == 1
         assert results[0]["description"] == "Weekly Groceries"
 
@@ -5744,7 +5751,7 @@ class TestSearchTransactions:
             notes="P2W1 groceries",
         )
 
-        results = gc_book.search_transactions("P2W1", field="notes", compact=False)
+        results = gc_book.search_transactions("P2W1", field="notes", compact=False)["transactions"]
         assert len(results) == 1
         assert results[0]["description"] == "Safeway"
         assert results[0]["notes"] == "P2W1 groceries"
@@ -5753,7 +5760,7 @@ class TestSearchTransactions:
         """Should return empty list when no notes match."""
         gc_book = GnuCashBook(str(test_book))
 
-        results = gc_book.search_transactions("nonexistent", field="notes", compact=False)
+        results = gc_book.search_transactions("nonexistent", field="notes", compact=False)["transactions"]
         assert len(results) == 0
 
     def test_search_invalid_field(self, test_book: Path):
@@ -5770,20 +5777,18 @@ class TestSearchTransactions:
         with pytest.raises(ValueError, match="Invalid amount query"):
             gc_book.search_transactions(">notanumber", field="amount")
 
-    def test_search_compact_truncation_notice(self, test_book: Path):
-        """Compact mode appends truncation notice when matches exceed limit."""
+    def test_search_compact_indicator_when_over_limit(self, test_book: Path):
+        """Compact search leads with the indicator when matches truncate."""
         gc_book = GnuCashBook(str(test_book))
-        # Match all 3 transactions on a common substring, limit=2 forces truncation.
-        # 'a' appears in "Opening Balance", "Salary Deposit", "Weekly Groceries".
-        # Actually just use a broad amount filter for certainty.
+        # All 3 transactions have a positive amount; limit=2 → partial page.
         result = gc_book.search_transactions(">0", field="amount", limit=2, compact=True)
-        assert "[Showing 2 of 3 transactions" in result
+        assert result.split("\n")[0].startswith("Showing 1-2 of 3 transactions")
 
     def test_search_compact_cap_applied(self, test_book: Path):
-        """Limits above MAX_LIST_LIMIT get clamped with a note."""
+        """Limits above MAX_LIST_LIMIT are flagged in the indicator."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.search_transactions(">0", field="amount", limit=10000, compact=True)
-        assert "Limit capped at 250" in result
+        assert "limit capped at 250" in result.split("\n")[0]
 
 
 class TestCreateAccount:
@@ -6318,7 +6323,7 @@ class TestDeleteTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction to delete
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
         description = transactions[0]["description"]
 
@@ -6343,7 +6348,7 @@ class TestDeleteTransaction:
         """Should reject deletion of transaction with reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
 
@@ -6355,7 +6360,7 @@ class TestDeleteTransaction:
         """Should allow deletion with force=True despite reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
 
@@ -6413,7 +6418,7 @@ class TestUpdateTransaction:
         """Should update only the description."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -6428,7 +6433,7 @@ class TestUpdateTransaction:
         """Should update only the date."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -6444,7 +6449,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get the groceries transaction (150.00)
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -6466,7 +6471,7 @@ class TestUpdateTransaction:
         """Should update description, date, and splits together."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -6497,7 +6502,7 @@ class TestUpdateTransaction:
         """Should raise ValueError for unbalanced splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="do not balance"):
@@ -6521,7 +6526,7 @@ class TestUpdateTransaction:
         """
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="Account not found"):
@@ -6537,7 +6542,7 @@ class TestUpdateTransaction:
         """Should add notes to an existing transaction."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.update_transaction(
@@ -6580,7 +6585,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get the groceries transaction and reconcile a split
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -6598,7 +6603,7 @@ class TestUpdateTransaction:
         """Should allow split updates with force=True despite reconciled splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -6617,7 +6622,7 @@ class TestUpdateTransaction:
         """Should allow description/date/notes changes without force on reconciled."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -6644,7 +6649,7 @@ class TestUpdateTransaction:
         gc_book = GnuCashBook(str(multi_currency_book))
 
         # Find the cross-currency transfer (USD checking → EUR savings).
-        txns = gc_book.search_transactions("Transfer to EUR", compact=False)
+        txns = gc_book.search_transactions("Transfer to EUR", compact=False)["transactions"]
         assert txns, "Test setup: cross-currency transfer not found"
         tx = txns[0]
         checking_split = next(
@@ -6709,7 +6714,7 @@ class TestReplaceSplits:
         # Find the grocery transaction.
         transactions = gc_book.search_transactions(
             "Weekly Groceries", compact=False,
-        )
+        )["transactions"]
         guid = transactions[0]["guid"]
 
         # Build the ``%`` shortcut form — same shape the tool layer
@@ -6759,7 +6764,7 @@ class TestReplaceSplits:
 
         transactions = gc_book.search_transactions(
             "Weekly Groceries", compact=False,
-        )
+        )["transactions"]
         guid = transactions[0]["guid"]
 
         accounts_list = gc_book.list_accounts(compact=False)
@@ -6788,7 +6793,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         original_splits = transactions[0]["splits"]
 
@@ -6825,7 +6830,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         original_date = transactions[0]["date"]
         original_description = transactions[0]["description"]
@@ -6859,7 +6864,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         original_splits = transactions[0]["splits"]
 
@@ -6888,7 +6893,7 @@ class TestReplaceSplits:
         """Should reject splits that don't balance to zero."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="do not balance"):
@@ -6904,7 +6909,7 @@ class TestReplaceSplits:
         """Should reject fewer than 2 splits."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="At least 2 splits"):
@@ -6919,7 +6924,7 @@ class TestReplaceSplits:
         """Should reject splits with non-existent accounts."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="Account not found"):
@@ -6935,7 +6940,7 @@ class TestReplaceSplits:
         """Should reject splits to placeholder accounts."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Expenses is a placeholder in test_book
@@ -6966,7 +6971,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction and reconcile one of its splits
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -6985,7 +6990,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction and reconcile one of its splits
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         split_guid = transactions[0]["splits"][0]["guid"]
         gc_book.set_reconcile_state(split_guid, "y")
@@ -7113,7 +7118,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(test_book))
 
         # Find the grocery transaction (2 splits)
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
         assert len(transactions[0]["splits"]) == 2
 
@@ -7176,7 +7181,7 @@ class TestReplaceSplits:
         """Should preserve memo on new splits when provided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)
+        transactions = gc_book.search_transactions("Weekly Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.replace_splits(
@@ -7204,7 +7209,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(multi_currency_book))
 
         # Find a USD transaction
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Try to replace splits to EUR account without quantity
@@ -7222,7 +7227,7 @@ class TestReplaceSplits:
         gc_book = GnuCashBook(str(multi_currency_book))
 
         # Find a USD transaction
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Recategorize with proper quantity
@@ -7250,7 +7255,7 @@ class TestReplaceSplits:
         """Should reject quantity with opposite sign from amount."""
         gc_book = GnuCashBook(str(multi_currency_book))
 
-        transactions = gc_book.search_transactions("Groceries", compact=False)
+        transactions = gc_book.search_transactions("Groceries", compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="same sign"):
@@ -7275,7 +7280,7 @@ class TestSetReconcileState:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a split guid
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = gc_book.set_reconcile_state(split_guid, "c")
@@ -7283,7 +7288,7 @@ class TestSetReconcileState:
         # `reconcile_state` in the response was an input echo — dropped.
         # Persistence verified below via list_transactions read-back.
         assert result["status"] == "updated"
-        refreshed = gc_book.list_transactions(compact=False)
+        refreshed = gc_book.list_transactions(compact=False)["transactions"]
         updated_split = next(
             s for t in refreshed for s in t["splits"] if s["guid"] == split_guid
         )
@@ -7293,7 +7298,7 @@ class TestSetReconcileState:
         """Should set split to reconciled state with date."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = gc_book.set_reconcile_state(
@@ -7304,7 +7309,7 @@ class TestSetReconcileState:
         # reconcile_state echo is gone; persistence check below.
         assert result["status"] == "updated"
         assert result["reconcile_date"] is not None
-        refreshed = gc_book.list_transactions(compact=False)
+        refreshed = gc_book.list_transactions(compact=False)["transactions"]
         updated_split = next(
             s for t in refreshed for s in t["splits"] if s["guid"] == split_guid
         )
@@ -7314,7 +7319,7 @@ class TestSetReconcileState:
         """Should reset split to new state."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         # First set to cleared
@@ -7324,7 +7329,7 @@ class TestSetReconcileState:
         result = gc_book.set_reconcile_state(split_guid, "n")
 
         assert result["reconcile_date"] is None
-        refreshed = gc_book.list_transactions(compact=False)
+        refreshed = gc_book.list_transactions(compact=False)["transactions"]
         updated_split = next(
             s for t in refreshed for s in t["splits"] if s["guid"] == split_guid
         )
@@ -7334,7 +7339,7 @@ class TestSetReconcileState:
         """Should raise ValueError for invalid state."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         with pytest.raises(ValueError, match="Invalid reconcile state"):
@@ -7490,7 +7495,7 @@ class TestReconcileAccount:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a split from a different account
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         expense_split = None
         for split in transactions[0]["splits"]:
             if "Expenses" in split["account"]:
@@ -7805,7 +7810,7 @@ class TestVoidTransaction:
         interpretation depended on the host's current zone."""
         from datetime import datetime as _dt
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         gc_book.void_transaction(guid=guid, reason="test")
@@ -7839,7 +7844,7 @@ class TestVoidTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction to void
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         result = gc_book.void_transaction(guid, reason="Entered in error")
@@ -7868,7 +7873,7 @@ class TestVoidTransaction:
         caller knows what they just broke."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Mark one split as reconciled before voiding.
@@ -7897,7 +7902,7 @@ class TestVoidTransaction:
         """Belt-and-suspenders: a clean (no reconciled splits)
         void must not invent a warning."""
         gc_book = GnuCashBook(str(test_book))
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         result = gc_book.void_transaction(
             transactions[0]["guid"], reason="Test",
         )
@@ -7907,7 +7912,7 @@ class TestVoidTransaction:
         """Should raise ValueError if no reason provided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="reason is required"):
@@ -7924,7 +7929,7 @@ class TestVoidTransaction:
         """Should raise ValueError if already voided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         # Void once
@@ -7943,7 +7948,7 @@ class TestUnvoidTransaction:
         gc_book = GnuCashBook(str(test_book))
 
         # Get original transaction values
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
         original = gc_book.get_transaction(guid)
         original_values = {s["account"]: s["value"] for s in original["splits"]}
@@ -7972,7 +7977,7 @@ class TestUnvoidTransaction:
         """Should raise ValueError if transaction is not voided."""
         gc_book = GnuCashBook(str(test_book))
 
-        transactions = gc_book.list_transactions(compact=False)
+        transactions = gc_book.list_transactions(compact=False)["transactions"]
         guid = transactions[0]["guid"]
 
         with pytest.raises(ValueError, match="not voided"):
@@ -10767,9 +10772,10 @@ class TestShortGuidRoundTripClosure:
 
     def test_transaction_short_guid_round_trip(self, test_book: Path):
         gc_book = GnuCashBook(str(test_book))
-        # list_transactions compact emits 8+ hex prefixes.
+        # list_transactions compact emits 8+ hex prefixes. Line 0 is the
+        # "Showing X-Y of Z" indicator; the first data row is line 1.
         compact = gc_book.list_transactions()
-        line = compact.strip().split("\n")[0]
+        line = compact.strip().split("\n")[1]
         # Format: "YYYY-MM-DD<TAB>SHORTGUID<TAB>amount<TAB>..."
         short_guid = line.split("\t")[1]
         assert short_guid and len(short_guid) >= 8
@@ -10787,9 +10793,11 @@ class TestShortGuidRoundTripClosure:
         compact = gc_book.get_unreconciled_splits(
             account_name="Assets:Checking",
         )
+        # Line 0 is the "Showing X-Y of Z splits" indicator; the first
+        # split row is line 1.
         # Format: ``"short_guid<TAB>date<TAB>description<TAB>amount<TAB>state"``
         # — the short GUID is column 0.
-        line = compact.strip().split("\n")[0]
+        line = compact.strip().split("\n")[1]
         short_split = line.split("\t")[0]
         assert short_split and len(short_split) >= 8
         # Feed it back into set_reconcile_state — the canonical split

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1017,7 +1017,7 @@ class TestListAndGetBudget:
     def test_list_empty(self, budget_book: Path):
         """Listing budgets on a book with no budgets returns empty list."""
         book = GnuCashBook(str(budget_book))
-        result = book.list_budgets(compact=False)
+        result = book.list_budgets(compact=False)["budgets"]
         assert result == []
 
     def test_list_single_budget(self, budget_book: Path):
@@ -1025,7 +1025,7 @@ class TestListAndGetBudget:
         book = GnuCashBook(str(budget_book))
         book.create_budget(name="2026 Budget", year=2026, num_periods=12)
 
-        result = book.list_budgets(compact=False)
+        result = book.list_budgets(compact=False)["budgets"]
         assert len(result) == 1
         assert result[0]["name"] == "2026 Budget"
         assert result[0]["num_periods"] == 12
@@ -1078,7 +1078,7 @@ class TestDeleteBudget:
 
         # Verify it's gone
         assert book.get_budget(compact=False, name="2026 Budget") is None
-        assert book.list_budgets(compact=False) == []
+        assert book.list_budgets(compact=False)["budgets"] == []
 
     def test_delete_with_amounts(self, budget_book: Path):
         """Delete a budget with amounts (cascade delete)."""
@@ -1092,7 +1092,7 @@ class TestDeleteBudget:
 
         result = book.delete_budget("2026 Budget")
         assert result["status"] == "deleted"
-        assert book.list_budgets(compact=False) == []
+        assert book.list_budgets(compact=False)["budgets"] == []
 
     def test_delete_nonexistent_raises(self, budget_book: Path):
         """Deleting a nonexistent budget raises ValueError."""
@@ -1139,7 +1139,7 @@ class TestBudgetIntegration:
         )
 
         # Verify listing
-        budgets = book.list_budgets(compact=False)
+        budgets = book.list_budgets(compact=False)["budgets"]
         assert len(budgets) == 1
         assert budgets[0]["name"] == "2026 Budget"
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -85,14 +85,15 @@ class TestListCustomers:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_customers()
-        assert result == ""
+        assert result == "Showing 0 of 0 customers"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_customer(name="Beta Corp")
         gb.create_customer(name="Alpha Inc")
         result = gb.list_customers()
-        lines = result.strip().split("\n")
+        # Skip the leading "Showing X-Y of Z customers" indicator.
+        lines = result.strip().split("\n")[1:]
         assert len(lines) == 2
         # Sorted by name
         assert "Alpha Inc" in lines[0]
@@ -101,7 +102,7 @@ class TestListCustomers:
     def test_verbose_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_customer(name="Acme Corp")
-        result = gb.list_customers(compact=False)
+        result = gb.list_customers(compact=False)["customers"]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Acme Corp"
@@ -170,14 +171,14 @@ class TestListVendors:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_vendors()
-        assert result == ""
+        assert result == "Showing 0 of 0 vendors"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_vendor(name="Zeta Supply")
         gb.create_vendor(name="Alpha Parts")
         result = gb.list_vendors()
-        lines = result.strip().split("\n")
+        lines = result.strip().split("\n")[1:]  # skip indicator
         assert len(lines) == 2
         assert "Alpha Parts" in lines[0]
         assert "Zeta Supply" in lines[1]
@@ -185,7 +186,7 @@ class TestListVendors:
     def test_verbose_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_vendor(name="Office Depot")
-        result = gb.list_vendors(compact=False)
+        result = gb.list_vendors(compact=False)["vendors"]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Office Depot"
@@ -279,14 +280,14 @@ class TestListEmployees:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_employees()
-        assert result == ""
+        assert result == "Showing 0 of 0 employees"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_employee(name="Beta Hire")
         gb.create_employee(name="Alpha Hire")
         result = gb.list_employees()
-        lines = result.strip().split("\n")
+        lines = result.strip().split("\n")[1:]  # skip indicator
         assert len(lines) == 2
         # Sorted by name
         assert "Alpha Hire" in lines[0]
@@ -295,7 +296,7 @@ class TestListEmployees:
     def test_verbose_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_employee(name="Jane Smith")
-        result = gb.list_employees(compact=False)
+        result = gb.list_employees(compact=False)["employees"]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Jane Smith"
@@ -448,7 +449,7 @@ class TestListJobs:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_jobs()
-        assert result == ""
+        assert result == "Showing 0 of 0 jobs"
 
     def test_compact_default(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -468,7 +469,7 @@ class TestListJobs:
         gb.create_job(
             owner_id="000001", owner_type="customer", name="X",
         )
-        result = gb.list_jobs(compact=False)
+        result = gb.list_jobs(compact=False)["jobs"]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "X"
@@ -485,10 +486,10 @@ class TestListJobs:
         gb.create_job(
             owner_id="000001", owner_type="vendor", name="Vend",
         )
-        cust = gb.list_jobs(owner_type="customer", compact=False)
+        cust = gb.list_jobs(owner_type="customer", compact=False)["jobs"]
         assert len(cust) == 1
         assert cust[0]["name"] == "Cust"
-        vend = gb.list_jobs(owner_type="vendor", compact=False)
+        vend = gb.list_jobs(owner_type="vendor", compact=False)["jobs"]
         assert len(vend) == 1
         assert vend[0]["name"] == "Vend"
 
@@ -516,11 +517,11 @@ class TestListJobs:
         # Deactivate the second
         gb.update_job(job_id=inactive["id"], active=False)
         # Default lists only active
-        result = gb.list_jobs(compact=False)
+        result = gb.list_jobs(compact=False)["jobs"]
         assert len(result) == 1
         assert result[0]["id"] == active["id"]
         # include_inactive surfaces both
-        result_all = gb.list_jobs(active_only=False, compact=False)
+        result_all = gb.list_jobs(active_only=False, compact=False)["jobs"]
         assert len(result_all) == 2
 
 
@@ -1047,7 +1048,7 @@ class TestJobPr88ReviewFollowups:
             post_account="Assets:Accounts Receivable",
             owner_type="customer",
         )
-        outstanding = gb.get_outstanding_invoices(compact=False)
+        outstanding = gb.get_outstanding_invoices(compact=False)["invoices"]
         row = next(r for r in outstanding if r["id"] == inv["id"])
         # The bug: pre-fix, owner_name was None on job-attached
         # posted invoices.
@@ -1072,7 +1073,7 @@ class TestJobPr88ReviewFollowups:
             name="X", reference="",  # empty ref to test strip behavior
         )
         # Direct book method returns the list shape unchanged.
-        rows = gb.list_jobs(compact=False)
+        rows = gb.list_jobs(compact=False)["jobs"]
         assert len(rows) == 1
         # Empty reference SHOULD survive the verbose JSON path
         # — the bug was that _json stripped it. We verify the
@@ -1376,11 +1377,11 @@ class TestUpdateCustomer:
         gb.create_customer(name="Old Customer")
         gb.update_customer(customer_id="000001", active=False)
 
-        active_only = gb.list_customers(active_only=True, compact=False)
+        active_only = gb.list_customers(active_only=True, compact=False)["customers"]
         assert all(c["id"] != "000001" for c in active_only)
         all_customers = gb.list_customers(
             active_only=False, compact=False,
-        )
+        )["customers"]
         assert any(c["id"] == "000001" for c in all_customers)
 
     def test_update_address_creates_when_missing(self, business_book):
@@ -1569,7 +1570,7 @@ class TestUpdateEmployee:
 
         active_only = gb.list_employees(
             active_only=True, compact=False,
-        )
+        )["employees"]
         assert all(e["id"] != "000001" for e in active_only)
 
 
@@ -1681,7 +1682,7 @@ class TestCreateBillterm:
         gb = GnuCashBook(str(business_book))
         gb.create_billterm(name="Net 30")
         gb.create_billterm(name="Net 60", due_days=60)
-        result = gb.list_billterms(compact=False)
+        result = gb.list_billterms(compact=False)["billterms"]
         assert len(result) == 2
         names = {bt["name"] for bt in result}
         assert names == {"Net 30", "Net 60"}
@@ -1693,7 +1694,7 @@ class TestListBillterms:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_billterms()
-        assert result == ""
+        assert result == "Showing 0 of 0 billterms"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1705,7 +1706,7 @@ class TestListBillterms:
     def test_verbose_format(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_billterm(name="Net 30", due_days=30, description="Standard terms")
-        result = gb.list_billterms(compact=False)
+        result = gb.list_billterms(compact=False)["billterms"]
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "Net 30"
@@ -1942,8 +1943,8 @@ class TestListTaxtables:
 
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
-        assert gb.list_taxtables() == ""
-        assert gb.list_taxtables(compact=False) == []
+        assert gb.list_taxtables() == "Showing 0 of 0 taxtables"
+        assert gb.list_taxtables(compact=False)["taxtables"] == []
 
     def test_compact_single_entry(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -1984,7 +1985,7 @@ class TestListTaxtables:
             entries=[{"type": "percentage", "amount": "5",
                       "account": gst}],
         )
-        result = gb.list_taxtables(compact=False)
+        result = gb.list_taxtables(compact=False)["taxtables"]
         assert len(result) == 1
         assert result[0]["name"] == "GST 5%"
         assert result[0]["refcount"] == 0
@@ -1999,7 +2000,7 @@ class TestListTaxtables:
                 entries=[{"type": "percentage", "amount": "5",
                           "account": gst}],
             )
-        result = gb.list_taxtables(compact=False)
+        result = gb.list_taxtables(compact=False)["taxtables"]
         assert [t["name"] for t in result] == ["Alpha", "Mu", "Zeta"]
 
 
@@ -5805,7 +5806,7 @@ class TestCreditNoteDisplayPolish:
             post_account="Assets:Accounts Receivable",
             owner_type="customer",
         )
-        rows = gb.get_outstanding_invoices(compact=False)
+        rows = gb.get_outstanding_invoices(compact=False)["invoices"]
         cn_row = next(r for r in rows if r["id"] == cn["id"])
         assert cn_row["is_credit_note"] is True
 
@@ -6035,7 +6036,7 @@ class TestListInvoices:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_invoices()
-        assert result == ""
+        assert result == "Showing 0 of 0 invoices"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -6051,19 +6052,18 @@ class TestListInvoices:
         gb.create_customer(name="Acme Corp")
         gb.create_invoice(customer_id="000001")
         result = gb.list_invoices(compact=False)
-        # Verbose mode returns the envelope shape that matches
-        # get_unreconciled_splits / get_prices: invoices list +
-        # count + total + notice.
+        # Verbose mode returns the uniform pagination envelope:
+        # invoices list + showing + total + offset + count.
         assert isinstance(result, dict)
         assert "invoices" in result
         assert "count" in result
         assert "total" in result
-        assert "notice" in result
+        assert "showing" in result
         invoices = result["invoices"]
         assert len(invoices) == 1
         assert invoices[0]["type"] == "invoice"
         assert result["total"] == 1
-        assert result["notice"] is None  # nothing truncated
+        assert result["showing"].startswith("Showing 1-1 of 1 invoices")
 
     def test_filter_by_customer_type(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -8598,7 +8598,7 @@ class TestOverpaymentGuard:
                 amount="4500.00",
             )
         # Lot untouched by the rejected payment.
-        rows = gb.get_outstanding_invoices(compact=False)
+        rows = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert Decimal(rows[0]["amount_due"]) == Decimal("3500.00")
 
     def test_overpay_after_partial_rejected_exact_ok(self, business_book):
@@ -8706,7 +8706,7 @@ class TestOverpaymentGuard:
             ar_split.lot = lot_obj
             book.save()
 
-        rows = gb.get_outstanding_invoices(compact=False)
+        rows = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(rows) == 1
         row = rows[0]
         assert Decimal(row["amount_due"]) == Decimal("-200.00")
@@ -8740,7 +8740,7 @@ class TestOverpaymentGuard:
             post_date="2025-10-01",  # long past — clock would tick
         )
 
-        rows = gb.get_outstanding_invoices(compact=False)
+        rows = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(rows) == 1
         row = rows[0]
         assert row["is_credit_note"] is True
@@ -9438,7 +9438,7 @@ class TestGetOutstandingInvoices:
 
     def test_empty_when_none_posted(self, business_book):
         gb = GnuCashBook(str(business_book))
-        result = gb.get_outstanding_invoices(compact=False)
+        result = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert result == []
 
     def test_shows_posted_unpaid(self, business_book):
@@ -9456,7 +9456,7 @@ class TestGetOutstandingInvoices:
             invoice_id="000001",
             post_account="Assets:Accounts Receivable",
         )
-        result = gb.get_outstanding_invoices(compact=False)
+        result = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(result) == 1
         assert result[0]["id"] == "000001"
         assert Decimal(result[0]["amount_due"]) == Decimal("500")
@@ -9481,7 +9481,7 @@ class TestGetOutstandingInvoices:
             payment_account="Assets:Checking",
             amount="500",
         )
-        result = gb.get_outstanding_invoices(compact=False)
+        result = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(result) == 0
 
     def test_partially_paid_shows_correct_amounts(self, business_book):
@@ -9504,7 +9504,7 @@ class TestGetOutstandingInvoices:
             payment_account="Assets:Checking",
             amount="200",
         )
-        result = gb.get_outstanding_invoices(compact=False)
+        result = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(result) == 1
         assert Decimal(result[0]["amount_due"]) == Decimal("300")
         assert Decimal(result[0]["amount_paid"]) == Decimal("200")
@@ -9537,7 +9537,7 @@ class TestGetOutstandingInvoices:
             invoice_id="000002",
             post_account="Assets:Accounts Receivable",
         )
-        result = gb.get_outstanding_invoices(customer_id="000001", compact=False)
+        result = gb.get_outstanding_invoices(customer_id="000001", compact=False)["invoices"]
         assert len(result) == 1
         assert result[0]["owner_name"] == "Acme Corp"
 
@@ -9557,7 +9557,7 @@ class TestGetOutstandingInvoices:
             post_account="Liabilities:Accounts Payable",
             owner_type="vendor",
         )
-        result = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
+        result = gb.get_outstanding_invoices(owner_type="vendor", compact=False)["invoices"]
         assert len(result) == 1
         assert result[0]["type"] == "bill"
 
@@ -9651,7 +9651,7 @@ class TestPhase3CommsContracts:
             post_account="Assets:Accounts Receivable",
             post_date="2026-01-01",
         )
-        result = gb.get_outstanding_invoices(compact=False)
+        result = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert isinstance(result, list)
         assert result[0]["due_date"] is not None
         assert result[0]["days_past_due"] is not None
@@ -9724,11 +9724,10 @@ class TestPhase3CommsContracts:
     def test_list_invoices_verbose_envelope_with_truncation(
         self, business_book,
     ):
-        """Bookkeeper-flagged inconsistency: compact mode appended a
-        ``[Showing N of M]`` notice when truncated, but verbose mode
-        returned just a bare list with no truncation signal.
-        Now both modes carry ``count`` / ``total`` / ``notice`` so a
-        verbose-mode caller knows the result is incomplete.
+        """Both modes carry the pagination indicator so a verbose-mode
+        caller knows the result is incomplete: compact leads with the
+        ``Showing X-Y of Z`` line, verbose carries it in ``showing``
+        alongside ``count`` / ``total`` / ``offset``.
         """
         gb = GnuCashBook(str(business_book))
         # 5 invoices, ask for 3.
@@ -9740,9 +9739,8 @@ class TestPhase3CommsContracts:
         assert len(result["invoices"]) == 3
         assert result["count"] == 3
         assert result["total"] == 5
-        assert result["notice"] is not None
-        assert "Showing 3 of 5" in result["notice"]
-        assert "invoices" in result["notice"]
+        assert result["offset"] == 0
+        assert "Showing 1-3 of 5 invoices" in result["showing"]
 
 
 # ============== Vendor Spending Report Tests ==============
@@ -9915,7 +9913,7 @@ class TestInvoiceLifecycle:
         assert Decimal(post_result["total"]) == Decimal("1000")
 
         # Verify outstanding
-        outstanding = gb.get_outstanding_invoices(compact=False)
+        outstanding = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(outstanding) == 1
         assert Decimal(outstanding[0]["amount_due"]) == Decimal("1000")
 
@@ -9928,7 +9926,7 @@ class TestInvoiceLifecycle:
         assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
 
         # Verify no longer outstanding
-        outstanding = gb.get_outstanding_invoices(compact=False)
+        outstanding = gb.get_outstanding_invoices(compact=False)["invoices"]
         assert len(outstanding) == 0
 
     def test_full_bill_lifecycle(self, business_book):
@@ -9958,7 +9956,7 @@ class TestInvoiceLifecycle:
         assert Decimal(post_result["total"]) == Decimal("100")
 
         # Verify outstanding
-        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)["invoices"]
         assert len(outstanding) == 1
 
         # Pay
@@ -9971,7 +9969,7 @@ class TestInvoiceLifecycle:
         assert Decimal(pay_result["remaining_balance"]) == Decimal("0")
 
         # Verify cleared
-        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)
+        outstanding = gb.get_outstanding_invoices(owner_type="vendor", compact=False)["invoices"]
         assert len(outstanding) == 0
 
 
@@ -10725,7 +10723,7 @@ class TestCrossCommodityArRelief:
         assert gb.get_balance(
             account_name="Assets:Accounts Receivable"
         ) == Decimal("0"), "phantom A/R residue after full settlement"
-        assert gb.get_outstanding_invoices(compact=False) == []
+        assert gb.get_outstanding_invoices(compact=False)["invoices"] == []
 
     def test_partial_payment_relieves_pro_rata(self, business_book):
         """A 40% payment relieves 40% of the carried quantity, so

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,7 +9,12 @@ from decimal import Decimal
 
 import pytest
 
-from gnucash_mcp.tools._helpers import _apply_limit, _format_number, _resolve_id_alias
+from gnucash_mcp.tools._helpers import (
+    _apply_limit,
+    _format_number,
+    _paginate,
+    _resolve_id_alias,
+)
 
 
 class TestFormatNumber:
@@ -204,6 +209,167 @@ class TestApplyLimit:
         # Truncation preserves input order (just ``items[:n]``).
         items, _ = _apply_limit(list(range(20)), limit=3)
         assert items == [0, 1, 2]
+
+
+class TestPaginate:
+    """Tests for ``_paginate`` — the offset+limit chokepoint that emits
+    the always-present ``Showing X-Y of Z`` indicator. Mirrors the
+    test list in specs/PAGINATION.md."""
+
+    # ── First page / default ─────────────────────────────────────
+
+    def test_default_first_page(self):
+        # Spec test 1: default call shows ``1-50 of N`` when N > 50.
+        page, ind = _paginate(
+            list(range(109)), entity_name="transactions"
+        )
+        assert page == list(range(50))
+        assert ind == "Showing 1-50 of 109 transactions"
+
+    def test_second_page_offset(self):
+        # Spec test 2: offset=50 returns ``51-100 of N`` with the
+        # correct rows.
+        page, ind = _paginate(
+            list(range(109)), offset=50, entity_name="transactions"
+        )
+        assert page == list(range(50, 100))
+        assert ind == "Showing 51-100 of 109 transactions"
+
+    def test_last_partial_page(self):
+        # Spec test 3: last page shows a partial range.
+        page, ind = _paginate(
+            list(range(109)), offset=100, entity_name="transactions"
+        )
+        assert page == list(range(100, 109))
+        assert ind == "Showing 101-109 of 109 transactions"
+
+    def test_full_set_fits_one_page(self):
+        # Spec test 4: N <= limit shows ``1-N of N``.
+        page, ind = _paginate(
+            list(range(23)), entity_name="transactions"
+        )
+        assert page == list(range(23))
+        assert ind == "Showing 1-23 of 23 transactions"
+
+    # ── Edge cases ───────────────────────────────────────────────
+
+    def test_zero_results(self):
+        # Spec test 5.
+        page, ind = _paginate([], entity_name="transactions")
+        assert page == []
+        assert ind == "Showing 0 of 0 transactions"
+
+    def test_offset_beyond_total(self):
+        # Spec test 6.
+        page, ind = _paginate(
+            list(range(109)), offset=200, entity_name="transactions"
+        )
+        assert page == []
+        assert "of 109 transactions" in ind
+        assert "offset 200 exceeds result count" in ind
+
+    def test_count_only_mode(self):
+        # Spec test 7: limit=0 returns the count-only indicator.
+        page, ind = _paginate(
+            list(range(245)), limit=0, entity_name="transactions"
+        )
+        assert page == []
+        assert ind == "Showing 0 of 245 transactions"
+
+    def test_count_only_includes_date_range(self):
+        page, ind = _paginate(
+            list(range(245)),
+            limit=0,
+            entity_name="transactions",
+            date_range=("2026-01-01", "2026-06-18"),
+        )
+        assert page == []
+        assert ind == (
+            "Showing 0 of 245 transactions "
+            "(2026-01-01 to 2026-06-18)"
+        )
+
+    # ── Date range ───────────────────────────────────────────────
+
+    def test_date_range_appended(self):
+        # Spec test 9: date range reflects the full result set.
+        _, ind = _paginate(
+            list(range(109)),
+            entity_name="transactions",
+            date_range=("2026-05-01", "2026-06-12"),
+        )
+        assert ind == (
+            "Showing 1-50 of 109 transactions "
+            "(2026-05-01 to 2026-06-12)"
+        )
+
+    def test_date_range_omitted_when_undated(self):
+        _, ind = _paginate(
+            list(range(5)), entity_name="accounts", date_range=None
+        )
+        assert ind == "Showing 1-5 of 5 accounts"
+
+    def test_date_range_skipped_when_member_missing(self):
+        _, ind = _paginate(
+            list(range(5)),
+            entity_name="prices",
+            date_range=(None, None),
+        )
+        assert ind == "Showing 1-5 of 5 prices"
+
+    # ── Server-side cap ──────────────────────────────────────────
+
+    def test_limit_above_cap_clamps_with_note(self):
+        page, ind = _paginate(
+            list(range(500)), limit=999, max_cap=250,
+            entity_name="transactions",
+        )
+        assert len(page) == 250
+        assert ind == (
+            "Showing 1-250 of 500 transactions; limit capped at 250"
+        )
+
+    def test_cap_note_present_even_when_results_fit(self):
+        # Like ``_apply_limit``'s "[Limit capped at N]" heads-up: a
+        # requested limit above the ceiling is flagged so the LLM knows
+        # the server cap exists, even when the page held everything.
+        _, ind = _paginate(
+            list(range(100)), limit=999, max_cap=250,
+            entity_name="transactions",
+        )
+        assert ind == (
+            "Showing 1-100 of 100 transactions; limit capped at 250"
+        )
+
+    def test_no_cap_note_when_limit_within_cap(self):
+        _, ind = _paginate(
+            list(range(100)), limit=200, max_cap=250,
+            entity_name="transactions",
+        )
+        assert "capped" not in ind
+        assert ind == "Showing 1-100 of 100 transactions"
+
+    # ── Defaults / clamping ──────────────────────────────────────
+
+    def test_falsy_limit_uses_default(self):
+        page, _ = _paginate(
+            list(range(100)), limit=None, default=10,
+            entity_name="x",
+        )
+        assert len(page) == 10
+
+    def test_negative_offset_clamps_to_zero(self):
+        page, ind = _paginate(
+            list(range(10)), offset=-5, entity_name="x"
+        )
+        assert page == list(range(10))
+        assert ind == "Showing 1-10 of 10 x"
+
+    def test_indicator_always_returned(self):
+        # The contract: indicator is never None, for any input.
+        for args in [([],), (list(range(3)),), (list(range(300)),)]:
+            _, ind = _paginate(*args, entity_name="x")
+            assert isinstance(ind, str) and ind
 
 
 class TestSafeToolWriteVerificationRouting:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -276,46 +276,98 @@ class TestPaginate:
         assert page == []
         assert ind == "Showing 0 of 245 transactions"
 
-    def test_count_only_includes_date_range(self):
+    def test_count_only_spans_full_set(self):
+        # Count-only has no page, so the range is the full set's scope.
+        rows = [{"d": f"2026-01-{i:02d}"} for i in range(1, 11)]
         page, ind = _paginate(
-            list(range(245)),
-            limit=0,
-            entity_name="transactions",
-            date_range=("2026-01-01", "2026-06-18"),
+            rows, limit=0, entity_name="transactions",
+            date_key=lambda r: r["d"],
         )
         assert page == []
         assert ind == (
-            "Showing 0 of 245 transactions "
-            "(2026-01-01 to 2026-06-18)"
+            "Showing 0 of 10 transactions (2026-01-01 to 2026-01-10)"
         )
 
-    # ── Date range ───────────────────────────────────────────────
+    # ── Date range — spans the current PAGE ──────────────────────
 
-    def test_date_range_appended(self):
-        # Spec test 9: date range reflects the full result set.
+    def _dated_rows(self):
+        # 10 rows, one per day 2026-01-01 .. 2026-01-10.
+        return [{"d": f"2026-01-{i:02d}"} for i in range(1, 11)]
+
+    def test_page_range_is_current_page_not_full_set(self):
+        rows = self._dated_rows()
         _, ind = _paginate(
-            list(range(109)),
+            rows, offset=3, limit=3, entity_name="transactions",
+            date_key=lambda r: r["d"],
+        )
+        # Rows 4-6 carry dates 04/05/06 — the page's window, not the
+        # full 01..10 span. This is the actionable navigation signal.
+        assert ind == (
+            "Showing 4-6 of 10 transactions (2026-01-04 to 2026-01-06)"
+        )
+
+    def test_page_range_moves_with_offset(self):
+        rows = self._dated_rows()
+        _, first = _paginate(
+            rows, offset=0, limit=3, date_key=lambda r: r["d"],
             entity_name="transactions",
-            date_range=("2026-05-01", "2026-06-12"),
+        )
+        _, second = _paginate(
+            rows, offset=3, limit=3, date_key=lambda r: r["d"],
+            entity_name="transactions",
+        )
+        assert "(2026-01-01 to 2026-01-03)" in first
+        assert "(2026-01-04 to 2026-01-06)" in second
+
+    def test_full_page_spans_whole_set(self):
+        # When everything fits, page range == full range.
+        rows = self._dated_rows()
+        _, ind = _paginate(
+            rows, entity_name="transactions", date_key=lambda r: r["d"],
         )
         assert ind == (
-            "Showing 1-50 of 109 transactions "
-            "(2026-05-01 to 2026-06-12)"
+            "Showing 1-10 of 10 transactions (2026-01-01 to 2026-01-10)"
         )
 
-    def test_date_range_omitted_when_undated(self):
+    def test_date_key_handles_date_and_datetime(self):
+        from datetime import date, datetime
+        rows = [
+            {"d": date(2026, 3, 1)},
+            {"d": datetime(2026, 3, 15, 10, 59)},
+        ]
         _, ind = _paginate(
-            list(range(5)), entity_name="accounts", date_range=None
+            rows, entity_name="transactions", date_key=lambda r: r["d"],
         )
+        assert ind.endswith("(2026-03-01 to 2026-03-15)")
+
+    def test_date_key_trims_iso_timestamp_to_day(self):
+        rows = [{"d": "2026-04-30T10:59:00+00:00"}]
+        _, ind = _paginate(
+            rows, entity_name="backups", date_key=lambda r: r["d"],
+        )
+        assert ind == "Showing 1-1 of 1 backups (2026-04-30 to 2026-04-30)"
+
+    def test_date_omitted_when_no_date_key(self):
+        _, ind = _paginate(list(range(5)), entity_name="accounts")
         assert ind == "Showing 1-5 of 5 accounts"
 
-    def test_date_range_skipped_when_member_missing(self):
+    def test_date_skipped_when_all_rows_undated(self):
+        rows = [{"d": None}, {"d": None}]
         _, ind = _paginate(
-            list(range(5)),
-            entity_name="prices",
-            date_range=(None, None),
+            rows, entity_name="prices", date_key=lambda r: r["d"],
         )
-        assert ind == "Showing 1-5 of 5 prices"
+        assert ind == "Showing 1-2 of 2 prices"
+
+    def test_offset_beyond_total_shows_full_scope(self):
+        rows = self._dated_rows()
+        page, ind = _paginate(
+            rows, offset=50, entity_name="transactions",
+            date_key=lambda r: r["d"],
+        )
+        assert page == []
+        assert "offset 50 exceeds result count" in ind
+        # No page to span, so fall back to the full set's window.
+        assert "(2026-01-01 to 2026-01-10)" in ind
 
     # ── Server-side cap ──────────────────────────────────────────
 

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -571,7 +571,7 @@ class TestSplitToDictLotGuid:
         txn_desc = lot_detail["splits"][0]["description"]
 
         # Search for the transaction
-        txns = book.search_transactions(query=txn_desc, field="description", compact=False)
+        txns = book.search_transactions(query=txn_desc, field="description", compact=False)["transactions"]
         assert len(txns) > 0
         txn = book.get_transaction(txns[0]["guid"])
 

--- a/tests/test_lots.py
+++ b/tests/test_lots.py
@@ -91,7 +91,7 @@ class TestCreateLot:
 class TestListLots:
     def test_list_lots_empty(self, investment_book: Path):
         book = GnuCashBook(str(investment_book))
-        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
+        result = book.list_lots(account="Assets:Investments:VTSAX", compact=False)["lots"]
         assert result == []
 
     def test_list_lots_with_lots(self, investment_book: Path):
@@ -107,7 +107,7 @@ class TestListLots:
         result = book.list_lots(
             account="Assets:Investments:VTSAX",
             include_closed=True, compact=False,
-        )
+        )["lots"]
         assert len(result) == 2
         titles = {r["title"] for r in result}
         assert titles == {"Lot A", "Lot B"}
@@ -128,14 +128,14 @@ class TestListLots:
         # Default view: zero empty lots show up.
         result = book.list_lots(
             account="Assets:Investments:VTSAX", compact=False,
-        )
+        )["lots"]
         assert result == []
 
         # Audit view: both surface.
         result = book.list_lots(
             account="Assets:Investments:VTSAX",
             include_closed=True, compact=False,
-        )
+        )["lots"]
         assert len(result) == 2
 
     def test_list_lots_exclude_closed(self, investment_book: Path):
@@ -161,7 +161,7 @@ class TestListLots:
         # Default: exclude closed AND empty.
         result = book.list_lots(
             account="Assets:Investments:VTSAX", compact=False,
-        )
+        )["lots"]
         assert len(result) == 1
         assert result[0]["title"] == "Open Lot"
 
@@ -169,7 +169,7 @@ class TestListLots:
         result = book.list_lots(
             account="Assets:Investments:VTSAX",
             include_closed=True, compact=False,
-        )
+        )["lots"]
         assert len(result) == 2
 
 
@@ -528,11 +528,11 @@ class TestFullLotWorkflow:
         assert len(lot_detail["splits"]) == 2
 
         # Verify excluded from default list
-        lots = book.list_lots(account="Assets:Investments:VTSAX", compact=False)
+        lots = book.list_lots(account="Assets:Investments:VTSAX", compact=False)["lots"]
         assert len(lots) == 0
 
         # Verify included when include_closed=True
-        lots = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True, compact=False)
+        lots = book.list_lots(account="Assets:Investments:VTSAX", include_closed=True, compact=False)["lots"]
         assert len(lots) == 1
         assert lots[0]["is_closed"] is True
 

--- a/tests/test_pathological_shapes.py
+++ b/tests/test_pathological_shapes.py
@@ -156,7 +156,7 @@ class TestCrossSurfaceAgreement:
         without raising, in compact and verbose modes."""
         gb = GnuCashBook(str(pathological_book.path))
 
-        verbose = gb.list_transactions(compact=False, limit=250)
+        verbose = gb.list_transactions(compact=False, limit=250)["transactions"]
         descriptions = {t["description"] for t in verbose}
         assert "Opening balance" in descriptions
         assert "Transfer to savings" in descriptions
@@ -167,7 +167,7 @@ class TestCrossSurfaceAgreement:
 
         hits = gb.search_transactions(
             "Manual overpayment", compact=False,
-        )
+        )["transactions"]
         assert len(hits) == 1
         assert isinstance(
             gb.search_transactions("150", field="amount"), str
@@ -189,7 +189,7 @@ class TestNativeSxTemplateLeak:
         self, pathological_book,
     ):
         gb = GnuCashBook(str(pathological_book.path))
-        verbose = gb.list_transactions(compact=False, limit=250)
+        verbose = gb.list_transactions(compact=False, limit=250)["transactions"]
         descriptions = {t["description"] for t in verbose}
         assert "Mortgage Payment" not in descriptions, (
             "SX template recipe rendered as a real transaction"
@@ -199,11 +199,11 @@ class TestNativeSxTemplateLeak:
         self, pathological_book,
     ):
         gb = GnuCashBook(str(pathological_book.path))
-        assert gb.search_transactions("Mortgage", compact=False) == []
+        assert gb.search_transactions("Mortgage", compact=False)["transactions"] == []
         # Amount search must not surface the template's 2,485 either.
         assert gb.search_transactions(
             "2485", field="amount", compact=False,
-        ) == []
+        )["transactions"] == []
 
     def test_template_does_not_stretch_dashboard_dates(
         self, pathological_book,
@@ -460,7 +460,7 @@ class TestFutureDatedNowSurfaces:
         assert Decimal(nw["net_worth"]) == EXPECTED_NET_WORTH
         # ...but the register still shows it — it's a real entry,
         # just not a "now" event.
-        verbose = gb.list_transactions(compact=False, limit=250)
+        verbose = gb.list_transactions(compact=False, limit=250)["transactions"]
         assert "Scheduled rent (future)" in {
             t["description"] for t in verbose
         }
@@ -487,14 +487,14 @@ class TestNullPostDateRows:
         self._null_grocery_date(gc)
 
         # Unbounded listing renders it (sorted oldest, date=None).
-        listed = gc.list_transactions(compact=False, limit=50)
+        listed = gc.list_transactions(compact=False, limit=50)["transactions"]
         by_desc = {t["description"]: t for t in listed}
         assert "Weekly Groceries" in by_desc
         assert by_desc["Weekly Groceries"]["date"] is None
         # A start_date bound excludes what can't be dated.
         bounded = gc.list_transactions(
             start_date=date(2024, 1, 1), compact=False,
-        )
+        )["transactions"]
         assert "Weekly Groceries" not in {
             t["description"] for t in bounded
         }
@@ -502,7 +502,7 @@ class TestNullPostDateRows:
         assert "(no date)" in gc.list_transactions(compact=True)
         assert len(gc.search_transactions(
             "Weekly Groceries", compact=False,
-        )) == 1
+        )["transactions"]) == 1
         gc.get_book_summary()
 
     def test_duplicate_detection_skips_undated_rows(

--- a/tests/test_pathological_shapes.py
+++ b/tests/test_pathological_shapes.py
@@ -133,7 +133,7 @@ class TestCrossSurfaceAgreement:
         gb = GnuCashBook(str(pathological_book.path))
         rows = {
             r["id"]: r
-            for r in gb.get_outstanding_invoices(compact=False)
+            for r in gb.get_outstanding_invoices(compact=False)["invoices"]
         }
 
         overpaid = rows[pathological_book.usd_invoice_id]

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -192,7 +192,7 @@ class TestListScheduled:
 
     def test_empty_list(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
-        result = gb.list_scheduled_transactions(compact=False)
+        result = gb.list_scheduled_transactions(compact=False)["scheduled_transactions"]
         assert result == []
 
     def test_lists_created(self, scheduled_book):
@@ -207,7 +207,7 @@ class TestListScheduled:
             start_date="2026-01-01",
             frequency="monthly",
         )
-        result = gb.list_scheduled_transactions(compact=False)
+        result = gb.list_scheduled_transactions(compact=False)["scheduled_transactions"]
         assert len(result) == 1
         assert result[0]["name"] == "Rent"
         assert result[0]["frequency"] == "monthly"
@@ -242,12 +242,12 @@ class TestListScheduled:
         gb.update_scheduled_transaction(r1["guid"], enabled=False)
 
         # Default: enabled_only=True
-        enabled = gb.list_scheduled_transactions(enabled_only=True, compact=False)
+        enabled = gb.list_scheduled_transactions(enabled_only=True, compact=False)["scheduled_transactions"]
         assert len(enabled) == 1
         assert enabled[0]["name"] == "Utils"
 
         # All
-        all_sx = gb.list_scheduled_transactions(enabled_only=False, compact=False)
+        all_sx = gb.list_scheduled_transactions(enabled_only=False, compact=False)["scheduled_transactions"]
         assert len(all_sx) == 2
 
 
@@ -271,7 +271,7 @@ class TestGetUpcoming:
             start_date=tomorrow.isoformat(),
             frequency="monthly",
         )
-        result = gb.get_upcoming_transactions(days=14, compact=False)
+        result = gb.get_upcoming_transactions(days=14, compact=False)["upcoming_transactions"]
         assert len(result) == 1
         assert result[0]["name"] == "Rent"
         assert result[0]["amount"] == "1850.00"
@@ -291,7 +291,7 @@ class TestGetUpcoming:
             start_date=future.isoformat(),
             frequency="monthly",
         )
-        result = gb.get_upcoming_transactions(days=14, compact=False)
+        result = gb.get_upcoming_transactions(days=14, compact=False)["upcoming_transactions"]
         assert len(result) == 0
 
     def test_disabled_excluded(self, scheduled_book):
@@ -308,7 +308,7 @@ class TestGetUpcoming:
             frequency="monthly",
         )
         gb.update_scheduled_transaction(r["guid"], enabled=False)
-        result = gb.get_upcoming_transactions(days=14, compact=False)
+        result = gb.get_upcoming_transactions(days=14, compact=False)["upcoming_transactions"]
         assert len(result) == 0
 
 
@@ -514,7 +514,7 @@ class TestDeleteScheduled:
         assert result["name"] == "Rent"
 
         # Verify gone
-        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)
+        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)["scheduled_transactions"]
         assert len(listed) == 0
 
     def test_delete_nonexistent_error(self, scheduled_book):
@@ -686,7 +686,7 @@ class TestScheduledIntegration:
         )
 
         # List
-        listed = gb.list_scheduled_transactions(compact=False)
+        listed = gb.list_scheduled_transactions(compact=False)["scheduled_transactions"]
         assert len(listed) == 1
         assert listed[0]["name"] == "Monthly Rent"
         assert listed[0]["enabled"] is True
@@ -714,7 +714,7 @@ class TestScheduledIntegration:
 
         # Delete
         gb.delete_scheduled_transaction(sx["guid"])
-        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)
+        listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)["scheduled_transactions"]
         assert len(listed) == 0
 
     def test_multiple_frequencies(self, scheduled_book):
@@ -733,7 +733,7 @@ class TestScheduledIntegration:
                 frequency=freq,
             )
 
-        listed = gb.list_scheduled_transactions(compact=False)
+        listed = gb.list_scheduled_transactions(compact=False)["scheduled_transactions"]
         assert len(listed) == 5
         freqs = {sx["frequency"] for sx in listed}
         assert freqs == {"weekly", "biweekly", "monthly", "quarterly", "yearly"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,7 +1,9 @@
 """Tests for MCP server tools and resources."""
 
+import inspect
 import json
 import os
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1416,3 +1418,91 @@ class TestStrictToolKwargs:
             )
             with pytest.raises(ValidationError):
                 arg_model.model_validate({"this_is_not_a_real_kwarg": "x"})
+
+
+# Compact line-1 indicator: "Showing 1-50 of 109 …" or "Showing 0 of 0 …".
+_INDICATOR_RE = re.compile(r"^Showing (0|\d+-\d+) of \d+ [a-z]")
+
+# (tool, runnable kwargs against the standard test book, verbose entity
+# key). A None key marks a TSV-only tool with no verbose envelope.
+_PAGINATED_TOOLS = [
+    ("list_accounts", {}, "accounts"),
+    ("list_transactions", {}, "transactions"),
+    ("search_transactions", {"query": "a"}, "transactions"),
+    ("get_unreconciled_splits", {"account": "Assets:Checking"}, "splits"),
+    ("list_customers", {}, "customers"),
+    ("list_vendors", {}, "vendors"),
+    ("list_employees", {}, "employees"),
+    ("list_billterms", {}, "billterms"),
+    ("list_taxtables", {}, "taxtables"),
+    ("list_invoices", {}, "invoices"),
+    ("list_jobs", {}, "jobs"),
+    ("get_outstanding_invoices", {}, "invoices"),
+    ("list_scheduled_transactions", {}, "scheduled_transactions"),
+    ("get_upcoming_transactions", {}, "upcoming_transactions"),
+    ("list_commodities", {}, "commodities"),
+    ("get_prices", {"commodity": "USD", "namespace": "CURRENCY"}, "prices"),
+    ("list_lots", {"account": "Assets:Checking"}, "lots"),
+    ("list_budgets", {}, "budgets"),
+    ("list_backups", {}, None),
+    ("get_audit_log", {}, None),
+]
+
+
+class TestPaginationCoverage:
+    """Contract lock for the pagination rollout: every list-returning
+    tool leads with a ``Showing X-Y of Z`` indicator, accepts
+    ``offset``/``limit``, and (where it has a verbose mode) returns the
+    uniform envelope. Mirrors TestToolFileVsModulesMapping — adding a
+    list tool without pagination should fail loudly here."""
+
+    @pytest.mark.parametrize(
+        "tool_name", [t[0] for t in _PAGINATED_TOOLS]
+    )
+    def test_tool_accepts_offset_and_limit(self, tool_name):
+        fn = getattr(server_module, tool_name)
+        params = inspect.signature(fn).parameters
+        assert "offset" in params, f"{tool_name} missing offset param"
+        assert "limit" in params, f"{tool_name} missing limit param"
+
+    @pytest.mark.parametrize(
+        "tool_name,kwargs", [(t[0], t[1]) for t in _PAGINATED_TOOLS]
+    )
+    def test_compact_leads_with_indicator(
+        self, setup_book_env, tool_name, kwargs
+    ):
+        result = getattr(server_module, tool_name)(**kwargs)
+        line0 = result.split("\n")[0]
+        # get_audit_log can't reach its indicator in this fixture: no
+        # log dir is configured, so it returns the not-initialized /
+        # no-file sentinel. Its indicator format is locked by the book
+        # path that DOES have entries; here we only assert it doesn't
+        # masquerade as a row list.
+        if tool_name == "get_audit_log" and not line0.startswith("Showing"):
+            assert "audit log" in line0.lower() or "error" in line0.lower()
+            return
+        assert _INDICATOR_RE.match(line0), (
+            f"{tool_name} compact line 0 is not an indicator: {line0!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "tool_name,kwargs,key",
+        [(t[0], t[1], t[2]) for t in _PAGINATED_TOOLS if t[2]],
+    )
+    def test_verbose_returns_uniform_envelope(
+        self, setup_book_env, tool_name, kwargs, key
+    ):
+        result = getattr(server_module, tool_name)(verbose=True, **kwargs)
+        data = json.loads(result)
+        assert isinstance(data, dict), f"{tool_name} verbose is not a dict"
+        for field in ("showing", "total", "offset", "count"):
+            assert field in data, f"{tool_name} verbose missing {field!r}"
+        assert _INDICATOR_RE.match(data["showing"]), (
+            f"{tool_name} 'showing' is not an indicator: {data['showing']!r}"
+        )
+        assert key in data, f"{tool_name} verbose missing entity key {key!r}"
+
+    def test_count_only_mode(self, setup_book_env):
+        """limit=0 yields a zero-page indicator with the full total."""
+        result = server_module.list_transactions(limit=0)
+        assert result.startswith("Showing 0 of 3 transactions")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -187,20 +187,26 @@ class TestListTransactionsTool:
     """Tests for list_transactions tool."""
 
     def test_list_all_transactions(self, setup_book_env):
-        """Should return all transactions."""
+        """Should return all transactions in a paginated envelope."""
         result = server_module.list_transactions(verbose=True)
 
         data = json.loads(result)
-        assert isinstance(data, list)
-        assert len(data) == 3
+        assert isinstance(data, dict)
+        assert len(data["transactions"]) == 3
+        assert data["total"] == 3
+        assert data["offset"] == 0
+        assert data["showing"] == (
+            "Showing 1-3 of 3 transactions (2024-01-01 to 2024-01-20)"
+        )
 
     def test_list_transactions_by_account(self, setup_book_env):
         """Should filter by account."""
         result = server_module.list_transactions(account="Expenses:Groceries", verbose=True)
 
         data = json.loads(result)
-        assert len(data) == 1
-        assert data[0]["description"] == "Weekly Groceries"
+        assert data["total"] == 1
+        assert len(data["transactions"]) == 1
+        assert data["transactions"][0]["description"] == "Weekly Groceries"
 
     def test_list_transactions_date_range(self, setup_book_env):
         """Should filter by date range."""
@@ -209,8 +215,25 @@ class TestListTransactionsTool:
         )
 
         data = json.loads(result)
-        assert len(data) == 1
-        assert data[0]["description"] == "Salary Deposit"
+        assert data["total"] == 1
+        assert data["transactions"][0]["description"] == "Salary Deposit"
+
+    def test_list_transactions_offset_pages(self, setup_book_env):
+        """offset should page through the result set."""
+        page2 = json.loads(
+            server_module.list_transactions(limit=2, offset=2, verbose=True)
+        )
+        assert page2["offset"] == 2
+        assert page2["total"] == 3
+        assert len(page2["transactions"]) == 1
+        assert page2["showing"].startswith("Showing 3-3 of 3 transactions")
+
+    def test_list_transactions_count_only(self, setup_book_env):
+        """limit=0 returns the count without rows."""
+        data = json.loads(server_module.list_transactions(limit=0, verbose=True))
+        assert data["transactions"] == []
+        assert data["total"] == 3
+        assert data["showing"].startswith("Showing 0 of 3 transactions")
 
 
 class TestGetTransactionTool:
@@ -345,15 +368,17 @@ class TestSearchTransactionsTool:
         result = server_module.search_transactions("Salary", verbose=True)
 
         data = json.loads(result)
-        assert len(data) == 1
-        assert data[0]["description"] == "Salary Deposit"
+        assert data["total"] == 1
+        assert data["transactions"][0]["description"] == "Salary Deposit"
 
     def test_search_by_amount(self, setup_book_env):
         """Should find transactions by amount range."""
         result = server_module.search_transactions(">500", field="amount", verbose=True)
 
         data = json.loads(result)
-        assert len(data) == 2  # Opening Balance (1000) and Salary (2000)
+        # Opening Balance (1000) and Salary (2000)
+        assert data["total"] == 2
+        assert len(data["transactions"]) == 2
 
 
 class TestCreateAccountTool:
@@ -475,7 +500,7 @@ class TestDeleteTransactionTool:
     def test_delete_transaction(self, setup_book_env):
         """Should delete a transaction and return result."""
         # First get a transaction to delete
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.delete_transaction(guid)
@@ -491,7 +516,7 @@ class TestDeleteTransactionTool:
 
     def test_delete_reconciled_rejected(self, setup_book_env):
         """Should reject deleting a transaction with reconciled splits."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
         server_module.set_reconcile_state(split_guid, "y")
         guid = transactions[0]["guid"]
@@ -504,7 +529,7 @@ class TestDeleteTransactionTool:
 
     def test_delete_reconciled_force(self, setup_book_env):
         """Should allow deleting reconciled transaction with force=True."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
         server_module.set_reconcile_state(split_guid, "y")
         guid = transactions[0]["guid"]
@@ -529,7 +554,7 @@ class TestUpdateTransactionTool:
 
     def test_update_description(self, setup_book_env):
         """Should update transaction description."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -543,7 +568,7 @@ class TestUpdateTransactionTool:
 
     def test_update_date(self, setup_book_env):
         """Should update transaction date."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -558,7 +583,7 @@ class TestUpdateTransactionTool:
     def test_update_splits(self, setup_book_env):
         """Should update transaction split amounts."""
         # Find the groceries transaction which has known accounts
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -588,7 +613,7 @@ class TestUpdateTransactionTool:
 
     def test_update_unbalanced_splits(self, setup_book_env):
         """Should return error for unbalanced splits."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.update_transaction(
@@ -605,7 +630,7 @@ class TestUpdateTransactionTool:
 
     def test_update_reconciled_splits_rejected(self, setup_book_env):
         """Should reject updating splits on a reconciled transaction."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -627,7 +652,7 @@ class TestUpdateTransactionTool:
 
     def test_update_reconciled_force(self, setup_book_env):
         """Should allow updating reconciled splits with force=True."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         groceries_trans = next(
             t for t in transactions if t["description"] == "Weekly Groceries"
         )
@@ -661,7 +686,7 @@ class TestReplaceSplitsTool:
         )
 
         # Find a transaction to replace splits on
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         grocery_txn = next(
             t for t in transactions if "Groceries" in t["description"]
         )
@@ -686,7 +711,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_returns_previous_splits(self, setup_book_env):
         """Should include previous_splits for audit trail."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         grocery_txn = next(
             t for t in transactions if "Groceries" in t["description"]
         )
@@ -706,7 +731,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_unbalanced_error(self, setup_book_env):
         """Should return error for unbalanced splits."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.replace_splits(
@@ -723,7 +748,7 @@ class TestReplaceSplitsTool:
 
     def test_replace_splits_placeholder_error(self, setup_book_env):
         """Should return error for placeholder account."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.replace_splits(
@@ -744,7 +769,7 @@ class TestSetReconcileStateTool:
 
     def test_set_reconcile_state(self, setup_book_env):
         """Should set reconcile state on a split."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = server_module.set_reconcile_state(split_guid, "c")
@@ -752,7 +777,7 @@ class TestSetReconcileStateTool:
         data = json.loads(result)
         # `reconcile_state` echo dropped — verified through read-back.
         assert data["status"] == "updated"
-        refreshed = json.loads(server_module.list_transactions(verbose=True))
+        refreshed = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         updated_split = next(
             s for t in refreshed for s in t["splits"] if s["guid"] == split_guid
         )
@@ -760,7 +785,7 @@ class TestSetReconcileStateTool:
 
     def test_set_reconcile_state_invalid(self, setup_book_env):
         """Should return error for invalid state."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         split_guid = transactions[0]["splits"][0]["guid"]
 
         result = server_module.set_reconcile_state(split_guid, "x")
@@ -842,7 +867,7 @@ class TestVoidTransactionTool:
 
     def test_void_transaction(self, setup_book_env):
         """Should void a transaction."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.void_transaction(guid, "Test void reason")
@@ -853,7 +878,7 @@ class TestVoidTransactionTool:
 
     def test_void_transaction_no_reason(self, setup_book_env):
         """Should return error if no reason provided."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.void_transaction(guid, "")
@@ -867,7 +892,7 @@ class TestUnvoidTransactionTool:
 
     def test_unvoid_transaction(self, setup_book_env):
         """Should restore a voided transaction."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         # Void first
@@ -881,7 +906,7 @@ class TestUnvoidTransactionTool:
 
     def test_unvoid_not_voided(self, setup_book_env):
         """Should return error if transaction not voided."""
-        transactions = json.loads(server_module.list_transactions(verbose=True))
+        transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]
         guid = transactions[0]["guid"]
 
         result = server_module.unvoid_transaction(guid)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -82,20 +82,23 @@ class TestListAccountsTool:
         assert "\n" in result
 
     def test_list_accounts_verbose(self, setup_book_env):
-        """verbose=True should return full JSON."""
+        """verbose=True should return the paginated envelope."""
         result = server_module.list_accounts(verbose=True)
 
         data = json.loads(result)
-        assert isinstance(data, list)
-        assert len(data) > 0
-        fullnames = {a["fullname"] for a in data}
+        assert isinstance(data, dict)
+        assert data["showing"].startswith("Showing 1-")
+        accounts = data["accounts"]
+        assert len(accounts) > 0
+        fullnames = {a["fullname"] for a in accounts}
         assert "Assets" in fullnames
         assert "Assets:Checking" in fullnames
 
     def test_list_accounts_root_filter(self, setup_book_env):
         """root parameter should filter accounts."""
         result = server_module.list_accounts(root="Expenses")
-        lines = result.strip().split("\n")
+        # Skip the leading "Showing X-Y of Z accounts" indicator.
+        lines = result.strip().split("\n")[1:]
         for line in lines:
             # Compact line format: '%shortguid<TAB>fullname [ANNOTATION]'.
             # Pull the path portion off before checking the prefix.
@@ -106,8 +109,7 @@ class TestListAccountsTool:
         """root + verbose should return filtered JSON."""
         result = server_module.list_accounts(root="Assets", verbose=True)
         data = json.loads(result)
-        assert isinstance(data, list)
-        for a in data:
+        for a in data["accounts"]:
             assert a["fullname"].startswith("Assets")
 
 


### PR DESCRIPTION
## Summary

Adds pagination to **all 20 list-returning tools** so a truncated view is never silent — every list response now leads with a `Showing X-Y of Z <entity> (date range)` indicator and accepts an `offset`. This closes the failure class behind the original bug: 93 of 109 checking transactions were returned, the LLM assumed completeness, and 16 missing entries went undetected for a reconciliation session.

- **Chokepoint** — `_paginate(items, offset, limit, default=50, max_cap=250, entity_name, date_key)` in `gnucash_mcp/_format.py` retired *both* prior truncation mechanisms (`_apply_limit` and the bespoke `_truncation_notice`). Handles count-only (`limit=0`), offset-beyond-total, the 250 server cap (with a `; limit capped at 250` note), and the date range. The `_iso_date` normalizer lives in layer-neutral `_format.py` so the book layer never reaches upward.
- **Date range spans the current page, not the full set.** On a chronological list the page's window is the actionable navigation signal — `offset=250 → (2025-10-17 to 2025-12-13)` lets the LLM do the time arithmetic ("I'm in Oct–Dec, I need May → jump toward the front") instead of paging blindly. Count-only (`limit=0`) and offset-beyond-total keep the full-set range, since they have no page and answer the "what's the scope?" question. Callers pass a `date_key` callable (`row → date/datetime/ISO`); `_paginate` computes the range from whatever rows it shows.
- **Uniform verbose envelope** everywhere: `{<entity>, showing, total, offset, count}`. The 14 tools that previously returned bare JSON lists now return the envelope; the 6 that already had `{…, count, total, notice}` envelopes swapped `notice` → `showing` + `offset`.
- **Dated tools** (`list_transactions`, `search_transactions`, `get_unreconciled_splits`, `list_invoices`, `get_outstanding_invoices`, `get_prices`, `get_upcoming_transactions`, `list_backups`) render `(earliest to latest)`; undated tools omit the parens.
- **Two principled deviations**, documented in code: `list_backups` paginates at the tool layer so its book method stays a full list for internal callers; `get_audit_log` uses a recency-anchored window (offset pages *backward* from the newest entry) since a log is read newest-first.
- **Contract lock** — `tests/test_tools.py::TestPaginationCoverage` is parametrized over all 20 tools: each accepts `offset`/`limit`, leads compact output with the indicator, and (where it has a verbose mode) returns the uniform envelope. Mirrors `TestToolFileVsModulesMapping` — a new list tool added without pagination fails loudly here.

## Test plan

- [x] 22 unit tests for `_paginate` covering every spec edge case (first/second/last page, zero results, offset-beyond-total, count-only, cap note, defaults/clamping) plus the page-range behavior (range moves with offset, count-only spans full scope, date/datetime/ISO-timestamp normalization)
- [x] `TestPaginationCoverage` contract test green across all 20 tools
- [x] Full suite: **1675/1675 pass**
- [x] Bookkeeper round: ~12 non-business tools validated live; the page-range refinement came directly from bookkeeper feedback (full range repeated on every page is dead weight after page 1)
- [x] Business tools (8) smoke-tested against Alex's book (LLC, 4 customers, 39 invoices, jobs, taxtables) — dated indicators, paging, count-only, verbose envelopes all correct
- [x] Cap guard verified on Alex's checking (1672 txns): `limit=1000` → `Showing 1-250 of 1672 transactions; limit capped at 250 (…)`; `offset=250` continues `Showing 251-500 of 1672`
- [x] Page-range verified on Alex's checking: `count-only → (2025-01-01 to 2026-05-30)` full scope; `offset=0 → (2025-12-13 to 2026-05-30)`; `offset=250 → (2025-10-17 to 2025-12-13)`; `offset=1500 → (2025-01-01 to 2025-02-18)`