### PR TITLE
fix(i18n): locale-robust account resolution (v1.4 Tier A/B/C/D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,29 @@ module contributes zero tools to the MCP surface.
   `_parse_owner_type(value)`, which returns the piecash int code or
   raises with a message naming the valid options. A new owner-typed
   tool should follow the same path.
+- **Identify accounts by `GNCAccountType`, never by an English name.**
+  GnuCash localizes account *names* per locale but never *types*. Code
+  that keys off an English literal (`_find_account(book, "Income")`,
+  `"mortgage" in fullname`, `name.startswith("Imbalance-")`) is wrong
+  the moment the book is `de_DE`/`es_MX`/`zh_CN`/… Resolve top-level
+  accounts by type via `_top_level_account_of_type`; where a name
+  *must* be used, resolve it from the book's own data, not a hard-coded
+  word. Two traps make this stricter than it looks:
+  - **Two independent translation sources that disagree.** Wizard chart
+    templates (`data/accounts/<locale>/*.gnucash-xea`) and the runtime
+    gettext catalog (`po/<lang>.po`) don't always match — a German
+    book's top-level income is the template's **"Erträge"** while the
+    catalog translation of "Income" is **"Ertrag"**. So a "look up the
+    localized word and match it" fix is unsafe for template-created
+    accounts. `_infer_book_locale` therefore *votes* across several
+    top-level type accounts rather than trusting any one.
+  - **Designated accounts self-heal via a KVP slot.** The FX and
+    discount resolvers store the resolved account's GUID on the root
+    account (`gnc-mcp/fx-gain-loss-acct`, etc.) on first use, then
+    resolve by GUID forever after (`_resolve_designated_account`). This
+    is locale- AND rename-proof; the leaf name becomes purely cosmetic,
+    which is what makes localized created-account names (§6.3) safe. A
+    stale slot falls through to the lower layers and is rewritten.
 
 ### Data model conventions
 
@@ -248,6 +271,15 @@ existed.
   for audit-trail purposes. Code that asks "does this lot/account
   have any payment activity" must filter on `s.value != 0` or
   `s.reconcile_state != 'v'`, not on split presence alone.
+- **GDATE columns are compact `YYYYMMDD` strings — don't feed them to
+  `date.fromisoformat` raw.** Date slots/columns stored as GnuCash
+  GDATE (e.g. `slots.gdate_val`, an invoice's `trans-date-due`) come
+  back as `"20260528"`, no dashes. Python 3.11+ `date.fromisoformat`
+  accepts that; **3.10 (a supported target) rejects it and raises.**
+  Normalize to digits and build the date explicitly. The bite is
+  worse when the caller wraps the parse in a broad `except` — a 3.10
+  `ValueError` then silently drops the feature (this is exactly how
+  overdue-invoice/bill warnings went dark until found).
 
 ---
 

--- a/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
+++ b/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
@@ -355,6 +355,12 @@ Because Layer 0 makes resolution GUID-based, the created leaf name is
 purely cosmetic and can be localized freely without risking later
 resolution.
 
+**Locale source of truth (decided).** Infer the locale from the book's
+own account names, with `GNUCASH_LOCALE` as an optional override.
+Inference is zero-config and matches the book the user actually has;
+the env override covers ambiguity. (Settled — formerly the §10 open
+question.)
+
 - `_infer_book_locale(book)`: (1) honor an explicit `GNUCASH_LOCALE`
   env/config override; else (2) reverse-match the book's top-level
   type accounts against the bundled catalog table (if the top-level
@@ -380,21 +386,31 @@ interoperable choice.
 - **Mortgage term (B).** Remove the `"mortgage"` substring heuristic.
   There is no "mortgage" account type, so the locale-correct source of
   truth is explicit data: honor the existing `minimum_payment` slot and
-  add an optional `loan_term_months` slot. When neither is set, use a
-  single conservative default term and **surface a warning** that the
-  estimate is rough — rather than guessing 30y-vs-5y from an English
-  word. (Removes the assumption entirely; also fixes English books that
-  named the account "Home Loan".)
+  add an optional `loan_term_months` slot. **No default term.** When
+  neither slot is set, *omit the minimum-payment estimate entirely* and
+  surface `"set loan_term_months for payment estimates"` rather than
+  guessing — a 30y-vs-5y guess differs by an order of magnitude, and a
+  wrong estimate on camera is worse than no estimate. (Removes the
+  assumption entirely; also fixes English books that named the account
+  "Home Loan".)
 - **Loan bucketing (B).** Replace the `"loan"` substring with a type
   split: `CREDIT` → "Credit cards", other `LIABILITY` → "Loans & other
   liabilities". Locale-correct; minor, intentional relabeling.
 - **Imbalance/Orphan detection (C).** Replace the English-prefix check
-  with a structural predicate, e.g.
-  `_is_auto_imbalance_account(account, root)` =
-  `account.parent is root` **and** `account.type == "BANK"` **and**
-  `re.search(r"-[A-Z]{3}$", account.name)` (or account currency ≠
-  default → unsuffixed form also handled). Optional tiebreaker: the
-  locale `.po` word for Imbalance/Orphan. No English string-compare.
+  with a structural-plus-catalog predicate,
+  `_is_auto_balancing_account(account, root)`: `account.type == "BANK"`
+  **and** `account.parent is root` **and** `account.name.lower()`
+  starts with any "Imbalance"/"Orphan" entry in the bundled locale
+  catalog (`_BALANCING_ACCOUNT_NAME_PREFIXES`, §6.3). The catalog
+  **prefix** match is what makes the currency suffix irrelevant: one
+  rule accepts both the suffixed form (`Ungleichgewicht-EUR`, when the
+  account currency ≠ book default) and the unsuffixed form
+  (`Ungleichgewicht`, when it equals the default). `type == BANK` +
+  `parent is root` are the structural invariants that keep the prefix
+  match off ordinary user accounts; unknown locales degrade to the
+  English words. `Orphaned Gains` is deliberately **not** matched — it
+  is type `INCOME`, a legitimate account, not a defect. No English
+  string-compare.
 
 ---
 
@@ -506,14 +522,10 @@ future body of work and explicitly not promised by v1.4.
 
 ## 10. Open questions
 
-1. **Locale source of truth.** Is inferring locale from the book's own
-   account names (§6.3) acceptable, or should `GNUCASH_LOCALE` be
-   required for localized names? (Inference is zero-config and matches
-   the book the user actually has; the env override covers ambiguity.)
-2. **Trading-Accounts books** (§4.5) — confirm via a live test that a
+1. **Trading-Accounts books** (§4.5) — confirm via a live test that a
    post-commit scrub doesn't interact with our FX split. Low
    probability; cheap to check on the German persona.
-3. **Catalog coverage.** Seed from the cousin doc's 12-language table
+2. **Catalog coverage.** Seed from the cousin doc's 12-language table
    now; decide later whether to parse all 61 `po/` locales at build
    time. Not a blocker — English fallback is safe.
 

--- a/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
+++ b/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
@@ -1,0 +1,518 @@
+# Internationalization & Account-Resolution — Implementation Spec
+
+**Status:** Approved for implementation, targeting v1.4 (the first
+widely-promoted release).
+**Author:** Claude (Opus 4.8), 2026-06-25, consolidating work by
+Claude Cowork ("the cousin," same weights) and a source-probe subagent.
+**Consolidates:** `specs/PRE_1_4_ROADMAP.md` (Tier 2),
+`specs/gnucash-account-naming-i18n.md` (the cousin's GnuCash reference),
+the 2026-06-25 GnuCash-source probe (embedded below), and the
+codebase audit performed this session.
+
+This document has two jobs, in order: (1) **preserve** how this
+analysis came together — the investigation, the reversals, the
+provenance — for anyone interested in how the work was done under
+Claude; and (2) **specify** the implementation precisely enough to
+build cold.
+
+---
+
+## 1. How this came together (preservation)
+
+The work originated not from a bug report but from a release-readiness
+question. The arc:
+
+1. **"Is v1.4 enough for a real release?"** Review of the six PRs since
+   v1.3.1 (batch entry, pagination, group-by, multi-book, an FX
+   correctness audit, FX entry-sanity warnings) concluded: yes, minor-
+   release-grade, with the FX correctness work the strongest part.
+
+2. **"Most of my users are non-English locales."** Stephen's
+   correction flipped the calculus. The headline of v1.4 is multi-
+   currency correctness; the user base is majority non-US. That
+   intersection is where the project was weakest.
+
+3. **The paradox.** *"How do they use it if it's broken?"* Resolved by
+   separating three things the project had silently conflated —
+   **geography ≠ locale ≠ account-naming language.** A "non-US" user
+   may run an English-named book (`en_IN` is a shipped GnuCash locale;
+   technical users everywhere run English GnuCash). And the one hard
+   failure is on a *narrow* path (business-module cross-currency
+   invoice settlement), so most users never reach it. The breakage is
+   real but had been hidden by selection bias in who had found the
+   project so far. A promoted launch removes that bias.
+
+4. **The audit.** A systematic sweep (this session) for every place the
+   server keys logic off English account *structure* rather than off
+   the locale-invariant account *type* enum. Findings in §5.
+
+5. **The cousin's reference doc.** `gnucash-account-naming-i18n.md`,
+   produced by Claude Cowork against the GnuCash source: the
+   type-vs-name principle, the two independent translation sources, the
+   special-account naming rules, and a gain/loss-account detection
+   strategy.
+
+6. **The source probe.** One claim the cousin's doc *implied* and the
+   plan *assumed* — that GnuCash has a native mechanism for booking
+   invoice-payment FX that we should match — was sent to a subagent to
+   verify against current GnuCash source. It was **refuted** (§4.3),
+   which reshaped the FX design. The probe also independently
+   **confirmed** the cousin doc's three load-bearing source claims,
+   establishing the document as trustworthy.
+
+**Reversals worth recording** (the value the verification added):
+- *"Reuse GnuCash's native gains account"* — **withdrawn.** No native
+  gains account exists on an invoice-only book; it is commodity-
+  trading-only.
+- *"GnuCash books invoice FX somewhere we should match"* — **false.**
+  Native GnuCash recognizes no FX gain/loss on invoice payment at all;
+  our behavior is a deliberate improvement, not a deviation.
+- *"Imbalance/Orphan detection is the hardest fix"* — **wrong.** A
+  `parent == root` structural signal makes it tractable.
+
+The lesson embedded here: a fluent, plausible plan is only as good as
+its contact with the source. Three confident claims did not survive
+that contact. Verify before you build, especially the claims that feel
+obviously true.
+
+---
+
+## 2. Problem statement
+
+GnuCash localizes account **names** per the user's locale; it never
+localizes account **types**. The server, grown from an originally
+USD/English-only codebase, still keys several behaviors off English
+names and paths. On a localized book (`de_DE`, `es_MX`, `zh_CN`, …)
+those behaviors range from cosmetic-wrong to a hard exception.
+
+For a release that will be promoted to a predominantly non-US audience
+— very likely demonstrated on video — "works only on English-named
+books" is not acceptable. This spec makes account resolution
+**locale-robust**: identify accounts by type and stable structural
+signals, never by an English literal.
+
+Scope boundary: this is *correctness* i18n (the server does the right
+thing on a localized book), **not** *presentation* i18n (translating
+the server's own output strings). The latter is large and explicitly
+deferred (§9).
+
+---
+
+## 3. The one principle
+
+> **Identify accounts by `GNCAccountType`, never by name.**
+
+The type enum (`ASSET`, `LIABILITY`, `EQUITY`, `INCOME`, `EXPENSE`,
+`BANK`, `CASH`, `CREDIT`, `STOCK`, `MUTUAL`, `TRADING`, `RECEIVABLE`,
+`PAYABLE`, `ROOT`, …) is identical in every locale. Account names are
+localized free text. Where a name *must* be used (display, or a
+tiebreaker), resolve it from the book's own data or the message
+catalog for the book's locale — never compare to a hard-coded English
+word.
+
+**The two-translation-sources trap.** There are two *independent*
+sources of localized names that do **not** always agree:
+- **Wizard chart templates** (`data/accounts/<locale>/*.gnucash-xea`),
+  hand-translated per locale.
+- **Runtime gettext catalog** (`po/<lang>.po`), used for auto-created
+  accounts (Imbalance, Orphan, Opening Balances, …).
+
+Example: a German book's top-level income account is **"Erträge"**
+(template) while the catalog translation of "Income" is **"Ertrag"**
+(§ verified in the cousin doc). Any fix that "looks up the localized
+word and matches it" is therefore unsafe for template-created
+accounts. This is the second reason the principle is *type, not name*.
+
+---
+
+## 4. Authoritative GnuCash facts (consolidated & verification status)
+
+Sourced from the cousin's reference doc and the 2026-06-25 probe.
+"CONFIRMED" = independently verified against current GnuCash `stable`
+source this session.
+
+### 4.1 Special auto-created accounts
+
+| Account | Name construction | Type | Parent |
+|---|---|---|---|
+| Imbalance | `_("Imbalance") + "-" + <mnemonic>` | `BANK` | root |
+| Orphan | `_("Orphan") + "-" + <mnemonic>` | `BANK` | root |
+| Orphaned Gains | `_("Orphaned Gains") + "-" + <mnemonic>` | `INCOME` | root |
+| Opening Balances | `_("Opening Balances")` (+ ` - <mnemonic>` multi-ccy) | `EQUITY` | equity acct |
+| Retained Earnings | `_("Retained Earnings")` | `EQUITY` | equity acct |
+| Trading | `_("Trading")` → `:<namespace>:<commodity>` | `TRADING` | root |
+
+- The leading word is gettext-localized; the **currency suffix is the
+  ISO mnemonic and is never translated.** CONFIRMED (`Scrub.cpp`:
+  `_("Orphan")`, `_("Imbalance")`; `Account.cpp::GetOrMakeOrphanAccount`).
+- Imbalance / Orphan / Orphaned-Gains are **direct children of root** —
+  this makes `parent == root` a locale-stable structural signal.
+  CONFIRMED.
+- Separator differs: Imbalance/Orphan/Orphaned-Gains use a bare hyphen
+  (`Imbalance-EUR`); the equity accounts use a spaced hyphen
+  (`Opening Balances - EUR`). The unsuffixed form appears when the
+  account currency equals the book default.
+
+### 4.2 GnuCash keys off translated names too — and self-heals
+
+`gnc_find_or_create_equity_account()` looks up the parent by
+`gnc_account_lookup_by_name(root, _("Equity"))`, then **verifies
+`type == EQUITY` and falls back to root**. Lesson adopted here: match
+by **type first**; use a localized name only as a tiebreaker, with a
+type-and-root fallback.
+
+### 4.3 The probe's headline: no native invoice-payment FX
+
+**Native GnuCash books NO realized FX gain/loss on cross-currency
+invoice payment.** CONFIRMED by tracing the business engine:
+
+- `gncOwner.c::gncOwnerCreatePaymentLotSecs` builds the payment so the
+  A/R split's value equals its amount (both in the *invoice* currency);
+  the user-supplied exchange rate only scales the *bank* split.
+- Payment lots offset invoice lots **only within the same account**
+  (`gncOwner.c`: `if (acct != gnc_lot_get_account(right_lot)) continue;`),
+  all in the invoice currency. The A/R is posted at face value and
+  closed at face value — **no rate-difference amount ever materializes
+  in the ledger.**
+- The `lot-mgmt/gains-acct` KVP slot and the `Orphaned Gains-CUR`
+  account belong **exclusively** to the commodity capital-gains path
+  (`cap-gains.cpp::xaccSplitComputeCapGains`, reachable only when a
+  split's commodity ≠ its transaction currency). The business module
+  **never invokes it.** `xaccAccountGainsAccount` is called only from
+  `cap-gains.cpp`.
+
+**Implication.** Our `pay_invoice` third FX split (PR #45) is a
+*deliberate, more-correct* cash-basis recognition of realized FX that
+native GnuCash omits. There is no native mechanism to "match," and **no
+native gains account to reuse** on an invoice-only book. We create our
+own account; we make its *resolution* locale-robust via a KVP slot
+(§6).
+
+### 4.4 Gain and loss net into ONE income account
+
+CONFIRMED: GnuCash files realized gains/losses in a single
+`ACCT_TYPE_INCOME` account; a loss is negative income. There is no
+separate EXPENSE loss account in native behavior. **Decision (§6.4):
+do not split FX into gain/loss accounts** — it diverges from universal
+GnuCash convention and reads wrong against native books.
+
+### 4.5 Known unknowns (not blockers; flagged for a live check)
+
+- **Trading-Accounts-enabled books** (`qof_book_use_trading_accounts`)
+  run a post-commit rebalancing scrub that *could* touch a payment
+  transaction. The business path doesn't opt in directly; untested.
+- **The GUI payment dialog** (`dialog-payment.c`) computes the exchange
+  rate it passes to the engine. The engine books no FX; an extra
+  GUI-side adjustment split is very unlikely but is the one corner the
+  probe could not reach from the engine alone.
+
+---
+
+## 5. The audit — every English-structural assumption
+
+Method: grep sweep across six assumption shapes (name lookups, hard-
+coded `:`-paths, substring classification, special-account prefixes,
+`.name`/`.fullname` literal comparisons, root/depth detection).
+Caveat: grep finds *literals*; positional assumptions encoded without a
+literal were spot-checked (depth/root detection is data-driven and
+safe). High confidence the behavioral set is complete.
+
+### Tier A — Throws (hard failure) — **1.4 BLOCKER**
+
+- **`book/business.py` FX-account resolution.**
+  `_get_or_create_fx_account` falls through to
+  `self._find_account(book, "Income")` (≈`business.py:440`) for the
+  create-parent. Returns `None` in a localized book → the first
+  cross-currency invoice settlement with rate drift **raises**.
+- **`book/business.py` discount-account resolution.** The parallel
+  `_get_or_create_discount_account` uses canonical paths
+  `"Expenses:Sales Discounts"` / `"Income:Purchase Discounts Taken"`
+  (≈`business.py:325`) and the same English-parent fallback. Same throw.
+- The fuzzy keyword tuples (`_FX_NAME_KEYWORDS`,
+  `_*_DISCOUNT_NAME_KEYWORDS`) are English substrings; in a localized
+  book they match nothing and fall straight to the throwing layer.
+
+### Tier B — Silent misclassification (no throw) — **fix for flagship**
+
+- **`book/reporting.py` mortgage term** (≈`reporting.py:1389`):
+  `is_mortgage = "mortgage" in account.fullname.lower()` selects a
+  360- vs 60-month amortization term for the `debt_payoff_plan`
+  minimum-payment estimate. A localized mortgage (`Hypothek`) falls to
+  the 5-year assumption → a **wrong computed number** (wildly
+  overestimated payment & payoff schedule). Bounded only by the
+  `minimum_payment` slot override.
+- **`book/core.py` loan bucketing** (≈`core.py:1583`):
+  `if "loan" in account.fullname.lower()` buckets liabilities into
+  loans-vs-other on the dashboard. Cosmetic (totals unaffected), but a
+  `Darlehen`/`Kredit` lands in the wrong bucket.
+
+### Tier C — Special-account detection — **fix for flagship (cheap)**
+
+- **`book/core.py` integrity warning** (≈`core.py:606`):
+  `name.startswith("Imbalance-") or name.startswith("Orphan-")` gates
+  the data-integrity warning. Both names are gettext-localized (§4.1),
+  so the warning **silently never fires** for non-English books — a
+  safety check going dark. Tractable via the `parent == root` signal
+  (§6.5).
+
+### Tier D — English leaks into output (nothing breaks) — **DEFER**
+
+- Auto-created account *names* are English (`Foreign Exchange
+  Gain/Loss`, the discount accounts). Addressed opportunistically by
+  §6.3 (localize the created leaf), but acceptable in English.
+- `reporting.py:756` injects the literal label `"Retained Earnings"`.
+- Whole-surface output-string localization (reports, warnings, errors,
+  audit log). The real i18n lift; needs a message-catalog decision.
+  **Out of scope for v1.4.**
+
+### Confirmed locale-SAFE (do not re-investigate)
+
+All report bucketing is type-based (`_ASSET_TYPES` / `_LIABILITY_TYPES`
+/ `_EQUITY_TYPES`, incl. the #107 RECEIVABLE/PAYABLE work); depth/
+grouping derives the top segment from real account names and walks
+parent links (`reporting.py:62`, `_get_account_depth`); rename/
+collision checks compare user names to each other; the `"Word:Word"`
+paths in `tools/*.py` are LLM-facing docstring **examples**, not
+lookups.
+
+---
+
+## 6. Design
+
+### 6.1 New chokepoint: top-level account by type
+
+A single helper retires the entire Tier-A throw class. In
+`book/_base.py` (or `book/business.py` if preferred local):
+
+```python
+def _top_level_account_of_type(self, book, acct_type):
+    """Resolve the top-level account of a given GNCAccountType —
+    the account of that type whose parent is the real root.
+
+    Returns (account, notice). Locale-invariant: keys off `type`
+    and `parent == book.root_account`, never a name.
+
+    - exactly one  -> (it, None)
+    - several      -> (deterministic pick, ambiguity-notice dict)
+    - none         -> create a top-level account of that type under
+                      root, named from the locale catalog (§6.3),
+                      return (new, None)
+    """
+```
+
+Rules:
+- Exclude template accounts via `self._template_account_guids(book)`.
+- "Top-level" = `account.parent is not None and
+  account.parent.guid == book.root_account.guid`.
+- Deterministic multi-pick: lowest `fullname` sort, with an
+  ambiguity-notice mirroring the existing `ambiguous_fx_account`
+  pattern.
+
+### 6.2 Designated-account resolver (FX + both discount sides)
+
+The FX path and the two discount paths are the same shape. Unify them
+on one resolver. Resolution order, **most authoritative first**:
+
+```
+Layer 0  KVP slot   read a stored GUID -> resolve -> validate
+                    (type + book-default currency). Locale-proof
+                    and rename-proof. THE primary path after first use.
+Layer 1  explicit   caller-supplied account argument (unchanged).
+Layer 2  fuzzy      keyword match over accounts of the target type in
+                    the default currency (unchanged; best-effort only).
+Layer 3  create     find parent via _top_level_account_of_type(target
+                    type); create the account; localize its leaf name
+                    (§6.3); WRITE its GUID to the Layer-0 slot.
+```
+
+The only behavioral change vs. today is: **Layer 0 added**, and
+**Layer 3's parent lookup is type-based instead of
+`_find_account("Income")`.** Layers 1–2 are preserved so existing
+English books behave identically.
+
+Per-role parameters:
+
+| Role | Target parent type | Slot key | Default leaf concept |
+|---|---|---|---|
+| FX gain/loss | `INCOME` | `gnc-mcp/fx-gain-loss-acct` | "Realized Gain/Loss" |
+| Sales discount (customer invoice) | `EXPENSE` | `gnc-mcp/sales-discount-acct` | "Sales Discounts" |
+| Purchase discount (vendor bill) | `INCOME` | `gnc-mcp/purchase-discount-acct` | "Purchase Discounts" |
+
+Slot storage: these are book-global, single-account-per-role (each is
+denominated in the book default currency), so a single slot on
+`book.root_account` per role suffices — no need for GnuCash's per-
+source-account, per-commodity slot path. Use the namespaced
+`gnc-mcp/<role>` convention (path-style key → hierarchical sub-slot;
+CLAUDE.md slot-naming rules). Read with `_slot_value_str`. On a stale/
+missing slot, fall through and re-write on next create.
+
+`_get_or_create_fx_account` and `_get_or_create_discount_account`
+become thin wrappers binding their row of the table.
+
+### 6.3 Localized leaf names (flagship polish; SHOULD, not blocker)
+
+Because Layer 0 makes resolution GUID-based, the created leaf name is
+purely cosmetic and can be localized freely without risking later
+resolution.
+
+- `_infer_book_locale(book)`: (1) honor an explicit `GNUCASH_LOCALE`
+  env/config override; else (2) reverse-match the book's top-level
+  type accounts against the bundled catalog table (if the top-level
+  INCOME account is "Erträge", infer `de`); else (3) `None`.
+- `_locale_account_name(concept, locale)`: look up a concept
+  ("Realized Gain/Loss", "Sales Discounts", …) in a bundled catalog
+  table seeded from the cousin doc's translation table (12 languages
+  for the core terms; extend by parsing `po/<lang>.po` later). Fall
+  back to the English name when locale is `None` or the concept is
+  missing.
+- An English fallback leaf is **harmless** — the slot still resolves
+  it. So this degrades gracefully and never blocks.
+
+### 6.4 FX gain vs loss: keep ONE income account
+
+Per §4.4. Do not implement separate gain/loss accounts. Remove the
+idea from the Tier-3 backlog (done in the roadmap). The single combined
+INCOME account, loss-as-negative-income, is the GnuCash-idiomatic and
+interoperable choice.
+
+### 6.5 Tier B & C fixes
+
+- **Mortgage term (B).** Remove the `"mortgage"` substring heuristic.
+  There is no "mortgage" account type, so the locale-correct source of
+  truth is explicit data: honor the existing `minimum_payment` slot and
+  add an optional `loan_term_months` slot. When neither is set, use a
+  single conservative default term and **surface a warning** that the
+  estimate is rough — rather than guessing 30y-vs-5y from an English
+  word. (Removes the assumption entirely; also fixes English books that
+  named the account "Home Loan".)
+- **Loan bucketing (B).** Replace the `"loan"` substring with a type
+  split: `CREDIT` → "Credit cards", other `LIABILITY` → "Loans & other
+  liabilities". Locale-correct; minor, intentional relabeling.
+- **Imbalance/Orphan detection (C).** Replace the English-prefix check
+  with a structural predicate, e.g.
+  `_is_auto_imbalance_account(account, root)` =
+  `account.parent is root` **and** `account.type == "BANK"` **and**
+  `re.search(r"-[A-Z]{3}$", account.name)` (or account currency ≠
+  default → unsuffixed form also handled). Optional tiebreaker: the
+  locale `.po` word for Imbalance/Orphan. No English string-compare.
+
+---
+
+## 7. Implementation plan
+
+One themed branch off `develop` — `fix/i18n-account-resolution` — all
+fixes share the theme "stop keying on English structure," which keeps
+it one coherent PR (lane discipline; not a balloon). Suggested commit
+order:
+
+1. `feat(_base): _top_level_account_of_type chokepoint` + unit tests.
+2. `feat(business): KVP-slot designated-account resolver` — Layer 0 +
+   type-based Layer 3; rewire `_get_or_create_fx_account` and
+   `_get_or_create_discount_account` onto it. (Tier A — the blocker.)
+3. `feat(i18n): book-locale inference + localized leaf names` (§6.3).
+   (Flagship polish; can be deferred to a follow-up commit without
+   blocking #2.)
+4. `fix(reporting): loan term from slot, not English keyword` +
+   `fix(core): loan bucketing by type` (Tier B).
+5. `fix(core): structural Imbalance/Orphan detection` (Tier C).
+6. `test(i18n): localized synthetic persona + regression locks` (§8).
+7. Update `CLAUDE.md` gotchas (type-not-name; the two-translation-
+   sources trap) and `specs/PRE_1_4_ROADMAP.md` (mark Tier 2 items
+   done).
+
+Invariants to preserve: piecash objects never cross the MCP boundary;
+every raw-SQL write paired with `_verify_*`; slot writes via the
+`entity[key]=value` accessor with `_slot_value_str` reads; no second
+book-open in the resolver (operate on the already-open session).
+
+---
+
+## 8. Test plan
+
+**The durable fix is a localized synthetic persona.** Alex (USD) and
+Lin Wei (CNY) are both English-named, which is exactly why this bug
+class was invisible. A third persona with a **native-localized account
+hierarchy** converts the whole class from invisible to a failing test.
+
+- **New persona (Abe owns final design):** a `de_DE`-hierarchy book —
+  EUR default, German account names (`Aktiva`, `Fremdkapital`,
+  `Erträge`, `Aufwand`, …), a USD-paying client to force cross-currency
+  invoicing, a `Hypothek` for the debt-payoff path, and a localized
+  Imbalance account to exercise Tier C. Built via a
+  `scripts/synthetic_book/` generator like the others, deterministic
+  seed, per-phase backups. Working name: *"Greta"* (placeholder).
+- **The acceptance test:** post and pay a cross-currency invoice on the
+  German book with rate drift. Pre-fix this **throws**; post-fix it
+  settles, recognizes FX into a (German-named) top-level-INCOME child,
+  and the GUID round-trips through the slot.
+- **Unit/contract tests:**
+  - `_top_level_account_of_type` for 0/1/many, template exclusion,
+    non-English names.
+  - Resolver Layer 0 slot round-trip; stale-slot fallthrough + rewrite.
+  - Debt-payoff term from slot vs. default-with-warning; no English
+    keyword path remains.
+  - Structural Imbalance/Orphan detection on a localized name; the
+    integrity warning fires.
+  - A regression lock asserting **no `_find_account(book, "<English>")`
+    and no English-substring account classification** reappears in
+    `book/*.py` (a grep-style contract test in the spirit of
+    `TestWriteVerificationCoverage`).
+- **Bookkeeper validation:** the production signal. Necessary but
+  insufficient for math — route the FX number through explicit review
+  (the bookkeeper validates base cases, not hand-calcs). Cross-tool
+  sanity: the German book's net worth must agree across
+  `get_book_summary` / `balance_sheet` / `net_worth` to the cent, as
+  Alex and Lin Wei do.
+
+---
+
+## 9. Scope & release gating
+
+| Item | Tier | v1.4 |
+|---|---|---|
+| Type-based FX/discount parent + slot resolution | A | **MUST** (blocker) |
+| Mortgage term from slot, not keyword | B | **SHOULD** (wrong number on camera) |
+| Loan bucketing by type | B | SHOULD (cosmetic) |
+| Structural Imbalance/Orphan detection | C | SHOULD (cheap; safety warning) |
+| Localized created-account leaf names | D | SHOULD (flagship polish) |
+| Localized synthetic persona + regression locks | — | **MUST** (proves the fix) |
+| Output-string localization (reports/errors/audit) | D | **DEFER** |
+| Number-format locale policy (decimal separator) | D | **DEFER** |
+
+The **only hard blocker** is Tier A — it throws. Everything else
+improves the localized experience for the launch but does not crash.
+Given the flagship/video context, the recommendation is to ship A + the
+SHOULDs (they are individually small once the chokepoint exists) and
+defer only the genuinely large output-localization lift.
+
+This is a *correctness* i18n release. Full *presentation* i18n is a
+future body of work and explicitly not promised by v1.4.
+
+---
+
+## 10. Open questions
+
+1. **Locale source of truth.** Is inferring locale from the book's own
+   account names (§6.3) acceptable, or should `GNUCASH_LOCALE` be
+   required for localized names? (Inference is zero-config and matches
+   the book the user actually has; the env override covers ambiguity.)
+2. **Trading-Accounts books** (§4.5) — confirm via a live test that a
+   post-commit scrub doesn't interact with our FX split. Low
+   probability; cheap to check on the German persona.
+3. **Catalog coverage.** Seed from the cousin doc's 12-language table
+   now; decide later whether to parse all 61 `po/` locales at build
+   time. Not a blocker — English fallback is safe.
+
+---
+
+## 11. Source index
+
+- `specs/PRE_1_4_ROADMAP.md` — Tier 2 (the audit, in roadmap form).
+- `specs/gnucash-account-naming-i18n.md` — the cousin's GnuCash
+  reference (types, two translation sources, special-account rules,
+  gain/loss detection, 12-language translation table).
+- 2026-06-25 source probe — embedded in §4.3–4.5 (GnuCash `stable`:
+  `gncOwner.c`, `gncInvoice.c`, `cap-gains.cpp`, `Account.cpp`,
+  `Scrub.cpp`).
+- `CLAUDE.md` — slot conventions, `_template_account_guids`,
+  the "type, not name" gotchas this spec extends.

--- a/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
+++ b/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
@@ -362,15 +362,24 @@ the env override covers ambiguity. (Settled — formerly the §10 open
 question.)
 
 - `_infer_book_locale(book)`: (1) honor an explicit `GNUCASH_LOCALE`
-  env/config override; else (2) reverse-match the book's top-level
-  type accounts against the bundled catalog table (if the top-level
-  INCOME account is "Erträge", infer `de`); else (3) `None`.
-- `_locale_account_name(concept, locale)`: look up a concept
-  ("Realized Gain/Loss", "Sales Discounts", …) in a bundled catalog
-  table seeded from the cousin doc's translation table (12 languages
-  for the core terms; extend by parsing `po/<lang>.po` later). Fall
-  back to the English name when locale is `None` or the concept is
-  missing.
+  env/config override, reduced to its language code; else (2) **vote**
+  — match the book's top-level type accounts against the bundled
+  gettext structural-word catalog and take the language with the most
+  matches (≥ 2, so a lone coincidental hit doesn't drive inference);
+  else (3) `None`. Voting (not a single-account lookup) is required by
+  the two-translation-sources trap (§3): a German book's top-level
+  income is the *template* word "Erträge", which does **not** equal
+  the *gettext* "Ertrag" — but Assets/Expenses/Equity
+  ("Aktiva"/"Aufwand"/"Eigenkapital") match exactly and carry the
+  vote. A numbered chart (SKR03) matches too few and correctly falls
+  back to English.
+- `_locale_account_name(concept, english_default, locale)`: look up a
+  concept ("Realized Gain/Loss", "Sales Discounts", …) in a bundled
+  catalog seeded from the cousin doc's translation table (12 languages
+  for the core terms; extend by parsing `po/<lang>.po` later). Returns
+  `english_default` when `locale` is `None`/unknown or the concept has
+  no translation. (Only the FX concept ships translations today; the
+  discount concepts have none in GnuCash and stay English.)
 - An English fallback leaf is **harmless** — the slot still resolves
   it. So this degrades gracefully and never blocks.
 

--- a/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
+++ b/specs/I18N_ACCOUNT_RESOLUTION_SPEC.md
@@ -434,13 +434,27 @@ Lin Wei (CNY) are both English-named, which is exactly why this bug
 class was invisible. A third persona with a **native-localized account
 hierarchy** converts the whole class from invisible to a failing test.
 
-- **New persona (Abe owns final design):** a `de_DE`-hierarchy book —
-  EUR default, German account names (`Aktiva`, `Fremdkapital`,
-  `Erträge`, `Aufwand`, …), a USD-paying client to force cross-currency
-  invoicing, a `Hypothek` for the debt-payoff path, and a localized
-  Imbalance account to exercise Tier C. Built via a
-  `scripts/synthetic_book/` generator like the others, deterministic
-  seed, per-phase backups. Working name: *"Greta"* (placeholder).
+- **New persona — Sabine Brenner** (Abe owns the final build): a
+  Munich freelance Grafikdesignerin / Einzelunternehmerin running the
+  **SKR03 Standardkontenrahmen** — the chart a real German sole
+  proprietor actually uses, not a tidied-up English-shaped hierarchy.
+  EUR default; GnuCash's shipped `acctchrt_skr03` names (top-level
+  INCOME "Erlöse u. Erträge 2/8", EXPENSE "Aufwendungen 2/4", numbered
+  leaves like "8400 Erlöse USt. 19%", A/R "1400 Ford. a. Lieferungen
+  und Leistungen"); a USD-paying client to force cross-currency
+  invoicing; a `Hypothek` for the debt-payoff path; and a localized
+  Imbalance account for Tier C. Built via a `scripts/synthetic_book/`
+  generator like Alex/Lin Wei, deterministic seed, per-phase backups.
+
+  **Verified (2026-06-26):** SKR03 ships with GnuCash and — despite
+  being numbered and Kontenklasse-organized — maps to a clean **single
+  top-level account per fundamental type**, so
+  `_top_level_account_of_type` resolves it correctly: the FX account
+  lands under "Erlöse u. Erträge 2/8" and self-heals on repeat via the
+  English leaf. A minimal SKR03 slice with the real names is locked in
+  `test_i18n_account_resolution.py::TestSKR03Chart`. (An SKR03 purist
+  might want FX in a specific numbered account; auto-creation under the
+  income-class placeholder is correct-by-type and acceptable.)
 - **The acceptance test:** post and pay a cross-currency invoice on the
   German book with rate drift. Pre-fix this **throws**; post-fix it
   settles, recognizes FX into a (German-named) top-level-INCOME child,

--- a/specs/PRE_1_4_ROADMAP.md
+++ b/specs/PRE_1_4_ROADMAP.md
@@ -53,18 +53,114 @@ no account literally named "Income"; account *types* (RECEIVABLE,
 PAYABLE, INCOME…) are never localized. Verified against the GnuCash
 wiki (Account_Hierarchy_Template, Locale_Settings).
 
+### Audit (2026-06-25): every place the server keys on English structure
+
+Systematic grep sweep across six assumption shapes — name lookups,
+hardcoded `:`-paths, substring classification, special-account
+prefixes, `.name`/`.fullname` literal comparisons, root/depth
+detection. **Caveat:** grep finds English *literals*; it can't prove
+the absence of a positional assumption encoded without one (those
+were spot-checked — depth/root detection is data-driven and safe).
+High confidence the *behavioral* set below is complete.
+
+**A — Throws (hard failure):**
 - **LEAD ITEM (correctness-grade): resolve helper-account parents by
-  TYPE, not English name.** `_get_or_create_fx_account` and the
-  discount-account path call `self._find_account(book, "Income")`,
-  which returns None in a localized book → the FIRST cross-currency
-  payment **throws**. Resolving by the top-level INCOME/EXPENSE-type
-  account fixes localization AND plain user-renames in one stroke.
-  (A/R / A/P resolution is already type-based, so it's safe.)
-- Localizable / configurable default account names (FX gain/loss,
-  discount) + locale-aware or configurable fuzzy keywords
-  (`_FX_NAME_KEYWORDS`, `_*_DISCOUNT_NAME_KEYWORDS`).
+  TYPE, not English name.** `_get_or_create_fx_account`
+  (`business.py:440`, `_find_account(book, "Income")`) and the
+  parallel discount-account path (canonical paths
+  `"Expenses:Sales Discounts"` / `"Income:Purchase Discounts Taken"`,
+  `business.py:325`) return None in a localized book → the FIRST
+  cross-currency payment with rate drift **throws**. Resolve by the
+  top-level INCOME/EXPENSE-type account instead; fixes localization
+  AND plain user-renames in one stroke. (A/R / A/P resolution is
+  already type-based, so it's safe.) Build the resolver to take a
+  target type as a parameter, not a constant — FX wants INCOME,
+  sales discount is contra-income, purchase discount is
+  contra-expense, and a future gain-vs-loss split (Tier 3) puts the
+  loss half under EXPENSE.
+- The fuzzy keyword tuples (`_FX_NAME_KEYWORDS`,
+  `_*_DISCOUNT_NAME_KEYWORDS`) are English substrings; in a localized
+  book they match nothing and fall straight to the throwing layer.
+
+**FX-account design — RESOLVED (2026-06-25 source probe + cousin doc
+`specs/gnucash-account-naming-i18n.md`).** Headline finding that
+reframes the fix: **native GnuCash books NO realized FX gain/loss on
+cross-currency invoice payment.** It closes A/R at *face value in the
+invoice currency* and lets the bank split absorb the rate
+(`gncOwner.c::gncOwnerCreatePaymentLotSecs`; lots offset only within
+the same account, all in the invoice currency, so no rate-difference
+amount ever materializes). The `lot-mgmt/gains-acct` slot +
+`Orphaned Gains-CUR` account belong **solely** to the commodity
+capital-gains path (`cap-gains.cpp::xaccSplitComputeCapGains`,
+reachable only when split commodity ≠ txn currency) — **never invoked
+by the business module.** So our `pay_invoice` third FX split (PR #45)
+is a *deliberate, more-correct* cash-basis recognition, **not** a
+deviation-bug — there is no native mechanism to "match," and (a
+correction to my earlier framing) **no native `Orphaned Gains`
+account to "reuse"** on an invoice-only book. The fix:
+1. **Creation** — resolve the top-level INCOME account by TYPE
+   (locale-robust), create the FX account under it, mirroring
+   GnuCash's own `GetOrMakeOrphanAccount` shape: a SINGLE income
+   account where a loss is negative income.
+2. **Resolution thereafter** — store the account GUID in a KVP slot
+   and resolve from the slot, never by name (GnuCash idiom:
+   `lot-mgmt/gains-acct/<commodity-unique-name>`, or our own
+   namespaced slot). Locale-proof AND rename-proof.
+3. Optionally localize the *created* name via the `.po` catalog
+   (cousin doc ships the table) — cosmetic, not a blocker.
+   Secondary claims in the cousin doc (`xaccAccountGainsAccount`,
+   `GetOrMakeOrphanAccount`, single-income-account netting) were all
+   independently CONFIRMED against current source during the probe.
+   Open known-unknown: Trading-Accounts-enabled books run a
+   post-commit rebalancing scrub that *could* touch the payment txn —
+   untested; flag for a live check if a user turns that on.
+
+**B — Silent misclassification (no throw — wrong bucket/number):**
+- `reporting.py:1389` — `is_mortgage = "mortgage" in account.fullname
+  .lower()` picks a 360- vs 60-month amortization term for the
+  `debt_payoff_plan` minimum-payment estimate. A localized mortgage
+  (`Hypothek`) falls to the 5-year assumption → wildly overestimated
+  payment + payoff schedule. **Changes a computed number** (bounded
+  only by the `minimum_payment` slot override).
+- `core.py:1583` — `if "loan" in account.fullname.lower()` buckets
+  liabilities into loans vs other on the dashboard. Cosmetic (totals
+  unaffected), but `Darlehen`/`Kredit` lands in the wrong bucket.
+
+**C — Special-account detection (CONFIRMED bug via GnuCash source):**
+- `core.py:606` — `name.startswith("Imbalance-") or
+  name.startswith("Orphan-")` gates the data-integrity warning.
+  GnuCash generates BOTH names through gettext — `Scrub.cpp`
+  `_("Orphan")` (L125) and `_("Imbalance")` (L464) — so they ARE
+  localized (`<translated>-<CUR>`). The warning silently never fires
+  for non-English books. **Tractable** (was mis-flagged "hardest"):
+  GnuCash hangs Imbalance / Orphan / Orphaned-Gains directly off the
+  **root** account, so `parent == root` is a locale-stable structural
+  signal (cousin doc + 2026-06-25 probe, `Account.cpp` / `Scrub.cpp`).
+  Detect via `parent == root` + type (`BANK` -> Imbalance/Orphan,
+  `INCOME` -> Orphaned Gains) + a `...-<ISO4217>` suffix, with the
+  locale `.po` word as an optional tiebreaker -- no English
+  string-compare. A *safety* warning going dark -- prioritize above
+  the cosmetic B/D items.
+
+**D — English leaks into output (nothing breaks; the cosmetic lift):**
+- Auto-created account *names* are English (`piecash.Account(name=
+  "Foreign Exchange Gain/Loss", ...)`, the discount accounts) — even
+  after the parent-by-type fix, you create an English-named account
+  inside a `de` book. Make default names localizable/configurable.
+- `reporting.py:756` injects the literal label `"Retained Earnings"`
+  into balance_sheet regardless of locale.
 - User-facing string localization (reports, warnings, errors, audit
   log) — the real lift; needs a message-catalog decision.
+
+**Confirmed locale-SAFE (don't re-litigate):** all report bucketing is
+type-based (`_ASSET_TYPES` etc., incl. the #107 RECEIVABLE/PAYABLE
+work); depth/grouping derives the top segment from real account names
+and walks parent links (`reporting.py:62`, `_get_account_depth`);
+rename/collision checks compare user names to each other; the
+`"Word:Word"` paths in `tools/*.py` are LLM-facing docstring examples,
+not lookups.
+
+### Remaining design items
 - Number-format locale policy (decimal separator): machine-canonical
   vs. display-localized.
 
@@ -79,7 +175,12 @@ wiki (Account_Hierarchy_Template, Locale_Settings).
   settlement; open foreign invoices aren't revalued at reporting dates.
   Feature-sized (a revaluation pass, delta → FX gain/loss). Timing-of-
   recognition only; converges to the same total at settlement.
-- Separate FX gain vs. loss accounts; taxtable default-taxtable UX.
+- ~~Separate FX gain vs. loss accounts~~ — **recommend AGAINST**
+  (2026-06-25 probe): native GnuCash nets gain+loss into ONE INCOME
+  account (a loss is negative income); a separate EXPENSE loss account
+  diverges from universal GnuCash convention and reads wrong against
+  native books. Keep the single combined account.
+- Taxtable default-taxtable UX (unrelated to FX) — still open.
 
 ## Housekeeping
 

--- a/specs/PRE_1_4_ROADMAP.md
+++ b/specs/PRE_1_4_ROADMAP.md
@@ -63,6 +63,19 @@ the absence of a positional assumption encoded without one (those
 were spot-checked — depth/root detection is data-driven and safe).
 High confidence the *behavioral* set below is complete.
 
+**Implementation status (branch `fix/i18n-account-resolution`):**
+Tiers **A, B, C are DONE** — `_top_level_account_of_type` chokepoint
+(`_base.py`), type-based FX/discount parent resolution (`business.py`),
+`loan_term_months` slot + 30y default (`reporting.py`), single
+"Loans & other" liability bucket (`core.py`), and
+`_is_auto_balancing_account` Imbalance/Orphan detection across 13
+locales (`_base.py`/`core.py`). End-to-end proven: a cross-currency
+invoice payment on a German book settles and books FX under "Erträge"
+(`tests/test_i18n_account_resolution.py`, 12 tests). **Remaining:**
+Tier D — localized *created* leaf names (flagship polish; the
+slot + locale-inference design in the spec §6.2-6.3) — and the full
+"Greta" synthetic persona.
+
 **A — Throws (hard failure):**
 - **LEAD ITEM (correctness-grade): resolve helper-account parents by
   TYPE, not English name.** `_get_or_create_fx_account`

--- a/specs/PRE_1_4_ROADMAP.md
+++ b/specs/PRE_1_4_ROADMAP.md
@@ -63,18 +63,35 @@ the absence of a positional assumption encoded without one (those
 were spot-checked — depth/root detection is data-driven and safe).
 High confidence the *behavioral* set below is complete.
 
-**Implementation status (branch `fix/i18n-account-resolution`):**
-Tiers **A, B, C are DONE** — `_top_level_account_of_type` chokepoint
-(`_base.py`), type-based FX/discount parent resolution (`business.py`),
-`loan_term_months` slot + 30y default (`reporting.py`), single
-"Loans & other" liability bucket (`core.py`), and
-`_is_auto_balancing_account` Imbalance/Orphan detection across 13
-locales (`_base.py`/`core.py`). End-to-end proven: a cross-currency
-invoice payment on a German book settles and books FX under "Erträge"
-(`tests/test_i18n_account_resolution.py`, 12 tests). **Remaining:**
-Tier D — localized *created* leaf names (flagship polish; the
-slot + locale-inference design in the spec §6.2-6.3) — and the full
-"Greta" synthetic persona.
+**Implementation status (branch `fix/i18n-account-resolution`):
+COMPLETE.** Tiers A, B, C, D all done.
+- **A** — `_top_level_account_of_type` chokepoint (`_base.py`) +
+  type-based FX/discount parent resolution, plus a **self-healing
+  KVP-slot designated-account resolver** (Layer 0: stores the resolved
+  GUID on the root account, so resolution after first use is rename-
+  and locale-proof; spec §6.2) (`business.py`).
+- **B** — `loan_term_months` slot with **no default**: a loan with no
+  explicit term (and no `minimum_payment`) is omitted from the payoff
+  plan with an actionable message rather than amortized from a guessed
+  term (`reporting.py`); single "Loans & other" liability bucket
+  (`core.py`).
+- **C** — `_is_auto_balancing_account` Imbalance/Orphan detection
+  across the shipped locales (`_base.py`/`core.py`).
+- **D** — **localized created-account leaf names**: `_infer_book_locale`
+  (votes top-level type accounts against the gettext catalog, ≥2 wins)
+  + `_locale_account_name` (spec §6.3). A tidy German book auto-creates
+  `Erträge:Realisierter Gewinn/Verlust`; English and numbered (SKR03)
+  charts fall back to the English leaf.
+
+End-to-end proven on a German book (cross-currency invoice payment
+settles and books FX under the localized income root) and
+**bookkeeper-validated to the penny** with a German-named FX account.
+The SKR03 (Sabine Brenner) chart slice is locked in
+`tests/test_i18n_account_resolution.py::TestSKR03Chart` (23 i18n tests
+total). Also fixed in passing: a Python-3.10 GDATE due-date parse bug
+that silently dropped overdue invoice/bill warnings. **Remaining
+(optional):** the full `scripts/synthetic_book/` Sabine persona
+generator (Abe's build), and the §7 housekeeping (CLAUDE.md gotchas).
 
 **A — Throws (hard failure):**
 - **LEAD ITEM (correctness-grade): resolve helper-account parents by

--- a/specs/gnucash-account-naming-i18n.md
+++ b/specs/gnucash-account-naming-i18n.md
@@ -1,0 +1,195 @@
+# GnuCash Account Naming & Internationalization — Reference
+
+Investigated against the GnuCash `master` source (github.com/Gnucash/gnucash). The goal: know
+which account names are locale-dependent so LLM/MCP tooling (which assumes English names like
+"Assets" or "Imbalance") can be made locale-robust.
+
+## TL;DR
+
+1. **Account *types* are language-independent enums; account *names* are localized free text.**
+   Never key logic off a name. The reliable identifier is `<act:type>` / `GNCAccountType`
+   (`ASSET`, `LIABILITY`, `EQUITY`, `INCOME`, `EXPENSE`, `BANK`, `CASH`, `CREDIT`, `STOCK`,
+   `MUTUAL`, `TRADING`, `RECEIVABLE`, `PAYABLE`, `ROOT`, …). These strings are stable across
+   every locale.
+
+2. There are **two independent translation sources**, and they do **not** always agree:
+   - **First-run wizard account charts** come from XML template files
+     (`data/accounts/<locale>/acctchrt_*.gnucash-xea`). Each locale's files are translated
+     by hand, independently of the message catalog.
+   - **Runtime auto-created accounts** (Imbalance, Orphan, Trading, Opening Balances,
+     Retained Earnings, Orphaned Gains) are named via `gettext` (`po/<lang>.po`) at the moment
+     they're created, using the *running* GnuCash locale.
+
+   Because these are separate, the top-level "Income" account in the German chart is
+   **"Erträge"** (from the template) while the `.po` translation of the word "Income" is
+   **"Ertrag"**. Do not assume the template name equals the catalog translation.
+
+3. **For gain/loss accounts, prefer the explicit KVP link over any name/type guess** — see the
+   dedicated section below. There is no FX/gain *type*; GnuCash files realized gains under
+   `INCOME`.
+
+## Auto-created accounts (the ones tools most often hard-code)
+
+Source: `libgnucash/engine/Scrub.cpp`, `libgnucash/engine/Account.cpp`,
+`libgnucash/app-utils/gnc-ui-util.cpp`.
+
+| Account | How the name is built | Type assigned | Separator | Parent |
+|---|---|---|---|---|
+| Imbalance | `_("Imbalance") + "-" + <currency mnemonic>` → `Imbalance-USD` | `ACCT_TYPE_BANK` | `-` (no spaces) | root |
+| Orphan | `_("Orphan") + "-" + <currency mnemonic>` → `Orphan-USD` | `ACCT_TYPE_BANK` | `-` (no spaces) | root |
+| Orphaned Gains | `_("Orphaned Gains") + "-" + <mnemonic>` → `Orphaned Gains-USD` | `ACCT_TYPE_INCOME` | `-` (no spaces) | root |
+| Trading (root) | `_("Trading")`, then `:<namespace>:<commodity>` children | `ACCT_TYPE_TRADING` | n/a | root |
+| Opening Balances | `_("Opening Balances")`; multi-currency: `… + " - " + <mnemonic>` | `ACCT_TYPE_EQUITY` | ` - ` (spaces) | Equity-type acct |
+| Retained Earnings | `_("Retained Earnings")` | `ACCT_TYPE_EQUITY` | ` - ` (spaces) | Equity-type acct |
+
+Key details:
+- The **currency suffix is the ISO mnemonic** (USD, EUR, JPY …) and is **never translated**.
+  Only the leading word is localized.
+- **Separator differs**: Imbalance / Orphan / Orphaned Gains use a bare hyphen
+  (`Imbalance-EUR`); the equity accounts use a spaced hyphen (`Opening Balances - EUR`). The
+  unsuffixed form is used when the account currency equals the book's default currency.
+- **Imbalance, Orphan, and Orphaned Gains are all direct children of the root account**
+  (`construct_account()` / `GetOrMakeOrphanAccount()` both do "Hang the account off the root").
+  This makes `parent == root` a locale-stable structural signal. Disambiguate by type:
+  `BANK` → Imbalance/Orphan, `INCOME` → Orphaned Gains.
+- Trading sub-accounts (`Trading:CURRENCY:EUR`, etc.) use the commodity **namespace** and
+  **mnemonic**, which are not translated.
+
+### GnuCash's own code keys off translated names too
+
+`gnc_find_or_create_equity_account()` finds the parent by calling
+`gnc_account_lookup_by_name(root, _("Equity"))` and verifying `type == ACCT_TYPE_EQUITY`.
+It first tries the raw English msgid, then the translated form, then falls back to the root
+account. So GnuCash assumes the top-level Equity account carries the localized word "Equity" —
+but it self-heals via the type check and root fallback. Lesson for your tooling: match by
+**type first**, optionally use the localized name only as a tiebreaker.
+
+## FX / realized gain-loss account detection
+
+There is **no dedicated account type** for FX or realized gains — GnuCash files them under
+`ACCT_TYPE_INCOME`, and the **same account holds both gains and losses** (a loss is negative
+income; the default account's description is literally "Realized Gain/Loss"). So type alone
+(INCOME) cannot identify a gain/loss account. Use this tiered strategy, most reliable first.
+
+### 1. The KVP slot link — authoritative, locale-proof
+
+Source: `xaccAccountGainsAccount()` (`Account.cpp:4789`). Any account that throws off
+lot-based gains stores a **per-currency pointer** to its designated gains account:
+
+```
+slot path:  lot-mgmt → gains-acct → <commodity-unique-name>
+slot value: GUID of the gain/loss account
+```
+
+(`KEY_LOT_MGMT = "lot-mgmt"`, `Account.cpp:68`; `<commodity-unique-name>` is e.g.
+`CURRENCY::USD`.) Read this slot on the source account → you have the exact gains account, no
+name/type guessing. Collect every account referenced by any such slot across the book → that is
+your complete set of in-use gain/loss accounts. piecash exposes account slots, so this is
+directly available.
+
+### 2. Split-level linkage — empirical
+
+Source: `Split.cpp` (`PROP_GAINS_SPLIT`, `PROP_GAINS_SOURCE`, ~L95). Individual gains splits
+carry:
+- `gains-source` KVP → the originating (capital) split
+- `gains-split` KVP → reverse pointer
+- a `gains` status flag (`GAINS_STATUS_*`)
+
+Find the gains splits, read which account they post to → recovers the gain/loss accounts even on
+a book where the slot in (1) was never written.
+
+### 3. Default-account shape — heuristic fallback
+
+When no slot exists, GnuCash auto-creates the account via `GetOrMakeOrphanAccount()`
+(`Account.cpp:4745`):
+- **Name:** `_("Orphaned Gains") + "-" + <ISO mnemonic>` (bare hyphen) → `Orphaned Gains-USD`
+- **Type:** `ACCT_TYPE_INCOME`
+- **Parent:** direct child of **root**
+- **Description:** `_("Realized Gain/Loss")` ← more stable signal than the name
+- **Notes:** localized "Realized Gains or Losses from Commodity or Trading Accounts that
+  haven't been recorded elsewhere."
+
+Heuristic: `type == INCOME` **and** `parent == root` **and**
+(`name matches ^.+-<ISO4217>$` **or** `description == _("Realized Gain/Loss")`).
+
+### Detection order
+
+`KVP slot (1)` → `gains-source/gains-split splits (2)` → `INCOME + root-child + -CUR name /
+"Realized Gain/Loss" description (3)`. Type by itself is far too broad.
+
+### Implications for a server that creates its own FX account
+
+- A hand-rolled `"Foreign Exchange Gain/Loss"` INCOME account is **invisible** to GnuCash's lot
+  machinery unless you set the slot. When you create it, also write
+  `lot-mgmt/gains-acct/<commodity-unique-name>` on the source account pointing at it. Then
+  GnuCash's own scrubbing finds it, you won't double-create against a native
+  `Orphaned Gains-CUR`, and any detector resolves it deterministically.
+- GnuCash **nets gain and loss into one INCOME account**. Splitting into a gain (INCOME) and a
+  loss (EXPENSE) account is a deliberate divergence — fine on the write side, but when *reading*
+  a native book do **not** expect the loss half under EXPENSE.
+- `Orphaned Gains-CUR` shares the root-child `<word>-CUR` shape with Imbalance/Orphan, so it
+  surfaces in the same sweep — distinguish by type (`BANK` vs `INCOME`).
+
+## First-run wizard charts
+
+- Templates live in `data/accounts/<locale>/`. Locales shipped: C, ca, cs, da, de_AT, de_CH,
+  de_DE, el_GR, en_GB, en_IN, es_AR, es_ES, es_MX, fi_FI, fr_BE, fr_CA, fr_CH, fr_FR, he, hr,
+  hu, it, ja, ko, lt, lv, nb, nl, pl, pt_BR, pt_PT, ru, sk, sv_AX, sv_FI, sv_SE, tr_TR, zh_CN,
+  zh_HK, zh_TW (plus C = English source-of-truth). If no chart exists for the user's locale,
+  GnuCash falls back to C (English) names.
+- Each account in the XML has `<act:name>` (localized, free text) and `<act:type>` (the enum,
+  always uppercase English). The internal Root is `<act:name>Root Account</act:name>` and is
+  not translated (not user-visible).
+- Example, English vs German `acctchrt_common`:
+
+  | English (`C`) | German (`de_DE`) | type |
+  |---|---|---|
+  | Assets | Aktiva | ASSET |
+  | Current Assets | Barvermögen | ASSET |
+  | Checking Account | Girokonto | BANK |
+  | Savings Account | Sparkonto | BANK |
+  | Cash in Wallet | Bargeld | CASH |
+  | Liabilities | Fremdkapital | LIABILITY |
+  | Credit Card | Kreditkarte | CREDIT |
+  | Income | Erträge | INCOME |
+
+  Note these are the **template** strings — independent from the `.po` catalog below.
+
+## Translation reference (from `po/<lang>.po`, gettext msgstr)
+
+These are the **runtime / catalog** translations — exactly what auto-created accounts use, and
+the type-label translations GnuCash shows in its UI. (61 message-catalog locales ship in total.)
+
+| English | de | fr | es | it | pt_BR | nl | ru | ja | zh_CN | ko | pl | sv |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Imbalance | Ausgleichskonto | Non soldé | Descuadre | Sbilancio | Desequilíbrio | Niet in balans | Дисбаланс | 貸借不一致 | 不平衡的 | 대차 불일치 | Niezrównoważenie | Obalans |
+| Orphan | Ausbuchungskonto | Orphelin | Huérfano | Orfano | Órfão | Verweesd | Упущенный | 不明 | 孤立的 | 고아 | Osierocone | Föräldralös |
+| Orphaned Gains | Unverknüpfte Gewinne | Gains orphelins | Ganancias Huérfanas | Guadagni rimasti orfani | Ganhos órfãos | Verweesde resultaten | Упущенная прибыль | 不明な利得 | 孤立的收益 | 버린 이익 | Zyski osierocone | Föräldralösa vinster |
+| Realized Gain/Loss | Realisierter Gewinn/Verlust | Gains/pertes réalisés | Ganancias/Pérdidas Ocurridas | Profitti e perdite realizzati | Ganhos e perdas realizados | Gerealiseerde winst/verlies | Реализованная прибыль/убыток | 実現損益 | 已实现获利(亏损) | 실제 이익/손실 | Zyski/straty zrealizowane | Reavinst/-förlust |
+| Trading | Devisenhandel | Mouvements | Comerciales | Trading | Comércio | Handelsportefeuille | Торговля | 通貨取引 | 贸易 | 매매 | Handlowe | Handel |
+| Opening Balances | Anfangsbestand | Soldes initiaux | Saldos de Apertura | Saldi d'apertura | Saldos iniciais | Beginsaldi | Начальное сальдо | 開始残高 | 期初余额 | 잔고 | Bilanse otwarcia | Ingående saldon |
+| Retained Earnings | Einbehaltener Gewinn | Report à Nouveau | Ganancias Retenidas | Utili portati a nuovo | Ganhos retidos | Ingehouden winst | Нераспределённая прибыль | 利益剰余金 | 留存收益 | 이익 잉여금 | Dochody zatrzymane | Balanserade vinstmedel |
+| Equity | Eigenkapital | Capitaux propres | Patrimonio | Patrimonio netto | Patrimônio líquido | Eigen vermogen | Собственные средства | 純資産 | 所有者权益 | 자기자본 | Kapitał własny | Eget kapital |
+| Assets | Aktiva | Actifs (avoirs) | Activos | Attività | Ativos | Activa | Активы | 資産 | 资产 | 자산 | Aktywa | Tillgångar |
+| Liabilities | Fremdkapital | Passifs (dettes) | Pasivos | Passività | Passivos | Vreemd vermogen | Обязательства | 負債 | 负债 | 부채 | Pasywa | Skulder |
+| Income | Ertrag | Revenus | Ingreso | Entrate | Receita | Opbrengsten | Приход | 収益 | 收入 | 수입 | Przychody | Inkomst |
+| Expenses | Aufwand | Dépenses | Gastos | Uscite | Despesas | Kosten | Расходы | 費用 | 支出 | 비용 | Wydatki | Utgifter |
+
+(All cells verified from the catalog. Regenerate for any of the 61 shipped locales by parsing
+`po/<lang>.po` for these msgids.)
+
+## Recommendations for LLM / MCP tooling
+
+- **Identify accounts by `GNCAccountType`, not by name.** Build summaries, "find the Imbalance
+  account", root-category detection, etc. off the type enum. This is the only locale-stable key.
+- For the special runtime accounts, **match by `type` + `parent == root` + a
+  `^<word>(-| - )?<ISO?>` pattern** where `<word>` is resolved from the active locale's `.po`
+  (Imbalance/Orphan: BANK; Orphaned Gains: INCOME; equity ones: EQUITY). Don't string-compare to
+  the English word.
+- For gain/loss accounts, **read the `lot-mgmt/gains-acct` slot first**; fall back to
+  gains-source/gains-split splits, then to the INCOME-root-child shape. See the FX section above.
+- When you must display or create a localized name, pull it from the catalog for the book's
+  locale rather than hard-coding English; and when you create a gains account, set the slot so
+  the rest of the system can find it.
+- Remember template names (wizard hierarchy) ≠ catalog translations; if you need the user's
+  actual top-level account names, read them from the book, don't infer from the language.

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -980,6 +980,56 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         }
         return chosen, notice
 
+    # GnuCash names its auto-created balancing accounts via gettext —
+    # ``_("Imbalance")-<CUR>`` and ``_("Orphan")-<CUR>`` (Scrub.cpp) —
+    # so the leading word is localized. An English-only prefix check
+    # misses them on a localized book and the data-integrity warning
+    # goes dark. These are the catalog translations of "Imbalance" and
+    # "Orphan" across the shipped GnuCash locales, lowercased; a leaf
+    # name that STARTS WITH any of them is a balancing account (the
+    # "-<CUR>" suffix, when present, follows the word). Source:
+    # specs/gnucash-account-naming-i18n.md.
+    _BALANCING_ACCOUNT_NAME_PREFIXES = frozenset(
+        s.lower()
+        for s in (
+            # "Imbalance"
+            "Imbalance", "Ausgleichskonto", "Non soldé", "Descuadre",
+            "Sbilancio", "Desequilíbrio", "Niet in balans", "Дисбаланс",
+            "貸借不一致", "不平衡的", "대차 불일치", "Niezrównoważenie",
+            "Obalans",
+            # "Orphan"
+            "Orphan", "Ausbuchungskonto", "Orphelin", "Huérfano",
+            "Orfano", "Órfão", "Verweesd", "Упущенный", "不明",
+            "孤立的", "고아", "Osierocone", "Föräldralös",
+        )
+    )
+
+    def _is_auto_balancing_account(
+        self, account: piecash.Account, root: piecash.Account
+    ) -> bool:
+        """True iff ``account`` is a GnuCash auto-created Imbalance or
+        Orphan balancing account.
+
+        A non-zero balance on one of these is a structural defect the
+        dashboard surfaces. Locale-robust: match by **structure** —
+        type ``BANK``, a direct child of root (both invariants of how
+        GnuCash hangs these accounts) — plus a leading word from the
+        known Imbalance/Orphan catalog translations. Unknown locales
+        degrade to the English forms; the structural gate keeps false
+        positives off ordinary user accounts. (``Orphaned Gains`` is
+        deliberately excluded — it is type ``INCOME``, a legitimate
+        account, not a defect.)
+        """
+        if account.type != "BANK":
+            return False
+        if account.parent is None or account.parent.guid != root.guid:
+            return False
+        leaf = account.name.lower()
+        return any(
+            leaf.startswith(p)
+            for p in self._BALANCING_ACCOUNT_NAME_PREFIXES
+        )
+
     # ── Short account GUIDs ───────────────────────────────────────────
     #
     # Format "%XXXXXXX" (literal "%" + ≥7 hex chars) — cheap on the

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -924,6 +924,62 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
                 return account
         return None
 
+    def _top_level_account_of_type(
+        self, book: piecash.Book, acct_type: str
+    ) -> "tuple[piecash.Account | None, dict | None]":
+        """Find the top-level account of a given ``GNCAccountType``.
+
+        "Top-level" = a direct child of the real root account. This is
+        the locale-invariant replacement for English-name parent
+        lookups such as ``_find_account(book, "Income")``: it keys off
+        ``type`` and ``parent is root``, never a name, so it works on a
+        localized book (German "Erträge", etc.) **and** survives a user
+        renaming the account. Account *types* are never localized;
+        names always are.
+
+        Returns ``(account, notice)``:
+
+        - exactly one match → ``(account, None)``
+        - several → the lowest-``fullname`` pick plus an
+          ``ambiguous_top_level_account`` notice (mirrors the
+          ``ambiguous_fx_account`` convention so callers can surface it)
+        - none → ``(None, None)``
+
+        The scheduled-transaction template subtree is excluded, as
+        everywhere else accounts are surfaced.
+        """
+        root = book.root_account
+        template_guids = self._template_account_guids(book)
+        candidates = sorted(
+            (
+                a
+                for a in book.accounts
+                if a.guid not in template_guids
+                and a.type == acct_type
+                and a.parent is not None
+                and a.parent.guid == root.guid
+            ),
+            key=lambda a: a.fullname,
+        )
+        if not candidates:
+            return None, None
+        if len(candidates) == 1:
+            return candidates[0], None
+        chosen = candidates[0]
+        names = ", ".join(a.fullname for a in candidates)
+        notice = {
+            "type": "ambiguous_top_level_account",
+            "account_type": acct_type,
+            "candidates": [a.fullname for a in candidates],
+            "chosen": chosen.fullname,
+            "message": (
+                f"Found {len(candidates)} top-level {acct_type} "
+                f"accounts ({names}); using {chosen.fullname!r}. Pass "
+                f"an explicit account to override."
+            ),
+        }
+        return chosen, notice
+
     # ── Short account GUIDs ───────────────────────────────────────────
     #
     # Format "%XXXXXXX" (literal "%" + ≥7 hex chars) — cheap on the

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1030,6 +1030,145 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
             for p in self._BALANCING_ACCOUNT_NAME_PREFIXES
         )
 
+    # ── Book-locale inference + localized account names (§6.3) ────────
+    #
+    # When we auto-create an FX/discount account on a localized book we
+    # give it a localized leaf name so it reads naturally in the user's
+    # language. This is purely cosmetic: resolution after first use is
+    # GUID-based (the Layer-0 designated-account slot), so the leaf name
+    # never participates in finding the account again — an English
+    # fallback is always safe and never blocks.
+    #
+    # gettext (po/<lang>.po) translations of the five structural type
+    # words, keyed by GNCAccountType, used ONLY to infer the book locale
+    # from its top-level accounts. Source: gnucash-account-naming-i18n.md.
+    # Locale keys are normalized 2-letter codes (pt_BR→pt, zh_CN→zh).
+    _STRUCTURAL_TYPE_NAMES = {
+        "de": {"ASSET": "Aktiva", "LIABILITY": "Fremdkapital",
+               "INCOME": "Ertrag", "EXPENSE": "Aufwand",
+               "EQUITY": "Eigenkapital"},
+        "fr": {"ASSET": "Actifs (avoirs)", "LIABILITY": "Passifs (dettes)",
+               "INCOME": "Revenus", "EXPENSE": "Dépenses",
+               "EQUITY": "Capitaux propres"},
+        "es": {"ASSET": "Activos", "LIABILITY": "Pasivos",
+               "INCOME": "Ingreso", "EXPENSE": "Gastos",
+               "EQUITY": "Patrimonio"},
+        "it": {"ASSET": "Attività", "LIABILITY": "Passività",
+               "INCOME": "Entrate", "EXPENSE": "Uscite",
+               "EQUITY": "Patrimonio netto"},
+        "pt": {"ASSET": "Ativos", "LIABILITY": "Passivos",
+               "INCOME": "Receita", "EXPENSE": "Despesas",
+               "EQUITY": "Patrimônio líquido"},
+        "nl": {"ASSET": "Activa", "LIABILITY": "Vreemd vermogen",
+               "INCOME": "Opbrengsten", "EXPENSE": "Kosten",
+               "EQUITY": "Eigen vermogen"},
+        "ru": {"ASSET": "Активы", "LIABILITY": "Обязательства",
+               "INCOME": "Приход", "EXPENSE": "Расходы",
+               "EQUITY": "Собственные средства"},
+        "ja": {"ASSET": "資産", "LIABILITY": "負債", "INCOME": "収益",
+               "EXPENSE": "費用", "EQUITY": "純資産"},
+        "zh": {"ASSET": "资产", "LIABILITY": "负债", "INCOME": "收入",
+               "EXPENSE": "支出", "EQUITY": "所有者权益"},
+        "ko": {"ASSET": "자산", "LIABILITY": "부채", "INCOME": "수입",
+               "EXPENSE": "비용", "EQUITY": "자기자본"},
+        "pl": {"ASSET": "Aktywa", "LIABILITY": "Pasywa",
+               "INCOME": "Przychody", "EXPENSE": "Wydatki",
+               "EQUITY": "Kapitał własny"},
+        "sv": {"ASSET": "Tillgångar", "LIABILITY": "Skulder",
+               "INCOME": "Inkomst", "EXPENSE": "Utgifter",
+               "EQUITY": "Eget kapital"},
+    }
+
+    # Localized leaf names for the accounts we auto-create, keyed by an
+    # internal concept slug then normalized locale code. Only concepts
+    # with a translation table appear here; a missing concept or locale
+    # degrades to the caller's English default. Seeded from the
+    # "Realized Gain/Loss" row of gnucash-account-naming-i18n.md;
+    # extend by parsing po/<lang>.po later (the discount concepts have
+    # no shipped GnuCash translation, so they stay English for now).
+    _LOCALIZED_ACCOUNT_NAMES = {
+        "fx_gain_loss": {
+            "de": "Realisierter Gewinn/Verlust",
+            "fr": "Gains/pertes réalisés",
+            "es": "Ganancias/Pérdidas Ocurridas",
+            "it": "Profitti e perdite realizzati",
+            "pt": "Ganhos e perdas realizados",
+            "nl": "Gerealiseerde winst/verlies",
+            "ru": "Реализованная прибыль/убыток",
+            "ja": "実現損益",
+            "zh": "已实现获利(亏损)",
+            "ko": "실제 이익/손실",
+            "pl": "Zyski/straty zrealizowane",
+            "sv": "Reavinst/-förlust",
+        },
+    }
+
+    def _infer_book_locale(self, book: piecash.Book) -> str | None:
+        """Infer the book's locale (a normalized 2-letter language
+        code) for naming auto-created accounts. Decided source of
+        truth (§6.3):
+
+        1. ``GNUCASH_LOCALE`` env override, reduced to its language
+           code (``de_DE.UTF-8`` → ``de``).
+        2. else **vote**: match the book's top-level type accounts
+           against the gettext structural-word catalog; the language
+           with the most matches wins (>= 2, so a single coincidental
+           hit doesn't drive inference).
+        3. else ``None`` → English leaf names.
+
+        Voting (not a single-account lookup) sidesteps the two-
+        translation-sources trap: a German book's top-level income is
+        the template word "Erträge", which does NOT equal the gettext
+        "Ertrag" — but Assets/Expenses/Equity ("Aktiva"/"Aufwand"/
+        "Eigenkapital") match exactly, so German still resolves. A
+        numbered chart like SKR03 matches too few to trigger and
+        correctly falls back to English.
+        """
+        import os
+        override = os.environ.get("GNUCASH_LOCALE")
+        if override:
+            code = override.strip().split(".")[0].split("_")[0].lower()
+            return code or None
+
+        root = book.root_account
+        template_guids = self._template_account_guids(book)
+        names_by_type: dict[str, list[str]] = {}
+        for acct in book.accounts:
+            if acct.guid in template_guids:
+                continue
+            if acct.parent is None or acct.parent.guid != root.guid:
+                continue
+            names_by_type.setdefault(acct.type, []).append(
+                acct.name.strip().lower()
+            )
+        if not names_by_type:
+            return None
+
+        best_lang, best_score = None, 0
+        for lang, type_words in self._STRUCTURAL_TYPE_NAMES.items():
+            score = sum(
+                1
+                for atype, word in type_words.items()
+                if any(n == word.lower() for n in names_by_type.get(atype, ()))
+            )
+            if score > best_score:
+                best_lang, best_score = lang, score
+        return best_lang if best_score >= 2 else None
+
+    def _locale_account_name(
+        self, concept: str, english_default: str, locale: str | None,
+    ) -> str:
+        """Localized leaf name for an auto-created-account ``concept``,
+        or ``english_default`` when no localization applies (``locale``
+        is None/unknown, or the concept has no translation). Cosmetic
+        only — resolution is GUID-based, so the fallback never blocks.
+        """
+        if locale is None:
+            return english_default
+        return self._LOCALIZED_ACCOUNT_NAMES.get(concept, {}).get(
+            locale, english_default
+        )
+
     # ── Short account GUIDs ───────────────────────────────────────────
     #
     # Format "%XXXXXXX" (literal "%" + ≥7 hex chars) — cheap on the

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -556,8 +556,15 @@ class BusinessMixin:
         # the session would trip a NOT NULL on splits.tx_guid. The
         # final book.save() at the end of pay_invoice flushes everything
         # together with their now-set tx_guids.
+        # Localize the leaf on a non-English book (§6.3). Cosmetic only:
+        # the slot write below makes the next resolve GUID-based, so the
+        # localized name never has to be matched again.
+        fx_leaf = self._locale_account_name(
+            "fx_gain_loss", "Foreign Exchange Gain/Loss",
+            self._infer_book_locale(book),
+        )
         fx_acct = piecash.Account(
-            name="Foreign Exchange Gain/Loss",
+            name=fx_leaf,
             type="INCOME",
             parent=income,
             commodity=default_currency,
@@ -597,6 +604,7 @@ class BusinessMixin:
             keywords = self._PURCHASE_DISCOUNT_NAME_KEYWORDS
             side_label = "purchase discounts taken"
             slot_key = self._PURCHASE_DISCOUNT_SLOT_KEY
+            concept = "purchase_discount"
         else:
             canonical_path = self.SALES_DISCOUNTS_PATH
             canonical_type = "EXPENSE"
@@ -604,6 +612,7 @@ class BusinessMixin:
             keywords = self._SALES_DISCOUNT_NAME_KEYWORDS
             side_label = "sales discounts"
             slot_key = self._SALES_DISCOUNT_SLOT_KEY
+            concept = "sales_discount"
 
         # Layer 1: caller-supplied account wins.
         if discount_account is not None:
@@ -684,7 +693,13 @@ class BusinessMixin:
 
         # Don't flush here; the caller is still building the payment
         # transaction. Same rationale as the FX-account auto-create.
-        leaf_name = canonical_path.split(":")[-1]
+        # Localized leaf on a non-English book (§6.3); falls back to the
+        # English canonical leaf when no translation exists for the
+        # concept (the discount concepts have none shipped yet).
+        leaf_name = self._locale_account_name(
+            concept, canonical_path.split(":")[-1],
+            self._infer_book_locale(book),
+        )
         disc_acct = piecash.Account(
             name=leaf_name,
             type=canonical_type,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -358,14 +358,17 @@ class BusinessMixin:
            caller to pass ``fx_account``. Don't guess between
            user-created accounts.
         3. **Canonical default**: existing ``Income:Foreign Exchange
-           Gain/Loss``, else auto-create it under ``Income`` — so
-           books without foreign-currency activity never accumulate
-           an unused account.
+           Gain/Loss``, else auto-create it under the top-level INCOME
+           account resolved *by type* — locale-robust, so it works on
+           a book whose income root is "Erträge"/"Ingresos"/… (and
+           survives a user rename), instead of throwing on a missing
+           English "Income". Falls back to creating a top-level INCOME
+           account only if the book has none at all.
 
         Raises:
-            ValueError: ``fx_account`` supplied but missing or not
-                INCOME/EXPENSE; or no ``Income`` parent to create
-                under.
+            ValueError: ``fx_account`` supplied but missing, not
+                INCOME/EXPENSE, or denominated in a non-default
+                currency.
         """
         default_currency = self._require_default_currency(book)
 
@@ -437,13 +440,25 @@ class BusinessMixin:
         if fx_acct is not None:
             return fx_acct, notice
 
-        income = self._find_account(book, "Income")
+        # Resolve the parent by TYPE, not the English name "Income".
+        # On a localized book the income root is "Erträge"/"Ingresos"/…,
+        # so _find_account(book, "Income") returns None and the old
+        # code threw here — the first cross-currency payment failing.
+        # Fall back to creating a top-level INCOME account only if the
+        # book genuinely has none.
+        income, parent_notice = self._top_level_account_of_type(
+            book, "INCOME"
+        )
         if income is None:
-            raise ValueError(
-                "Realized FX gain/loss on cross-currency payment needs "
-                "an Income parent account, but none exists. Create "
-                "Income (type=INCOME, placeholder) first."
+            income = piecash.Account(
+                name="Income",
+                type="INCOME",
+                parent=book.root_account,
+                commodity=default_currency,
+                placeholder=1,
             )
+        if notice is None:
+            notice = parent_notice
 
         # Construct — piecash.Account auto-adds to the session via the
         # parent linkage. Don't flush here: the caller is still building
@@ -544,16 +559,25 @@ class BusinessMixin:
         if disc_acct is not None:
             return disc_acct, notice
 
-        parent = self._find_account(book, canonical_parent_path)
-        if parent is None:
-            raise ValueError(
-                f"Early-payment discount on this payment needs an "
-                f"{canonical_parent_path} parent account, but none "
-                f"exists. Create {canonical_parent_path} (type="
-                f"{canonical_type}, placeholder) first."
-            )
-
+        # Resolve the parent by TYPE (INCOME/EXPENSE), not the English
+        # name "Income"/"Expenses" — locale-robust and rename-proof.
+        # Fall back to creating the top-level account only if the book
+        # has none of that type.
+        parent, parent_notice = self._top_level_account_of_type(
+            book, canonical_type
+        )
         default_currency = self._require_default_currency(book)
+        if parent is None:
+            parent = piecash.Account(
+                name=canonical_parent_path,
+                type=canonical_type,
+                parent=book.root_account,
+                commodity=default_currency,
+                placeholder=1,
+            )
+        if notice is None:
+            notice = parent_notice
+
         # Don't flush here; the caller is still building the payment
         # transaction. Same rationale as the FX-account auto-create.
         leaf_name = canonical_path.split(":")[-1]

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -340,6 +340,74 @@ class BusinessMixin:
         "vendor discounts",
     )
 
+    # ── Designated-account KVP slots (Layer 0 of the resolvers) ──────
+    #
+    # Once the FX / discount account is first resolved or created, its
+    # GUID is stored in a book-global slot on the root account. Every
+    # later resolution reads that GUID directly (Layer 0) — immune to
+    # both account renames and the book's locale, because the name no
+    # longer participates once the slot is populated. A stale or missing
+    # slot falls through to the lower layers, which re-populate it on the
+    # next create, so the designation self-heals.
+    #
+    # Path-style ``gnc-mcp/<role>`` keys (hierarchical sub-slots in the
+    # KVP store) per the slot-naming convention. One account per role,
+    # each denominated in the book default currency, so a single slot on
+    # the root account suffices — no per-source-account/per-commodity
+    # path is needed.
+    _FX_ACCOUNT_SLOT_KEY = "gnc-mcp/fx-gain-loss-acct"
+    _SALES_DISCOUNT_SLOT_KEY = "gnc-mcp/sales-discount-acct"
+    _PURCHASE_DISCOUNT_SLOT_KEY = "gnc-mcp/purchase-discount-acct"
+
+    def _resolve_designated_account(self, book, slot_key):
+        """Layer 0: resolve a designated FX/discount account from its
+        root-account KVP slot.
+
+        Returns the Account iff the slot holds a GUID that still
+        resolves to an INCOME/EXPENSE account in the book default
+        currency. A missing, empty, or stale slot (the account was
+        deleted, retyped, or re-denominated) returns ``None`` — the
+        caller falls through to the lower layers and re-writes the slot
+        on the next create, so the designation self-heals.
+
+        GUID-based, hence locale- and rename-proof: the account can be
+        renamed or re-parented freely after first use and still resolve.
+        """
+        try:
+            raw = book.root_account[slot_key]
+        except KeyError:
+            return None
+        guid = _slot_value_str(raw)
+        if not guid:
+            return None
+        acct = self._resolve_account(book, guid)
+        if acct is None:
+            return None
+        if acct.type not in {"INCOME", "EXPENSE"}:
+            return None
+        if acct.commodity != self._require_default_currency(book):
+            return None
+        return acct
+
+    def _store_designated_account(self, book, slot_key, account) -> None:
+        """Persist ``account``'s GUID to a root-account KVP slot so
+        future resolutions hit Layer 0 (a direct, locale-/rename-proof
+        GUID lookup) instead of re-deriving the account by name.
+
+        Called once the FX/discount account is definitively resolved
+        (found at its canonical path or freshly created). piecash
+        assigns ``guid`` at flush, not construction, and we cannot
+        flush mid-payment-build (orphan splits would trip a NOT NULL on
+        ``splits.tx_guid``); so a freshly created account is still
+        guid-less here. Assign the canonical guid now — piecash uses it
+        at INSERT — and the slot persists with the caller's final
+        ``book.save()``.
+        """
+        if account.guid is None:
+            import uuid
+            account.guid = uuid.uuid4().hex
+        book.root_account[slot_key] = account.guid
+
     def _get_or_create_fx_account(self, book, fx_account: str | None = None):
         """Find or lazily create the FX-gain/loss account.
 
@@ -349,8 +417,16 @@ class BusinessMixin:
 
         Resolution order:
 
+        0. **Stored designation** — a GUID written to the
+           ``gnc-mcp/fx-gain-loss-acct`` root slot on a prior resolve/
+           create. Consulted only when no explicit ``fx_account`` is
+           given; GUID-based, so it is immune to a rename of the FX
+           account and to the book's locale. The primary path after
+           first use.
         1. **Explicit ``fx_account``** (path, ``%short``, or full
            GUID) — validated for existence and INCOME/EXPENSE type.
+           A per-call override; wins over the stored designation and
+           is not itself persisted.
         2. **Fuzzy match**, leaf-name substring against
            ``_FX_NAME_KEYWORDS`` over INCOME/EXPENSE accounts:
            exactly one match → use it; zero → fall through; more
@@ -401,6 +477,15 @@ class BusinessMixin:
                 )
             return acct, None
 
+        # Layer 0: a stored designation wins for the no-explicit-arg
+        # case (the usual pay_invoice path). GUID-based, so it survives
+        # a rename of the FX account and works on any locale.
+        slotted = self._resolve_designated_account(
+            book, self._FX_ACCOUNT_SLOT_KEY
+        )
+        if slotted is not None:
+            return slotted, None
+
         # Layer 2: fuzzy match by leaf-name substring. Only
         # default-currency candidates qualify — see the commodity
         # rationale on the explicit-account path above.
@@ -438,6 +523,11 @@ class BusinessMixin:
         # Layer 3: canonical default (existing or auto-create).
         fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
         if fx_acct is not None:
+            # Lock in the designation so the next call hits Layer 0
+            # directly — even on a book that already had this account.
+            self._store_designated_account(
+                book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
+            )
             return fx_acct, notice
 
         # Resolve the parent by TYPE, not the English name "Income".
@@ -477,6 +567,9 @@ class BusinessMixin:
                 "and pay-date). Auto-created on first use."
             ),
         )
+        self._store_designated_account(
+            book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
+        )
         return fx_acct, notice
 
     def _get_or_create_discount_account(
@@ -486,9 +579,11 @@ class BusinessMixin:
         """Find or lazily create the early-payment-discount account.
 
         Direct parallel to ``_get_or_create_fx_account`` — same
-        three-layer resolution (explicit > fuzzy match > canonical
-        default with auto-create) and the same ``(account, notice)``
-        return shape.
+        four-layer resolution (stored designation > explicit > fuzzy
+        match > canonical default with auto-create) and the same
+        ``(account, notice)`` return shape. The Layer-0 slot is
+        per-side, so the sales and purchase designations are
+        independent.
 
         ``owner_type_is_bill`` selects the side: True → vendor-bill
         payment (or customer credit-note refund), discount is INCOME
@@ -501,12 +596,14 @@ class BusinessMixin:
             canonical_parent_path = "Income"
             keywords = self._PURCHASE_DISCOUNT_NAME_KEYWORDS
             side_label = "purchase discounts taken"
+            slot_key = self._PURCHASE_DISCOUNT_SLOT_KEY
         else:
             canonical_path = self.SALES_DISCOUNTS_PATH
             canonical_type = "EXPENSE"
             canonical_parent_path = "Expenses"
             keywords = self._SALES_DISCOUNT_NAME_KEYWORDS
             side_label = "sales discounts"
+            slot_key = self._SALES_DISCOUNT_SLOT_KEY
 
         # Layer 1: caller-supplied account wins.
         if discount_account is not None:
@@ -524,6 +621,12 @@ class BusinessMixin:
                     f"receive an early-payment-discount split."
                 )
             return acct, None
+
+        # Layer 0: a stored designation wins for the no-explicit-arg
+        # case. Per-side slot, GUID-based — rename- and locale-proof.
+        slotted = self._resolve_designated_account(book, slot_key)
+        if slotted is not None:
+            return slotted, None
 
         # Layer 2: fuzzy match by leaf-name substring.
         template_guids = self._template_account_guids(book)
@@ -557,6 +660,7 @@ class BusinessMixin:
         # Layer 3: canonical default (existing or auto-create).
         disc_acct = self._find_account(book, canonical_path)
         if disc_acct is not None:
+            self._store_designated_account(book, slot_key, disc_acct)
             return disc_acct, notice
 
         # Resolve the parent by TYPE (INCOME/EXPENSE), not the English
@@ -593,6 +697,7 @@ class BusinessMixin:
                 f"validation passes. Auto-created on first use."
             ),
         )
+        self._store_designated_account(book, slot_key, disc_acct)
         return disc_acct, notice
 
     def _get_invoice_billterm(self, book, inv):

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1750,6 +1750,20 @@ class BusinessMixin:
         if row and row[0]:
             gdate_val = row[0]
             if isinstance(gdate_val, str):
+                # GnuCash GDATE columns return a compact ``YYYYMMDD``
+                # string; other paths yield ISO ``YYYY-MM-DD``. Python
+                # 3.11+ ``date.fromisoformat`` accepts both, but 3.10
+                # (a supported target) rejects the compact form and
+                # raises — which the warnings collector's broad
+                # ``except`` then swallows, silently dropping the
+                # overdue warning. Normalize to digits first.
+                digits = gdate_val.strip().replace("-", "")[:8]
+                if len(digits) == 8 and digits.isdigit():
+                    return (
+                        date(int(digits[:4]), int(digits[4:6]),
+                             int(digits[6:8])),
+                        False,
+                    )
                 return date.fromisoformat(gdate_val[:10]), False
             if isinstance(gdate_val, datetime):
                 return gdate_val.date(), False

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -89,7 +89,6 @@ class _SummaryData:
     # Account categorization (per-leaf rows the section renderers iterate).
     asset_leaves: list[tuple[str, Decimal, str | None]] = field(default_factory=list)
     credit_cards: list[tuple[str, Decimal]] = field(default_factory=list)
-    loan_accts: list[tuple[str, Decimal]] = field(default_factory=list)
     other_liab_accts: list[tuple[str, Decimal]] = field(default_factory=list)
     receivable_accts: list[tuple[str, Decimal]] = field(default_factory=list)
     payable_accts: list[tuple[str, Decimal]] = field(default_factory=list)
@@ -100,7 +99,6 @@ class _SummaryData:
     receivables_total: Decimal = Decimal("0")
     payables_total: Decimal = Decimal("0")
     credit_total: Decimal = Decimal("0")
-    loan_total: Decimal = Decimal("0")
     other_liab_total: Decimal = Decimal("0")
 
     # Counts.
@@ -598,13 +596,16 @@ class CoreMixin:
         rates_for_sort = self._rates_as_of(
             book, today, default_currency,
         )
+        root = book.root_account
         integrity: list[tuple[Decimal, str]] = []
         for account in accounts:
-            if account.type == "ROOT":
+            # Locale-robust: GnuCash localizes the "Imbalance"/"Orphan"
+            # leading word, so a structural+catalog match replaces the
+            # old English-only prefix check (which never fired on a
+            # localized book — the warning silently went dark).
+            if not self._is_auto_balancing_account(account, root):
                 continue
             name = account.name
-            if not (name.startswith("Imbalance-") or name.startswith("Orphan-")):
-                continue
             balance = self._own_splits_balance(account)
             if balance != 0:
                 acct_commodity = (
@@ -1580,12 +1581,12 @@ class CoreMixin:
                         today=today,
                     )
                     pos_value = -usd_value
-                    if "loan" in account.fullname.lower():
-                        data.loan_accts.append((leaf, pos_value))
-                    else:
-                        data.other_liab_accts.append(
-                            (leaf, pos_value)
-                        )
+                    # Loans and other liabilities are the same TYPE —
+                    # GnuCash has no "loan" account type — so we don't
+                    # sub-classify by name. The old "loan" substring
+                    # was English-only (missed "Darlehen"/"Kredit" and
+                    # any rename); one bucket is locale-correct.
+                    data.other_liab_accts.append((leaf, pos_value))
             elif account.type == "RECEIVABLE":
                 if balance != 0:
                     # A/R is debit-natural: positive balance = owed to us.
@@ -1635,17 +1636,13 @@ class CoreMixin:
             sum(b for _, b in data.credit_cards)
             if data.credit_cards else Decimal(0)
         )
-        data.loan_total = _r2(
-            sum(b for _, b in data.loan_accts)
-            if data.loan_accts else Decimal(0)
-        )
         data.other_liab_total = _r2(
             sum(b for _, b in data.other_liab_accts)
             if data.other_liab_accts else Decimal(0)
         )
         data.liabilities_total = _r2(
-            data.credit_total + data.loan_total
-            + data.other_liab_total + data.payables_total
+            data.credit_total + data.other_liab_total
+            + data.payables_total
         )
         return data
 
@@ -1749,8 +1746,8 @@ class CoreMixin:
         lives in ``_render_receivables_payables``.
         """
         liab_count = (
-            len(data.credit_cards) + len(data.loan_accts)
-            + len(data.other_liab_accts) + len(data.payable_accts)
+            len(data.credit_cards) + len(data.other_liab_accts)
+            + len(data.payable_accts)
         )
         lines = [
             f"Liabilities: {liab_count} accounts, "
@@ -1761,18 +1758,13 @@ class CoreMixin:
                 f"  Credit cards ({len(data.credit_cards)}): "
                 f"{currency} {data.credit_total}"
             )
-        if data.loan_accts:
-            lines.append(
-                f"  Loans ({len(data.loan_accts)}): "
-                f"{currency} {data.loan_total}"
-            )
         if data.other_liab_accts:
             lines.append(
-                f"  Other ({len(data.other_liab_accts)}): "
+                f"  Loans & other ({len(data.other_liab_accts)}): "
                 f"{currency} {data.other_liab_total}"
             )
         all_liab_leaves = (
-            data.credit_cards + data.loan_accts + data.other_liab_accts
+            data.credit_cards + data.other_liab_accts
         )
         if len(all_liab_leaves) > 1:
             all_liab_leaves.sort(key=lambda x: x[1], reverse=True)

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1274,6 +1274,11 @@ class ReportingMixin:
             # valued in the book default; collected here and excluded
             # from the schedule (see the loop guard below).
             excluded_debts: list[str] = []
+            # LIABILITY accounts with an APR and balance but no way to
+            # estimate a payment (neither minimum_payment nor
+            # loan_term_months slot). Omitted from the plan rather than
+            # estimated from a guessed term — see the LIABILITY branch.
+            unestimable_debts: list[str] = []
             # Counted so the no-debts error distinguishes "no debt
             # accounts at all" from "they exist but lack the apr
             # slot" — the user's next action differs.
@@ -1383,18 +1388,17 @@ class ReportingMixin:
                     else:
                         # LIABILITY: amortization formula
                         # PMT = P × r(1+r)^n / ((1+r)^n − 1).
-                        # Term from the optional `loan_term_months`
-                        # slot, else default to 30y. We deliberately do
-                        # NOT guess "mortgage vs. other" from the
-                        # account name: that was English-only (it missed
-                        # "Hypothek"/"Darlehen" and any rename). A 30y
-                        # default under-states a short loan's payment
-                        # mildly rather than over-stating a mortgage's
-                        # — over-statement is what trips the budget gate
-                        # (the failure the 2%-rule comment above guards
-                        # against). Set `loan_term_months` or
-                        # `minimum_payment` for an exact figure.
-                        term_months = 360
+                        # Term comes ONLY from the `loan_term_months`
+                        # slot. There is no "mortgage" account type to
+                        # key off, and no safe default term: a 30y-vs-5y
+                        # guess differs by an order of magnitude, so a
+                        # guessed estimate is wrong enough to be worse
+                        # than none (a low guess understates the payment;
+                        # a high one trips the budget gate). Without the
+                        # slot — or an explicit `minimum_payment` above —
+                        # omit this debt from the plan and tell the user
+                        # what to set, rather than fabricate a figure.
+                        term_months = None
                         lt_val = slot_by_name.get("loan_term_months")
                         if lt_val is not None:
                             try:
@@ -1408,6 +1412,9 @@ class ReportingMixin:
                                     term_months = parsed
                             except (InvalidOperation, ValueError):
                                 pass
+                        if term_months is None:
+                            unestimable_debts.append(account.fullname)
+                            continue
                         monthly_rate = (
                             apr / Decimal("100") / Decimal("12")
                         )
@@ -1455,6 +1462,20 @@ class ReportingMixin:
                 f"{', '.join(sorted(excluded_debts))}"
             )
 
+        # Debts omitted because their payment can't be estimated without
+        # guessing the amortization term — surfaced so the reader knows
+        # the plan is partial and exactly what to set to complete it.
+        unestimable_warning = None
+        if unestimable_debts:
+            unestimable_warning = (
+                f"{len(unestimable_debts)} debt(s) omitted — no "
+                f"'loan_term_months' or 'minimum_payment' slot, so the "
+                f"payment can't be estimated without guessing the loan "
+                f"term: {', '.join(sorted(unestimable_debts))}. Set "
+                f"loan_term_months (or minimum_payment) via "
+                f"set_account_slot for payment estimates."
+            )
+
         if not debts:
             # Nothing left to plan but some debts were excluded for lack
             # of an FX rate — lead with that actionable cause (distinct
@@ -1482,6 +1503,18 @@ class ReportingMixin:
                     "chart of accounts. Create the debt account(s) "
                     "first via create_account, then set their APR "
                     "via set_account_slot."
+                )
+            # Distinct from the apr-missing case below: these debts have
+            # an APR and balance but no term/payment to estimate from.
+            if unestimable_debts:
+                raise ValueError(
+                    f"{len(unestimable_debts)} loan/liability account(s) "
+                    f"have an APR and balance but no way to estimate a "
+                    f"minimum payment: "
+                    f"{', '.join(sorted(unestimable_debts))}. Set a "
+                    f"'loan_term_months' (amortization term) or "
+                    f"'minimum_payment' slot on each via "
+                    f"set_account_slot."
                 )
             raise ValueError(
                 f"Found {debt_typed_account_count} CREDIT/LIABILITY "
@@ -1562,9 +1595,15 @@ class ReportingMixin:
                 ),
             },
         }
+        warnings: list[str] = []
         if excluded_warning:
             full["excluded"] = sorted(excluded_debts)
-            full["warnings"] = [excluded_warning]
+            warnings.append(excluded_warning)
+        if unestimable_warning:
+            full["unestimable"] = sorted(unestimable_debts)
+            warnings.append(unestimable_warning)
+        if warnings:
+            full["warnings"] = warnings
 
         if not compact:
             return full
@@ -1584,4 +1623,6 @@ class ReportingMixin:
         )
         if excluded_warning:
             compact_out += f"\n⚠ {excluded_warning}"
+        if unestimable_warning:
+            compact_out += f"\n⚠ {unestimable_warning}"
         return compact_out

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1383,11 +1383,31 @@ class ReportingMixin:
                     else:
                         # LIABILITY: amortization formula
                         # PMT = P × r(1+r)^n / ((1+r)^n − 1).
-                        # Term: 30y when "mortgage" appears in the
-                        # path, else 5y; non-standard terms should
-                        # set the minimum_payment slot.
-                        is_mortgage = "mortgage" in account.fullname.lower()
-                        term_months = 360 if is_mortgage else 60
+                        # Term from the optional `loan_term_months`
+                        # slot, else default to 30y. We deliberately do
+                        # NOT guess "mortgage vs. other" from the
+                        # account name: that was English-only (it missed
+                        # "Hypothek"/"Darlehen" and any rename). A 30y
+                        # default under-states a short loan's payment
+                        # mildly rather than over-stating a mortgage's
+                        # — over-statement is what trips the budget gate
+                        # (the failure the 2%-rule comment above guards
+                        # against). Set `loan_term_months` or
+                        # `minimum_payment` for an exact figure.
+                        term_months = 360
+                        lt_val = slot_by_name.get("loan_term_months")
+                        if lt_val is not None:
+                            try:
+                                lt_str = (
+                                    str(lt_val.value)
+                                    if hasattr(lt_val, "value")
+                                    else str(lt_val)
+                                )
+                                parsed = int(Decimal(lt_str))
+                                if parsed > 0:
+                                    term_months = parsed
+                            except (InvalidOperation, ValueError):
+                                pass
                         monthly_rate = (
                             apr / Decimal("100") / Decimal("12")
                         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1006,6 +1006,95 @@ def debt_book(tmp_path: Path) -> Path:
     return book_path
 
 
+@pytest.fixture
+def localized_book(tmp_path: Path) -> Path:
+    """A book with a German (`de_DE`-style) account hierarchy.
+
+    EUR default. Account *names* are German; account *types* are the
+    locale-invariant enum, exactly as a real localized GnuCash book is
+    laid out. Crucially there is **no account literally named "Income"
+    or "Expenses"** — so any code that resolves a helper-account parent
+    by English name throws here, while type-based resolution succeeds.
+
+    Chart:
+    - Aktiva (ASSET) → Girokonto (BANK), Forderungen (RECEIVABLE)
+    - Fremdkapital (LIABILITY) → Verbindlichkeiten (PAYABLE)
+    - Erträge (INCOME) → Umsatzerlöse (INCOME)
+    - Aufwand (EXPENSE) → Bürobedarf (EXPENSE)
+    - Eigenkapital (EQUITY) → Anfangsbestand (EQUITY)
+    - Opening balance: €10,000 in Girokonto.
+    """
+    book_path = tmp_path / "localized.gnucash"
+
+    book = piecash.create_book(
+        str(book_path), currency="EUR", overwrite=True,
+    )
+    root = book.root_account
+    eur = book.default_currency
+
+    aktiva = piecash.Account(
+        name="Aktiva", type="ASSET", parent=root,
+        commodity=eur, placeholder=True,
+    )
+    girokonto = piecash.Account(
+        name="Girokonto", type="BANK", parent=aktiva, commodity=eur,
+    )
+    piecash.Account(
+        name="Forderungen", type="RECEIVABLE", parent=aktiva, commodity=eur,
+    )
+
+    fremdkapital = piecash.Account(
+        name="Fremdkapital", type="LIABILITY", parent=root,
+        commodity=eur, placeholder=True,
+    )
+    piecash.Account(
+        name="Verbindlichkeiten", type="PAYABLE", parent=fremdkapital,
+        commodity=eur,
+    )
+
+    ertraege = piecash.Account(
+        name="Erträge", type="INCOME", parent=root,
+        commodity=eur, placeholder=True,
+    )
+    piecash.Account(
+        name="Umsatzerlöse", type="INCOME", parent=ertraege, commodity=eur,
+    )
+
+    aufwand = piecash.Account(
+        name="Aufwand", type="EXPENSE", parent=root,
+        commodity=eur, placeholder=True,
+    )
+    piecash.Account(
+        name="Bürobedarf", type="EXPENSE", parent=aufwand, commodity=eur,
+    )
+
+    eigenkapital = piecash.Account(
+        name="Eigenkapital", type="EQUITY", parent=root,
+        commodity=eur, placeholder=True,
+    )
+    anfangsbestand = piecash.Account(
+        name="Anfangsbestand", type="EQUITY", parent=eigenkapital,
+        commodity=eur,
+    )
+
+    book.save()
+
+    book.session.add(piecash.Transaction(
+        currency=eur,
+        description="Anfangsbestand",
+        post_date=date(2025, 12, 31),
+        splits=[
+            piecash.Split(account=girokonto, value=Decimal("10000")),
+            piecash.Split(account=anfangsbestand, value=Decimal("-10000")),
+        ],
+    ))
+
+    book.save()
+    book.close()
+
+    return book_path
+
+
 class PathologicalBook(typing.NamedTuple):
     """Handle returned by the ``pathological_book`` fixture.
 

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -457,9 +457,12 @@ class TestDebtPayoffAmortizingLoans:
         auto["apr"] = "4.90"
         # The amortization term is data, not inferred from the account
         # name (the old English "mortgage" substring was locale-
-        # fragile — it missed "Hypothek"/"Darlehen"). The Auto Loan
-        # declares its 5-year term via the loan_term_months slot; the
-        # Mortgage omits it and exercises the 30-year default.
+        # fragile — it missed "Hypothek"/"Darlehen"). Each loan
+        # declares its term via the loan_term_months slot: the Mortgage
+        # 30y, the Auto Loan 5y. There is no default term — a loan
+        # without this slot (and without minimum_payment) is omitted
+        # from the plan (see test_liability_without_term_is_omitted).
+        mortgage["loan_term_months"] = "360"
         auto["loan_term_months"] = "60"
         cc["apr"] = "18.25"
         book.save()
@@ -485,8 +488,8 @@ class TestDebtPayoffAmortizingLoans:
         return book_path
 
     def test_mortgage_uses_amortization_not_two_percent(self, tmp_path: Path):
-        """The mortgage minimum should be ~¥12-13K (amortization on a
-        30-year term), not ¥54K (2% of balance)."""
+        """The mortgage minimum should be ~¥12-13K (amortization on its
+        slot-declared 30-year term), not ¥54K (2% of balance)."""
         book_path = self._liability_book(tmp_path)
         gc_book = GnuCashBook(str(book_path))
 
@@ -498,9 +501,9 @@ class TestDebtPayoffAmortizingLoans:
             if d["account"] == "Liabilities:Loans:Mortgage":
                 mp = Decimal(d["minimum_payment"])
                 # 30-year amortization on ¥2,729,518 at 3.85% =
-                # ~¥12,789. Allow a generous ±¥500 band — the formula
-                # is exact; the band protects against future
-                # refactors choosing nearby term defaults.
+                # ~¥12,789, from the loan_term_months=360 slot. Allow a
+                # generous ±¥500 band — the formula is exact; the band
+                # absorbs rounding only.
                 assert Decimal("12200") < mp < Decimal("13400"), (
                     f"Mortgage minimum {mp} outside expected range"
                 )
@@ -527,12 +530,13 @@ class TestDebtPayoffAmortizingLoans:
                 assert Decimal("1700") < mp < Decimal("2000"), (
                     f"Auto loan minimum {mp} outside expected range"
                 )
-                # Discriminate by term: 5y (slot) → ~¥1,824; the 30y
-                # default would give ~¥514. Proves the loan_term_months
-                # slot drives the amortization, not the account name.
+                # Discriminate by term: the 5y slot → ~¥1,824, whereas
+                # the mortgage's 30y slot on the same balance would give
+                # far less. Proves the loan_term_months slot drives the
+                # amortization, not the account name (and not a default).
                 assert mp > Decimal("1500"), (
-                    "Auto loan got the 30-year default — the "
-                    "loan_term_months slot was not honored"
+                    "Auto loan minimum too low — the loan_term_months "
+                    "slot (60) was not honored"
                 )
                 break
         else:
@@ -601,6 +605,84 @@ class TestDebtPayoffAmortizingLoans:
                 break
         else:
             pytest.fail("Mortgage not found in results")
+
+    def test_liability_without_term_is_omitted(self, tmp_path: Path):
+        """A LIABILITY with an APR and balance but no loan_term_months
+        and no minimum_payment is omitted from the plan rather than
+        amortized from a guessed term — a wrong estimate (30y vs 5y
+        differ by an order of magnitude) is worse than none."""
+        book_path = self._liability_book(tmp_path)
+        gc_book = GnuCashBook(str(book_path))
+        # Strip the Mortgage's term slot so it has no payment source.
+        gc_book.delete_account_slot(
+            "Liabilities:Loans:Mortgage", "loan_term_months",
+        )
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="30000",
+        )
+
+        # Omitted from the actionable plan...
+        names = [d["account"] for d in result["debts"]]
+        assert "Liabilities:Loans:Mortgage" not in names
+        # ...and surfaced as unestimable with an actionable message,
+        # rather than silently dropped or guessed.
+        assert "Liabilities:Loans:Mortgage" in result["unestimable"]
+        assert any(
+            "loan_term_months" in w for w in result["warnings"]
+        ), "expected a warning naming loan_term_months"
+        # The estimable debts (Auto Loan term=60, Credit Card 2%) still plan.
+        assert "Liabilities:Loans:Auto Loan" in names
+
+    def test_all_liabilities_unestimable_raises_actionably(
+        self, tmp_path: Path,
+    ):
+        """If every qualifying debt is unestimable, the error names the
+        fix (set loan_term_months / minimum_payment), not the wrong
+        'no apr slot' cause."""
+        import piecash
+
+        book_path = tmp_path / "unestimable_only.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="USD", overwrite=True,
+        )
+        usd = book.default_currency
+        root = book.root_account
+        liabilities = piecash.Account(
+            name="Liabilities", type="LIABILITY", parent=root,
+            commodity=usd, placeholder=True,
+        )
+        loan = piecash.Account(
+            name="Personal Loan", type="LIABILITY", parent=liabilities,
+            commodity=usd,
+        )
+        equity = piecash.Account(
+            name="Equity", type="EQUITY", parent=root,
+            commodity=usd, placeholder=True,
+        )
+        opening = piecash.Account(
+            name="Opening Balance", type="EQUITY", parent=equity,
+            commodity=usd,
+        )
+        book.save()
+        loan["apr"] = "6.5"  # APR set, but no term and no minimum_payment.
+        book.save()
+        tx = piecash.Transaction(
+            currency=usd, description="Opening: Personal Loan",
+            post_date=date(2026, 1, 1),
+            splits=[
+                piecash.Split(account=loan, value=Decimal("-12000")),
+                piecash.Split(account=opening, value=Decimal("12000")),
+            ],
+        )
+        book.session.add(tx)
+        book.save()
+
+        gc_book = GnuCashBook(str(book_path))
+        with pytest.raises(ValueError, match="loan_term_months"):
+            gc_book.debt_payoff_plan(
+                compact=False, monthly_budget="5000",
+            )
 
 
 class TestDebtPayoffTemplateAccountFiltering:

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -455,6 +455,12 @@ class TestDebtPayoffAmortizingLoans:
 
         mortgage["apr"] = "3.85"
         auto["apr"] = "4.90"
+        # The amortization term is data, not inferred from the account
+        # name (the old English "mortgage" substring was locale-
+        # fragile — it missed "Hypothek"/"Darlehen"). The Auto Loan
+        # declares its 5-year term via the loan_term_months slot; the
+        # Mortgage omits it and exercises the 30-year default.
+        auto["loan_term_months"] = "60"
         cc["apr"] = "18.25"
         book.save()
 
@@ -505,7 +511,7 @@ class TestDebtPayoffAmortizingLoans:
             pytest.fail("Mortgage not found in results")
 
     def test_auto_loan_uses_amortization_not_two_percent(self, tmp_path: Path):
-        """Auto loan should use 5-year amortization default."""
+        """Auto loan uses its loan_term_months slot (5-year term)."""
         book_path = self._liability_book(tmp_path)
         gc_book = GnuCashBook(str(book_path))
 
@@ -521,13 +527,12 @@ class TestDebtPayoffAmortizingLoans:
                 assert Decimal("1700") < mp < Decimal("2000"), (
                     f"Auto loan minimum {mp} outside expected range"
                 )
-                # Nowhere near the broken 2% answer (¥1,936) — actually
-                # those are close here, so use the term as the
-                # discriminator instead. Auto with 5y term: ~¥1,824.
-                # Auto with 30y term (mortgage default): ~¥514.
+                # Discriminate by term: 5y (slot) → ~¥1,824; the 30y
+                # default would give ~¥514. Proves the loan_term_months
+                # slot drives the amortization, not the account name.
                 assert mp > Decimal("1500"), (
-                    "Auto loan got mortgage's 30-year term — name "
-                    "heuristic should require 'mortgage' in path"
+                    "Auto loan got the 30-year default — the "
+                    "loan_term_months slot was not honored"
                 )
                 break
         else:

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -367,3 +367,75 @@ class TestCrossCurrencyPaymentOnLocalizedBook:
             assert fx is not None
             assert fx.type == "INCOME"
             assert fx.commodity == b.default_currency  # EUR
+
+
+class TestSKR03Chart:
+    """Sabine Brenner's chart: the SKR03 Standardkontenrahmen that a
+    real German Einzelunternehmerin uses. It's numbered and organized
+    by Kontenklasse, not by the five fundamental types — but GnuCash's
+    shipped `acctchrt_skr03` template still wraps each class in a single
+    top-level account of the right TYPE. These tests use the actual
+    SKR03 top-level names (verified against GnuCash `stable`) to prove
+    the resolver handles the real chart, not just a tidy German one.
+    """
+
+    @staticmethod
+    def _skr03_book(path):
+        # Minimal slice of acctchrt_skr03: real top-level names, real
+        # nesting (income leaves live two levels deep under the
+        # top-level INCOME placeholder).
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        eur = book.default_currency
+        aktiva = piecash.Account(
+            name="Aktiva", type="ASSET", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        piecash.Account(
+            name="1200 Bank", type="BANK", parent=aktiva, commodity=eur,
+        )
+        ertraege = piecash.Account(
+            name="Erlöse u. Erträge 2/8", type="INCOME", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        erloeskonten = piecash.Account(
+            name="Erlöskonten 8", type="INCOME", parent=ertraege,
+            commodity=eur, placeholder=True,
+        )
+        piecash.Account(
+            name="8400 Erlöse USt. 19%", type="INCOME",
+            parent=erloeskonten, commodity=eur,
+        )
+        piecash.Account(
+            name="Aufwendungen 2/4", type="EXPENSE", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        book.save()
+        book.close()
+
+    def test_top_level_income_is_the_class_placeholder(self, tmp_path):
+        path = tmp_path / "skr03.gnucash"
+        self._skr03_book(path)
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            acct, notice = gb._top_level_account_of_type(b, "INCOME")
+            # The root-child placeholder, NOT the nested "Erlöskonten 8"
+            # or the leaf "8400 …".
+            assert acct.fullname == "Erlöse u. Erträge 2/8"
+            assert notice is None
+            exp, _ = gb._top_level_account_of_type(b, "EXPENSE")
+            assert exp.fullname == "Aufwendungen 2/4"
+
+    def test_fx_account_lands_under_skr03_income_root(self, tmp_path):
+        path = tmp_path / "skr03fx.gnucash"
+        self._skr03_book(path)
+        gb = GnuCashBook(str(path))
+        with gb.open(readonly=False) as b:
+            acct, _ = gb._get_or_create_fx_account(b)
+            assert acct.type == "INCOME"
+            assert acct.parent.fullname == "Erlöse u. Erträge 2/8"
+            assert (
+                acct.fullname
+                == "Erlöse u. Erträge 2/8:Foreign Exchange Gain/Loss"
+            )
+            b.save()

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -1,0 +1,81 @@
+"""Locale-robust account resolution (i18n).
+
+See ``specs/I18N_ACCOUNT_RESOLUTION_SPEC.md``. The governing principle:
+identify accounts by ``GNCAccountType`` (a locale-invariant enum),
+never by an English name. These tests run against the ``localized_book``
+fixture — a German-named chart with no account literally named "Income"
+or "Expenses" — so any English-name assumption fails loudly.
+"""
+
+import piecash
+
+from gnucash_mcp.book import GnuCashBook
+
+
+class TestTopLevelAccountOfType:
+    """The ``_top_level_account_of_type`` chokepoint — the
+    locale-invariant replacement for ``_find_account(book, "Income")``.
+    """
+
+    def test_finds_localized_income_parent(self, localized_book):
+        # The German top-level income account is "Erträge". Resolution
+        # is by TYPE, so it is found despite never being named "Income".
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            acct, notice = gb._top_level_account_of_type(b, "INCOME")
+            assert acct is not None
+            assert acct.fullname == "Erträge"
+            assert notice is None
+
+    def test_finds_localized_expense_parent(self, localized_book):
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            acct, notice = gb._top_level_account_of_type(b, "EXPENSE")
+            assert acct is not None
+            assert acct.fullname == "Aufwand"
+            assert notice is None
+
+    def test_ignores_nested_account_of_same_type(self, localized_book):
+        # "Umsatzerlöse" is INCOME but nested under "Erträge"; only the
+        # true top-level (root child) account must be returned.
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            acct, _ = gb._top_level_account_of_type(b, "INCOME")
+            assert acct.fullname == "Erträge"
+
+    def test_returns_none_when_type_absent(self, localized_book):
+        # The German chart has no top-level TRADING account.
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            acct, notice = gb._top_level_account_of_type(b, "TRADING")
+            assert acct is None
+            assert notice is None
+
+    def test_ambiguous_returns_lowest_fullname_with_notice(self, tmp_path):
+        # Two top-level INCOME accounts: deterministic lowest-fullname
+        # pick, plus a surfaced ambiguity notice.
+        path = tmp_path / "ambig.gnucash"
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        eur = book.default_currency
+        piecash.Account(
+            name="Erträge", type="INCOME", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        piecash.Account(
+            name="Andere Erträge", type="INCOME", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        book.save()
+        book.close()
+
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            acct, notice = gb._top_level_account_of_type(b, "INCOME")
+            assert acct is not None
+            assert acct.fullname == "Andere Erträge"  # 'A' < 'E'
+            assert notice is not None
+            assert notice["type"] == "ambiguous_top_level_account"
+            assert notice["account_type"] == "INCOME"
+            assert set(notice["candidates"]) == {"Andere Erträge", "Erträge"}
+            assert notice["chosen"] == "Andere Erträge"

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -107,9 +107,9 @@ class TestLocalizedHelperAccounts:
             assert acct.fullname == "Erträge:Foreign Exchange Gain/Loss"
             b.save()
 
-        # Idempotent: a second call resolves the same account (the
-        # English leaf self-matches the fuzzy layer) rather than
-        # creating a duplicate.
+        # Idempotent: the first create stored the account's GUID in the
+        # root slot, so the second call resolves the same account via
+        # Layer 0 rather than creating a duplicate.
         with gb.open(readonly=False) as b:
             acct2, _ = gb._get_or_create_fx_account(b)
             assert acct2.fullname == "Erträge:Foreign Exchange Gain/Loss"
@@ -133,6 +133,114 @@ class TestLocalizedHelperAccounts:
             assert purchase.type == "INCOME"
             assert purchase.parent.fullname == "Erträge"
             b.save()
+
+
+class TestDesignatedAccountSlotLayer0:
+    """§6.2 Layer 0: once resolved, the FX/discount account's GUID is
+    stored in a root-account slot and every later resolution reads that
+    GUID directly — making resolution self-healing, rename-proof, and
+    locale-proof. A stale slot falls through and is rewritten.
+    """
+
+    def test_fx_designation_survives_account_rename(self, localized_book):
+        # First resolve creates the account and writes its GUID to the
+        # gnc-mcp/fx-gain-loss-acct slot.
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            acct, _ = gb._get_or_create_fx_account(b)
+            b.save()
+            original_guid = acct.guid
+
+        # Rename the account to a word matching NO fuzzy keyword and not
+        # the canonical path — only the GUID slot (Layer 0) can find it.
+        gb.update_account(
+            "Erträge:Foreign Exchange Gain/Loss",
+            new_name="Wechselkursergebnis",
+        )
+
+        with gb.open(readonly=False) as b:
+            acct2, notice = gb._get_or_create_fx_account(b)
+            # Same account by GUID, despite the rename — no duplicate.
+            assert acct2.guid == original_guid
+            assert acct2.name == "Wechselkursergebnis"
+            assert notice is None
+
+    def test_explicit_arg_overrides_stored_designation(self, localized_book):
+        # An explicit fx_account wins over the slot and is NOT persisted
+        # as the new designation (it is a per-call override).
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            designated, _ = gb._get_or_create_fx_account(b)
+            b.save()
+            designated_guid = designated.guid
+        # Create a second, distinct INCOME account to pass explicitly.
+        gb.create_account(
+            "Sonstige Kursdifferenzen", "INCOME",
+            parent="Erträge", commodity="EUR",
+        )
+        with gb.open(readonly=False) as b:
+            override, _ = gb._get_or_create_fx_account(
+                b, fx_account="Erträge:Sonstige Kursdifferenzen"
+            )
+            assert override.fullname == "Erträge:Sonstige Kursdifferenzen"
+            # The slot still points at the original designation.
+            slotted = gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY
+            )
+            assert slotted.guid == designated_guid
+
+    def test_stale_slot_falls_through_and_rewrites(self, localized_book):
+        gb = GnuCashBook(str(localized_book))
+        # Point the slot at a well-formed GUID that resolves to nothing.
+        with gb.open(readonly=False) as b:
+            b.root_account[gb._FX_ACCOUNT_SLOT_KEY] = "deadbeef" * 4
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            # Layer 0 returns None on the dangling GUID; resolution
+            # falls through and lands a real account.
+            assert gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY
+            ) is None
+            acct, _ = gb._get_or_create_fx_account(b)
+            assert acct is not None
+            assert acct.type == "INCOME"
+            b.save()
+
+        # The slot self-healed: Layer 0 now resolves the real account.
+        with gb.open() as b:
+            resolved = gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY
+            )
+            assert resolved is not None
+            assert resolved.fullname == "Erträge:Foreign Exchange Gain/Loss"
+
+    def test_discount_sides_use_independent_slots(self, localized_book):
+        # Sales (EXPENSE) and purchase (INCOME) designations are stored
+        # under separate slot keys and resolve independently.
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            sales, _ = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=False
+            )
+            purchase, _ = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=True
+            )
+            b.save()
+            sales_guid, purchase_guid = sales.guid, purchase.guid
+
+        with gb.open() as b:
+            via_sales = gb._resolve_designated_account(
+                b, gb._SALES_DISCOUNT_SLOT_KEY
+            )
+            via_purchase = gb._resolve_designated_account(
+                b, gb._PURCHASE_DISCOUNT_SLOT_KEY
+            )
+            assert via_sales.guid == sales_guid
+            assert via_sales.type == "EXPENSE"
+            assert via_purchase.guid == purchase_guid
+            assert via_purchase.type == "INCOME"
+            assert via_sales.guid != via_purchase.guid
 
 
 class TestAutoBalancingAccountDetection:

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -211,10 +211,12 @@ class TestAutoBalancingAccountDetection:
 
 class TestLoanTermLocaleRobust:
     """Tier B: ``debt_payoff_plan`` must not guess a loan's
-    amortization term from an English "mortgage" substring. A German
-    "Hypothek" now gets the 30y default term (not the old 5y), and the
-    ``loan_term_months`` slot overrides it — both proven via the
-    budget gate (budget < sum-of-minimums raises).
+    amortization term from an English "mortgage" substring, and must
+    not fall back to a fabricated default term. A German "Hypothek"
+    with no ``loan_term_months`` (and no ``minimum_payment``) is
+    omitted from the plan with an actionable message rather than
+    amortized from a guessed term; setting ``loan_term_months`` makes
+    it estimable — both proven via the omit error / the budget gate.
     """
 
     @staticmethod
@@ -261,17 +263,20 @@ class TestLoanTermLocaleRobust:
         book.save()
         book.close()
 
-    def test_german_mortgage_gets_30y_default_not_5y(self, tmp_path):
-        # €200k @ 4%: ~€955/mo over 30y, ~€3,683/mo over 5y. A €2,000
-        # budget covers the 30y default but NOT the old 5y keyword
-        # term — so a clean run proves the English "mortgage" guess is
-        # gone (a "Hypothek" never matched it, so it used to amortize
-        # over 5y and blow the budget gate).
+    def test_german_mortgage_without_term_is_omitted_not_guessed(self, tmp_path):
+        # €200k @ 4% Hypothek with no loan_term_months and no
+        # minimum_payment. There is no "mortgage" account type and no
+        # default term to fall back on, so its payment can't be
+        # estimated — and it's the only debt, so the plan raises an
+        # actionable error naming loan_term_months rather than guessing
+        # a 30y (or 5y) term. Proves both: the English-keyword guess is
+        # gone (a "Hypothek" never matched it) AND there is no silent
+        # default standing in for the missing data.
         path = tmp_path / "hyp.gnucash"
         self._hypothek_book(path)
         gb = GnuCashBook(str(path))
-        result = gb.debt_payoff_plan(monthly_budget="2000", compact=True)
-        assert result  # no ValueError
+        with pytest.raises(ValueError, match="loan_term_months"):
+            gb.debt_payoff_plan(monthly_budget="2000", compact=True)
 
     def test_loan_term_months_slot_is_honored(self, tmp_path):
         # Force a 5y term via the slot → ~€3,683/mo minimum, which

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -282,3 +282,88 @@ class TestLoanTermLocaleRobust:
         gb = GnuCashBook(str(path))
         with pytest.raises(ValueError, match="less than the sum of minimum"):
             gb.debt_payoff_plan(monthly_budget="2000", compact=True)
+
+
+class TestCrossCurrencyPaymentOnLocalizedBook:
+    """End-to-end acceptance test. Paying a cross-currency invoice on a
+    localized (German) book used to raise ValueError inside
+    _get_or_create_fx_account — there is no account named "Income", so
+    the realized-FX recognition threw on the FIRST such payment. It now
+    settles and books the FX under the German income root "Erträge".
+    """
+
+    @staticmethod
+    def _add_usd_ar_and_price(gb, rate_date, rate_value):
+        # Mirror of the EUR helper in test_business, inverted: this book
+        # is EUR-default, so the foreign side is USD. Adds a USD A/R and
+        # a USD→EUR price.
+        with gb.open(readonly=False) as book:
+            eur = book.default_currency
+            usd = next(
+                (c for c in book.commodities if c.mnemonic == "USD"), None
+            )
+            if usd is None:
+                usd = piecash.factories.create_currency_from_ISO("USD")
+                book.session.add(usd)
+            if not any(
+                a.fullname == "Aktiva:Forderungen USD"
+                for a in book.accounts
+            ):
+                aktiva = next(
+                    a for a in book.accounts if a.fullname == "Aktiva"
+                )
+                book.session.add(piecash.Account(
+                    name="Forderungen USD", type="RECEIVABLE",
+                    parent=aktiva, commodity=usd,
+                ))
+            book.session.add(piecash.Price(
+                commodity=usd, currency=eur,
+                date=date.fromisoformat(rate_date),
+                value=str(rate_value), source="user:test", type="nav",
+            ))
+            book.save()
+
+    def test_pay_books_fx_under_localized_income_root(self, localized_book):
+        gb = GnuCashBook(str(localized_book))
+        # USD 1 = 0.90 EUR at post, 0.95 EUR at pay → rate drift → FX.
+        self._add_usd_ar_and_price(gb, "2026-03-10", "0.90")
+        self._add_usd_ar_and_price(gb, "2026-03-20", "0.95")
+
+        gb.create_customer(name="Acme USA", currency="USD")
+        gb.create_invoice(
+            customer_id="000001", currency="USD",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Erträge:Umsatzerlöse",
+            description="Beratung", quantity="1", price="1000.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Aktiva:Forderungen USD",
+            post_date="2026-03-10",
+        )
+
+        # The line that raised ValueError before the fix.
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Aktiva:Girokonto",
+            amount="1000.00",
+            payment_date="2026-03-20",
+        )
+
+        # Realized FX booked under the German income root, by TYPE.
+        assert "fx_realized" in result
+        assert (
+            result["fx_realized"]["account"]
+            == "Erträge:Foreign Exchange Gain/Loss"
+        )
+        with gb.open() as b:
+            fx = next(
+                (a for a in b.accounts
+                 if a.fullname == "Erträge:Foreign Exchange Gain/Loss"),
+                None,
+            )
+            assert fx is not None
+            assert fx.type == "INCOME"
+            assert fx.commodity == b.default_currency  # EUR

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -7,7 +7,11 @@ fixture — a German-named chart with no account literally named "Income"
 or "Expenses" — so any English-name assumption fails loudly.
 """
 
+from datetime import date
+from decimal import Decimal
+
 import piecash
+import pytest
 
 from gnucash_mcp.book import GnuCashBook
 
@@ -129,3 +133,152 @@ class TestLocalizedHelperAccounts:
             assert purchase.type == "INCOME"
             assert purchase.parent.fullname == "Erträge"
             b.save()
+
+
+class TestAutoBalancingAccountDetection:
+    """Tier C: GnuCash localizes the "Imbalance"/"Orphan" leading word,
+    so the old English-prefix check went dark on localized books. The
+    structural + catalog detector must catch them in any locale while
+    leaving ordinary accounts alone.
+    """
+
+    @staticmethod
+    def _make_book(path, specs):
+        # specs: (name, type, parent_name | None) — parent None = root.
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        eur = book.default_currency
+        made = {}
+        for name, atype, parent in specs:
+            made[name] = piecash.Account(
+                name=name, type=atype,
+                parent=root if parent is None else made[parent],
+                commodity=eur,
+            )
+        book.save()
+        book.close()
+
+    def test_detects_english_and_localized(self, tmp_path):
+        path = tmp_path / "bal.gnucash"
+        self._make_book(path, [
+            ("Aktiva", "ASSET", None),
+            ("Imbalance-USD", "BANK", None),        # English, suffixed
+            ("Ausgleichskonto-EUR", "BANK", None),  # de imbalance, suffixed
+            ("Ausbuchungskonto", "BANK", None),     # de orphan, unsuffixed
+            ("Girokonto", "BANK", "Aktiva"),        # ordinary nested bank
+            ("Tagesgeld", "BANK", None),            # ordinary root bank
+        ])
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            root = b.root_account
+            by_name = {a.name: a for a in b.accounts}
+            assert gb._is_auto_balancing_account(by_name["Imbalance-USD"], root)
+            assert gb._is_auto_balancing_account(
+                by_name["Ausgleichskonto-EUR"], root
+            )
+            assert gb._is_auto_balancing_account(
+                by_name["Ausbuchungskonto"], root
+            )
+            assert not gb._is_auto_balancing_account(
+                by_name["Girokonto"], root
+            )
+            assert not gb._is_auto_balancing_account(
+                by_name["Tagesgeld"], root
+            )
+
+    def test_structural_gate_excludes_nested_and_nonbank(self, tmp_path):
+        path = tmp_path / "bal2.gnucash"
+        self._make_book(path, [
+            ("Aktiva", "ASSET", None),
+            # Named like an imbalance account but NOT a root child.
+            ("Imbalance-USD", "BANK", "Aktiva"),
+            # "Orphaned Gains" is a legitimate INCOME account, not a
+            # defect — the BANK gate must exclude it even though its
+            # name starts with "orphan".
+            ("Orphaned Gains-USD", "INCOME", None),
+        ])
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            root = b.root_account
+            by_name = {a.name: a for a in b.accounts}
+            assert not gb._is_auto_balancing_account(
+                by_name["Imbalance-USD"], root
+            )
+            assert not gb._is_auto_balancing_account(
+                by_name["Orphaned Gains-USD"], root
+            )
+
+
+class TestLoanTermLocaleRobust:
+    """Tier B: ``debt_payoff_plan`` must not guess a loan's
+    amortization term from an English "mortgage" substring. A German
+    "Hypothek" now gets the 30y default term (not the old 5y), and the
+    ``loan_term_months`` slot overrides it — both proven via the
+    budget gate (budget < sum-of-minimums raises).
+    """
+
+    @staticmethod
+    def _hypothek_book(path, term_months_slot=None):
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        eur = book.default_currency
+        aktiva = piecash.Account(
+            name="Aktiva", type="ASSET", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        piecash.Account(
+            name="Girokonto", type="BANK", parent=aktiva, commodity=eur,
+        )
+        fremdkapital = piecash.Account(
+            name="Fremdkapital", type="LIABILITY", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        hypothek = piecash.Account(
+            name="Hypothek", type="LIABILITY", parent=fremdkapital,
+            commodity=eur,
+        )
+        eigenkapital = piecash.Account(
+            name="Eigenkapital", type="EQUITY", parent=root,
+            commodity=eur, placeholder=True,
+        )
+        anfang = piecash.Account(
+            name="Anfangsbestand", type="EQUITY", parent=eigenkapital,
+            commodity=eur,
+        )
+        book.save()
+        hypothek["apr"] = "4.00"   # no minimum_payment slot on purpose
+        if term_months_slot is not None:
+            hypothek["loan_term_months"] = term_months_slot
+        book.save()
+        book.session.add(piecash.Transaction(
+            currency=eur, description="Hypothek aufgenommen",
+            post_date=date(2025, 1, 1),
+            splits=[
+                piecash.Split(account=hypothek, value=Decimal("-200000")),
+                piecash.Split(account=anfang, value=Decimal("200000")),
+            ],
+        ))
+        book.save()
+        book.close()
+
+    def test_german_mortgage_gets_30y_default_not_5y(self, tmp_path):
+        # €200k @ 4%: ~€955/mo over 30y, ~€3,683/mo over 5y. A €2,000
+        # budget covers the 30y default but NOT the old 5y keyword
+        # term — so a clean run proves the English "mortgage" guess is
+        # gone (a "Hypothek" never matched it, so it used to amortize
+        # over 5y and blow the budget gate).
+        path = tmp_path / "hyp.gnucash"
+        self._hypothek_book(path)
+        gb = GnuCashBook(str(path))
+        result = gb.debt_payoff_plan(monthly_budget="2000", compact=True)
+        assert result  # no ValueError
+
+    def test_loan_term_months_slot_is_honored(self, tmp_path):
+        # Force a 5y term via the slot → ~€3,683/mo minimum, which
+        # exceeds the €2,000 budget and trips the gate. Proves the
+        # slot drives the term.
+        path = tmp_path / "hyp5y.gnucash"
+        self._hypothek_book(path, term_months_slot="60")
+        gb = GnuCashBook(str(path))
+        with pytest.raises(ValueError, match="less than the sum of minimum"):
+            gb.debt_payoff_plan(monthly_budget="2000", compact=True)

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -102,9 +102,11 @@ class TestLocalizedHelperAccounts:
             assert acct is not None
             assert acct.type == "INCOME"
             assert acct.commodity == b.default_currency
-            # Parent resolved by TYPE → the German income root.
+            # Parent resolved by TYPE → the German income root. The leaf
+            # is localized (§6.3): the tidy German chart infers "de", so
+            # the auto-created account reads naturally in German.
             assert acct.parent.fullname == "Erträge"
-            assert acct.fullname == "Erträge:Foreign Exchange Gain/Loss"
+            assert acct.fullname == "Erträge:Realisierter Gewinn/Verlust"
             b.save()
 
         # Idempotent: the first create stored the account's GUID in the
@@ -112,7 +114,7 @@ class TestLocalizedHelperAccounts:
         # Layer 0 rather than creating a duplicate.
         with gb.open(readonly=False) as b:
             acct2, _ = gb._get_or_create_fx_account(b)
-            assert acct2.fullname == "Erträge:Foreign Exchange Gain/Loss"
+            assert acct2.fullname == "Erträge:Realisierter Gewinn/Verlust"
 
     def test_discount_accounts_autocreate_under_localized_parents(
         self, localized_book
@@ -153,8 +155,9 @@ class TestDesignatedAccountSlotLayer0:
 
         # Rename the account to a word matching NO fuzzy keyword and not
         # the canonical path — only the GUID slot (Layer 0) can find it.
+        # (Leaf is the localized German name per §6.3.)
         gb.update_account(
-            "Erträge:Foreign Exchange Gain/Loss",
+            "Erträge:Realisierter Gewinn/Verlust",
             new_name="Wechselkursergebnis",
         )
 
@@ -213,7 +216,7 @@ class TestDesignatedAccountSlotLayer0:
                 b, gb._FX_ACCOUNT_SLOT_KEY
             )
             assert resolved is not None
-            assert resolved.fullname == "Erträge:Foreign Exchange Gain/Loss"
+            assert resolved.fullname == "Erträge:Realisierter Gewinn/Verlust"
 
     def test_discount_sides_use_independent_slots(self, localized_book):
         # Sales (EXPENSE) and purchase (INCOME) designations are stored
@@ -241,6 +244,95 @@ class TestDesignatedAccountSlotLayer0:
             assert via_purchase.guid == purchase_guid
             assert via_purchase.type == "INCOME"
             assert via_sales.guid != via_purchase.guid
+
+
+class TestBookLocaleInference:
+    """§6.3: infer the book locale from its own top-level accounts
+    (with a GNUCASH_LOCALE override), and localize auto-created leaf
+    names — falling back to English when no locale or translation
+    applies. Resolution stays GUID-based, so the leaf is cosmetic.
+    """
+
+    @staticmethod
+    def _english_book(path):
+        book = piecash.create_book(str(path), currency="USD", overwrite=True)
+        root = book.root_account
+        usd = book.default_currency
+        for name, atype in (
+            ("Assets", "ASSET"), ("Liabilities", "LIABILITY"),
+            ("Income", "INCOME"), ("Expenses", "EXPENSE"),
+            ("Equity", "EQUITY"),
+        ):
+            piecash.Account(name=name, type=atype, parent=root,
+                            commodity=usd, placeholder=True)
+        book.save()
+        book.close()
+
+    @staticmethod
+    def _numbered_german_book(path):
+        # SKR03-shaped: one structural word ("Aktiva") matches, the rest
+        # are numbered/non-standard — too few to trigger inference.
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        eur = book.default_currency
+        piecash.Account(name="Aktiva", type="ASSET", parent=root,
+                        commodity=eur, placeholder=True)
+        piecash.Account(name="Erlöse u. Erträge 2/8", type="INCOME",
+                        parent=root, commodity=eur, placeholder=True)
+        piecash.Account(name="Aufwendungen 2/4", type="EXPENSE",
+                        parent=root, commodity=eur, placeholder=True)
+        book.save()
+        book.close()
+
+    def test_infers_german_from_tidy_chart(self, localized_book):
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            # Aktiva/Fremdkapital/Aufwand/Eigenkapital match "de"; the
+            # template "Erträge" ≠ gettext "Ertrag" but voting carries it.
+            assert gb._infer_book_locale(b) == "de"
+
+    def test_returns_none_for_english_book(self, tmp_path):
+        path = tmp_path / "en.gnucash"
+        self._english_book(path)
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            assert gb._infer_book_locale(b) is None
+
+    def test_numbered_chart_below_threshold_returns_none(self, tmp_path):
+        path = tmp_path / "numbered.gnucash"
+        self._numbered_german_book(path)
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            # Only "Aktiva" matches (1 < 2) → None → English leaf.
+            assert gb._infer_book_locale(b) is None
+
+    def test_env_override_wins(self, localized_book, monkeypatch):
+        monkeypatch.setenv("GNUCASH_LOCALE", "fr_FR.UTF-8")
+        gb = GnuCashBook(str(localized_book))
+        with gb.open() as b:
+            # Override beats inference (which would say "de"); reduced
+            # to the bare language code.
+            assert gb._infer_book_locale(b) == "fr"
+
+    def test_locale_account_name_lookup_and_fallbacks(self, tmp_path):
+        path = tmp_path / "x.gnucash"
+        self._english_book(path)
+        gb = GnuCashBook(str(path))
+        en = "Foreign Exchange Gain/Loss"
+        # Hit.
+        assert (
+            gb._locale_account_name("fx_gain_loss", en, "de")
+            == "Realisierter Gewinn/Verlust"
+        )
+        # No locale → English default.
+        assert gb._locale_account_name("fx_gain_loss", en, None) == en
+        # Unknown locale → English default.
+        assert gb._locale_account_name("fx_gain_loss", en, "xx") == en
+        # Concept with no translation table → English default.
+        assert (
+            gb._locale_account_name("sales_discount", "Sales Discounts", "de")
+            == "Sales Discounts"
+        )
 
 
 class TestAutoBalancingAccountDetection:
@@ -465,16 +557,17 @@ class TestCrossCurrencyPaymentOnLocalizedBook:
             payment_date="2026-03-20",
         )
 
-        # Realized FX booked under the German income root, by TYPE.
+        # Realized FX booked under the German income root, by TYPE, with
+        # a localized leaf (§6.3 — the book infers "de").
         assert "fx_realized" in result
         assert (
             result["fx_realized"]["account"]
-            == "Erträge:Foreign Exchange Gain/Loss"
+            == "Erträge:Realisierter Gewinn/Verlust"
         )
         with gb.open() as b:
             fx = next(
                 (a for a in b.accounts
-                 if a.fullname == "Erträge:Foreign Exchange Gain/Loss"),
+                 if a.fullname == "Erträge:Realisierter Gewinn/Verlust"),
                 None,
             )
             assert fx is not None

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -79,3 +79,53 @@ class TestTopLevelAccountOfType:
             assert notice["account_type"] == "INCOME"
             assert set(notice["candidates"]) == {"Andere Erträge", "Erträge"}
             assert notice["chosen"] == "Andere Erträge"
+
+
+class TestLocalizedHelperAccounts:
+    """The Tier-A blocker: the FX and discount helper-account
+    resolvers used to call ``_find_account(book, "Income")`` and
+    **throw** on a localized book (no account named "Income"). They now
+    resolve the parent by type and create under the German roots.
+    """
+
+    def test_fx_account_autocreates_under_localized_income(
+        self, localized_book
+    ):
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            # This call raised ValueError before the fix.
+            acct, _ = gb._get_or_create_fx_account(b)
+            assert acct is not None
+            assert acct.type == "INCOME"
+            assert acct.commodity == b.default_currency
+            # Parent resolved by TYPE → the German income root.
+            assert acct.parent.fullname == "Erträge"
+            assert acct.fullname == "Erträge:Foreign Exchange Gain/Loss"
+            b.save()
+
+        # Idempotent: a second call resolves the same account (the
+        # English leaf self-matches the fuzzy layer) rather than
+        # creating a duplicate.
+        with gb.open(readonly=False) as b:
+            acct2, _ = gb._get_or_create_fx_account(b)
+            assert acct2.fullname == "Erträge:Foreign Exchange Gain/Loss"
+
+    def test_discount_accounts_autocreate_under_localized_parents(
+        self, localized_book
+    ):
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            # Sales discount → EXPENSE side → German expense root.
+            sales, _ = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=False
+            )
+            assert sales.type == "EXPENSE"
+            assert sales.parent.fullname == "Aufwand"
+
+            # Purchase discount → INCOME side → German income root.
+            purchase, _ = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=True
+            )
+            assert purchase.type == "INCOME"
+            assert purchase.parent.fullname == "Erträge"
+            b.save()


### PR DESCRIPTION
## Summary

Makes account resolution **locale-robust** so the server stops assuming an English-named GnuCash chart. Correctness work for the widely-promoted v1.4 release, whose users are predominantly non-US — including real German freelancers on the SKR03 Standardkontenrahmen.

**Why this matters (the paradox):** geography ≠ locale ≠ account-naming language. Many "non-US" users run English-named books (`en_IN` is a shipped locale; technical users run English GnuCash everywhere), so the one hard crash stayed hidden behind selection bias. A promoted launch removes that bias — a real `de_DE`/`es_MX`/`zh_CN` book doing cross-currency invoicing would have hit it on camera.

Full design, GnuCash-source findings, and reasoning (including three claims the verification *overturned*) live in **`specs/I18N_ACCOUNT_RESOLUTION_SPEC.md`** — written to be read cold. `specs/PRE_1_4_ROADMAP.md` Tier 2 tracks status.

**Status: Tiers A, B, C, D complete and bookkeeper-validated to the penny on a German book** — the FX gain/loss account was named in German and balanced exactly.

### The audit (every place the server keyed on English structure)

- **Tier A — throws (the blocker):** `_get_or_create_fx_account` / `_get_or_create_discount_account` fell through to `_find_account(book, "Income"/"Expenses")` → `None` on a localized book → the **first cross-currency invoice settlement with rate drift threw**.
- **Tier B — silent wrong values:** `debt_payoff_plan` picked a 30y-vs-5y amortization term from the English `"mortgage"` substring; the dashboard split liabilities on the English `"loan"` substring.
- **Tier C — safety warning gone dark:** the Imbalance/Orphan integrity check used English `"Imbalance-"/"Orphan-"` prefixes; GnuCash localizes those via gettext, so it **never fired** on a localized book.
- **Tier D — English leaks into created account names:** auto-created FX/discount accounts were always English-named, even on a localized book.

### What this PR implements

**Tier A — type-based resolution + self-healing slot**
- **`_top_level_account_of_type` chokepoint** (`_base.py`) — resolves the top-level account of a `GNCAccountType` by type + `parent is root`, never by name. Survives localization *and* a plain English rename.
- FX/discount parents resolved through the chokepoint (create a top-level account only if the book has none). The throw is gone.
- **Self-healing KVP-slot resolver (Layer 0)** — on first resolve/create, the account's GUID is stored on the root account (`gnc-mcp/fx-gain-loss-acct`, `…sales-discount-acct`, `…purchase-discount-acct`); every later call resolves by GUID, immune to renames and locale. A stale slot falls through and is rewritten. Resolution order is now **stored GUID → explicit arg → fuzzy keyword → create-and-store**.

**Tier B — explicit data, no guessing**
- Amortization term comes from a `loan_term_months` slot (or an explicit `minimum_payment`). **No default term** — a loan with neither is *omitted* from the payoff plan with an actionable "set loan_term_months" message, rather than amortized from a 30y-vs-5y guess (an order-of-magnitude error, wrong on camera). The `"mortgage"` substring is gone.
- Liabilities collapse to one "Loans & other" bucket by type (GnuCash has no loan *type* to split on); dead `loan_accts` fields removed.

**Tier C — structural detection**
- `_is_auto_balancing_account` — structural gate (BANK + root-child) + the catalog translations of "Imbalance"/"Orphan" across the shipped locales. `Orphaned Gains` (INCOME) correctly excluded.

**Tier D — localized created-account names**
- `_infer_book_locale` infers the book's language by **voting** the top-level type accounts against the gettext structural-word catalog (≥2 matches), with a `GNUCASH_LOCALE` override. Voting sidesteps the two-translation-sources trap: a German book's top-level income is the template "Erträge", which ≠ the gettext "Ertrag" — but Assets/Expenses/Equity match exactly and carry the vote. A numbered chart (SKR03) matches too few and falls back to English.
- `_locale_account_name` localizes the created leaf (12-language "Realized Gain/Loss" table for FX; discount concepts have no GnuCash translation and stay English). A German book now auto-creates **`Erträge:Realisierter Gewinn/Verlust`**. Safe precisely because Layer 0 made resolution GUID-based — the leaf name is purely cosmetic.

**Also fixed in passing**
- **Python-3.10 GDATE bug:** invoice due-dates are stored as compact `YYYYMMDD`; `date.fromisoformat` rejects that on 3.10 (3.11+ is lenient), and a broad `except` swallowed it — silently dropping overdue-invoice/bill warnings and due-dates in `get_outstanding_invoices`. Normalized the parse.

### Verified against the real GnuCash source

- **Native GnuCash books *no* FX gain/loss on invoice payment** (`gncOwner.c`); our `pay_invoice` recognition is a deliberate, more-correct divergence — there was no native mechanism to "match," and **no native gains account to reuse** (commodity-trading-only). Probe confirmed `xaccAccountGainsAccount`, `GetOrMakeOrphanAccount`, single-income-netting.
- **SKR03 (Sabine Brenner's real chart)** ships with GnuCash and maps to a clean single top-level account per type (`Erlöse u. Erträge 2/8` for INCOME, `Aufwendungen 2/4` for EXPENSE), so the resolver handles it; its numbered names correctly *don't* trigger leaf localization (English fallback).

## Test plan

- [x] `_top_level_account_of_type`: found / none / ambiguous / nested-excluded, on a German chart
- [x] Tier A: FX + both discount accounts auto-create under German parents (`Erträge`/`Aufwand`); idempotent via the Layer-0 slot
- [x] Layer 0: rename-proof round-trip, explicit-arg override (not persisted), stale-slot fallthrough + rewrite, independent sales/purchase slots
- [x] Tier B: untermed German `Hypothek` is *omitted* with an actionable message; `loan_term_months` slot honored; all-unestimable raises actionably; `test_debt_payoff` updated to the no-default contract
- [x] Tier C: detects English + localized Imbalance/Orphan; structural gate excludes nested + non-BANK (`Orphaned Gains`)
- [x] Tier D: infers `de` from a tidy German chart, `None` for English + numbered (SKR03) charts, `GNUCASH_LOCALE` override; name lookup + fallbacks
- [x] **End-to-end:** post + pay a USD invoice on the EUR-default German book → settles, books FX under **`Erträge:Realisierter Gewinn/Verlust`** (raised `ValueError` before)
- [x] **SKR03:** resolution + FX placement against the real `acctchrt_skr03` top-level names (English leaf)
- [x] Python-3.10 GDATE fix: overdue invoice/bill warnings + `get_outstanding_invoices` due-dates restored
- [x] Full suite green (**1761 passed, 0 failed**), English books unaffected
- [x] **Bookkeeper round on a localized book — passed.** FX gain/loss account named in German, balanced to the penny.
