### PR TITLE
feat(multi-book): comma… os.pathsep-separated GNUCASH_BOOK_PATH + switch_book

### DIFF
--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 from datetime import date
+from pathlib import Path
 from typing import Annotated
 
 from pydantic import Field
@@ -292,6 +293,15 @@ TOOL_MODULES: dict[str, list[str]] = {
 }
 
 
+# Inline tools registered at import that are deliberately NOT part of
+# the TOOL_MODULES partition. ``switch_book`` is a conditional
+# meta-tool: registered inline like get_server_config, but kept only
+# when 2+ books are configured (added to the keep set in
+# _apply_module_filter), so it can't live in a static module list. The
+# validators and the contract tests exclude it.
+_INLINE_UNMAPPED_TOOLS: set[str] = {"switch_book"}
+
+
 def _validate_module_groups() -> None:
     """Every member of a MODULE_GROUPS expansion must exist in
     TOOL_MODULES — a typo'd member would otherwise silently drop
@@ -333,7 +343,7 @@ def _validate_tool_modules() -> None:
         all_mapped.update(tools)
 
     registered = set(mcp._tool_manager._tools.keys())
-    unmapped = registered - all_mapped
+    unmapped = registered - all_mapped - _INLINE_UNMAPPED_TOOLS
     if unmapped:
         raise RuntimeError(
             f"Tools registered but not in TOOL_MODULES: {sorted(unmapped)}. "
@@ -519,6 +529,13 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
     for mod_name in sorted(enabled_modules):
         keep.update(TOOL_MODULES[mod_name])
 
+    # switch_book is an inline meta-tool outside the module partition;
+    # keep it only when there are 2+ books to switch between. Otherwise
+    # the removal pass below drops it (single-book sessions have
+    # nothing to switch to).
+    if multi_book_active():
+        keep.add("switch_book")
+
     # Remove tools not in the keep set (covers server.py-registered tools
     # that belong to non-enabled modules, and any stale entries)
     for tool_name in list(mcp._tool_manager._tools.keys()):
@@ -539,23 +556,194 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
 # Runtime server state — populated by main(), read by get_server_config tool
 _server_state: dict = {}
 
-# Global book instance - initialized on first use
+# ── Multi-book registry ────────────────────────────────────────────
+# GNUCASH_BOOK_PATH may hold a single path OR a comma-separated list.
+# The server keeps one "current" book and switches between them
+# in-session via the switch_book tool (no restart, no re-registration —
+# every tool calls get_book() per operation, so repointing _book is
+# transparent to all of them).
+#
+# - _book_paths:    resolved, validated paths in declared order.
+# - _current_path:  the active book's resolved path.
+# - _book_registry: lazy instance cache keyed by resolved-path str, so
+#                   re-selecting a book reuses its instance (and its
+#                   GUID-prefix caches).
+# - _book:          the CURRENT instance. Resetting it to None is the
+#                   re-init point tests rely on.
+_book_paths: list[Path] = []
+_current_path: Path | None = None
+_book_registry: dict[str, GnuCashBook] = {}
 _book = None
+
+# Effective logging mode. Seeded from env at import; main() may widen
+# it via the --debug / --noaudit CLI flags. switch_book reads these to
+# re-point logging at the newly-active book.
+_logging_debug: bool = False
+_logging_audit: bool = True
 
 # Class used to construct the book — set by main() to match enabled modules.
 # Defaults to the "all modules" class so tests and direct imports still work.
 _book_class: type = GnuCashBook
 
 
+class _BookPathError(FileNotFoundError):
+    """Invalid GNUCASH_BOOK_PATH entry (missing file / not a file /
+    duplicate filename).
+
+    Subclasses FileNotFoundError so a missing book surfaces at runtime
+    with the same ``file_not_found`` error_type the single-book path
+    always produced (the book constructor raised FileNotFoundError).
+    main() catches the specific type to fail fast with SystemExit at
+    startup. The *unset/empty* env case is a plain ValueError instead
+    — that path's "GNUCASH_BOOK_PATH ... not set" contract predates
+    multi-book and is never reached from main() (which guards on a
+    non-empty value first).
+    """
+
+
+def _parse_book_paths(value: str | None) -> list[Path]:
+    """Parse GNUCASH_BOOK_PATH (one path, or a comma-separated list).
+
+    Splits on ``,``, strips, drops empties, and resolves each entry to
+    an absolute path that must exist and be a regular file.
+
+    Raises:
+        ValueError: value unset or empty.
+        _BookPathError: any entry missing or not a regular file; or two
+            entries sharing a filename (basename collisions make
+            switch_book's prefix matching ambiguous).
+    """
+    if not value or not value.strip():
+        raise ValueError(
+            "GNUCASH_BOOK_PATH environment variable not set"
+        )
+    raw = [p.strip() for p in value.split(",") if p.strip()]
+    if not raw:
+        raise ValueError(
+            "GNUCASH_BOOK_PATH environment variable not set"
+        )
+
+    paths: list[Path] = []
+    errors: list[str] = []
+    for p in raw:
+        try:
+            resolved = Path(p).resolve(strict=True)
+        except (FileNotFoundError, OSError):
+            errors.append(f"  - {p!r}: not found")
+            continue
+        if not resolved.is_file():
+            errors.append(f"  - {p!r}: not a regular file")
+            continue
+        paths.append(resolved)
+
+    # Filenames must be unique — switch_book matches on them.
+    seen: dict[str, Path] = {}
+    for path in paths:
+        if path.name in seen:
+            errors.append(
+                f"  - duplicate book filename {path.name!r}: "
+                f"{seen[path.name]} and {path} (filenames must be "
+                f"unique so switch_book can match by name)"
+            )
+        else:
+            seen[path.name] = path
+
+    if errors:
+        raise _BookPathError(
+            "Invalid GNUCASH_BOOK_PATH:\n" + "\n".join(errors)
+        )
+    return paths
+
+
+def _book_for(path: Path) -> GnuCashBook:
+    """Get-or-create the cached book instance for a resolved path."""
+    key = str(path)
+    inst = _book_registry.get(key)
+    if inst is None:
+        inst = _book_class(key)
+        _book_registry[key] = inst
+    return inst
+
+
+def multi_book_active() -> bool:
+    """True when more than one valid book path is configured.
+
+    Read by tool wrappers (e.g. get_book_summary) to decide whether to
+    surface the current-book marker, and by _apply_module_filter to
+    gate switch_book's visibility.
+    """
+    return len(_book_paths) > 1
+
+
 def get_book():
-    """Get or create the GnuCashBook instance."""
-    global _book
+    """Get or create the current GnuCashBook instance.
+
+    Honors a comma-separated GNUCASH_BOOK_PATH: when no book is
+    selected yet, the first valid path becomes current. switch_book
+    repoints the selection mid-session. Resetting ``_book`` to None
+    forces re-initialization from the environment — the reset point
+    tests rely on.
+    """
+    global _book, _current_path, _book_paths
     if _book is None:
-        path = os.environ.get("GNUCASH_BOOK_PATH")
-        if not path:
-            raise ValueError("GNUCASH_BOOK_PATH environment variable not set")
-        _book = _book_class(path)
+        # Re-read the env so a test that swapped GNUCASH_BOOK_PATH and
+        # reset _book picks up the new value.
+        _book_paths = _parse_book_paths(os.environ.get("GNUCASH_BOOK_PATH"))
+        if _current_path not in _book_paths:
+            _current_path = _book_paths[0]
+        _book = _book_for(_current_path)
     return _book
+
+
+def _activate_logging(path: Path) -> None:
+    """(Re-)point audit/debug logging at ``path``.
+
+    Used on book switch so each book's writes land in its own
+    .mcp/audit trail. setup_logging clears its handlers on every call,
+    so repeated invocations don't stack handlers.
+    """
+    if _logging_audit or _logging_debug:
+        setup_logging(
+            book_path=str(path),
+            debug=_logging_debug,
+            audit=_logging_audit,
+            get_book=get_book,
+        )
+
+
+def _switch_book_impl(name: str) -> str:
+    """Make the book whose filename uniquely prefix-matches ``name``
+    the current book. See the switch_book tool docstring.
+    """
+    global _book, _current_path
+    if not _book_paths:
+        # Cold start (direct single-call use): populate the registry.
+        get_book()
+
+    needle = name.strip().lower()
+    if not needle:
+        raise ValueError("switch_book requires a book name")
+
+    matches = [p for p in _book_paths if p.name.lower().startswith(needle)]
+    available = ", ".join(p.name for p in _book_paths)
+    if not matches:
+        raise ValueError(
+            f"No book matches {name!r}. Available books: {available}"
+        )
+    if len(matches) > 1:
+        ambiguous = ", ".join(p.name for p in matches)
+        raise ValueError(
+            f"Book name {name!r} is ambiguous — matches: {ambiguous}. "
+            f"Use a longer prefix."
+        )
+
+    target = matches[0]
+    _current_path = target
+    _book = _book_for(target)
+    _activate_logging(target)  # logs follow the active book
+    _server_state["book_path"] = str(target)
+    _server_state["current_book"] = target.name
+    return f"Switched to: {target.name}"
 
 
 # Initialize logging at module import time
@@ -564,7 +752,18 @@ def get_book():
 # Logs are stored alongside the book file: {book_path}.mcp/audit/ and {book_path}.mcp/debug/
 _debug_mode = os.environ.get("GNUCASH_MCP_DEBUG") == "1"
 _audit_mode = os.environ.get("GNUCASH_MCP_NOAUDIT") != "1"
-_book_path = os.environ.get("GNUCASH_BOOK_PATH")
+_logging_debug = _debug_mode
+_logging_audit = _audit_mode
+# Initial logging points at the first valid book. Best-effort at
+# import (a bad path is left for main() to fail-fast on); switch_book
+# repoints it per active book later.
+_book_path = None
+_raw_book_path = os.environ.get("GNUCASH_BOOK_PATH")
+if _raw_book_path:
+    try:
+        _book_path = str(_parse_book_paths(_raw_book_path)[0])
+    except _BookPathError:
+        _book_path = None
 if _book_path and (_audit_mode or _debug_mode):
     setup_logging(
         book_path=_book_path,
@@ -616,6 +815,15 @@ def _get_server_config_impl() -> str:
         f"Debug mode: {str(_server_state.get('debug', False)).lower()}",
         f"Version: {__version__}",
     ]
+    # Multi-book sessions: name the current book and list the rest so
+    # the client knows what switch_book can target. Single-book runs
+    # keep the bare ``Book:`` line above and add nothing.
+    book_paths = _server_state.get("book_paths") or []
+    if len(book_paths) > 1:
+        lines.append(
+            f"Current book: {_server_state.get('current_book', 'unknown')}"
+        )
+        lines.append(f"Available books: {', '.join(book_paths)}")
     dc_ok = _server_state.get("default_currency_ok")
     if dc_ok is False:
         lines.append("Warning: Book has no default currency set")
@@ -641,6 +849,36 @@ def get_server_config() -> str:
     this session.
     """
     return _get_server_config_impl()
+
+
+# Registered inline at import, but OUTSIDE the TOOL_MODULES partition
+# (see _INLINE_UNMAPPED_TOOLS). _apply_module_filter adds it to the
+# keep set only when 2+ books are configured; single-book sessions
+# have nothing to switch to, so the keep pass drops it.
+#
+# No @audit_log — the switch is session config, not a book write. And
+# because logging follows the active book, every subsequent write is
+# attributed to the correct book's trail without a marker here.
+@mcp.tool()
+@safe_tool
+def switch_book(
+    name: Annotated[
+        str,
+        Field(
+            description="Book to activate, matched as a "
+            "case-insensitive prefix of its filename. Must uniquely "
+            "identify one configured book (see get_server_config for "
+            "the list)."
+        ),
+    ],
+) -> str:
+    """Switch the active GnuCash book (multi-book sessions only).
+
+    All subsequent tool calls — and the audit/debug logs — operate on
+    the newly-selected book until the next switch. Only present when
+    GNUCASH_BOOK_PATH lists 2+ books.
+    """
+    return _switch_book_impl(name)
 
 
 # ============== Main ==============
@@ -706,7 +944,11 @@ Options:
   -h, --help           Show this help message
 
 Environment variables:
-  GNUCASH_BOOK_PATH          Path to GnuCash SQLite book (required)
+  GNUCASH_BOOK_PATH          Path to GnuCash SQLite book (required). May
+                             be a comma-separated list of books; the
+                             first is current at startup and switch_book
+                             changes the active one in-session. Filenames
+                             must be unique (switch_book matches by name).
   GNUCASH_MCP_MODULES        Tool modules to load — same values as
                              --modules (e.g. "bookkeeper" or "core,reporting")
   GNUCASH_MCP_DEBUG=1        Enable debug logging
@@ -735,7 +977,24 @@ default, or at GNUCASH_LOG_DIR if set:
 """)
         sys.exit(0)
 
-    book_path = os.environ.get("GNUCASH_BOOK_PATH")
+    global _book_paths, _current_path, _logging_debug, _logging_audit
+    global _book_class
+
+    # GNUCASH_BOOK_PATH: one path or a comma-separated list. Fail fast
+    # on any invalid/duplicate entry (unset is tolerated — tools error
+    # at call time, matching the prior behavior). ``book_path`` below
+    # is the CURRENT book, used for logging / health / display.
+    raw_book_path = os.environ.get("GNUCASH_BOOK_PATH")
+    if raw_book_path and raw_book_path.strip():
+        try:
+            _book_paths = _parse_book_paths(raw_book_path)
+        except _BookPathError as exc:
+            print(str(exc), file=sys.stderr)
+            raise SystemExit(2)
+        _current_path = _book_paths[0]
+        book_path = str(_current_path)
+    else:
+        book_path = None
 
     # Parse CLI flags
     debug_flag = "--debug" in sys.argv
@@ -757,19 +1016,23 @@ default, or at GNUCASH_LOG_DIR if set:
     if modules_value is None:
         modules_value = os.environ.get("GNUCASH_MCP_MODULES")
 
-    # Re-init logging if CLI flags override env vars
+    # Re-init logging if CLI flags override env vars. Update the
+    # effective-mode globals so switch_book repoints with the same
+    # debug/audit settings.
     if debug_flag or noaudit_flag:
         audit_enabled = not noaudit_flag
-        if book_path and (audit_enabled or debug_flag):
+        _logging_debug = debug_flag or _debug_mode
+        _logging_audit = audit_enabled and _audit_mode
+        if book_path and (_logging_audit or _logging_debug):
             setup_logging(
                 book_path=book_path,
-                debug=debug_flag,
-                audit=audit_enabled,
+                debug=_logging_debug,
+                audit=_logging_audit,
                 get_book=get_book,
             )
-            if debug_flag:
+            if _logging_debug:
                 debug_log(f"Server starting via CLI. Book: {book_path}")
-                debug_log(f"Debug logging enabled, audit={'enabled' if audit_enabled else 'disabled'}")
+                debug_log(f"Debug logging enabled, audit={'enabled' if _logging_audit else 'disabled'}")
 
     # Validate and apply module filter (also lazy-loads extracted modules)
     _validate_module_groups()
@@ -780,7 +1043,6 @@ default, or at GNUCASH_LOG_DIR if set:
     # modules. If get_book() has already been called (tests / module
     # import), leave the existing instance alone; otherwise subsequent
     # get_book() calls will use this class.
-    global _book_class
     # Expand each loaded module to its backing mixin set via
     # MODULE_BACKED_BY (default 1:1).
     backing_mixins: set[str] = set()
@@ -821,6 +1083,8 @@ default, or at GNUCASH_LOG_DIR if set:
         "modules": modules_display,
         "tool_count": tool_count,
         "book_path": book_path or "not set",
+        "book_paths": [p.name for p in _book_paths],
+        "current_book": _current_path.name if _current_path else None,
         "debug": debug_flag,
         "default_currency_ok": currency_ok,
     })

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -721,6 +721,42 @@ def _activate_logging(path: Path) -> None:
         )
 
 
+def _book_orientation(book_instance) -> str:
+    """One-line snapshot of a book for post-switch reorientation:
+    ``N transactions | N customers | N vendors | N employees | CUR
+    base currency``.
+
+    Transactions exclude scheduled-transaction template recipes (the
+    same filter get_book_summary uses, so the counts agree). Business
+    counts are omitted when zero so personal books stay uncluttered.
+    Best-effort — a locked or unreadable book yields a soft fallback
+    rather than failing the switch.
+    """
+    try:
+        with book_instance.open(readonly=True) as book:
+            template_guids = book_instance._template_account_guids(book)
+            txns = sum(
+                1 for t in book.transactions
+                if not book_instance._is_template_transaction(
+                    t, template_guids
+                )
+            )
+            parts = [f"{txns:,} transaction{'s' if txns != 1 else ''}"]
+            for label, coll in (
+                ("customer", book.customers),
+                ("vendor", book.vendors),
+                ("employee", book.employees),
+            ):
+                n = len(coll)
+                if n:
+                    parts.append(f"{n} {label}{'s' if n != 1 else ''}")
+            cur = book.default_currency
+            parts.append(f"{cur.mnemonic if cur else '?'} base currency")
+            return " | ".join(parts)
+    except Exception:
+        return "(book ready; orientation snapshot unavailable)"
+
+
 def _switch_book_impl(name: str) -> str:
     """Make the book whose filename uniquely prefix-matches ``name``
     the current book. See the switch_book tool docstring.
@@ -748,12 +784,35 @@ def _switch_book_impl(name: str) -> str:
         )
 
     target = matches[0]
+    previous = _current_path
+
+    # No-op switch — already on this book. Don't emit the reset
+    # banner (nothing changed); just reaffirm and reorient.
+    if previous is not None and target == previous:
+        return (
+            f"Already on: {target.name}\n"
+            f"{_book_orientation(_book_for(target))}"
+        )
+
     _current_path = target
     _book = _book_for(target)
     _activate_logging(target)  # logs follow the active book
     _server_state["book_path"] = str(target)
     _server_state["current_book"] = target.name
-    return f"Switched to: {target.name}"
+
+    # Loud context-reset banner: the LLM may be carrying account
+    # names, GUIDs, and entity refs from the previous book — all
+    # invalid here, and a stale GUID prefix could even mis-resolve to
+    # a DIFFERENT entity in this book. Naming the previous book makes
+    # the boundary explicit. Snapshot reorients in one line.
+    prev_name = previous.name if previous else "the previous book"
+    return (
+        f"⚠ CONTEXT RESET: All account names, GUIDs, and entity "
+        f"references from the previous book ({prev_name}) are now "
+        f"invalid. Do not reuse them.\n\n"
+        f"Switched to: {target.name}\n"
+        f"{_book_orientation(_book)}"
+    )
 
 
 # Initialize logging at module import time

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -557,7 +557,8 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
 _server_state: dict = {}
 
 # ── Multi-book registry ────────────────────────────────────────────
-# GNUCASH_BOOK_PATH may hold a single path OR a comma-separated list.
+# GNUCASH_BOOK_PATH may hold a single path OR an os.pathsep-separated
+# list (``:`` on POSIX, ``;`` on Windows — the PATH convention).
 # The server keeps one "current" book and switches between them
 # in-session via the switch_book tool (no restart, no re-registration —
 # every tool calls get_book() per operation, so repointing _book is
@@ -602,10 +603,19 @@ class _BookPathError(FileNotFoundError):
 
 
 def _parse_book_paths(value: str | None) -> list[Path]:
-    """Parse GNUCASH_BOOK_PATH (one path, or a comma-separated list).
+    """Parse GNUCASH_BOOK_PATH (one path, or an os.pathsep-separated list).
 
-    Splits on ``,``, strips, drops empties, and resolves each entry to
-    an absolute path that must exist and be a regular file.
+    The separator is ``os.pathsep`` — ``:`` on POSIX, ``;`` on Windows
+    — the same convention PATH/PYTHONPATH use. Comma was rejected as a
+    separator because it is a common filename character (a book named
+    ``financials, invoicing.gnucash`` would have mis-split, and no
+    shell escaping could prevent it — the shell can't signal "this
+    separator byte is literal" to a downstream parser). The one
+    residual limit, a literal ``os.pathsep`` inside a path, is rare and
+    identical to PATH's own constraint.
+
+    Splits on ``os.pathsep``, strips, drops empties, and resolves each
+    entry to an absolute path that must exist and be a regular file.
 
     Raises:
         ValueError: value unset or empty.
@@ -617,7 +627,7 @@ def _parse_book_paths(value: str | None) -> list[Path]:
         raise ValueError(
             "GNUCASH_BOOK_PATH environment variable not set"
         )
-    raw = [p.strip() for p in value.split(",") if p.strip()]
+    raw = [p.strip() for p in value.split(os.pathsep) if p.strip()]
     if not raw:
         raise ValueError(
             "GNUCASH_BOOK_PATH environment variable not set"
@@ -678,7 +688,7 @@ def multi_book_active() -> bool:
 def get_book():
     """Get or create the current GnuCashBook instance.
 
-    Honors a comma-separated GNUCASH_BOOK_PATH: when no book is
+    Honors an os.pathsep-separated GNUCASH_BOOK_PATH: when no book is
     selected yet, the first valid path becomes current. switch_book
     repoints the selection mid-session. Resetting ``_book`` to None
     forces re-initialization from the environment — the reset point
@@ -945,10 +955,12 @@ Options:
 
 Environment variables:
   GNUCASH_BOOK_PATH          Path to GnuCash SQLite book (required). May
-                             be a comma-separated list of books; the
-                             first is current at startup and switch_book
-                             changes the active one in-session. Filenames
-                             must be unique (switch_book matches by name).
+                             be an os.pathsep-separated list of books
+                             (":" on macOS/Linux, ";" on Windows — same
+                             as PATH); the first is current at startup
+                             and switch_book changes the active one
+                             in-session. Filenames must be unique
+                             (switch_book matches by name).
   GNUCASH_MCP_MODULES        Tool modules to load — same values as
                              --modules (e.g. "bookkeeper" or "core,reporting")
   GNUCASH_MCP_DEBUG=1        Enable debug logging
@@ -980,7 +992,7 @@ default, or at GNUCASH_LOG_DIR if set:
     global _book_paths, _current_path, _logging_debug, _logging_audit
     global _book_class
 
-    # GNUCASH_BOOK_PATH: one path or a comma-separated list. Fail fast
+    # GNUCASH_BOOK_PATH: one path or an os.pathsep-separated list. Fail fast
     # on any invalid/duplicate entry (unset is tolerated — tools error
     # at call time, matching the prior behavior). ``book_path`` below
     # is the CURRENT book, used for logging / health / display.

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -76,7 +76,21 @@ def register(mcp, get_book) -> None:
         in a single text response. Use this first to orient yourself.
         """
         book = get_book()
-        return book.get_book_summary()
+        summary = book.get_book_summary()
+        # Multi-book sessions: name the current book up front so the
+        # client knows which book these numbers belong to. The book
+        # layer stays ignorant of server session state, so the marker
+        # is added here, not in get_book_summary itself.
+        from gnucash_mcp import server as _server
+        if _server.multi_book_active():
+            from gnucash_mcp._format import _book_display_name
+            name = _book_display_name(book.book_path)
+            count = len(_server._book_paths)
+            summary = (
+                f"Current book: {name} ({count} books available — "
+                f"switch_book to change)\n{summary}"
+            )
+        return summary
 
     @mcp.tool()
     @safe_tool

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,5 +1,6 @@
 """Tests for tool module filtering and server configuration."""
 
+import os
 import re
 from pathlib import Path
 
@@ -974,21 +975,30 @@ class TestMultiBook:
     def test_parse_multi_path_preserves_order(self, two_books):
         from gnucash_mcp.server import _parse_book_paths
         alex, beast = two_books
-        result = _parse_book_paths(f"{alex},{beast}")
+        result = _parse_book_paths(f"{alex}{os.pathsep}{beast}")
         assert result == [alex.resolve(), beast.resolve()]
 
     def test_parse_strips_whitespace_and_empties(self, two_books):
         from gnucash_mcp.server import _parse_book_paths
         alex, beast = two_books
-        result = _parse_book_paths(f" {alex} , , {beast} ")
+        sep = os.pathsep
+        result = _parse_book_paths(f" {alex} {sep} {sep} {beast} ")
         assert result == [alex.resolve(), beast.resolve()]
+
+    def test_parse_allows_comma_in_filename(self, tmp_path):
+        """Regression guard: a single book whose name contains a comma
+        (the rejected separator) must parse as ONE path."""
+        from gnucash_mcp.server import _parse_book_paths
+        name = "financials, invoicing, and metrics.gnucash"
+        book = _make_min_book(tmp_path / name)
+        assert _parse_book_paths(str(book)) == [book.resolve()]
 
     def test_parse_missing_path_fails_fast(self, two_books, tmp_path):
         from gnucash_mcp.server import _parse_book_paths, _BookPathError
         alex, _ = two_books
         missing = tmp_path / "nope.gnucash"
         with pytest.raises(_BookPathError, match="not found"):
-            _parse_book_paths(f"{alex},{missing}")
+            _parse_book_paths(f"{alex}{os.pathsep}{missing}")
 
     def test_book_path_error_is_file_not_found(self):
         """Missing-book errors must subclass FileNotFoundError so the
@@ -1005,7 +1015,7 @@ class TestMultiBook:
         b1 = _make_min_book(d1 / "dup.gnucash")
         b2 = _make_min_book(d2 / "dup.gnucash")
         with pytest.raises(_BookPathError, match="duplicate book filename"):
-            _parse_book_paths(f"{b1},{b2}")
+            _parse_book_paths(f"{b1}{os.pathsep}{b2}")
 
     def test_parse_unset_raises_valueerror(self):
         from gnucash_mcp.server import _parse_book_paths
@@ -1106,7 +1116,7 @@ class TestMultiBook:
     def test_get_book_selects_first_as_current(self, two_books, monkeypatch):
         import gnucash_mcp.server as srv
         alex, beast = two_books
-        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex},{beast}")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex}{os.pathsep}{beast}")
         srv._book = None
         srv._current_path = None
         srv._book_registry = {}
@@ -1152,7 +1162,7 @@ class TestMultiBook:
         import gnucash_mcp.server as srv
         import gnucash_mcp.logging_config as logcfg
         alex, beast = two_books
-        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex},{beast}")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex}{os.pathsep}{beast}")
         srv._book = None
         srv._current_path = None
         srv._book_registry = {}

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -50,7 +50,12 @@ class TestToolModulesMapping:
         all_mapped = set()
         for tools in TOOL_MODULES.values():
             all_mapped.update(tools)
+        # switch_book is an inline meta-tool deliberately outside the
+        # partition (registered at import, kept only in multi-book
+        # sessions); exclude it like the server validator does.
+        from gnucash_mcp.server import _INLINE_UNMAPPED_TOOLS
         registered = set(mcp._tool_manager._tools.keys())
+        registered -= _INLINE_UNMAPPED_TOOLS
         assert registered.issubset(all_mapped)
 
     def test_every_tool_module_backs_onto_extracted_files(self):
@@ -870,3 +875,320 @@ class TestModuleGroupsValidation:
                 _validate_module_groups()
         finally:
             srv.MODULE_GROUPS = original
+
+
+# ── Multi-book accounting ──────────────────────────────────────────
+
+
+def _make_min_book(path: Path) -> Path:
+    """Create a minimal valid USD book with one funded account."""
+    import piecash
+    from datetime import date
+    from decimal import Decimal
+
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    root = book.root_account
+    assets = piecash.Account(
+        name="Assets", type="ASSET", parent=root, commodity=usd,
+        placeholder=True,
+    )
+    checking = piecash.Account(
+        name="Checking", type="BANK", parent=assets, commodity=usd,
+    )
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", parent=root, commodity=usd,
+        placeholder=True,
+    )
+    opening = piecash.Account(
+        name="Opening Balance", type="EQUITY", parent=equity,
+        commodity=usd,
+    )
+    book.save()
+    book.session.add(piecash.Transaction(
+        currency=usd, description="Opening Balance",
+        post_date=date(2026, 1, 1),
+        splits=[
+            piecash.Split(account=checking, value=Decimal("1000")),
+            piecash.Split(account=opening, value=Decimal("-1000")),
+        ],
+    ))
+    book.save()
+    book.close()
+    return path
+
+
+class TestMultiBook:
+    """Comma-separated GNUCASH_BOOK_PATH, the switch_book tool, and the
+    current-book surfacing in get_server_config / get_book_summary."""
+
+    @pytest.fixture
+    def two_books(self, tmp_path: Path):
+        """Two distinct-named books: alex.gnucash and beast-man.gnucash."""
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        beast = _make_min_book(tmp_path / "beast-man.gnucash")
+        return alex, beast
+
+    @pytest.fixture(autouse=True)
+    def restore_state(self):
+        """Snapshot and restore every global the multi-book paths touch."""
+        import gnucash_mcp.server as srv
+        import gnucash_mcp.logging_config as logcfg
+
+        saved = {
+            "_book": srv._book,
+            "_book_paths": list(srv._book_paths),
+            "_current_path": srv._current_path,
+            "_book_registry": dict(srv._book_registry),
+            "_logging_debug": srv._logging_debug,
+            "_logging_audit": srv._logging_audit,
+        }
+        server_state_copy = dict(_server_state)
+        tools_copy = dict(mcp._tool_manager._tools)
+        loaded_copy = set(_loaded_tool_files)
+        log_saved = (
+            logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
+        )
+        yield
+        srv._book = saved["_book"]
+        srv._book_paths = saved["_book_paths"]
+        srv._current_path = saved["_current_path"]
+        srv._book_registry = saved["_book_registry"]
+        srv._logging_debug = saved["_logging_debug"]
+        srv._logging_audit = saved["_logging_audit"]
+        _server_state.clear()
+        _server_state.update(server_state_copy)
+        mcp._tool_manager._tools.clear()
+        mcp._tool_manager._tools.update(tools_copy)
+        _reset_lazy_load_state()
+        _loaded_tool_files.update(loaded_copy)
+        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
+
+    # ── _parse_book_paths ──────────────────────────────────────────
+
+    def test_parse_single_path(self, two_books):
+        from gnucash_mcp.server import _parse_book_paths
+        alex, _ = two_books
+        assert _parse_book_paths(str(alex)) == [alex.resolve()]
+
+    def test_parse_multi_path_preserves_order(self, two_books):
+        from gnucash_mcp.server import _parse_book_paths
+        alex, beast = two_books
+        result = _parse_book_paths(f"{alex},{beast}")
+        assert result == [alex.resolve(), beast.resolve()]
+
+    def test_parse_strips_whitespace_and_empties(self, two_books):
+        from gnucash_mcp.server import _parse_book_paths
+        alex, beast = two_books
+        result = _parse_book_paths(f" {alex} , , {beast} ")
+        assert result == [alex.resolve(), beast.resolve()]
+
+    def test_parse_missing_path_fails_fast(self, two_books, tmp_path):
+        from gnucash_mcp.server import _parse_book_paths, _BookPathError
+        alex, _ = two_books
+        missing = tmp_path / "nope.gnucash"
+        with pytest.raises(_BookPathError, match="not found"):
+            _parse_book_paths(f"{alex},{missing}")
+
+    def test_book_path_error_is_file_not_found(self):
+        """Missing-book errors must subclass FileNotFoundError so the
+        runtime error_type stays ``file_not_found``."""
+        from gnucash_mcp.server import _BookPathError
+        assert issubclass(_BookPathError, FileNotFoundError)
+
+    def test_parse_duplicate_basename_fails_fast(self, tmp_path):
+        from gnucash_mcp.server import _parse_book_paths, _BookPathError
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        b1 = _make_min_book(d1 / "dup.gnucash")
+        b2 = _make_min_book(d2 / "dup.gnucash")
+        with pytest.raises(_BookPathError, match="duplicate book filename"):
+            _parse_book_paths(f"{b1},{b2}")
+
+    def test_parse_unset_raises_valueerror(self):
+        from gnucash_mcp.server import _parse_book_paths
+        with pytest.raises(ValueError, match="GNUCASH_BOOK_PATH"):
+            _parse_book_paths(None)
+        with pytest.raises(ValueError, match="GNUCASH_BOOK_PATH"):
+            _parse_book_paths("   ")
+
+    # ── switch_book visibility ─────────────────────────────────────
+
+    def test_switch_book_present_with_two_books(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        srv._book_paths = [alex.resolve(), beast.resolve()]
+        _apply_module_filter("all")
+        assert "switch_book" in mcp._tool_manager._tools
+
+    def test_switch_book_absent_with_one_book(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, _ = two_books
+        srv._book_paths = [alex.resolve()]
+        _apply_module_filter("all")
+        assert "switch_book" not in mcp._tool_manager._tools
+
+    def test_switch_book_absent_when_unconfigured(self):
+        import gnucash_mcp.server as srv
+        srv._book_paths = []
+        _apply_module_filter("all")
+        assert "switch_book" not in mcp._tool_manager._tools
+
+    def test_tool_count_single_book(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, _ = two_books
+        srv._book_paths = [alex.resolve()]
+        _apply_module_filter("all")
+        assert len(mcp._tool_manager._tools) == 107
+
+    def test_tool_count_multi_book(self, two_books):
+        """The lone runtime delta from single-book: switch_book (108).
+        Each filter call relies on switch_book being registered at
+        import; the production flow filters once at startup."""
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        srv._book_paths = [alex.resolve(), beast.resolve()]
+        _apply_module_filter("all")
+        assert len(mcp._tool_manager._tools) == 108
+
+    # ── switch_book matching ───────────────────────────────────────
+
+    def _select(self, srv, two_books):
+        alex, beast = two_books
+        srv._book = None
+        srv._current_path = None
+        srv._book_registry = {}
+        srv._book_paths = [alex.resolve(), beast.resolve()]
+        srv._current_path = alex.resolve()
+        srv._book = srv._book_for(alex.resolve())
+
+    def test_switch_by_unique_prefix(self, two_books):
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)
+        msg = srv._switch_book_impl("beast")
+        assert msg == "Switched to: beast-man.gnucash"
+        assert srv._current_path.name == "beast-man.gnucash"
+        assert srv.get_book().book_path.name == "beast-man.gnucash"
+
+    def test_switch_is_case_insensitive(self, two_books):
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)
+        assert srv._switch_book_impl("BEAST").endswith("beast-man.gnucash")
+
+    def test_switch_no_match_lists_available(self, two_books):
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)
+        with pytest.raises(ValueError, match="No book matches"):
+            srv._switch_book_impl("zzz")
+
+    def test_switch_ambiguous_prefix_raises(self, tmp_path):
+        import gnucash_mcp.server as srv
+        a = _make_min_book(tmp_path / "report-q1.gnucash")
+        b = _make_min_book(tmp_path / "report-q2.gnucash")
+        srv._book = None
+        srv._book_registry = {}
+        srv._book_paths = [a.resolve(), b.resolve()]
+        srv._current_path = a.resolve()
+        srv._book = srv._book_for(a.resolve())
+        with pytest.raises(ValueError, match="ambiguous"):
+            srv._switch_book_impl("report")
+
+    def test_switch_empty_name_raises(self, two_books):
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)
+        with pytest.raises(ValueError, match="requires a book name"):
+            srv._switch_book_impl("   ")
+
+    # ── get_book cold-start selection ──────────────────────────────
+
+    def test_get_book_selects_first_as_current(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex},{beast}")
+        srv._book = None
+        srv._current_path = None
+        srv._book_registry = {}
+        srv._book_paths = []
+        book = srv.get_book()
+        assert book.book_path.name == "alex.gnucash"
+        assert srv._current_path.name == "alex.gnucash"
+        assert srv.multi_book_active() is True
+
+    # ── get_server_config ──────────────────────────────────────────
+
+    def test_server_config_lists_books_when_multi(self):
+        _server_state.clear()
+        _server_state.update({
+            "modules": "core", "tool_count": 108,
+            "book_path": "/secret/dir/alex.gnucash",
+            "book_paths": ["alex.gnucash", "beast-man.gnucash"],
+            "current_book": "alex.gnucash",
+            "debug": False,
+        })
+        out = _get_server_config_impl()
+        assert "Current book: alex.gnucash" in out
+        assert "Available books: alex.gnucash, beast-man.gnucash" in out
+        assert "/secret/dir" not in out  # no directory leakage
+
+    def test_server_config_no_book_list_when_single(self):
+        _server_state.clear()
+        _server_state.update({
+            "modules": "core", "tool_count": 107,
+            "book_path": "/dir/alex.gnucash",
+            "book_paths": ["alex.gnucash"],
+            "current_book": "alex.gnucash",
+            "debug": False,
+        })
+        out = _get_server_config_impl()
+        assert "Available books:" not in out
+        assert "Current book:" not in out
+        assert "Book: alex.gnucash" in out
+
+    # ── logging follows the active book ────────────────────────────
+
+    def test_logging_follows_switch(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        import gnucash_mcp.logging_config as logcfg
+        alex, beast = two_books
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", f"{alex},{beast}")
+        srv._book = None
+        srv._current_path = None
+        srv._book_registry = {}
+        srv._book_paths = []
+        srv._logging_audit = True
+        srv._logging_debug = False
+        srv.get_book()  # cold-start: current = alex
+        srv._switch_book_impl("beast")
+        assert logcfg._book_path_str.endswith("beast-man.gnucash")
+
+    # ── get_book_summary current-book marker ───────────────────────
+
+    def test_summary_marks_current_book_when_multi(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        srv._book = None
+        srv._current_path = None
+        srv._book_registry = {}
+        srv._book_paths = [alex.resolve(), beast.resolve()]
+        srv._current_path = alex.resolve()
+        srv._book = srv._book_for(alex.resolve())
+        _apply_module_filter("all")
+        summary = mcp._tool_manager._tools["get_book_summary"].fn()
+        first = summary.split("\n", 1)[0]
+        assert first.startswith("Current book: alex.gnucash")
+        assert "2 books available" in first
+
+    def test_summary_unmarked_when_single(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, _ = two_books
+        srv._book = None
+        srv._current_path = None
+        srv._book_registry = {}
+        srv._book_paths = [alex.resolve()]
+        srv._current_path = alex.resolve()
+        srv._book = srv._book_for(alex.resolve())
+        _apply_module_filter("all")
+        summary = mcp._tool_manager._tools["get_book_summary"].fn()
+        assert summary.split("\n", 1)[0].startswith("Book: alex.gnucash")

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1078,14 +1078,44 @@ class TestMultiBook:
         import gnucash_mcp.server as srv
         self._select(srv, two_books)
         msg = srv._switch_book_impl("beast")
-        assert msg == "Switched to: beast-man.gnucash"
+        assert "Switched to: beast-man.gnucash" in msg
         assert srv._current_path.name == "beast-man.gnucash"
         assert srv.get_book().book_path.name == "beast-man.gnucash"
 
     def test_switch_is_case_insensitive(self, two_books):
         import gnucash_mcp.server as srv
         self._select(srv, two_books)
-        assert srv._switch_book_impl("BEAST").endswith("beast-man.gnucash")
+        assert "beast-man.gnucash" in srv._switch_book_impl("BEAST")
+
+    def test_switch_emits_context_reset_banner(self, two_books):
+        """The response must loudly invalidate the previous book's refs
+        (naming it) and reorient with a one-line snapshot — the
+        bookkeeper-flagged guard against silent cross-book collisions."""
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)  # current = alex
+        msg = srv._switch_book_impl("beast")
+        assert "CONTEXT RESET" in msg
+        assert "alex.gnucash" in msg          # names the PREVIOUS book
+        assert "invalid" in msg.lower()
+        assert "Switched to: beast-man.gnucash" in msg
+        assert "base currency" in msg          # orientation snapshot
+
+    def test_switch_noop_skips_reset_banner(self, two_books):
+        """Switching to the already-current book is a no-op — it must
+        NOT claim a context reset."""
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)  # current = alex
+        msg = srv._switch_book_impl("alex")
+        assert msg.startswith("Already on: alex.gnucash")
+        assert "CONTEXT RESET" not in msg
+
+    def test_orientation_reports_currency_and_count(self, two_books):
+        import gnucash_mcp.server as srv
+        alex, _ = two_books
+        snap = srv._book_orientation(srv._book_for(alex.resolve()))
+        # _make_min_book seeds one transaction in a USD book.
+        assert "1 transaction" in snap
+        assert "USD base currency" in snap
 
     def test_switch_no_match_lists_available(self, two_books):
         import gnucash_mcp.server as srv


### PR DESCRIPTION
## Summary
- `GNUCASH_BOOK_PATH` now accepts an **`os.pathsep`-separated list** of books (`:` on POSIX, `;` on Windows — the PATH convention). A single path behaves exactly as before. Comma was rejected as a separator because it collides with real filenames (e.g. `financials, invoicing.gnucash`) — using it had regressed single-book paths.
- New **`switch_book`** tool changes the active book in-session, matched by **unique case-insensitive filename prefix**. It's an inline meta-tool kept *out* of the module partition and added to the keep-set only when **2+ books** are configured, so single-book sessions are unchanged (107 tools; 108 in multi-book).
- Switching repoints the `_book` singleton (transparent to every tool — they all call `get_book()` per op), **follows the audit/debug logs** to the active book's `.mcp` dir, and returns a loud **CONTEXT RESET banner** naming the previous book plus a one-line orientation snapshot (txn count, business-entity counts when present, base currency) — guarding against silently reusing stale account names / GUIDs / entity refs across books. A no-op re-switch skips the banner.
- `get_server_config` lists the **current + available books** in multi-book mode; `get_book_summary` marks the current book (tool layer; single-book and the book-level method are untouched).
- **Fail-fast at startup** on any invalid path or duplicate filename (duplicates would make prefix matching ambiguous).

## Test plan
- [x] `uv run pytest` — full suite green (1702 on branch; **1721** merged against current develop)
- [x] `tests/test_modules.py::TestMultiBook` — parse / fail-fast / duplicate-name / comma-in-filename regression guard / visibility / prefix matching / case-insensitivity / server-config / log-follow / context-reset banner / no-op / orientation
- [x] `main()` fail-fast on invalid path → exit 2 (verified)
- [x] Integrated two-book walkthrough: parse → filter → config → switch → banner
- [x] Bookkeeper live-validated `switch_book` against two real books (lin-wei + books); their context-reset-banner finding is implemented here
- [x] Clean merge onto current develop (group-by PR #105) — disjoint files, no conflicts