### PR TITLE
feat: group_by sub-period columns for the aggregation reports

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -16,10 +16,139 @@ Two pieces:
   plug in its own entity name.
 """
 
+import calendar
 import os
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import TypeVar
+
+
+# ── Period bucketing (group_by) ────────────────────────────────────
+
+# Valid group_by sub-period granularities for the period breakdowns
+# (spending_by_category, income_by_source, cash_flow,
+# vendor_spending_report). Shared so every consumer rejects the same
+# set and the column-label vocabulary stays in one place.
+_GROUP_BY_VALUES = ("month", "quarter", "year")
+
+
+def _period_label(d: date, group_by: str) -> str:
+    """Map a date to its sub-period column label.
+
+    ``month`` → ``YYYY-MM``; ``quarter`` → ``YYYY-Q#``; ``year`` →
+    ``YYYY``. Used both to enumerate columns and to bucket each
+    record by its date, so the two always agree.
+    """
+    if group_by == "month":
+        return f"{d.year:04d}-{d.month:02d}"
+    if group_by == "quarter":
+        return f"{d.year:04d}-Q{(d.month - 1) // 3 + 1}"
+    return f"{d.year:04d}"
+
+
+def _enumerate_periods(
+    start_date: date, end_date: date, group_by: str
+) -> list[tuple[str, date]]:
+    """Ordered ``(label, anchor_date)`` pairs covering the range.
+
+    Every sub-period that overlaps ``[start_date, end_date]`` gets a
+    column, including empty ones (so a gap month still renders a
+    ``0.00`` column). The anchor date is the period's natural
+    calendar end clamped to ``end_date`` — FX/commodity rates value
+    each period at its own close, never at today's rates.
+    """
+    periods: list[tuple[str, date]] = []
+    if group_by == "month":
+        y, m = start_date.year, start_date.month
+        while (y, m) <= (end_date.year, end_date.month):
+            last = date(y, m, calendar.monthrange(y, m)[1])
+            periods.append((f"{y:04d}-{m:02d}", min(last, end_date)))
+            m += 1
+            if m > 12:
+                m, y = 1, y + 1
+    elif group_by == "quarter":
+        y = start_date.year
+        q = (start_date.month - 1) // 3 + 1
+        end_q = (end_date.month - 1) // 3 + 1
+        while (y, q) <= (end_date.year, end_q):
+            last_month = q * 3
+            last = date(y, last_month, calendar.monthrange(y, last_month)[1])
+            periods.append((f"{y:04d}-Q{q}", min(last, end_date)))
+            q += 1
+            if q > 4:
+                q, y = 1, y + 1
+    else:  # year
+        for y in range(start_date.year, end_date.year + 1):
+            periods.append((f"{y:04d}", min(date(y, 12, 31), end_date)))
+    return periods
+
+
+def _strip_common_prefix(names: list[str]) -> list[str]:
+    """Drop a shared top-level ``Expenses:`` / ``Income:`` prefix.
+
+    Leaf labels stay readable when every row shares a prefix; full
+    paths survive a heterogeneous mix (or names without a ``:`` at
+    all, e.g. vendor names).
+    """
+    if names and ":" in names[0]:
+        candidate = names[0].split(":")[0] + ":"
+        if all(n.startswith(candidate) for n in names):
+            return [n[len(candidate):] for n in names]
+    return list(names)
+
+
+def _format_grouped_tsv(
+    *,
+    period_labels: list[str],
+    displayed_names: list[str],
+    totals: dict[str, dict[str, Decimal]],
+    row_totals: dict[str, Decimal],
+    period_totals: dict[str, Decimal],
+    grand_total: Decimal,
+    excluded: list[tuple[str, Decimal]],
+    label: str,
+) -> str:
+    """Render an entity × sub-period breakdown as a TSV table.
+
+    Columns: the leading ``label``, one per sub-period, then ``Total``
+    (sum across periods) and ``Avg`` (Total / number of periods). The
+    trailing ``TOTAL`` row sums every entity per period —
+    net-negative-overall entities are netted in here even though they
+    get no row of their own, keeping the column totals tied to
+    single-period mode. ``excluded`` (entities dropped from the rows)
+    drives an explanatory footnote when non-empty.
+
+    Shared by the category/source breakdowns and vendor spending; the
+    cash-flow trend uses its own fixed-row formatter.
+    """
+    num_periods = len(period_labels)
+    leaves = _strip_common_prefix(displayed_names)
+    lines = ["\t".join([label, *period_labels, "Total", "Avg"])]
+    for name, leaf in zip(displayed_names, leaves):
+        per = totals.get(name, {})
+        cells = [leaf]
+        cells += [f"{per.get(pl, Decimal('0')):.2f}" for pl in period_labels]
+        tot = row_totals[name]
+        avg = tot / num_periods if num_periods else Decimal("0")
+        cells += [f"{tot:.2f}", f"{avg:.2f}"]
+        lines.append("\t".join(cells))
+
+    avg_total = grand_total / num_periods if num_periods else Decimal("0")
+    total_cells = ["TOTAL"]
+    total_cells += [f"{period_totals[pl]:.2f}" for pl in period_labels]
+    total_cells += [f"{grand_total:.2f}", f"{avg_total:.2f}"]
+    lines.append("\t".join(total_cells))
+
+    out = "\n".join(lines)
+    if excluded:
+        netted = ", ".join(
+            f"{n} {t:,.2f}"
+            for n, t in sorted(excluded, key=lambda x: x[1])
+        )
+        out += (
+            f"\n({len(excluded)} net-negative netted into TOTAL: {netted})"
+        )
+    return out
 
 
 # ── Numeric formatting ─────────────────────────────────────────────

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -26,7 +26,13 @@ from gnucash_mcp.book._base import (
     _verify_composite_write,
     _verify_write,
 )
-from gnucash_mcp._format import _paginate
+from gnucash_mcp._format import (
+    _GROUP_BY_VALUES,
+    _enumerate_periods,
+    _format_grouped_tsv,
+    _paginate,
+    _period_label,
+)
 
 
 def _commodity_quantum(commodity) -> Decimal:
@@ -7050,12 +7056,121 @@ class BusinessMixin:
                 "invoices": invoice_rows,
             }
 
+    def _bill_billed_total(self, book, bill) -> Decimal:
+        """Total billed on a bill, in the bill's own currency.
+
+        Mirrors the single-period path: the invoice-entries grand
+        total, falling back to the post-lot balance when entries are
+        empty or corrupted (substituting 0 would understate the
+        vendor's total by the whole bill).
+        """
+        try:
+            return self._get_invoice_entries_and_total(
+                book, bill,
+            )["grand_total"]
+        except ValueError:
+            post_acct = book.session.query(
+                piecash.Account
+            ).filter_by(guid=bill.post_acc_guid).first()
+            if post_acct:
+                for lot in post_acct.lots:
+                    if lot.guid == bill.post_lot_guid:
+                        return abs(self._calculate_lot_balance(lot))
+            return Decimal(0)
+
+    def _grouped_vendor_spending(
+        self,
+        book,
+        *,
+        bills,
+        start_date: date,
+        end_date: date,
+        group_by: str,
+        default_currency,
+    ) -> str:
+        """Bucket total-billed per vendor into sub-period columns.
+
+        Each bill lands in its ``date_posted`` sub-period and converts
+        at that period's close — never today's rates. Bills with no FX
+        rate on file are excluded from the converted totals and
+        surfaced in a trailing warning, exactly as the single-period
+        report handles them.
+        """
+        periods = _enumerate_periods(start_date, end_date, group_by)
+        period_labels = [pl for pl, _ in periods]
+        rates_by_period = {
+            pl: self._rates_as_of(book, anchor) for pl, anchor in periods
+        }
+        quantum = _commodity_quantum(default_currency)
+
+        totals: dict[str, dict[str, Decimal]] = {}
+        unconverted: dict[str, dict] = {}
+        for bill in bills:
+            posted = _safe_invoice_date(bill, "date_posted")
+            if posted is None:
+                continue
+            plabel = _period_label(posted.date(), group_by)
+            total = self._bill_billed_total(book, bill)
+
+            if bill.currency != default_currency:
+                rate = rates_by_period[plabel].get(bill.currency.guid)
+                if rate is None:
+                    u = unconverted.setdefault(
+                        bill.currency.mnemonic,
+                        {"total_billed": Decimal(0), "bill_count": 0},
+                    )
+                    u["total_billed"] += total
+                    u["bill_count"] += 1
+                    continue
+                total = (total * rate).quantize(quantum)
+
+            v = self._find_vendor_by_guid(book, bill.owner_guid)
+            v_name = v.name if v else "Unknown"
+            bucket = totals.setdefault(v_name, {})
+            bucket[plabel] = bucket.get(plabel, Decimal(0)) + total
+
+        row_totals = {
+            name: sum(per.values(), Decimal(0))
+            for name, per in totals.items()
+        }
+        # Billed totals are non-negative, so there is no net-negative
+        # exclusion here (unlike the category breakdowns).
+        displayed_names = sorted(
+            row_totals, key=lambda n: row_totals[n], reverse=True,
+        )
+        period_totals = {pl: Decimal(0) for pl in period_labels}
+        for per in totals.values():
+            for pl, v in per.items():
+                period_totals[pl] += v
+        grand_total = sum(row_totals.values(), Decimal(0))
+
+        out = _format_grouped_tsv(
+            period_labels=period_labels,
+            displayed_names=displayed_names,
+            totals=totals,
+            row_totals=row_totals,
+            period_totals=period_totals,
+            grand_total=grand_total,
+            excluded=[],
+            label="Vendor",
+        )
+        if unconverted:
+            mnem = default_currency.mnemonic
+            for ccy, d in unconverted.items():
+                out += (
+                    f"\n⚠ {d['bill_count']} bill(s) in {ccy} excluded from "
+                    f"{mnem} totals — no exchange rate on file "
+                    f"(raw {ccy}: billed {d['total_billed']})"
+                )
+        return out
+
     def vendor_spending_report(
         self,
         start_date: str,
         end_date: str,
         vendor_id: str | None = None,
         compact: bool = True,
+        group_by: str | None = None,
     ) -> dict | str:
         """Get spending breakdown by vendor for a period.
 
@@ -7068,8 +7183,20 @@ class BusinessMixin:
             vendor_id: Optional filter to one vendor.
             compact: Aligned text table with TOTAL row (default),
                 or the structured dict.
+            group_by: ``None`` (default) for the single-period
+                billed/paid/outstanding view; ``"month"`` /
+                ``"quarter"`` / ``"year"`` to split the range into
+                sub-period columns of **total billed** per vendor and
+                return a multi-period TSV table — surfaces per-vendor
+                spend trends (a spike at one vendor in one month).
         """
         from piecash.business.invoice import Invoice
+
+        if group_by is not None and group_by not in _GROUP_BY_VALUES:
+            raise ValueError(
+                f"Invalid group_by '{group_by}'. Must be one of: "
+                f"{', '.join(_GROUP_BY_VALUES)}."
+            )
 
         parsed_start = date.fromisoformat(start_date)
         parsed_end = date.fromisoformat(end_date)
@@ -7111,6 +7238,16 @@ class BusinessMixin:
                 if parsed_start <= posted.date() <= parsed_end:
                     filtered_bills.append(b)
             bills = filtered_bills
+
+            if group_by is not None:
+                return self._grouped_vendor_spending(
+                    book,
+                    bills=bills,
+                    start_date=parsed_start,
+                    end_date=parsed_end,
+                    group_by=group_by,
+                    default_currency=default_currency,
+                )
 
             vendor_data: dict[str, dict] = {}
             # Bills with no rate on file are EXCLUDED from

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -195,6 +195,49 @@ def _format_grouped_tsv(
     return out
 
 
+def _format_grouped_cashflow_tsv(
+    *,
+    period_labels: list[str],
+    inflows: dict[str, Decimal],
+    outflows: dict[str, Decimal],
+    account_label: str,
+    transfers_excluded: int,
+) -> str:
+    """Render a multi-period cash-flow trend as a TSV table.
+
+    Three fixed rows — Inflows, Outflows (positive magnitude, matching
+    single-period), and Net (Inflows − Outflows, the build-vs-burn
+    signal a trend view exists for). Columns are the sub-periods plus
+    Total and Avg. A leading title line names the account scope; a
+    trailing note surfaces the ``include_transfers`` escape hatch.
+    """
+    num_periods = len(period_labels)
+    net = {pl: inflows[pl] - outflows[pl] for pl in period_labels}
+
+    def _row(name: str, values: dict[str, Decimal]) -> str:
+        cells = [name]
+        cells += [f"{values[pl]:.2f}" for pl in period_labels]
+        tot = sum(values.values(), Decimal("0"))
+        avg = tot / num_periods if num_periods else Decimal("0")
+        cells += [f"{tot:.2f}", f"{avg:.2f}"]
+        return "\t".join(cells)
+
+    lines = [
+        account_label,
+        "\t".join(["Cash flow", *period_labels, "Total", "Avg"]),
+        _row("Inflows", inflows),
+        _row("Outflows", outflows),
+        _row("Net", net),
+    ]
+    out = "\n".join(lines)
+    if transfers_excluded:
+        out += (
+            f"\n({transfers_excluded} internal transfer txn(s) excluded; "
+            f"include_transfers=true to include)"
+        )
+    return out
+
+
 def _money_compact(value: Decimal, currency: str = "USD") -> str:
     """Format a monetary amount for compact-mode reports.
 
@@ -1009,7 +1052,8 @@ class ReportingMixin:
         end_date: date,
         account: str | None = None,
         include_transfers: bool = False,
-    ) -> dict:
+        group_by: str | None = None,
+    ) -> dict | str:
         """Calculate cash flow (inflows and outflows) for a period.
 
         Scope: BANK and CASH accounts only. Credit-card movements
@@ -1030,14 +1074,23 @@ class ReportingMixin:
             account: Optional single-account filter.
             include_transfers: True includes every cash movement —
                 useful for reconciling against a bank statement.
+            group_by: ``None`` (default) for the single-period dict;
+                ``"month"`` / ``"quarter"`` / ``"year"`` to split the
+                range into sub-period columns and return an
+                Inflows / Outflows / Net trend table (a TSV string).
 
         Returns:
             ``{account, inflows, outflows}`` plus, when transfers
             were filtered, ``transfers_excluded`` — the count of
             distinct cash-touching transactions skipped (surfaced so
             the LLM can mention the ``include_transfers`` escape
-            hatch).
+            hatch). With ``group_by``, a multi-period TSV table.
         """
+        if group_by is not None and group_by not in _GROUP_BY_VALUES:
+            raise ValueError(
+                f"Invalid group_by '{group_by}'. Must be one of: "
+                f"{', '.join(_GROUP_BY_VALUES)}."
+            )
         with self.open(readonly=True) as book:
             # Named-account or all-cash filter; both push to SQL.
             if account:
@@ -1050,6 +1103,7 @@ class ReportingMixin:
                     end_date=end_date,
                     account_guids=frozenset({target_account.guid}),
                 )
+                account_label = target_account.fullname
             else:
                 rows = self._query_filtered_splits(
                     book,
@@ -1057,6 +1111,7 @@ class ReportingMixin:
                     end_date=end_date,
                     account_types=_CASH_TYPES,
                 )
+                account_label = "All cash/bank accounts"
 
             # GUIDs of "real" cash-flow transactions; everything
             # else is a transfer unless include_transfers.
@@ -1066,6 +1121,17 @@ class ReportingMixin:
                 )
             else:
                 cashflow_txn_guids = None  # don't filter
+
+            if group_by is not None:
+                return self._grouped_cash_flow(
+                    book,
+                    rows=rows,
+                    start_date=start_date,
+                    end_date=end_date,
+                    cashflow_txn_guids=cashflow_txn_guids,
+                    group_by=group_by,
+                    account_label=account_label,
+                )
 
             factors = self._account_conversion_factors(book, end_date)
             inflows = Decimal("0")
@@ -1093,16 +1159,65 @@ class ReportingMixin:
             # The canonical fullname is echoed so %short/GUID input
             # still yields a readable name.
             result = {
-                "account": (
-                    target_account.fullname if account
-                    else "All cash/bank accounts"
-                ),
+                "account": account_label,
                 "inflows": str(inflows),
                 "outflows": str(outflows),
             }
             if transfers_excluded:
                 result["transfers_excluded"] = len(transfers_excluded)
             return result
+
+    def _grouped_cash_flow(
+        self,
+        book: piecash.Book,
+        *,
+        rows,
+        start_date: date,
+        end_date: date,
+        cashflow_txn_guids: set[str] | None,
+        group_by: str,
+        account_label: str,
+    ) -> str:
+        """Bucket the cash-flow splits into per-period inflows/outflows.
+
+        Same classification as the single-period path — voided splits
+        skipped, internal transfers excluded unless the caller passed
+        ``cashflow_txn_guids=None`` — but each split lands in its
+        post_date's sub-period and converts at that period's close.
+        """
+        periods = _enumerate_periods(start_date, end_date, group_by)
+        period_labels = [pl for pl, _ in periods]
+        factors_by_period = {
+            pl: self._account_conversion_factors(book, anchor)
+            for pl, anchor in periods
+        }
+
+        inflows = {pl: Decimal("0") for pl in period_labels}
+        outflows = {pl: Decimal("0") for pl in period_labels}
+        transfers_excluded: set[str] = set()
+        for split, txn, acct in rows:
+            if _is_voided(split):
+                continue
+            if cashflow_txn_guids is not None \
+                    and txn.guid not in cashflow_txn_guids:
+                transfers_excluded.add(txn.guid)
+                continue
+            plabel = _period_label(txn.post_date, group_by)
+            amt = self._split_in_default_currency(
+                split, acct, factors_by_period.get(plabel, {}).get(acct.guid)
+            )
+            if amt > 0:
+                inflows[plabel] += amt
+            elif amt < 0:
+                outflows[plabel] += -amt
+
+        return _format_grouped_cashflow_tsv(
+            period_labels=period_labels,
+            inflows=inflows,
+            outflows=outflows,
+            account_label=account_label,
+            transfers_excluded=len(transfers_excluded),
+        )
 
     def _cashflow_txn_guids(
         self,

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -12,14 +12,19 @@ per-boundary snapshots — O(splits + intervals), not
 O(intervals × splits).
 """
 
-import calendar
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
 import piecash
 
 from gnucash_mcp.book._base import _is_voided, _to_decimal
-from gnucash_mcp._format import _format_number
+from gnucash_mcp._format import (
+    _GROUP_BY_VALUES,
+    _enumerate_periods,
+    _format_grouped_tsv,
+    _format_number,
+    _period_label,
+)
 
 # Account-type groups shared by the reports' SQL IN() clauses — one
 # canonical definition. RECEIVABLE/PAYABLE are included: A/R is an
@@ -31,9 +36,6 @@ _LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT", "PAYABLE"})
 _EQUITY_TYPES = frozenset({"EQUITY"})
 _NET_INCOME_TYPES = frozenset({"INCOME", "EXPENSE"})
 _CASH_TYPES = frozenset({"BANK", "CASH"})
-
-# Valid group_by sub-period granularities for the period breakdowns.
-_GROUP_BY_VALUES = ("month", "quarter", "year")
 
 
 def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> str:
@@ -76,123 +78,6 @@ def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> s
         f"{'TOTAL':<{name_width}}  {total:>{amount_width},.2f}"
     )
     return "\n".join(lines)
-
-
-def _period_label(d: date, group_by: str) -> str:
-    """Map a date to its sub-period column label.
-
-    ``month`` → ``YYYY-MM``; ``quarter`` → ``YYYY-Q#``; ``year`` →
-    ``YYYY``. Used both to enumerate columns and to bucket each
-    split by its ``post_date``, so the two always agree.
-    """
-    if group_by == "month":
-        return f"{d.year:04d}-{d.month:02d}"
-    if group_by == "quarter":
-        return f"{d.year:04d}-Q{(d.month - 1) // 3 + 1}"
-    return f"{d.year:04d}"
-
-
-def _enumerate_periods(
-    start_date: date, end_date: date, group_by: str
-) -> list[tuple[str, date]]:
-    """Ordered ``(label, anchor_date)`` pairs covering the range.
-
-    Every sub-period that overlaps ``[start_date, end_date]`` gets a
-    column, including empty ones (so a gap month still renders a
-    ``0.00`` column). The anchor date is the period's natural
-    calendar end clamped to ``end_date`` — FX/commodity rates value
-    each period at its own close, never at today's rates.
-    """
-    periods: list[tuple[str, date]] = []
-    if group_by == "month":
-        y, m = start_date.year, start_date.month
-        while (y, m) <= (end_date.year, end_date.month):
-            last = date(y, m, calendar.monthrange(y, m)[1])
-            periods.append((f"{y:04d}-{m:02d}", min(last, end_date)))
-            m += 1
-            if m > 12:
-                m, y = 1, y + 1
-    elif group_by == "quarter":
-        y = start_date.year
-        q = (start_date.month - 1) // 3 + 1
-        end_q = (end_date.month - 1) // 3 + 1
-        while (y, q) <= (end_date.year, end_q):
-            last_month = q * 3
-            last = date(y, last_month, calendar.monthrange(y, last_month)[1])
-            periods.append((f"{y:04d}-Q{q}", min(last, end_date)))
-            q += 1
-            if q > 4:
-                q, y = 1, y + 1
-    else:  # year
-        for y in range(start_date.year, end_date.year + 1):
-            periods.append((f"{y:04d}", min(date(y, 12, 31), end_date)))
-    return periods
-
-
-def _strip_common_prefix(names: list[str]) -> list[str]:
-    """Drop a shared top-level ``Expenses:`` / ``Income:`` prefix.
-
-    Mirrors :func:`_format_breakdown_tsv`'s single-period behaviour —
-    leaf labels stay readable when every row shares a prefix, full
-    paths survive a heterogeneous mix.
-    """
-    if names and ":" in names[0]:
-        candidate = names[0].split(":")[0] + ":"
-        if all(n.startswith(candidate) for n in names):
-            return [n[len(candidate):] for n in names]
-    return list(names)
-
-
-def _format_grouped_tsv(
-    *,
-    period_labels: list[str],
-    displayed_names: list[str],
-    totals: dict[str, dict[str, Decimal]],
-    cat_totals: dict[str, Decimal],
-    period_totals: dict[str, Decimal],
-    grand_total: Decimal,
-    excluded: list[tuple[str, Decimal]],
-    label: str,
-) -> str:
-    """Render the multi-period breakdown as a tab-separated table.
-
-    Columns: the leading label, one per sub-period, then ``Total``
-    (sum across periods) and ``Avg`` (Total / number of periods).
-    The trailing ``TOTAL`` row sums every category per period —
-    net-negative-overall categories are netted in here even though
-    they get no row of their own, keeping the column totals tied to
-    single-period mode and to income − spending = net income.
-    """
-    num_periods = len(period_labels)
-    leaves = _strip_common_prefix(displayed_names)
-    lines = ["\t".join([label, *period_labels, "Total", "Avg"])]
-    for name, leaf in zip(displayed_names, leaves):
-        per = totals.get(name, {})
-        cells = [leaf]
-        cells += [
-            f"{per.get(pl, Decimal('0')):.2f}" for pl in period_labels
-        ]
-        tot = cat_totals[name]
-        avg = tot / num_periods if num_periods else Decimal("0")
-        cells += [f"{tot:.2f}", f"{avg:.2f}"]
-        lines.append("\t".join(cells))
-
-    avg_total = grand_total / num_periods if num_periods else Decimal("0")
-    total_cells = ["TOTAL"]
-    total_cells += [f"{period_totals[pl]:.2f}" for pl in period_labels]
-    total_cells += [f"{grand_total:.2f}", f"{avg_total:.2f}"]
-    lines.append("\t".join(total_cells))
-
-    out = "\n".join(lines)
-    if excluded:
-        netted = ", ".join(
-            f"{n} {t:,.2f}"
-            for n, t in sorted(excluded, key=lambda x: x[1])
-        )
-        out += (
-            f"\n({len(excluded)} net-negative netted into TOTAL: {netted})"
-        )
-    return out
 
 
 def _format_grouped_cashflow_tsv(
@@ -428,7 +313,7 @@ class ReportingMixin:
             period_labels=period_labels,
             displayed_names=displayed_names,
             totals=totals,
-            cat_totals=cat_totals,
+            row_totals=cat_totals,
             period_totals=period_totals,
             grand_total=grand_total,
             excluded=excluded,

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -12,6 +12,7 @@ per-boundary snapshots — O(splits + intervals), not
 O(intervals × splits).
 """
 
+import calendar
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
@@ -30,6 +31,9 @@ _LIABILITY_TYPES = frozenset({"LIABILITY", "CREDIT", "PAYABLE"})
 _EQUITY_TYPES = frozenset({"EQUITY"})
 _NET_INCOME_TYPES = frozenset({"INCOME", "EXPENSE"})
 _CASH_TYPES = frozenset({"BANK", "CASH"})
+
+# Valid group_by sub-period granularities for the period breakdowns.
+_GROUP_BY_VALUES = ("month", "quarter", "year")
 
 
 def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> str:
@@ -72,6 +76,123 @@ def _format_breakdown_tsv(rows: list[dict], total: Decimal, label_key: str) -> s
         f"{'TOTAL':<{name_width}}  {total:>{amount_width},.2f}"
     )
     return "\n".join(lines)
+
+
+def _period_label(d: date, group_by: str) -> str:
+    """Map a date to its sub-period column label.
+
+    ``month`` → ``YYYY-MM``; ``quarter`` → ``YYYY-Q#``; ``year`` →
+    ``YYYY``. Used both to enumerate columns and to bucket each
+    split by its ``post_date``, so the two always agree.
+    """
+    if group_by == "month":
+        return f"{d.year:04d}-{d.month:02d}"
+    if group_by == "quarter":
+        return f"{d.year:04d}-Q{(d.month - 1) // 3 + 1}"
+    return f"{d.year:04d}"
+
+
+def _enumerate_periods(
+    start_date: date, end_date: date, group_by: str
+) -> list[tuple[str, date]]:
+    """Ordered ``(label, anchor_date)`` pairs covering the range.
+
+    Every sub-period that overlaps ``[start_date, end_date]`` gets a
+    column, including empty ones (so a gap month still renders a
+    ``0.00`` column). The anchor date is the period's natural
+    calendar end clamped to ``end_date`` — FX/commodity rates value
+    each period at its own close, never at today's rates.
+    """
+    periods: list[tuple[str, date]] = []
+    if group_by == "month":
+        y, m = start_date.year, start_date.month
+        while (y, m) <= (end_date.year, end_date.month):
+            last = date(y, m, calendar.monthrange(y, m)[1])
+            periods.append((f"{y:04d}-{m:02d}", min(last, end_date)))
+            m += 1
+            if m > 12:
+                m, y = 1, y + 1
+    elif group_by == "quarter":
+        y = start_date.year
+        q = (start_date.month - 1) // 3 + 1
+        end_q = (end_date.month - 1) // 3 + 1
+        while (y, q) <= (end_date.year, end_q):
+            last_month = q * 3
+            last = date(y, last_month, calendar.monthrange(y, last_month)[1])
+            periods.append((f"{y:04d}-Q{q}", min(last, end_date)))
+            q += 1
+            if q > 4:
+                q, y = 1, y + 1
+    else:  # year
+        for y in range(start_date.year, end_date.year + 1):
+            periods.append((f"{y:04d}", min(date(y, 12, 31), end_date)))
+    return periods
+
+
+def _strip_common_prefix(names: list[str]) -> list[str]:
+    """Drop a shared top-level ``Expenses:`` / ``Income:`` prefix.
+
+    Mirrors :func:`_format_breakdown_tsv`'s single-period behaviour —
+    leaf labels stay readable when every row shares a prefix, full
+    paths survive a heterogeneous mix.
+    """
+    if names and ":" in names[0]:
+        candidate = names[0].split(":")[0] + ":"
+        if all(n.startswith(candidate) for n in names):
+            return [n[len(candidate):] for n in names]
+    return list(names)
+
+
+def _format_grouped_tsv(
+    *,
+    period_labels: list[str],
+    displayed_names: list[str],
+    totals: dict[str, dict[str, Decimal]],
+    cat_totals: dict[str, Decimal],
+    period_totals: dict[str, Decimal],
+    grand_total: Decimal,
+    excluded: list[tuple[str, Decimal]],
+    label: str,
+) -> str:
+    """Render the multi-period breakdown as a tab-separated table.
+
+    Columns: the leading label, one per sub-period, then ``Total``
+    (sum across periods) and ``Avg`` (Total / number of periods).
+    The trailing ``TOTAL`` row sums every category per period —
+    net-negative-overall categories are netted in here even though
+    they get no row of their own, keeping the column totals tied to
+    single-period mode and to income − spending = net income.
+    """
+    num_periods = len(period_labels)
+    leaves = _strip_common_prefix(displayed_names)
+    lines = ["\t".join([label, *period_labels, "Total", "Avg"])]
+    for name, leaf in zip(displayed_names, leaves):
+        per = totals.get(name, {})
+        cells = [leaf]
+        cells += [
+            f"{per.get(pl, Decimal('0')):.2f}" for pl in period_labels
+        ]
+        tot = cat_totals[name]
+        avg = tot / num_periods if num_periods else Decimal("0")
+        cells += [f"{tot:.2f}", f"{avg:.2f}"]
+        lines.append("\t".join(cells))
+
+    avg_total = grand_total / num_periods if num_periods else Decimal("0")
+    total_cells = ["TOTAL"]
+    total_cells += [f"{period_totals[pl]:.2f}" for pl in period_labels]
+    total_cells += [f"{grand_total:.2f}", f"{avg_total:.2f}"]
+    lines.append("\t".join(total_cells))
+
+    out = "\n".join(lines)
+    if excluded:
+        netted = ", ".join(
+            f"{n} {t:,.2f}"
+            for n, t in sorted(excluded, key=lambda x: x[1])
+        )
+        out += (
+            f"\n({len(excluded)} net-negative netted into TOTAL: {netted})"
+        )
+    return out
 
 
 def _money_compact(value: Decimal, currency: str = "USD") -> str:
@@ -190,12 +311,94 @@ class ReportingMixin:
 
     # ── Period breakdowns ─────────────────────────────────────────────
 
+    def _grouped_breakdown(
+        self,
+        book: piecash.Book,
+        *,
+        start_date: date,
+        end_date: date,
+        depth: int,
+        account_type: str,
+        sign: Decimal,
+        group_by: str,
+        label: str,
+    ) -> str:
+        """Multi-period breakdown shared by spending/income.
+
+        One indexed pass over the range's splits, bucketed by
+        ``(group_account, sub-period)``. ``sign`` flips income's
+        stored-negative convention (``-1``) vs spending (``1``); the
+        rest is identical to the single-period path — same ``depth``
+        grouping, same net-after-aggregation rule (a category whose
+        total across ALL periods is ≤ 0 is dropped from the rows but
+        still netted into the column totals).
+        """
+        periods = _enumerate_periods(start_date, end_date, group_by)
+        period_labels = [pl for pl, _ in periods]
+        # Each period values at its own close — never today's rates
+        # against a historical period's quantities.
+        factors_by_period = {
+            pl: self._account_conversion_factors(book, anchor)
+            for pl, anchor in periods
+        }
+
+        rows = self._query_filtered_splits(
+            book,
+            start_date=start_date,
+            end_date=end_date,
+            account_types=frozenset({account_type}),
+        )
+
+        # category fullname → {period_label: signed Decimal}
+        totals: dict[str, dict[str, Decimal]] = {}
+        for split, txn, account in rows:
+            plabel = _period_label(txn.post_date, group_by)
+            factor = factors_by_period.get(plabel, {}).get(account.guid)
+            amount = sign * self._split_in_default_currency(
+                split, account, factor,
+            )
+            group_account = self._get_account_at_depth(account, depth)
+            bucket = totals.setdefault(group_account.fullname, {})
+            bucket[plabel] = bucket.get(plabel, Decimal("0")) + amount
+
+        cat_totals = {
+            name: sum(per.values(), Decimal("0"))
+            for name, per in totals.items()
+        }
+        displayed_names = sorted(
+            (n for n, t in cat_totals.items() if t > 0),
+            key=lambda n: cat_totals[n],
+            reverse=True,
+        )
+        excluded = [(n, t) for n, t in cat_totals.items() if t < 0]
+
+        # Column totals sum every category — net-negative ones netted
+        # in even though they have no row, so the totals match
+        # single-period mode.
+        period_totals = {pl: Decimal("0") for pl in period_labels}
+        for per in totals.values():
+            for pl, v in per.items():
+                period_totals[pl] += v
+        grand_total = sum(cat_totals.values(), Decimal("0"))
+
+        return _format_grouped_tsv(
+            period_labels=period_labels,
+            displayed_names=displayed_names,
+            totals=totals,
+            cat_totals=cat_totals,
+            period_totals=period_totals,
+            grand_total=grand_total,
+            excluded=excluded,
+            label=label,
+        )
+
     def spending_by_category(
         self,
         start_date: date,
         end_date: date,
         depth: int = 1,
         compact: bool = True,
+        group_by: str | None = None,
     ) -> dict | str:
         """Get spending breakdown by expense category.
 
@@ -210,7 +413,30 @@ class ReportingMixin:
                 leaf.
             compact: Aligned text table (default) or the structured
                 dict.
+            group_by: ``None`` (default) for the single-period
+                aggregation above; ``"month"`` / ``"quarter"`` /
+                ``"year"`` to split the range into sub-period columns
+                and return a multi-period TSV table (always a string;
+                ``compact`` is ignored — the table is the output).
         """
+        if group_by is not None:
+            if group_by not in _GROUP_BY_VALUES:
+                raise ValueError(
+                    f"Invalid group_by '{group_by}'. Must be one of: "
+                    f"{', '.join(_GROUP_BY_VALUES)}."
+                )
+            with self.open(readonly=True) as book:
+                return self._grouped_breakdown(
+                    book,
+                    start_date=start_date,
+                    end_date=end_date,
+                    depth=depth,
+                    account_type="EXPENSE",
+                    sign=Decimal("1"),
+                    group_by=group_by,
+                    label="Category",
+                )
+
         with self.open(readonly=True) as book:
             rows = self._query_filtered_splits(
                 book,
@@ -297,6 +523,7 @@ class ReportingMixin:
         end_date: date,
         depth: int = 1,
         compact: bool = True,
+        group_by: str | None = None,
     ) -> dict | str:
         """Get income breakdown by source.
 
@@ -307,7 +534,28 @@ class ReportingMixin:
             start_date / end_date: Period bounds (inclusive).
             depth: Grouping depth (1 = top-level).
             compact: Aligned text table (default) or structured dict.
+            group_by: ``None`` (default) for single-period; ``"month"``
+                / ``"quarter"`` / ``"year"`` for a multi-period TSV
+                table — see ``spending_by_category``.
         """
+        if group_by is not None:
+            if group_by not in _GROUP_BY_VALUES:
+                raise ValueError(
+                    f"Invalid group_by '{group_by}'. Must be one of: "
+                    f"{', '.join(_GROUP_BY_VALUES)}."
+                )
+            with self.open(readonly=True) as book:
+                return self._grouped_breakdown(
+                    book,
+                    start_date=start_date,
+                    end_date=end_date,
+                    depth=depth,
+                    account_type="INCOME",
+                    sign=Decimal("-1"),
+                    group_by=group_by,
+                    label="Source",
+                )
+
         with self.open(readonly=True) as book:
             rows = self._query_filtered_splits(
                 book,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1571,6 +1571,7 @@ def register(mcp, get_book) -> None:
         end_date: str,
         vendor_id: str | None = None,
         verbose: bool = False,
+        group_by: str | None = None,
     ) -> str:
         """Get spending breakdown by vendor for a period.
 
@@ -1585,6 +1586,9 @@ def register(mcp, get_book) -> None:
             end_date: End of period (YYYY-MM-DD).
             vendor_id: Optional filter to a specific vendor.
             verbose: If true, return the structured dict.
+            group_by: Optional "month", "quarter", or "year" — split the
+                range into sub-period columns of total billed per vendor
+                and return a multi-period TSV table. Overrides verbose.
         """
         book = get_book()
         result = book.vendor_spending_report(
@@ -1592,7 +1596,10 @@ def register(mcp, get_book) -> None:
             end_date=end_date,
             vendor_id=vendor_id,
             compact=not verbose,
+            group_by=group_by,
         )
+        if group_by:
+            return result
         if verbose:
             return _json(result)
         return result

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -151,6 +151,7 @@ def register(mcp, get_book) -> None:
         end_date: str,
         account: str | None = None,
         include_transfers: bool = False,
+        group_by: str | None = None,
     ) -> str:
         """Calculate cash flow (inflows and outflows) for a period.
 
@@ -175,6 +176,9 @@ def register(mcp, get_book) -> None:
             include_transfers: When False (default), filter internal
                 transfers. When True, include every cash/bank
                 movement regardless of category.
+            group_by: Optional "month", "quarter", or "year" — split
+                the range into sub-period columns and return an
+                Inflows / Outflows / Net trend table (TSV).
         """
         book = get_book()
         result = book.cash_flow(
@@ -182,7 +186,10 @@ def register(mcp, get_book) -> None:
             end_date=date.fromisoformat(end_date),
             account=account,
             include_transfers=include_transfers,
+            group_by=group_by,
         )
+        if group_by:
+            return result
         return _json(result)
 
     @mcp.tool()

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -17,6 +17,7 @@ def register(mcp, get_book) -> None:
         end_date: str,
         depth: int = 1,
         verbose: bool = False,
+        group_by: str | None = None,
     ) -> str:
         """Get spending breakdown by expense category for a period.
 
@@ -28,6 +29,10 @@ def register(mcp, get_book) -> None:
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
             verbose: If true, return the structured dict.
+            group_by: Optional "month", "quarter", or "year" — split the
+                range into sub-period columns and return a multi-period
+                TSV table (category rows, one column per period plus
+                Total and Avg). Overrides verbose.
         """
         book = get_book()
         result = book.spending_by_category(
@@ -35,7 +40,10 @@ def register(mcp, get_book) -> None:
             end_date=date.fromisoformat(end_date),
             depth=depth,
             compact=not verbose,
+            group_by=group_by,
         )
+        if group_by:
+            return result
         if verbose:
             return _json(result)
         return result
@@ -48,6 +56,7 @@ def register(mcp, get_book) -> None:
         end_date: str,
         depth: int = 1,
         verbose: bool = False,
+        group_by: str | None = None,
     ) -> str:
         """Get income breakdown by source for a period.
 
@@ -59,6 +68,10 @@ def register(mcp, get_book) -> None:
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
             verbose: If true, return the structured dict.
+            group_by: Optional "month", "quarter", or "year" — split the
+                range into sub-period columns and return a multi-period
+                TSV table (source rows, one column per period plus Total
+                and Avg). Overrides verbose.
         """
         book = get_book()
         result = book.income_by_source(
@@ -66,7 +79,10 @@ def register(mcp, get_book) -> None:
             end_date=date.fromisoformat(end_date),
             depth=depth,
             compact=not verbose,
+            group_by=group_by,
         )
+        if group_by:
+            return result
         if verbose:
             return _json(result)
         return result

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8238,6 +8238,242 @@ class TestIncomeBySource:
         assert Decimal(result["sources"][0]["amount"]) == Decimal("700")
 
 
+class TestGroupByBreakdown:
+    """group_by sub-period columns for spending/income breakdowns."""
+
+    @staticmethod
+    def _book(tmp_path: Path) -> Path:
+        """Three months (2026-03..05) of expenses + income.
+
+        Travel is positive overall (900) but negative in April (a
+        refund month). Shopping is net-negative overall (−200) — it
+        must drop from the rows but stay netted into the column
+        totals.
+        """
+        bp = tmp_path / "grouped.gnucash"
+        book = piecash.create_book(str(bp), currency="USD", overwrite=True)
+        usd = book.default_currency
+        root = book.root_account
+        assets = piecash.Account(name="Assets", type="ASSET", parent=root,
+                                 commodity=usd, placeholder=True)
+        checking = piecash.Account(name="Checking", type="BANK",
+                                   parent=assets, commodity=usd)
+        exp = piecash.Account(name="Expenses", type="EXPENSE", parent=root,
+                              commodity=usd, placeholder=True)
+        groceries = piecash.Account(name="Groceries", type="EXPENSE",
+                                    parent=exp, commodity=usd)
+        dining = piecash.Account(name="Dining", type="EXPENSE",
+                                 parent=exp, commodity=usd)
+        travel = piecash.Account(name="Travel", type="EXPENSE",
+                                 parent=exp, commodity=usd)
+        shopping = piecash.Account(name="Shopping", type="EXPENSE",
+                                   parent=exp, commodity=usd)
+        inc = piecash.Account(name="Income", type="INCOME", parent=root,
+                              commodity=usd, placeholder=True)
+        salary = piecash.Account(name="Salary", type="INCOME",
+                                 parent=inc, commodity=usd)
+        consulting = piecash.Account(name="Consulting", type="INCOME",
+                                     parent=inc, commodity=usd)
+        eq = piecash.Account(name="Equity", type="EQUITY", parent=root,
+                             commodity=usd, placeholder=True)
+        opening = piecash.Account(name="Opening", type="EQUITY",
+                                  parent=eq, commodity=usd)
+        book.save()
+
+        def tx(desc, d, acct, amt):
+            book.session.add(piecash.Transaction(
+                currency=usd, description=desc, post_date=d,
+                splits=[piecash.Split(account=acct, value=Decimal(amt)),
+                        piecash.Split(account=checking,
+                                      value=Decimal(amt) * -1)]))
+
+        tx("open", date(2026, 1, 1), opening, "-50000")
+        # Expenses (account gets a positive debit).
+        for d, amt in ((3, "500"), (4, "700"), (5, "500")):
+            tx("groceries", date(2026, d, 5), groceries, amt)
+        for d, amt in ((3, "500"), (4, "600"), (5, "350")):
+            tx("dining", date(2026, d, 6), dining, amt)
+        tx("flights", date(2026, 3, 7), travel, "1000")
+        tx("refund", date(2026, 4, 7), travel, "-200")
+        tx("taxi", date(2026, 5, 7), travel, "100")
+        tx("shop", date(2026, 3, 8), shopping, "100")
+        tx("shop-refund", date(2026, 4, 8), shopping, "-300")
+        # Income (income account gets a negative credit).
+        for d in (3, 4, 5):
+            tx("salary", date(2026, d, 1), salary, "-4000")
+        tx("consulting", date(2026, 4, 15), consulting, "-1000")
+        book.save()
+        return bp
+
+    @staticmethod
+    def _parse(tsv: str) -> dict[str, list[str]]:
+        """Header + each row keyed by its first cell → list of cells."""
+        lines = [ln for ln in tsv.splitlines()
+                 if "\t" in ln]  # drop any footnote line
+        out = {}
+        for ln in lines:
+            cells = ln.split("\t")
+            out[cells[0]] = cells
+        return out
+
+    def test_month_three_columns(self, tmp_path: Path):
+        """3-month range → 3 period columns + Total + Avg."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert rows["Category"] == [
+            "Category", "2026-03", "2026-04", "2026-05", "Total", "Avg",
+        ]
+        assert rows["Groceries"] == [
+            "Groceries", "500.00", "700.00", "500.00", "1700.00", "566.67",
+        ]
+        # Sorted by Total desc: Groceries > Dining > Travel.
+        order = [c[0] for c in rows.values()][1:]  # skip header
+        assert order == ["Groceries", "Dining", "Travel", "TOTAL"]
+
+    def test_quarter_two_columns(self, tmp_path: Path):
+        """6-month range → 2 quarter columns (Q1 partial, Q2)."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2026, 1, 1), end_date=date(2026, 6, 30),
+            group_by="quarter",
+        )
+        rows = self._parse(tsv)
+        assert rows["Category"] == [
+            "Category", "2026-Q1", "2026-Q2", "Total", "Avg",
+        ]
+        # Q1 = March data only; Q2 = April + May.
+        assert rows["Groceries"][1:3] == ["500.00", "1200.00"]
+
+    def test_year_two_columns_partial_empty(self, tmp_path: Path):
+        """18-month range → 2 year columns; the empty 2025 column
+        still renders as 0.00."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2025, 1, 1), end_date=date(2026, 6, 30),
+            group_by="year",
+        )
+        rows = self._parse(tsv)
+        assert rows["Category"] == [
+            "Category", "2025", "2026", "Total", "Avg",
+        ]
+        assert rows["Groceries"][1:] == ["0.00", "1700.00", "1700.00", "850.00"]
+
+    def test_no_group_by_unchanged(self, tmp_path: Path):
+        """Regression guard: omitting group_by keeps the single-period
+        dict shape."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        result = gc.spending_by_category(
+            compact=False,
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+        )
+        assert "categories" in result and "total" in result
+        assert Decimal(result["total"]) == Decimal("3850")
+
+    def test_invalid_group_by(self, tmp_path: Path):
+        """Unknown granularity → clear ValueError."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        with pytest.raises(ValueError, match="Invalid group_by"):
+            gc.spending_by_category(
+                start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+                group_by="week",
+            )
+
+    def test_negative_month_positive_overall_shown(self, tmp_path: Path):
+        """Travel is −200 in April but +900 overall → shown, with the
+        negative month displayed as-is."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert rows["Travel"] == [
+            "Travel", "1000.00", "-200.00", "100.00", "900.00", "300.00",
+        ]
+
+    def test_net_negative_overall_omitted_but_netted(self, tmp_path: Path):
+        """Shopping (−200 overall) drops from the rows but its values
+        still land in the column totals."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert "Shopping" not in rows
+        # TOTAL nets Shopping in: Mar 2100, Apr 800, May 950, grand 3850.
+        assert rows["TOTAL"] == [
+            "TOTAL", "2100.00", "800.00", "950.00", "3850.00", "1283.33",
+        ]
+        assert "net-negative netted into TOTAL" in tsv
+
+    def test_depth_groups_children(self, tmp_path: Path):
+        """depth collapses children under their parent just like
+        single-period mode."""
+        bp = tmp_path / "depth.gnucash"
+        book = piecash.create_book(str(bp), currency="USD", overwrite=True)
+        usd = book.default_currency
+        root = book.root_account
+        assets = piecash.Account(name="Assets", type="ASSET", parent=root,
+                                 commodity=usd, placeholder=True)
+        checking = piecash.Account(name="Checking", type="BANK",
+                                   parent=assets, commodity=usd)
+        exp = piecash.Account(name="Expenses", type="EXPENSE", parent=root,
+                              commodity=usd, placeholder=True)
+        food = piecash.Account(name="Food", type="EXPENSE", parent=exp,
+                               commodity=usd, placeholder=True)
+        groceries = piecash.Account(name="Groceries", type="EXPENSE",
+                                    parent=food, commodity=usd)
+        dining = piecash.Account(name="Dining", type="EXPENSE",
+                                 parent=food, commodity=usd)
+        book.save()
+        for acct, amt in ((groceries, "300"), (dining, "200")):
+            book.session.add(piecash.Transaction(
+                currency=usd, description="x", post_date=date(2026, 3, 5),
+                splits=[piecash.Split(account=acct, value=Decimal(amt)),
+                        piecash.Split(account=checking,
+                                      value=Decimal(amt) * -1)]))
+        book.save()
+        gc = GnuCashBook(str(bp))
+        depth1 = self._parse(gc.spending_by_category(
+            start_date=date(2026, 3, 1), end_date=date(2026, 3, 31),
+            group_by="month", depth=1))
+        # depth 1 → one "Food" row at 500.
+        assert "Food" in depth1 and depth1["Food"][1] == "500.00"
+        assert "Groceries" not in depth1
+        depth2 = self._parse(gc.spending_by_category(
+            start_date=date(2026, 3, 1), end_date=date(2026, 3, 31),
+            group_by="month", depth=2))
+        # depth 2 → split into the two leaves (the shared "Expenses:"
+        # prefix is stripped, leaving "Food:Groceries" / "Food:Dining").
+        assert "Food:Groceries" in depth2 and "Food:Dining" in depth2
+        assert "Food" not in depth2
+
+    def test_income_by_source_same_shape(self, tmp_path: Path):
+        """income_by_source mirrors spending: Source label, per-period
+        columns, sign flipped to positive income."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.income_by_source(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert rows["Source"] == [
+            "Source", "2026-03", "2026-04", "2026-05", "Total", "Avg",
+        ]
+        assert rows["Salary"] == [
+            "Salary", "4000.00", "4000.00", "4000.00", "12000.00", "4000.00",
+        ]
+        assert rows["Consulting"][2] == "1000.00"  # April only
+        assert rows["TOTAL"] == [
+            "TOTAL", "4000.00", "5000.00", "4000.00", "13000.00", "4333.33",
+        ]
+
+
 class TestBalanceSheet:
     """Tests for balance_sheet method."""
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8474,6 +8474,91 @@ class TestGroupByBreakdown:
         ]
 
 
+class TestGroupByCashFlow:
+    """group_by sub-period columns for cash_flow (Inflows/Outflows/Net)."""
+
+    def test_month_trend(self, tmp_path: Path):
+        """3-month range → Inflows / Outflows / Net rows, one column
+        per month plus Total and Avg."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        tsv = gc.cash_flow(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = TestGroupByBreakdown._parse(tsv)
+        assert rows["Cash flow"] == [
+            "Cash flow", "2026-03", "2026-04", "2026-05", "Total", "Avg",
+        ]
+        # Inflows: salary 4000/mo, + April consulting 1000 + April
+        # refunds (travel 200 + shopping 300).
+        assert rows["Inflows"] == [
+            "Inflows", "4000.00", "5500.00", "4000.00", "13500.00", "4500.00",
+        ]
+        assert rows["Outflows"] == [
+            "Outflows", "2100.00", "1300.00", "950.00", "4350.00", "1450.00",
+        ]
+        # Net is the build-vs-burn signal — every month positive here.
+        assert rows["Net"] == [
+            "Net", "1900.00", "4200.00", "3050.00", "9150.00", "3050.00",
+        ]
+        # The account-scope title line leads the table.
+        assert tsv.splitlines()[0] == "All cash/bank accounts"
+
+    def test_grouped_totals_match_single_period(self, tmp_path: Path):
+        """The grouped column totals reconcile with the single-period
+        cash_flow over the same range."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        single = gc.cash_flow(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+        )
+        rows = TestGroupByBreakdown._parse(gc.cash_flow(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            group_by="month",
+        ))
+        assert rows["Inflows"][-2] == f"{Decimal(single['inflows']):.2f}"
+        assert rows["Outflows"][-2] == f"{Decimal(single['outflows']):.2f}"
+
+    def test_quarter_columns(self, tmp_path: Path):
+        """6-month range → 2 quarter columns."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        rows = TestGroupByBreakdown._parse(gc.cash_flow(
+            start_date=date(2026, 1, 1), end_date=date(2026, 6, 30),
+            group_by="quarter",
+        ))
+        assert rows["Cash flow"] == [
+            "Cash flow", "2026-Q1", "2026-Q2", "Total", "Avg",
+        ]
+
+    def test_account_filter_with_group_by(self, tmp_path: Path):
+        """An explicit account scopes the trend and names it in the
+        title line."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        tsv = gc.cash_flow(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+            account="Assets:Checking", group_by="month",
+        )
+        assert tsv.splitlines()[0] == "Assets:Checking"
+
+    def test_invalid_group_by(self, tmp_path: Path):
+        """Unknown granularity → clear ValueError."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        with pytest.raises(ValueError, match="Invalid group_by"):
+            gc.cash_flow(
+                start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+                group_by="fortnight",
+            )
+
+    def test_no_group_by_unchanged(self, tmp_path: Path):
+        """Regression guard: omitting group_by keeps the single-period
+        dict shape."""
+        gc = GnuCashBook(str(TestGroupByBreakdown._book(tmp_path)))
+        result = gc.cash_flow(
+            start_date=date(2026, 3, 1), end_date=date(2026, 5, 31),
+        )
+        assert "inflows" in result and "outflows" in result
+        assert result["account"] == "All cash/bank accounts"
+
+
 class TestBalanceSheet:
     """Tests for balance_sheet method."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -9881,6 +9881,93 @@ class TestVendorSpendingReport:
         assert result["vendors"][0]["vendor_name"] == "Office Depot"
 
 
+class TestVendorSpendingGroupBy:
+    """group_by sub-period columns for vendor_spending_report."""
+
+    @staticmethod
+    def _seed(gb) -> None:
+        """Office Depot billed Feb (50) + Mar (70); Staples Mar (30)."""
+        gb.create_vendor(name="Office Depot")
+        gb.create_vendor(name="Staples")
+
+        def bill(bill_id, vendor_id, price, post_date):
+            gb.create_bill(vendor_id=vendor_id)
+            gb.add_bill_entry(
+                bill_id=bill_id,
+                account="Expenses:Office Supplies",
+                description="x", quantity="1", price=price,
+            )
+            gb.post_invoice(
+                invoice_id=bill_id,
+                post_account="Liabilities:Accounts Payable",
+                owner_type="vendor", post_date=post_date,
+            )
+
+        bill("000001", "000001", "50.00", "2026-02-15")
+        bill("000002", "000001", "70.00", "2026-03-10")
+        bill("000003", "000002", "30.00", "2026-03-20")
+
+    @staticmethod
+    def _parse(tsv: str) -> dict[str, list[str]]:
+        out = {}
+        for ln in tsv.splitlines():
+            if "\t" in ln:
+                cells = ln.split("\t")
+                out[cells[0]] = cells
+        return out
+
+    def test_month_columns(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._seed(gb)
+        tsv = gb.vendor_spending_report(
+            start_date="2026-01-01", end_date="2026-03-31",
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert rows["Vendor"] == [
+            "Vendor", "2026-01", "2026-02", "2026-03", "Total", "Avg",
+        ]
+        # Office Depot spikes in March; sorted first by total.
+        assert rows["Office Depot"] == [
+            "Office Depot", "0.00", "50.00", "70.00", "120.00", "40.00",
+        ]
+        assert rows["Staples"] == [
+            "Staples", "0.00", "0.00", "30.00", "30.00", "10.00",
+        ]
+        assert rows["TOTAL"] == [
+            "TOTAL", "0.00", "50.00", "100.00", "150.00", "50.00",
+        ]
+
+    def test_vendor_filter_with_group_by(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._seed(gb)
+        tsv = gb.vendor_spending_report(
+            start_date="2026-01-01", end_date="2026-03-31",
+            vendor_id="000001", group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert "Office Depot" in rows and "Staples" not in rows
+
+    def test_invalid_group_by(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        with pytest.raises(ValueError, match="Invalid group_by"):
+            gb.vendor_spending_report(
+                start_date="2026-01-01", end_date="2026-03-31",
+                group_by="decade",
+            )
+
+    def test_no_group_by_unchanged(self, business_book):
+        """Regression guard: omitting group_by keeps the dict shape."""
+        gb = GnuCashBook(str(business_book))
+        self._seed(gb)
+        result = gb.vendor_spending_report(
+            compact=False,
+            start_date="2026-01-01", end_date="2026-03-31",
+        )
+        assert "vendors" in result and "totals" in result
+        assert Decimal(result["totals"]["total_billed"]) == Decimal("150")
+
+
 # ============== End-to-End Lifecycle Tests ==============
 
 


### PR DESCRIPTION
## Summary

Adds an optional `group_by` parameter (`"month"` | `"quarter"` | `"year"`) to the four period-aggregation reports. When omitted, every report is **byte-for-byte unchanged** (regression-guarded). When set, the date range splits into sub-period columns and the tool returns a multi-period TSV table.

- **`spending_by_category`** / **`income_by_source`** — category/source rows × period columns, plus `Total` and `Avg`. Net-negative-overall categories drop from the rows but stay netted into the column totals (matching single-period semantics, so the grand total stays tied to net income).
- **`cash_flow`** — `Inflows` / `Outflows` / **`Net`** trend. Net per period is the build-vs-burn signal the single-period report omits as "derivable"; a trend view is exactly where it earns its place. Transfer-filtering, voided-skip, and the account filter all carry over.
- **`vendor_spending_report`** — per-vendor **total-billed** trend; surfaces a spend spike at one vendor in one month. No-rate bills excluded with a warning, as single-period.

### Currency correctness
Each sub-period values at its **own calendar close** (clamped to `end_date`), never at today's rates — the same "historical periods must not use today's rates" invariant the rest of the codebase enforces. For single-currency books the grouped grand total reconciles with the single-period total to the penny; for multi-currency books it can differ slightly (and is the *more* correct number, since each period reflects its own rate).

### Refactor
Three report families now bucket by period, so the shared helpers (`_GROUP_BY_VALUES`, `_enumerate_periods`, `_period_label`, `_strip_common_prefix`, `_format_grouped_tsv`) moved from `reporting.py` into the layer-neutral `_format.py`. `business.py` no longer reaches into `reporting.py`'s internals, and the next report that wants `group_by` imports one place.

## Test plan

- [x] 23 new tests across the three feature areas (month/quarter/year column counts, partial/empty boundary periods, invalid-value error, depth interaction, negative-month-positive-overall, net-negative omitted-but-netted, account/vendor filters, income & vendor parity, single-vs-grouped total reconciliation, no-group_by regression guards)
- [x] Full suite green (1694 passing)
- [x] Real-book output eyeballed on Alex (USD) and Lin Wei (multi-currency) for all four reports; grouped grand totals reconcile with single-period