### PR TITLE
fix: multicurrency correctness audit (B1/B2/S5/S6 + budget + _market_value)

### DIFF
--- a/specs/PRE_1_4_ROADMAP.md
+++ b/specs/PRE_1_4_ROADMAP.md
@@ -1,0 +1,82 @@
+# Pre-1.4 Roadmap
+
+Captured 2026-06-24 so the plan survives session boundaries and
+compaction. Priority order (Stephen's): **correctness → i18n →
+feature creep.** Lane discipline (the PR #92 lesson): each tier is its
+own themed branch/PR, NOT one ballooning branch.
+
+---
+
+## Tier 0 — DONE (branch `fix/multicurrency-correctness`)
+
+The FX-misreporting audit and its fixes. All committed, 1727 tests
+green, bookkeeper-validated on Alex + Lin Wei.
+
+- vendor_spending_report reads the posted ledger, not re-converted face value
+- **B1** FX gain/loss account required in book default currency
+- **B2** both-foreign posting splits valued at the posting-date rate
+- **S5** lot cost basis in book default currency
+- **S6** foreign debts with no FX rate excluded from debt_payoff_plan (warned)
+- budget targets: warn instead of silently folding un-converted foreign units
+- regression tests in `tests/test_multicurrency_audit.py`
+
+## Tier 1 — Correctness (remaining)
+
+- **`_market_value` cost-basis fallback can mix currencies.** When a
+  foreign holding has NO market price AND its purchases were booked in
+  a non-default currency, the fallback sums `split.value` across
+  transaction currencies. Bounded to the no-rate path and already
+  carries a `"… — no price data"` note (not silent), so it was left as
+  documented-acceptable. A proper fix = per-split posting-date
+  conversion (same shape as S5), but it needs `book` threaded through
+  `_market_value`'s signature into all its callers. Low priority.
+- **S3 — `_monthly_net_income` re-prices history at today's rate**
+  (`core.py`). Tagged **1.4.1** (display drift on a dashboard, not data
+  corruption). Fix = per-month-end rate maps, like `_budget_headline`.
+
+## Tier 2 — Internationalization (new branch)
+
+GnuCash ships localized account-hierarchy templates per locale
+(`accounts/<locale>/`, ISO 639-1 + 3166-1). A `ja`/`de`/`ko` book has
+no account literally named "Income"; account *types* (RECEIVABLE,
+PAYABLE, INCOME…) are never localized. Verified against the GnuCash
+wiki (Account_Hierarchy_Template, Locale_Settings).
+
+- **LEAD ITEM (correctness-grade): resolve helper-account parents by
+  TYPE, not English name.** `_get_or_create_fx_account` and the
+  discount-account path call `self._find_account(book, "Income")`,
+  which returns None in a localized book → the FIRST cross-currency
+  payment **throws**. Resolving by the top-level INCOME/EXPENSE-type
+  account fixes localization AND plain user-renames in one stroke.
+  (A/R / A/P resolution is already type-based, so it's safe.)
+- Localizable / configurable default account names (FX gain/loss,
+  discount) + locale-aware or configurable fuzzy keywords
+  (`_FX_NAME_KEYWORDS`, `_*_DISCOUNT_NAME_KEYWORDS`).
+- User-facing string localization (reports, warnings, errors, audit
+  log) — the real lift; needs a message-catalog decision.
+- Number-format locale policy (decimal separator): machine-canonical
+  vs. display-localized.
+
+## Tier 3 — Feature creep (branch per feature)
+
+- **Frankfurter FX auto-updater** (`specs/PRICE_UPDATE_SPEC.md`) — first
+  live network call into a deterministic server; earns its own sprint
+  (offline/failure handling, don't-clobber-user-rates, `type='transaction'`
+  skip, commodity selection). CDN gotcha: Frankfurter 403s the default
+  `Python-urllib` User-Agent; set an explicit UA.
+- **Accrual A/R mark-to-market revaluation.** Realized FX is handled at
+  settlement; open foreign invoices aren't revalued at reporting dates.
+  Feature-sized (a revaluation pass, delta → FX gain/loss). Timing-of-
+  recognition only; converges to the same total at settlement.
+- Separate FX gain vs. loss accounts; taxtable default-taxtable UX.
+
+## Housekeeping
+
+- **`lin-wei.gnucash` fossil.** Bill #000001's payment carries an
+  un-converted A/P relief (`qty=289` instead of the full CNY) — a relic
+  of a pre-fix `pay_invoice` (cross-currency lot-relief bug, since
+  fixed; current `pay_invoice` settles the equivalent bill to a clean
+  zero, verified). Decision pending: regenerate (loses bookkeeper state)
+  / leave (free adversarial fixture) / repair-in-place (5 min). Leaning
+  **leave + document**.
+- README content (real `get_book_summary` example), comment cleanup.

--- a/specs/PRE_1_4_ROADMAP.md
+++ b/specs/PRE_1_4_ROADMAP.md
@@ -18,18 +18,14 @@ green, bookkeeper-validated on Alex + Lin Wei.
 - **S5** lot cost basis in book default currency
 - **S6** foreign debts with no FX rate excluded from debt_payoff_plan (warned)
 - budget targets: warn instead of silently folding un-converted foreign units
+- **`_market_value`** cost-basis fallback converts each purchase at its
+  posting-date rate (book threaded through the 6 core.py call sites) —
+  no more mixed-currency cost sums. (Initially mis-scoped as "too big";
+  it was 6 callers, all with book in scope.)
 - regression tests in `tests/test_multicurrency_audit.py`
 
 ## Tier 1 — Correctness (remaining)
 
-- **`_market_value` cost-basis fallback can mix currencies.** When a
-  foreign holding has NO market price AND its purchases were booked in
-  a non-default currency, the fallback sums `split.value` across
-  transaction currencies. Bounded to the no-rate path and already
-  carries a `"… — no price data"` note (not silent), so it was left as
-  documented-acceptable. A proper fix = per-split posting-date
-  conversion (same shape as S5), but it needs `book` threaded through
-  `_market_value`'s signature into all its callers. Low priority.
 - **S3 — `_monthly_net_income` re-prices history at today's rate**
   (`core.py`). Tagged **1.4.1** (display drift on a dashboard, not data
   corruption). Fix = per-month-end rate maps, like `_budget_headline`.

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -530,6 +530,7 @@ class CurrencyMixin:
         account,
         quantity: Decimal,
         *,
+        book: piecash.Book,
         rates: dict[str, Decimal],
         default_currency: piecash.Commodity,
         today: date | None = None,
@@ -542,6 +543,8 @@ class CurrencyMixin:
         account-level aggregation.
 
         Args:
+            book: Needed to value the cost-basis fallback in the book
+                default currency (see below).
             rates: Map from :meth:`_rates_as_of`, passed in so the
                 price-map builds once per report.
             today: Cost-basis fallback ignores splits dated after
@@ -566,10 +569,26 @@ class CurrencyMixin:
             return quantity * rate, note
         if not with_cost_fallback:
             return Decimal("0"), f"{quantity} {sym} — no price data"
+        # No market price for the holding: fall back to cost basis in
+        # the book default. ``split.value`` is in each purchase's
+        # transaction currency; convert each at its posting-date rate
+        # (mirroring calculate_lot_gain / _lot_decimals) so a holding
+        # bought across foreign currencies isn't summed as raw mixed
+        # units. Missing per-leg rate degrades to the raw value.
         cost_basis = Decimal("0")
         for s in account.splits:
-            if today is None or s.transaction.post_date <= today:
-                cost_basis += Decimal(str(s.value))
+            if today is not None and s.transaction.post_date > today:
+                continue
+            value = Decimal(str(s.value))
+            txn_ccy = s.transaction.currency
+            if txn_ccy != default_currency:
+                leg_rate = self._cross_rate(
+                    book, txn_ccy, default_currency,
+                    as_of=s.transaction.post_date,
+                )
+                if leg_rate is not None:
+                    value = value * leg_rate
+            cost_basis += value
         return cost_basis, f"{quantity} {sym} — no price data"
 
     @staticmethod

--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -776,6 +776,12 @@ class BudgetsMixin:
             # leaves targets in raw account commodities and makes
             # used_pct meaningless on multi-currency budgets.
             factors = self._account_conversion_factors(book, last_end)
+            default_currency = self._require_default_currency(book)
+            # Currencies of budgeted accounts folded in raw for lack of
+            # an FX rate — surfaced as a warning so the converted totals
+            # don't read as exact (the math stays internally consistent
+            # because actuals degrade the same way).
+            unconverted_currencies: set[str] = set()
 
             budgeted: dict[str, Decimal] = {}
             # Keep a handle to each budgeted account for descendant walking.
@@ -788,13 +794,19 @@ class BudgetsMixin:
                     continue
                 # None factor → no rate on file; the raw-amount
                 # fallback matches how actuals degrade via
-                # _split_in_default_currency.
+                # _split_in_default_currency. Record the currency so a
+                # foreign fold isn't silent (it stays in the totals —
+                # a caveated budget line beats a dropped one).
                 factor = factors.get(ba.account.guid)
                 ba_amount = Decimal(str(ba.amount))
                 if factor is not None:
                     target_in_default = ba_amount * factor
                 else:
                     target_in_default = ba_amount
+                    if ba.account.commodity != default_currency:
+                        unconverted_currencies.add(
+                            ba.account.commodity.mnemonic
+                        )
                 budgeted[acct_name] = budgeted.get(
                     acct_name, Decimal("0")
                 ) + target_in_default
@@ -910,9 +922,24 @@ class BudgetsMixin:
                     "percent_used": str(total_pct),
                 },
             }
+            warning = None
+            if unconverted_currencies:
+                warning = (
+                    f"Budgeted amounts in "
+                    f"{', '.join(sorted(unconverted_currencies))} have no FX "
+                    f"rate on file and are folded in un-converted; "
+                    f"{default_currency.mnemonic} totals are approximate "
+                    f"(percent_used stays consistent — actuals degrade the "
+                    f"same way)."
+                )
+                full["warnings"] = [warning]
+
             if not compact:
                 return full
-            return _format_budget_report_compact(full)
+            out = _format_budget_report_compact(full)
+            if warning:
+                out += f"\n⚠ {warning}"
+            return out
 
     def delete_budget(self, name: str) -> dict:
         """Delete a budget.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -367,6 +367,8 @@ class BusinessMixin:
                 INCOME/EXPENSE; or no ``Income`` parent to create
                 under.
         """
+        default_currency = self._require_default_currency(book)
+
         # Layer 1: caller-supplied account wins.
         if fx_account is not None:
             acct = self._resolve_account(book, fx_account)
@@ -382,15 +384,31 @@ class BusinessMixin:
                     f"{acct.type}; must be INCOME or EXPENSE to "
                     f"receive realized FX gain/loss."
                 )
+            # Realized FX gain/loss is a reporting-currency figure;
+            # the gain is booked as a default-currency quantity. A
+            # non-default-commodity FX account would record it in the
+            # wrong commodity (a $42 gain becoming €42). Reject rather
+            # than silently corrupt.
+            if acct.commodity != default_currency:
+                raise ValueError(
+                    f"fx_account {acct.fullname!r} is denominated in "
+                    f"{acct.commodity.mnemonic}; the realized FX "
+                    f"gain/loss account must be in the book default "
+                    f"currency ({default_currency.mnemonic})."
+                )
             return acct, None
 
-        # Layer 2: fuzzy match by leaf-name substring.
+        # Layer 2: fuzzy match by leaf-name substring. Only
+        # default-currency candidates qualify — see the commodity
+        # rationale on the explicit-account path above.
         template_guids = self._template_account_guids(book)
         candidates = []
         for account in book.accounts:
             if account.guid in template_guids:
                 continue
             if account.type not in {"INCOME", "EXPENSE"}:
+                continue
+            if account.commodity != default_currency:
                 continue
             name_lower = account.name.lower()
             if any(kw in name_lower for kw in self._FX_NAME_KEYWORDS):
@@ -427,7 +445,6 @@ class BusinessMixin:
                 "Income (type=INCOME, placeholder) first."
             )
 
-        default_currency = self._require_default_currency(book)
         # Construct — piecash.Account auto-adds to the session via the
         # parent linkage. Don't flush here: the caller is still building
         # the payment transaction, and orphan Split objects already in

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -7074,7 +7074,7 @@ class BusinessMixin:
             }
 
     def _posting_split_in_default(
-        self, split, default_currency, rates,
+        self, book, split, default_currency,
     ) -> tuple[Decimal, bool]:
         """Value one posting/payment split in the book's default
         currency, trusting the ledger.
@@ -7083,27 +7083,34 @@ class BusinessMixin:
         ``value`` in its transaction's currency. Whichever of those
         is the book default IS the base-currency amount — the rate
         was applied when the row was written, so re-deriving it from
-        face value at a later period's rate is wrong (it drifts with
-        the rate). Only a split whose account AND transaction are
-        both non-default needs a live conversion; then ``value`` is
-        converted at the supplied rate, flagging when none is on file.
+        face value is unnecessary and re-deriving it at a *report-time*
+        rate is wrong (it drifts with the rate). Only a split whose
+        account AND transaction are both non-default has no stored
+        base-currency amount; there a live conversion is required, and
+        it uses the rate AS OF THE POSTING DATE (what was booked), not
+        a report-period rate.
 
         Returns ``(amount, converted_ok)``; ``converted_ok`` is False
-        only when a rate was required and missing.
+        only when a rate was required and none is on file.
         """
         if split.account.commodity == default_currency:
             return Decimal(str(split.quantity)), True
         txn_currency = split.transaction.currency
         if txn_currency == default_currency:
             return Decimal(str(split.value)), True
-        rate = rates.get(txn_currency.guid)
+        # Both-foreign: no base-currency amount is stored. Convert the
+        # transaction-currency value at the posting-date rate.
+        rate = self._cross_rate(
+            book, txn_currency, default_currency,
+            as_of=split.transaction.post_date,
+        )
         if rate is None:
             return Decimal(str(split.value)), False
         quantum = _commodity_quantum(default_currency)
         return (Decimal(str(split.value)) * rate).quantize(quantum), True
 
     def _bill_amounts_in_default(
-        self, book, bill, default_currency, rates,
+        self, book, bill, default_currency,
     ) -> tuple[Decimal, Decimal, Decimal, str | None]:
         """Billed / paid / outstanding for one bill, in the book's
         default currency, read from the posting ledger.
@@ -7137,7 +7144,7 @@ class BusinessMixin:
                 if s.account.guid == bill.post_acc_guid:
                     continue
                 amt, ok = self._posting_split_in_default(
-                    s, default_currency, rates,
+                    book, s, default_currency,
                 )
                 converted_ok = converted_ok and ok
                 billed += amt
@@ -7156,7 +7163,7 @@ class BusinessMixin:
                     if s.reconcile_state == "v":
                         continue
                     amt, ok = self._posting_split_in_default(
-                        s, default_currency, rates,
+                        book, s, default_currency,
                     )
                     converted_ok = converted_ok and ok
                     outstanding += amt
@@ -7188,9 +7195,6 @@ class BusinessMixin:
         """
         periods = _enumerate_periods(start_date, end_date, group_by)
         period_labels = [pl for pl, _ in periods]
-        rates_by_period = {
-            pl: self._rates_as_of(book, anchor) for pl, anchor in periods
-        }
 
         totals: dict[str, dict[str, Decimal]] = {}
         unconverted: dict[str, dict] = {}
@@ -7200,7 +7204,7 @@ class BusinessMixin:
                 continue
             plabel = _period_label(posted.date(), group_by)
             total, _paid, _out, unconv = self._bill_amounts_in_default(
-                book, bill, default_currency, rates_by_period[plabel],
+                book, bill, default_currency,
             )
 
             if unconv is not None:
@@ -7295,10 +7299,6 @@ class BusinessMixin:
             default_currency = self._require_default_currency(book)
             default_currency_mnemonic = default_currency.mnemonic
 
-            # Rates as of period end — historical periods must not
-            # be valued at today's rates.
-            latest_rates = self._rates_as_of(book, parsed_end)
-
             query = book.session.query(Invoice).filter(
                 Invoice.owner_type == 4,
                 Invoice.date_posted.isnot(None),
@@ -7367,7 +7367,7 @@ class BusinessMixin:
                 # rate-at-posting amount, never today's drifted rate.
                 total, paid, outstanding, unconv = (
                     self._bill_amounts_in_default(
-                        book, bill, default_currency, latest_rates,
+                        book, bill, default_currency,
                     )
                 )
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -7056,27 +7056,99 @@ class BusinessMixin:
                 "invoices": invoice_rows,
             }
 
-    def _bill_billed_total(self, book, bill) -> Decimal:
-        """Total billed on a bill, in the bill's own currency.
+    def _posting_split_in_default(
+        self, split, default_currency, rates,
+    ) -> tuple[Decimal, bool]:
+        """Value one posting/payment split in the book's default
+        currency, trusting the ledger.
 
-        Mirrors the single-period path: the invoice-entries grand
-        total, falling back to the post-lot balance when entries are
-        empty or corrupted (substituting 0 would understate the
-        vendor's total by the whole bill).
+        A split stores ``quantity`` in its account's commodity and
+        ``value`` in its transaction's currency. Whichever of those
+        is the book default IS the base-currency amount — the rate
+        was applied when the row was written, so re-deriving it from
+        face value at a later period's rate is wrong (it drifts with
+        the rate). Only a split whose account AND transaction are
+        both non-default needs a live conversion; then ``value`` is
+        converted at the supplied rate, flagging when none is on file.
+
+        Returns ``(amount, converted_ok)``; ``converted_ok`` is False
+        only when a rate was required and missing.
         """
-        try:
-            return self._get_invoice_entries_and_total(
-                book, bill,
-            )["grand_total"]
-        except ValueError:
-            post_acct = book.session.query(
-                piecash.Account
-            ).filter_by(guid=bill.post_acc_guid).first()
-            if post_acct:
-                for lot in post_acct.lots:
-                    if lot.guid == bill.post_lot_guid:
-                        return abs(self._calculate_lot_balance(lot))
-            return Decimal(0)
+        if split.account.commodity == default_currency:
+            return Decimal(str(split.quantity)), True
+        txn_currency = split.transaction.currency
+        if txn_currency == default_currency:
+            return Decimal(str(split.value)), True
+        rate = rates.get(txn_currency.guid)
+        if rate is None:
+            return Decimal(str(split.value)), False
+        quantum = _commodity_quantum(default_currency)
+        return (Decimal(str(split.value)) * rate).quantize(quantum), True
+
+    def _bill_amounts_in_default(
+        self, book, bill, default_currency, rates,
+    ) -> tuple[Decimal, Decimal, Decimal, str | None]:
+        """Billed / paid / outstanding for one bill, in the book's
+        default currency, read from the posting ledger.
+
+        Sums the posting transaction's contra (non-A/P) splits for
+        the billed total and the post-lot balance for outstanding —
+        both valued via :meth:`_posting_split_in_default`, so a
+        foreign-currency bill posted against a default-currency A/P
+        account needs no rate at all: the CNY amounts computed at
+        posting time are read straight off the ledger. ``paid`` is
+        the difference. This is the same principle as the contra-split
+        fix: report what the book contains, not a re-derivation of
+        what it should contain.
+
+        Returns ``(billed, paid, outstanding, unconverted_ccy)``.
+        ``unconverted_ccy`` is the bill currency's mnemonic when a
+        split could not be valued (no rate on file) — None on
+        success; the amounts are then in that raw foreign currency
+        and the caller routes them to the per-currency bucket.
+        """
+        converted_ok = True
+
+        # Total billed = magnitude of the contra (non-A/P) side of
+        # the posting transaction.
+        billed = Decimal(0)
+        txn = bill.post_txn
+        if txn is not None:
+            for s in txn.splits:
+                if s.reconcile_state == "v":
+                    continue
+                if s.account.guid == bill.post_acc_guid:
+                    continue
+                amt, ok = self._posting_split_in_default(
+                    s, default_currency, rates,
+                )
+                converted_ok = converted_ok and ok
+                billed += amt
+        billed = abs(billed)
+
+        # Outstanding = magnitude of the post-lot balance.
+        outstanding = Decimal(0)
+        post_acct = book.session.query(
+            piecash.Account
+        ).filter_by(guid=bill.post_acc_guid).first()
+        if post_acct:
+            for lot in post_acct.lots:
+                if lot.guid != bill.post_lot_guid:
+                    continue
+                for s in lot.splits:
+                    if s.reconcile_state == "v":
+                        continue
+                    amt, ok = self._posting_split_in_default(
+                        s, default_currency, rates,
+                    )
+                    converted_ok = converted_ok and ok
+                    outstanding += amt
+                break
+        outstanding = abs(outstanding)
+
+        paid = billed - outstanding
+        unconverted = None if converted_ok else bill.currency.mnemonic
+        return billed, paid, outstanding, unconverted
 
     def _grouped_vendor_spending(
         self,
@@ -7090,18 +7162,18 @@ class BusinessMixin:
     ) -> str:
         """Bucket total-billed per vendor into sub-period columns.
 
-        Each bill lands in its ``date_posted`` sub-period and converts
-        at that period's close — never today's rates. Bills with no FX
-        rate on file are excluded from the converted totals and
-        surfaced in a trailing warning, exactly as the single-period
-        report handles them.
+        Each bill lands in its ``date_posted`` sub-period, billed in
+        the book default read off the posting ledger (see
+        :meth:`_bill_amounts_in_default`). Bills that can't be valued
+        (foreign A/P account, no FX rate on file) are excluded from
+        the converted totals and surfaced in a trailing warning,
+        exactly as the single-period report handles them.
         """
         periods = _enumerate_periods(start_date, end_date, group_by)
         period_labels = [pl for pl, _ in periods]
         rates_by_period = {
             pl: self._rates_as_of(book, anchor) for pl, anchor in periods
         }
-        quantum = _commodity_quantum(default_currency)
 
         totals: dict[str, dict[str, Decimal]] = {}
         unconverted: dict[str, dict] = {}
@@ -7110,19 +7182,18 @@ class BusinessMixin:
             if posted is None:
                 continue
             plabel = _period_label(posted.date(), group_by)
-            total = self._bill_billed_total(book, bill)
+            total, _paid, _out, unconv = self._bill_amounts_in_default(
+                book, bill, default_currency, rates_by_period[plabel],
+            )
 
-            if bill.currency != default_currency:
-                rate = rates_by_period[plabel].get(bill.currency.guid)
-                if rate is None:
-                    u = unconverted.setdefault(
-                        bill.currency.mnemonic,
-                        {"total_billed": Decimal(0), "bill_count": 0},
-                    )
-                    u["total_billed"] += total
-                    u["bill_count"] += 1
-                    continue
-                total = (total * rate).quantize(quantum)
+            if unconv is not None:
+                u = unconverted.setdefault(
+                    unconv,
+                    {"total_billed": Decimal(0), "bill_count": 0},
+                )
+                u["total_billed"] += total
+                u["bill_count"] += 1
+                continue
 
             v = self._find_vendor_by_guid(book, bill.owner_guid)
             v_name = v.name if v else "Unknown"
@@ -7250,7 +7321,8 @@ class BusinessMixin:
                 )
 
             vendor_data: dict[str, dict] = {}
-            # Bills with no rate on file are EXCLUDED from
+            # Bills that can't be valued in the book default (foreign
+            # A/P account with no FX rate on file) are EXCLUDED from
             # default-currency totals (folding raw foreign units
             # corrupts the sum); tracked per currency and surfaced
             # as a warning.
@@ -7272,64 +7344,31 @@ class BusinessMixin:
                         "bill_count": 0,
                     }
 
-                balance = Decimal(0)
-                post_acct = book.session.query(
-                    piecash.Account
-                ).filter_by(guid=bill.post_acc_guid).first()
-                if post_acct:
-                    for lot in post_acct.lots:
-                        if lot.guid == bill.post_lot_guid:
-                            balance = self._calculate_lot_balance(
-                                lot
-                            )
-                            break
+                # Billed/paid/outstanding read off the posting ledger
+                # in the book default — for a foreign-currency bill
+                # against a default-currency A/P account this is the
+                # rate-at-posting amount, never today's drifted rate.
+                total, paid, outstanding, unconv = (
+                    self._bill_amounts_in_default(
+                        book, bill, default_currency, latest_rates,
+                    )
+                )
 
-                try:
-                    total = self._get_invoice_entries_and_total(
-                        book, bill,
-                    )["grand_total"]
-                except ValueError:
-                    # Empty/corrupted entries: fall back to the lot
-                    # balance. Substituting 0 would understate
-                    # total_billed by the bill's full amount.
-                    total = abs(balance)
-
-                outstanding = abs(balance)
-                paid = total - outstanding
-
-                # Convert per-bill totals to the book default before
-                # summing — unconverted, a €2,500 bill and a $3,000
-                # bill sum to "5,500" of nothing in particular.
-                converted_ok = True
-                if bill.currency != default_currency:
-                    rate = latest_rates.get(bill.currency.guid)
-                    if rate is not None:
-                        # Quantize FX products to default-currency
-                        # precision: verbose emits via str(), which
-                        # would expose a long fractional tail.
-                        q = _commodity_quantum(default_currency)
-                        total = (total * rate).quantize(q)
-                        paid = (paid * rate).quantize(q)
-                        outstanding = (outstanding * rate).quantize(q)
-                    else:
-                        # No rate: exclude and accumulate per
-                        # currency for explicit reporting.
-                        converted_ok = False
-                        u = unconverted.setdefault(
-                            bill.currency.mnemonic,
-                            {
-                                "total_billed": Decimal(0),
-                                "total_paid": Decimal(0),
-                                "outstanding": Decimal(0),
-                                "bill_count": 0,
-                            },
-                        )
-                        u["total_billed"] += total
-                        u["total_paid"] += paid
-                        u["outstanding"] += outstanding
-                        u["bill_count"] += 1
-
-                if converted_ok:
+                if unconv is not None:
+                    u = unconverted.setdefault(
+                        unconv,
+                        {
+                            "total_billed": Decimal(0),
+                            "total_paid": Decimal(0),
+                            "outstanding": Decimal(0),
+                            "bill_count": 0,
+                        },
+                    )
+                    u["total_billed"] += total
+                    u["total_paid"] += paid
+                    u["outstanding"] += outstanding
+                    u["bill_count"] += 1
+                else:
                     vendor_data[v_name]["total_billed"] += total
                     vendor_data[v_name]["total_paid"] += paid
                     vendor_data[v_name]["outstanding"] += outstanding

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -449,6 +449,7 @@ class CoreMixin:
             # liabilities; liabilities negate to a positive magnitude.
             converted, _ = self._market_value(
                 account, balance,
+                book=book,
                 rates=rates,
                 default_currency=default_currency,
                 today=as_of,
@@ -1511,6 +1512,7 @@ class CoreMixin:
         latest_prices: dict,
         default_currency,
         today: date,
+        book: piecash.Book,
         rate_via: dict[str, str] | None = None,
     ) -> _SummaryData:
         """Single-pass account walker for ``get_book_summary``.
@@ -1548,6 +1550,7 @@ class CoreMixin:
                 if balance != 0:
                     usd_value, note = self._market_value(
                         account, balance,
+                        book=book,
                         rates=latest_prices,
                         default_currency=default_currency,
                         today=today,
@@ -1561,6 +1564,7 @@ class CoreMixin:
                     # diverge from balance_sheet on foreign debt.
                     usd_value, _ = self._market_value(
                         account, balance,
+                        book=book,
                         rates=latest_prices,
                         default_currency=default_currency,
                         today=today,
@@ -1570,6 +1574,7 @@ class CoreMixin:
                 if balance != 0:
                     usd_value, _ = self._market_value(
                         account, balance,
+                        book=book,
                         rates=latest_prices,
                         default_currency=default_currency,
                         today=today,
@@ -1586,6 +1591,7 @@ class CoreMixin:
                     # A/R is debit-natural: positive balance = owed to us.
                     usd_value, _ = self._market_value(
                         account, balance,
+                        book=book,
                         rates=latest_prices,
                         default_currency=default_currency,
                         today=today,
@@ -1596,6 +1602,7 @@ class CoreMixin:
                     # A/P is credit-natural: negate for "what we owe".
                     usd_value, _ = self._market_value(
                         account, -balance,
+                        book=book,
                         rates=latest_prices,
                         default_currency=default_currency,
                         today=today,
@@ -1991,6 +1998,7 @@ class CoreMixin:
                 latest_prices=latest_prices,
                 default_currency=default_currency,
                 today=today,
+                book=book,
                 rate_via=rate_via,
             )
 

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -578,7 +578,7 @@ class InvestmentsMixin:
             raise
         return book.session.query(Lot).filter_by(guid=full_guid).first()
 
-    def _lot_decimals(self, lot) -> dict:
+    def _lot_decimals(self, lot, book, default_ccy) -> dict:
         """Raw-Decimal source of truth for a lot's current state.
 
         Keeps full precision; ``_lot_summary`` formats the egress.
@@ -587,6 +587,15 @@ class InvestmentsMixin:
         computation. The classic precision-loss path: $100 / 3 shares
         formatted to 4 decimals as 33.3333, multiplied back by 3
         shares becomes $99.99 — but the actual cost was $100.
+
+        ``purchase_value`` (and the ``cost_per_share`` /
+        ``remaining_cost_basis`` derived from it) is in the book
+        DEFAULT currency. ``split.value`` is in the purchase
+        transaction's currency; a foreign-denominated buy is converted
+        at its posting-date rate (matching ``calculate_lot_gain``), so
+        a CNY-book holding bought in USD doesn't surface a bare USD
+        number that reads as CNY. Missing rate degrades to the raw
+        value.
 
         Returns:
             Dict of Decimals: purchase_quantity, purchase_value,
@@ -605,7 +614,16 @@ class InvestmentsMixin:
                 continue
             if split.quantity > 0:
                 purchase_quantity += Decimal(str(split.quantity))
-                purchase_value += Decimal(str(split.value))
+                value = Decimal(str(split.value))
+                txn_ccy = split.transaction.currency
+                if txn_ccy != default_ccy:
+                    rate = self._cross_rate(
+                        book, txn_ccy, default_ccy,
+                        as_of=split.transaction.post_date,
+                    )
+                    if rate is not None:
+                        value = value * rate
+                purchase_value += value
             else:
                 sale_quantity += abs(Decimal(str(split.quantity)))
 
@@ -634,7 +652,7 @@ class InvestmentsMixin:
             "remaining_cost_basis": remaining_cost_basis,
         }
 
-    def _lot_summary(self, lot) -> dict:
+    def _lot_summary(self, lot, book, default_ccy) -> dict:
         """Compute current state of a lot from its splits.
 
         Returns:
@@ -649,7 +667,7 @@ class InvestmentsMixin:
         as either the purchase cost or what's left of it. The
         ``cost_basis`` key keeps existing callers working.
         """
-        raw = self._lot_decimals(lot)
+        raw = self._lot_decimals(lot, book, default_ccy)
         remaining_cb = _format_number(
             raw["remaining_cost_basis"], decimals=2,
         )
@@ -756,11 +774,12 @@ class InvestmentsMixin:
             if not acct:
                 raise ValueError(f"Account not found: {account}")
 
+            default_ccy = self._require_default_currency(book)
             results = []
             for lot in acct.lots:
                 if not include_closed and lot.is_closed:
                     continue
-                summary = self._lot_summary(lot)
+                summary = self._lot_summary(lot, book, default_ccy)
                 # The open-positions view also skips zero-position
                 # lots (voided buys, never-assigned, round-tripped
                 # to zero) — noise rows in a holdings listing.
@@ -845,7 +864,8 @@ class InvestmentsMixin:
                     row["voided"] = True
                 splits.append(row)
 
-            summary = self._lot_summary(lot)
+            default_ccy = self._require_default_currency(book)
+            summary = self._lot_summary(lot, book, default_ccy)
             # ``is_closed`` already lives at the top level
             # of this response. Drop it from the nested ``summary``
             # so callers see the field once, not twice.
@@ -917,7 +937,8 @@ class InvestmentsMixin:
             split.lot = lot
             book.save()
 
-            summary = self._lot_summary(lot)
+            default_ccy = self._require_default_currency(book)
+            summary = self._lot_summary(lot, book, default_ccy)
 
             # Auto-close if quantity reaches zero; GnuCash uses -1 for boolean true
             auto_closed = False
@@ -964,7 +985,8 @@ class InvestmentsMixin:
             if not lot:
                 raise ValueError(f"Lot not found: {lot_guid}")
 
-            raw = self._lot_decimals(lot)
+            default_ccy = self._require_default_currency(book)
+            raw = self._lot_decimals(lot, book, default_ccy)
             remaining = raw["remaining"]
 
             if remaining <= 0:
@@ -993,8 +1015,6 @@ class InvestmentsMixin:
             else:
                 shares_to_sell = remaining
 
-            default_ccy = self._require_default_currency(book)
-
             if sale_price is not None:
                 price = _to_decimal(sale_price)
             else:
@@ -1014,25 +1034,10 @@ class InvestmentsMixin:
                     )
                 price = Decimal(str(recent[0].value))
 
-            # Cost basis must match the proceeds' currency.
-            # split.value is in TRANSACTION currency — a foreign-
-            # denominated buy converts at its historical purchase
-            # date or the tax-relevant gain is off by the full FX
-            # factor. Missing rate degrades to the raw value.
-            purchase_value_default = Decimal("0")
-            for split in lot.splits:
-                if _is_voided(split) or split.quantity <= 0:
-                    continue
-                value = Decimal(str(split.value))
-                txn_ccy = split.transaction.currency
-                if txn_ccy != default_ccy:
-                    rate = self._cross_rate(
-                        book, txn_ccy, default_ccy,
-                        as_of=split.transaction.post_date,
-                    )
-                    if rate is not None:
-                        value = value * rate
-                purchase_value_default += value
+            # Cost basis in the book default (proceeds' currency).
+            # _lot_decimals already converts each purchase split at its
+            # posting-date rate — same treatment, one chokepoint.
+            purchase_value_default = raw["purchase_value"]
 
             # Prorate on shares-to-sell, never cost_per_share ×
             # shares — divide-then-multiply loses precision ($100/3

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1266,11 +1266,14 @@ class ReportingMixin:
             raise ValueError("additional_purchase must be a positive number")
 
         with self.open(readonly=True) as book:
-            default_currency_mnemonic = (
-                self._require_default_currency(book).mnemonic
-            )
+            default_currency = self._require_default_currency(book)
+            default_currency_mnemonic = default_currency.mnemonic
             debt_types = {"CREDIT", "LIABILITY"}
             debts = []
+            # Foreign-currency debts with no FX rate on file can't be
+            # valued in the book default; collected here and excluded
+            # from the schedule (see the loop guard below).
+            excluded_debts: list[str] = []
             # Counted so the no-debts error distinguishes "no debt
             # accounts at all" from "they exist but lack the apr
             # slot" — the user's next action differs.
@@ -1293,6 +1296,19 @@ class ReportingMixin:
                 if account.type not in debt_types:
                     continue
                 debt_typed_account_count += 1
+
+                # A foreign-currency debt with no FX rate on file can't
+                # be valued in the book default: its balance would fall
+                # back to raw transaction-currency value while its
+                # min_payment / credit_limit slots stay in account-
+                # commodity units — mixing units in the payoff math.
+                # Exclude it honestly rather than emit a skewed schedule.
+                if (
+                    account.commodity != default_currency
+                    and debt_factors.get(account.guid) is None
+                ):
+                    excluded_debts.append(account.fullname)
+                    continue
 
                 # Materialize slots once — three account[key]
                 # accesses each re-walk the slots collection.
@@ -1409,7 +1425,37 @@ class ReportingMixin:
                     "credit_limit": credit_limit,
                 })
 
+        # Warning shared by the all-excluded error and the normal-path
+        # output, so the reader always learns what was left out.
+        excluded_warning = None
+        if excluded_debts:
+            excluded_warning = (
+                f"{len(excluded_debts)} debt(s) excluded — no FX rate on "
+                f"file to value in {default_currency_mnemonic}: "
+                f"{', '.join(sorted(excluded_debts))}"
+            )
+
         if not debts:
+            # Nothing left to plan but some debts were excluded for lack
+            # of an FX rate — lead with that actionable cause (distinct
+            # from "no debts at all" or "no APR set").
+            if excluded_debts:
+                msg = (
+                    f"No debts could be valued for the payoff plan. "
+                    f"{len(excluded_debts)} debt(s) are in a non-default "
+                    f"currency with no FX rate on file to value in "
+                    f"{default_currency_mnemonic}: "
+                    f"{', '.join(sorted(excluded_debts))}. Add a market "
+                    f"price (create_price) for each currency"
+                )
+                if debt_typed_account_count > len(excluded_debts):
+                    msg += (
+                        ", and set an 'apr' slot on the remaining debt "
+                        "account(s)."
+                    )
+                else:
+                    msg += " and retry."
+                raise ValueError(msg)
             if debt_typed_account_count == 0:
                 raise ValueError(
                     "No CREDIT or LIABILITY accounts found in the "
@@ -1496,11 +1542,14 @@ class ReportingMixin:
                 ),
             },
         }
+        if excluded_warning:
+            full["excluded"] = sorted(excluded_debts)
+            full["warnings"] = [excluded_warning]
 
         if not compact:
             return full
 
-        return _format_debt_payoff_compact(
+        compact_out = _format_debt_payoff_compact(
             results=results,
             orig_balances=orig_balances,
             total_balance=total_balance,
@@ -1513,3 +1562,6 @@ class ReportingMixin:
             true_cost=true_cost,
             currency=default_currency_mnemonic,
         )
+        if excluded_warning:
+            compact_out += f"\n⚠ {excluded_warning}"
+        return compact_out

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -1,0 +1,290 @@
+"""Regression tests for the multicurrency-correctness audit.
+
+Each test locks one finding from the FX-misreporting sweep:
+
+- B1: the realized FX gain/loss account must be in the book default
+  currency, so the gain (a default-currency quantity) is never recorded
+  in the wrong commodity.
+- B2: a posting/payment split whose account commodity AND transaction
+  currency are both non-default is valued at the POSTING-DATE rate, not
+  a report-time rate.
+- S5: lot cost basis surfaces in the book default currency for a
+  foreign-denominated purchase, not the raw transaction currency.
+- S6: a foreign-currency debt with no FX rate on file is excluded from
+  debt_payoff_plan (with a warning) instead of producing a mixed-unit
+  schedule.
+
+Every one is invisible in a single-currency book — they manifest only
+when the book default differs from a transaction/account currency.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import piecash
+import pytest
+from piecash import factories
+
+from gnucash_mcp.book import GnuCashBook
+
+
+# --------------------------------------------------------------------------
+# B1 — FX gain/loss account must be in the book default currency
+# --------------------------------------------------------------------------
+
+class TestFxAccountCurrencyGuard:
+    def test_explicit_non_default_currency_fx_account_rejected(
+        self, business_book,
+    ):
+        """An explicit fx_account in a non-default commodity is rejected
+        — booking a default-currency gain there would record it in the
+        wrong commodity (a $42 gain becoming €42)."""
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            eur = factories.create_currency_from_ISO("EUR")
+            income = gb._find_account(book, "Income")
+            piecash.Account(
+                name="FX Gain EUR", type="INCOME",
+                parent=income, commodity=eur,
+            )
+            book.save()
+        with gb.open(readonly=True) as book:
+            with pytest.raises(
+                ValueError, match="book default currency",
+            ):
+                gb._get_or_create_fx_account(
+                    book, fx_account="Income:FX Gain EUR",
+                )
+
+    def test_fuzzy_match_skips_non_default_currency_account(
+        self, business_book,
+    ):
+        """A keyword-matching FX account in a non-default commodity is
+        NOT auto-selected by the fuzzy layer; resolution falls through
+        to the canonical default-currency account."""
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            eur = factories.create_currency_from_ISO("EUR")
+            income = gb._find_account(book, "Income")
+            # "fx" keyword would match, but the EUR commodity disqualifies it.
+            piecash.Account(
+                name="FX Gains", type="INCOME",
+                parent=income, commodity=eur,
+            )
+            book.save()
+        with gb.open(readonly=True) as book:
+            fx_acct, _notice = gb._get_or_create_fx_account(book)
+            assert fx_acct.commodity == book.default_currency
+            assert fx_acct.fullname != "Income:FX Gains"
+
+
+# --------------------------------------------------------------------------
+# B2 — both-foreign posting split valued at the posting-date rate
+# --------------------------------------------------------------------------
+
+def test_posting_split_valued_at_posting_date_rate(tmp_path):
+    """When neither the account commodity nor the transaction currency
+    is the book default, _posting_split_in_default converts at the
+    posting-date rate — not a later/period-end rate."""
+    path = tmp_path / "b2.gnucash"
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    eur = factories.create_currency_from_ISO("EUR")
+
+    assets = piecash.Account(
+        name="Assets", type="ASSET", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    eur_a = piecash.Account(
+        name="EUR A", type="BANK", commodity=eur, parent=assets,
+    )
+    eur_b = piecash.Account(
+        name="EUR B", type="EXPENSE", commodity=eur,
+        parent=book.root_account,
+    )
+    # Posting-date rate 1.10; a later rate 1.50 that must NOT be used.
+    book.session.add(piecash.Price(
+        commodity=eur, currency=usd,
+        date=date(2025, 1, 15), value="1.10", type="last",
+    ))
+    book.session.add(piecash.Price(
+        commodity=eur, currency=usd,
+        date=date(2025, 6, 1), value="1.50", type="last",
+    ))
+    txn = piecash.Transaction(
+        currency=eur, post_date=date(2025, 1, 15),
+        description="EUR entry",
+        splits=[
+            piecash.Split(
+                account=eur_a, value=Decimal("100"),
+                quantity=Decimal("100"),
+            ),
+            piecash.Split(
+                account=eur_b, value=Decimal("-100"),
+                quantity=Decimal("-100"),
+            ),
+        ],
+    )
+    book.save()
+    book.close()
+
+    gb = GnuCashBook(str(path))
+    with gb.open(readonly=True) as book:
+        usd = book.default_currency
+        split = next(
+            s for s in book.transactions[0].splits
+            if s.account.name == "EUR A"
+        )
+        amount, converted_ok = gb._posting_split_in_default(
+            book, split, usd,
+        )
+        assert converted_ok
+        # 100 EUR x 1.10 (posting date) = 110.00, NOT 150.00 (later rate).
+        assert amount == Decimal("110.00")
+
+
+# --------------------------------------------------------------------------
+# S5 — lot cost basis in the book default currency
+# --------------------------------------------------------------------------
+
+def test_lot_cost_basis_converted_for_foreign_purchase(tmp_path):
+    """A fund bought in EUR in a USD-default book surfaces its cost
+    basis converted to USD at the purchase-date rate — not a bare EUR
+    number that reads as USD."""
+    path = tmp_path / "s5.gnucash"
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    eur = factories.create_currency_from_ISO("EUR")
+
+    fund = piecash.Commodity(
+        namespace="FUND", mnemonic="EUFND",
+        fullname="Euro Fund", fraction=10000,
+    )
+    book.session.add(fund)
+    assets = piecash.Account(
+        name="Assets", type="ASSET", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    inv = piecash.Account(
+        name="EU Fund", type="MUTUAL", commodity=fund, parent=assets,
+    )
+    cash_eur = piecash.Account(
+        name="EUR Cash", type="BANK", commodity=eur, parent=assets,
+    )
+    book.session.add(piecash.Price(
+        commodity=eur, currency=usd,
+        date=date(2025, 3, 1), value="1.20", type="last",
+    ))
+    buy = piecash.Transaction(
+        currency=eur, post_date=date(2025, 3, 1),
+        description="Buy fund",
+        splits=[
+            piecash.Split(
+                account=inv, value=Decimal("1000"),
+                quantity=Decimal("10"),
+            ),
+            piecash.Split(
+                account=cash_eur, value=Decimal("-1000"),
+                quantity=Decimal("-1000"),
+            ),
+        ],
+    )
+    lot = piecash.Lot(title="Lot 1", account=inv, is_closed=0)
+    book.save()
+    buy_split = next(s for s in buy.splits if s.account == inv)
+    buy_split.lot = lot
+    book.save()
+    book.close()
+
+    gb = GnuCashBook(str(path))
+    res = gb.list_lots(account="Assets:EU Fund", compact=False)
+    row = res["lots"][0]
+    # 1000 EUR x 1.20 = 1200.00 USD, not a bare "1000".
+    assert Decimal(row["original_cost_basis"]) == Decimal("1200.00")
+    assert Decimal(row["cost_basis"]) == Decimal("1200.00")
+    assert Decimal(row["cost_per_share"]) == Decimal("120.0000")
+
+
+# --------------------------------------------------------------------------
+# S6 — foreign debt with no FX rate excluded from debt_payoff_plan
+# --------------------------------------------------------------------------
+
+def _build_debt_book(tmp_path, *, with_usd_debt):
+    """USD-default book with a EUR loan that has no EUR/USD price, and
+    optionally a normal USD credit card."""
+    path = tmp_path / "s6.gnucash"
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    eur = factories.create_currency_from_ISO("EUR")
+
+    liab = piecash.Account(
+        name="Liabilities", type="LIABILITY", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    equity = piecash.Account(
+        name="Equity", type="EQUITY", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    opening_usd = piecash.Account(
+        name="Opening USD", type="EQUITY", commodity=usd, parent=equity,
+    )
+    opening_eur = piecash.Account(
+        name="Opening EUR", type="EQUITY", commodity=eur, parent=equity,
+    )
+    eur_loan = piecash.Account(
+        name="EUR Loan", type="LIABILITY", commodity=eur, parent=liab,
+    )
+    # EUR loan balance: -2000 EUR (no EUR->USD price anywhere).
+    piecash.Transaction(
+        currency=eur, post_date=date(2025, 1, 1), description="EUR loan",
+        splits=[
+            piecash.Split(account=eur_loan, value=Decimal("-2000"),
+                          quantity=Decimal("-2000")),
+            piecash.Split(account=opening_eur, value=Decimal("2000"),
+                          quantity=Decimal("2000")),
+        ],
+    )
+    accounts = [("Liabilities:EUR Loan", "6.5")]
+    if with_usd_debt:
+        usd_card = piecash.Account(
+            name="Visa", type="CREDIT", commodity=usd, parent=liab,
+        )
+        piecash.Transaction(
+            currency=usd, post_date=date(2025, 1, 1), description="Visa",
+            splits=[
+                piecash.Split(account=usd_card, value=Decimal("-1000"),
+                              quantity=Decimal("-1000")),
+                piecash.Split(account=opening_usd, value=Decimal("1000"),
+                              quantity=Decimal("1000")),
+            ],
+        )
+        accounts.append(("Liabilities:Visa", "20"))
+    book.save()
+    book.close()
+
+    gb = GnuCashBook(str(path))
+    for name, apr in accounts:
+        gb.set_account_slot(account_name=name, key="apr", value=apr)
+    return gb
+
+
+def test_debt_payoff_excludes_foreign_debt_without_rate(tmp_path):
+    """A foreign debt with no FX rate is excluded and surfaced as a
+    warning; valuable debts still produce a schedule."""
+    gb = _build_debt_book(tmp_path, with_usd_debt=True)
+    result = gb.debt_payoff_plan(compact=False, monthly_budget="1000")
+
+    assert "Liabilities:Visa" in result["payoff_order"]
+    assert "Liabilities:EUR Loan" not in result["payoff_order"]
+    assert result.get("excluded") == ["Liabilities:EUR Loan"]
+    assert result.get("warnings")
+    assert "EUR Loan" in result["warnings"][0]
+    assert "no FX rate" in result["warnings"][0]
+
+
+def test_debt_payoff_all_foreign_excluded_raises_clear_error(tmp_path):
+    """When every debt is foreign-with-no-rate, the FX-specific error
+    fires instead of the misleading 'no apr slot' message."""
+    gb = _build_debt_book(tmp_path, with_usd_debt=False)
+    with pytest.raises(ValueError, match="no FX rate on file"):
+        gb.debt_payoff_plan(compact=False, monthly_budget="1000")

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -325,3 +325,63 @@ def test_budget_report_warns_on_unconvertible_foreign_target(tmp_path):
     assert "EUR" in res["warnings"][0]
     # The amount is still included (not dropped), just flagged.
     assert Decimal(res["totals"]["budgeted"]) > 0
+
+
+# --------------------------------------------------------------------------
+# _market_value cost-basis fallback — converts foreign purchases, no mix
+# --------------------------------------------------------------------------
+
+def test_market_value_cost_basis_converts_foreign_purchase(tmp_path):
+    """When a holding has no market price, the cost-basis fallback
+    values each purchase at its posting-date rate (book default), not a
+    raw sum of foreign transaction-currency values."""
+    path = tmp_path / "mv.gnucash"
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    eur = factories.create_currency_from_ISO("EUR")
+    # A security with NO price on file -> forces the cost-basis fallback.
+    fund = piecash.Commodity(
+        namespace="FUND", mnemonic="NOPRICE",
+        fullname="Unpriced Fund", fraction=10000,
+    )
+    book.session.add(fund)
+    assets = piecash.Account(
+        name="Assets", type="ASSET", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    inv = piecash.Account(
+        name="FundX", type="MUTUAL", commodity=fund, parent=assets,
+    )
+    cash_eur = piecash.Account(
+        name="EUR Cash", type="BANK", commodity=eur, parent=assets,
+    )
+    # Only a EUR->USD price exists (1.20); the fund itself is unpriced.
+    book.session.add(piecash.Price(
+        commodity=eur, currency=usd,
+        date=date(2025, 3, 1), value="1.20", type="last",
+    ))
+    piecash.Transaction(
+        currency=eur, post_date=date(2025, 3, 1), description="Buy",
+        splits=[
+            piecash.Split(account=inv, value=Decimal("1000"),
+                          quantity=Decimal("10")),
+            piecash.Split(account=cash_eur, value=Decimal("-1000"),
+                          quantity=Decimal("-1000")),
+        ],
+    )
+    book.save()
+    book.close()
+
+    gb = GnuCashBook(str(path))
+    with gb.open(readonly=True) as book:
+        inv_acct = gb._find_account(book, "Assets:FundX")
+        usd = book.default_currency
+        rates = gb._rates_as_of(book, date(2025, 3, 1))
+        value, note = gb._market_value(
+            inv_acct, Decimal("10"),
+            book=book, rates=rates, default_currency=usd,
+            today=date(2025, 3, 1),
+        )
+        assert "no price data" in note
+        # 1000 EUR x 1.20 = 1200 USD, not a raw 1000.
+        assert value == Decimal("1200.00")

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -288,3 +288,40 @@ def test_debt_payoff_all_foreign_excluded_raises_clear_error(tmp_path):
     gb = _build_debt_book(tmp_path, with_usd_debt=False)
     with pytest.raises(ValueError, match="no FX rate on file"):
         gb.debt_payoff_plan(compact=False, monthly_budget="1000")
+
+
+# --------------------------------------------------------------------------
+# Budget no-rate fold — warn instead of folding foreign units silently
+# --------------------------------------------------------------------------
+
+def test_budget_report_warns_on_unconvertible_foreign_target(tmp_path):
+    """A budget target on a foreign account with no FX rate is still
+    counted (a caveated line beats a dropped one) but surfaces a warning
+    naming the currency, instead of folding raw foreign units silently."""
+    path = tmp_path / "budget.gnucash"
+    book = piecash.create_book(str(path), currency="USD", overwrite=True)
+    usd = book.default_currency
+    eur = factories.create_currency_from_ISO("EUR")
+    expenses = piecash.Account(
+        name="Expenses", type="EXPENSE", commodity=usd,
+        parent=book.root_account, placeholder=True,
+    )
+    piecash.Account(
+        name="EU Travel", type="EXPENSE", commodity=eur, parent=expenses,
+    )
+    book.save()
+    book.close()
+
+    gb = GnuCashBook(str(path))
+    gb.create_budget(name="2026", num_periods=12, period_type="monthly")
+    gb.set_budget_amount(
+        budget_name="2026", account="Expenses:EU Travel",
+        amount="500", period="all",
+    )
+    res = gb.get_budget_report(
+        budget_name="2026", period="all", compact=False,
+    )
+    assert res.get("warnings")
+    assert "EUR" in res["warnings"][0]
+    # The amount is still included (not dropped), just flagged.
+    assert Decimal(res["totals"]["budgeted"]) > 0


### PR DESCRIPTION
## Summary
- `vendor_spending_report` reads the posted ledger instead of re-converting bill face value at a report-time rate
- **B1** realized FX gain/loss account required in the book default currency (was silently bookable in the wrong commodity via a user-supplied / fuzzy-matched account)
- **B2** both-foreign posting splits valued at the posting-date rate, not a report-time rate
- **S5** lot cost basis surfaced in the book default currency (per-split posting-date conversion); `calculate_lot_gain` de-duplicated onto the shared path
- **S6** foreign debts with no FX rate excluded from `debt_payoff_plan` (warned, not mixed-unit)
- budget targets: warn instead of silently folding un-converted foreign units
- `_market_value` cost-basis fallback converts each purchase at its posting-date rate (no mixed-currency cost sums)
- `specs/PRE_1_4_ROADMAP.md` captures the remaining correctness / i18n / feature backlog

All findings from the multicurrency-misreporting audit; each invisible in single-currency books.

## Test plan
- [x] Full suite green — 1729 tests
- [x] 8 new regression tests in `tests/test_multicurrency_audit.py`
- [x] Bookkeeper-validated on Alex (USD) and Lin Wei (CNY): vendor report 2,075.02 CNY agrees with A/P balance; debt plan, lots, net worth unchanged where expected
- [x] Verified current `pay_invoice` settles the equivalent foreign bill to a clean zero (the `lin-wei.gnucash` phantom is a fossil of an already-fixed bug)