### PR TITLE
feat(i18n): complete locale coverage — Imbalance/Orphan detection + FX account naming

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1062,65 +1062,120 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
     #
     # gettext (po/<lang>.po) translations of the five structural type
     # words, keyed by GNCAccountType, used ONLY to infer the book locale
-    # from its top-level accounts. Source: gnucash-account-naming-i18n.md.
-    # Locale keys are normalized 2-letter codes (pt_BR→pt, zh_CN→zh).
+    # from its top-level accounts (voting; >=2 matches win). Extracted
+    # from every shipped GnuCash po catalog that has all five words AND a
+    # Realized Gain/Loss name (47 locales); inference and naming move
+    # together, so a detected locale always has a leaf name. Locale keys
+    # are normalized codes (pt_BR→pt, zh_CN→zh); variant files that would
+    # collide on a key are skipped. Regenerate per gnucash-account-
+    # naming-i18n.md.
     _STRUCTURAL_TYPE_NAMES = {
-        "de": {"ASSET": "Aktiva", "LIABILITY": "Fremdkapital",
-               "INCOME": "Ertrag", "EXPENSE": "Aufwand",
-               "EQUITY": "Eigenkapital"},
-        "fr": {"ASSET": "Actifs (avoirs)", "LIABILITY": "Passifs (dettes)",
-               "INCOME": "Revenus", "EXPENSE": "Dépenses",
-               "EQUITY": "Capitaux propres"},
-        "es": {"ASSET": "Activos", "LIABILITY": "Pasivos",
-               "INCOME": "Ingreso", "EXPENSE": "Gastos",
-               "EQUITY": "Patrimonio"},
-        "it": {"ASSET": "Attività", "LIABILITY": "Passività",
-               "INCOME": "Entrate", "EXPENSE": "Uscite",
-               "EQUITY": "Patrimonio netto"},
-        "pt": {"ASSET": "Ativos", "LIABILITY": "Passivos",
-               "INCOME": "Receita", "EXPENSE": "Despesas",
-               "EQUITY": "Patrimônio líquido"},
-        "nl": {"ASSET": "Activa", "LIABILITY": "Vreemd vermogen",
-               "INCOME": "Opbrengsten", "EXPENSE": "Kosten",
-               "EQUITY": "Eigen vermogen"},
-        "ru": {"ASSET": "Активы", "LIABILITY": "Обязательства",
-               "INCOME": "Приход", "EXPENSE": "Расходы",
-               "EQUITY": "Собственные средства"},
-        "ja": {"ASSET": "資産", "LIABILITY": "負債", "INCOME": "収益",
-               "EXPENSE": "費用", "EQUITY": "純資産"},
-        "zh": {"ASSET": "资产", "LIABILITY": "负债", "INCOME": "收入",
-               "EXPENSE": "支出", "EQUITY": "所有者权益"},
-        "ko": {"ASSET": "자산", "LIABILITY": "부채", "INCOME": "수입",
-               "EXPENSE": "비용", "EQUITY": "자기자본"},
-        "pl": {"ASSET": "Aktywa", "LIABILITY": "Pasywa",
-               "INCOME": "Przychody", "EXPENSE": "Wydatki",
-               "EQUITY": "Kapitał własny"},
-        "sv": {"ASSET": "Tillgångar", "LIABILITY": "Skulder",
-               "INCOME": "Inkomst", "EXPENSE": "Utgifter",
-               "EQUITY": "Eget kapital"},
+        "ar": {"ASSET": "الأصول", "LIABILITY": "الالتزامات", "INCOME": "الدخل", "EXPENSE": "المصروفات", "EQUITY": "حقوق الملكية"},
+        "as": {"ASSET": "সম্পত্তিবোৰ", "LIABILITY": "বিশ্বাসযোগ্যতাবোৰ", "INCOME": "উপাৰ্জন", "EXPENSE": "ব্যয়বোৰ", "EQUITY": "সাধাৰণ অংশ"},
+        "bg": {"ASSET": "Активи:", "LIABILITY": "Пасиви", "INCOME": "Доход", "EXPENSE": "Разходи", "EQUITY": "Собствен капитал"},
+        "brx": {"ASSET": "सम्पति", "LIABILITY": "दाहार", "INCOME": "आय", "EXPENSE": "खरसा", "EQUITY": "बन्दक"},
+        "ca": {"ASSET": "Actiu", "LIABILITY": "Passiu", "INCOME": "Ingressos", "EXPENSE": "Despeses", "EQUITY": "Patrimoni"},
+        "cs": {"ASSET": "Aktiva", "LIABILITY": "Pasiva", "INCOME": "Příjmy", "EXPENSE": "Náklady", "EQUITY": "Vlastní jmění"},
+        "da": {"ASSET": "Aktiver", "LIABILITY": "Passiver", "INCOME": "Indtægt", "EXPENSE": "Udgifter", "EQUITY": "Egenkapital"},
+        "de": {"ASSET": "Aktiva", "LIABILITY": "Fremdkapital", "INCOME": "Ertrag", "EXPENSE": "Aufwand", "EQUITY": "Eigenkapital"},
+        "doi": {"ASSET": "जैदाद", "LIABILITY": "देनदारियां", "INCOME": "आमदन", "EXPENSE": "खर्चे", "EQUITY": "इक्विटी"},
+        "el": {"ASSET": "Ενεργητικό", "LIABILITY": "Παθητικό", "INCOME": "Έσοδα", "EXPENSE": "Έξοδα", "EQUITY": "Καθαρή θέση"},
+        "es": {"ASSET": "Activos", "LIABILITY": "Pasivos", "INCOME": "Ingreso", "EXPENSE": "Gastos", "EQUITY": "Patrimonio"},
+        "fi": {"ASSET": "Vastaavaa", "LIABILITY": "Vieras pääoma", "INCOME": "Tulo", "EXPENSE": "Menot", "EQUITY": "Oma pääoma"},
+        "fr": {"ASSET": "Actifs (avoirs)", "LIABILITY": "Passifs (dettes)", "INCOME": "Revenus", "EXPENSE": "Dépenses", "EQUITY": "Capitaux propres"},
+        "gu": {"ASSET": "સંપત્તિઓ", "LIABILITY": "જવાબદારી", "INCOME": "આવક", "EXPENSE": "ખર્ચ", "EQUITY": "હિસ્સો"},
+        "he": {"ASSET": "נכסים", "LIABILITY": "התחייבויות", "INCOME": "הכנסות", "EXPENSE": "הוצאות", "EQUITY": "הון"},
+        "hi": {"ASSET": "संपत्तियां ", "LIABILITY": "देयताएं ", "INCOME": "आय", "EXPENSE": "खर्चे", "EQUITY": "इक्विटी"},
+        "hr": {"ASSET": "Imovina", "LIABILITY": "Obveze", "INCOME": "Prihod", "EXPENSE": "Rashod", "EQUITY": "Kapital"},
+        "hu": {"ASSET": "Eszközök", "LIABILITY": "Kötelezettségek", "INCOME": "Bevétel", "EXPENSE": "Kiadások", "EQUITY": "Saját tőke"},
+        "id": {"ASSET": "Aset", "LIABILITY": "Liabilitas", "INCOME": "Pendapatan", "EXPENSE": "Pengeluaran", "EQUITY": "Ekuitas"},
+        "it": {"ASSET": "Attività", "LIABILITY": "Passività", "INCOME": "Entrate", "EXPENSE": "Uscite", "EQUITY": "Patrimonio netto"},
+        "ja": {"ASSET": "資産", "LIABILITY": "負債", "INCOME": "収益", "EXPENSE": "費用", "EQUITY": "純資産"},
+        "kn": {"ASSET": "ಆಸ್ತಿಗಳು", "LIABILITY": "ಹೊಣೆಗಾರಿಕೆಗಳು", "INCOME": "ಆದಾಯ", "EXPENSE": "ಖರ್ಚುಗಳು", "EQUITY": "ಈಕ್ವಿಟಿ"},
+        "ko": {"ASSET": "자산", "LIABILITY": "부채", "INCOME": "수입", "EXPENSE": "비용", "EQUITY": "자기자본"},
+        "kok": {"ASSET": "एसेट्स", "LIABILITY": "देणी", "INCOME": "उत्पन्न", "EXPENSE": "खर्च", "EQUITY": "समभाग"},
+        "ks": {"ASSET": "एिसीट", "LIABILITY": "लायबोलटी", "INCOME": "ईनकम", "EXPENSE": "खरचो", "EQUITY": "बराबरी"},
+        "lt": {"ASSET": "Turtas", "LIABILITY": "Įsipareigojimai", "INCOME": "Pajamos", "EXPENSE": "Sąnaudos", "EQUITY": "Nuosavybė"},
+        "lv": {"ASSET": "Aktīvi", "LIABILITY": "Pasīvi", "INCOME": "Ieņēmumi", "EXPENSE": "izdevumi", "EQUITY": "Pašu kapitāls"},
+        "mai": {"ASSET": "संपत्ति", "LIABILITY": "देयता", "INCOME": "आय", "EXPENSE": "खर्च", "EQUITY": "इक्विटी"},
+        "mni": {"ASSET": "ꯂꯟ-ꯊꯨꯝ", "LIABILITY": "ꯂꯥꯏꯌꯕꯤꯂꯤꯇꯤꯁ", "INCOME": "ꯏꯟꯀꯝ", "EXPENSE": "ꯆꯥꯗꯤꯡ", "EQUITY": "ꯏꯀꯨꯏꯇꯤ"},
+        "mr": {"ASSET": "मालमत्ता", "LIABILITY": "दायित्व", "INCOME": "मिळकत", "EXPENSE": "खर्च", "EQUITY": "इक्विटी"},
+        "nb": {"ASSET": "Eiendeler", "LIABILITY": "Gjeld", "INCOME": "Inntekt", "EXPENSE": "Kostnader", "EQUITY": "Egenkapital"},
+        "ne": {"ASSET": "सम्पत्ति", "LIABILITY": "दायित्व", "INCOME": "आम्दानी", "EXPENSE": "खर्चहरु", "EQUITY": "इक्युटी"},
+        "nl": {"ASSET": "Activa", "LIABILITY": "Vreemd vermogen", "INCOME": "Opbrengsten", "EXPENSE": "Kosten", "EQUITY": "Eigen vermogen"},
+        "pl": {"ASSET": "Aktywa", "LIABILITY": "Pasywa", "INCOME": "Przychody", "EXPENSE": "Wydatki", "EQUITY": "Kapitał własny"},
+        "pt": {"ASSET": "Ativos", "LIABILITY": "Passivos", "INCOME": "Receita", "EXPENSE": "Despesas", "EQUITY": "Patrimônio líquido"},
+        "ro": {"ASSET": "Active", "LIABILITY": "Pasive", "INCOME": "Venituri", "EXPENSE": "Cheltuieli", "EQUITY": "Capital propriu"},
+        "ru": {"ASSET": "Активы", "LIABILITY": "Обязательства", "INCOME": "Приход", "EXPENSE": "Расходы", "EQUITY": "Собственные средства"},
+        "sk": {"ASSET": "Aktíva", "LIABILITY": "Pasíva", "INCOME": "Príjem", "EXPENSE": "Výdavky", "EQUITY": "Vlastné imanie"},
+        "sr": {"ASSET": "Добра", "LIABILITY": "Дуговања", "INCOME": "Приход", "EXPENSE": "Расходи", "EQUITY": "Акција"},
+        "sv": {"ASSET": "Tillgångar", "LIABILITY": "Skulder", "INCOME": "Inkomst", "EXPENSE": "Utgifter", "EQUITY": "Eget kapital"},
+        "ta": {"ASSET": "சொத்துக்கள்", "LIABILITY": "பொறுப்பீடுகள்", "INCOME": "ஊதியம்", "EXPENSE": "செலவுகள்", "EQUITY": "உறுப்பு"},
+        "te": {"ASSET": "ఆస్తులు", "LIABILITY": "అప్పులు", "INCOME": "ఆదాయం", "EXPENSE": "వ్యయాలు", "EQUITY": "ఈక్విటీ"},
+        "tr": {"ASSET": "Varlıklar", "LIABILITY": "Y.Kaynaklar", "INCOME": "Gelir", "EXPENSE": "Gider", "EQUITY": "Özkaynak"},
+        "uk": {"ASSET": "Активи", "LIABILITY": "Зобов'язання", "INCOME": "Надходження", "EXPENSE": "Видатки", "EQUITY": "Маржа"},
+        "ur": {"ASSET": "مالیات", "LIABILITY": "ادائیگی", "INCOME": "آمدنی", "EXPENSE": "خرچ", "EQUITY": "اكویٹی"},
+        "vi": {"ASSET": "Tài sản", "LIABILITY": "Tài sản nợ", "INCOME": "Thu nhập", "EXPENSE": "Phí tổn", "EQUITY": "Cổ phần"},
+        "zh": {"ASSET": "资产", "LIABILITY": "负债", "INCOME": "收入", "EXPENSE": "支出", "EQUITY": "所有者权益"},
     }
 
     # Localized leaf names for the accounts we auto-create, keyed by an
-    # internal concept slug then normalized locale code. Only concepts
-    # with a translation table appear here; a missing concept or locale
-    # degrades to the caller's English default. Seeded from the
-    # "Realized Gain/Loss" row of gnucash-account-naming-i18n.md;
-    # extend by parsing po/<lang>.po later (the discount concepts have
-    # no shipped GnuCash translation, so they stay English for now).
+    # internal concept slug then normalized locale code. A missing
+    # concept or locale degrades to the caller's English default. The
+    # fx_gain_loss row is the "Realized Gain/Loss" translation for every
+    # shipped locale that also has a complete structural-word set (47,
+    # from po/<lang>.po), kept in lockstep with _STRUCTURAL_TYPE_NAMES.
+    # The discount concepts have no shipped GnuCash translation, so they
+    # stay English.
     _LOCALIZED_ACCOUNT_NAMES = {
         "fx_gain_loss": {
+            "ar": "مكسب/خسارة محقَّقة",
+            "as": "লাভ/লোচকান বুজি লোৱা হল",
+            "bg": "Реализирана печалба/загуба",
+            "brx": "आदाय खालामनाय मुलाम्फा/खहा",
+            "ca": "Guanys/pèrdues realitzats",
+            "cs": "Realizovaný zisk/ztráta",
+            "da": "Realiseret overskud/tab",
             "de": "Realisierter Gewinn/Verlust",
-            "fr": "Gains/pertes réalisés",
+            "doi": "स्वीकृत नऱफा/ नुक्सान",
+            "el": "Πραγματοποιηθέντα Κέρδη/Ζημιές",
             "es": "Ganancias/Pérdidas Ocurridas",
+            "fi": "Toteutuneet tulot/menot",
+            "fr": "Gains/pertes réalisés",
+            "gu": "વાસ્તવિક લાભ/નુક્શાન",
+            "he": "רוח/הפסד ממומש",
+            "hi": "वास्तविक लाभ/हानि",
+            "hr": "Ostvarena dobit/gubitak",
+            "hu": "Realizált nyereség/veszteség",
+            "id": "Keuntungan/Kerugian Direalisasikan",
             "it": "Profitti e perdite realizzati",
-            "pt": "Ganhos e perdas realizados",
-            "nl": "Gerealiseerde winst/verlies",
-            "ru": "Реализованная прибыль/убыток",
             "ja": "実現損益",
-            "zh": "已实现获利(亏损)",
+            "kn": "ನಗದುಗೊಳಿಸಲಾದ ಗಳಿಕೆ/ನಷ್ಟ",
             "ko": "실제 이익/손실",
+            "kok": "मेळिल्लो नफो / तोटो",
+            "ks": "रीयालायज़ीड फॊयदी /नुकसान",
+            "lt": "Patirtas pelnas/nuostolis",
+            "lv": "Realizētie ieņēmumi/zaudējumi",
+            "mai": "वास्तविक लाभ/हानि",
+            "mni": "ꯐꯪꯂꯕ ꯑꯇꯣꯡꯕ/ꯑꯃꯥꯡꯕ",
+            "mr": "विक्री करून आलेला नफा/तोटा",
+            "nb": "Realisert over-/underskudd",
+            "ne": "असूल गरिएको नाफा/नोक्सान",
+            "nl": "Gerealiseerde winst/verlies",
             "pl": "Zyski/straty zrealizowane",
+            "pt": "Ganhos e perdas realizados",
+            "ro": "Câștiguri/pierderi realizate",
+            "ru": "Реализованная прибыль/убыток",
+            "sk": "Realizované Zisky/Straty",
+            "sr": "Остварени добитак/губитак",
             "sv": "Reavinst/-förlust",
+            "ta": "விவரிக்கப்பட்ட இலாபம்/இழப்பு",
+            "te": "గ్రహించిన లాభం/నష్టం",
+            "tr": "Gerçekleşmiş Kazanç/Kayıp",
+            "uk": "Отримані прибутки/втрати",
+            "ur": "حقیقی نفع/ نقصان",
+            "vi": "Gia tăng/giảm thực xảy ra",
+            "zh": "已实现获利(亏损)",
         },
     }
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -985,22 +985,43 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
     # so the leading word is localized. An English-only prefix check
     # misses them on a localized book and the data-integrity warning
     # goes dark. These are the catalog translations of "Imbalance" and
-    # "Orphan" across the shipped GnuCash locales, lowercased; a leaf
-    # name that STARTS WITH any of them is a balancing account (the
-    # "-<CUR>" suffix, when present, follows the word). Source:
-    # specs/gnucash-account-naming-i18n.md.
+    # "Orphan" for every shipped GnuCash locale, extracted from
+    # po/<lang>.po (stable branch); fuzzy and untranslated entries are
+    # excluded — GnuCash's runtime ignores fuzzy, and an untranslated
+    # locale falls back to the English forms, which are listed. Lower-
+    # cased; a leaf name that STARTS WITH any of them is a balancing
+    # account (the "-<CUR>" suffix, when present, follows the word).
+    # Regenerate via the recipe in specs/gnucash-account-naming-i18n.md.
     _BALANCING_ACCOUNT_NAME_PREFIXES = frozenset(
         s.lower()
         for s in (
-            # "Imbalance"
-            "Imbalance", "Ausgleichskonto", "Non soldé", "Descuadre",
-            "Sbilancio", "Desequilíbrio", "Niet in balans", "Дисбаланс",
-            "貸借不一致", "不平衡的", "대차 불일치", "Niezrównoważenie",
-            "Obalans",
-            # "Orphan"
-            "Orphan", "Ausbuchungskonto", "Orphelin", "Huérfano",
-            "Orfano", "Órfão", "Verweesd", "Упущенный", "不明",
-            "孤立的", "고아", "Osierocone", "Föräldralös",
+            # "Imbalance" — every shipped GnuCash locale
+            'Ausgleichskonto', 'Açık', 'Chưa cân bằng', 'Debalans',
+            'Descuadre', 'Desequilibri', 'Desequilibrio',
+            'Desequilíbrio', 'Deskoadratzea', 'Dezechilibru',
+            'Disbalansas', 'Epätasapaino', 'Imbalance',
+            'Kiegyenlítés', 'Nerovnováha', 'Nevyváženost',
+            'Niet in balans', 'Niezrównoważenie', 'Non soldé',
+            'Obalans', 'Sbilancio', 'Starpība', 'Tak-seimbang',
+            'Ubalance', 'Ubalanse', 'osomotolon', 'Χωρίς ισοζύγιο',
+            'Дебаланс', 'Дисбаланс', 'Невідповідність', 'Неравнена',
+            'חוסר איזון', 'حساب عدم التوازن', 'عدم تناسب', 'ناتراز',
+            'असंतुलन', 'असंतुलित', 'असन्तुलित', 'गॊर मसावात',
+            'समानथायगैयै', 'অসমতা', 'ইমবেলেন্স', 'અસંતુલિત',
+            'சமநிலையில்லாத', 'అసమతుల్యం', 'ಅಸಮತೋಲನ', '不平衡的', '失調',
+            '貸借不一致', 'ꯏꯝꯕꯦꯂꯦꯟꯁ', '대차 불일치',
+            # "Orphan" — every shipped GnuCash locale
+            'Apleistas', 'Ausbuchungskonto', 'Açık', 'Egyedülálló',
+            'Foreldreløs', 'Föräldralös', 'Hittebarn', 'Huérfano',
+            'Nepovezano', 'Nesaistīts', 'Orfan', 'Orfano', 'Orfe',
+            'Orphan', 'Orphelin', 'Orpo', 'Osierocone', 'Sirota',
+            'Sirotek', 'Terlantar', 'Thừa', 'Umezurtza', 'Verweesd',
+            'onath', 'Órfã', 'Órfão', 'Ορφανό', 'Занедбаний',
+            'Изоставена', 'Напуштено', 'Упущенный', 'יתומים',
+            'حساب الأيتام', 'یتیم', 'अनाथ', 'आरफन', 'बेवारिसी',
+            'मावरिया', 'लावारस', 'लावारिस', 'অনাথ', 'ওর্ফান',
+            'આધાર વિનાનું', 'கைவிடப்பட்டது', 'అనాథ', 'ಆರ್ಫನ್', '不明',
+            '孤立的', '無主的', 'ꯑꯣꯔꯐꯥꯟ', '고아',
         )
     )
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -624,7 +624,13 @@ class CoreMixin:
                         sort_magnitude = abs(balance * rate)
                 integrity.append((
                     sort_magnitude,
-                    f"{name}: {balance} (data integrity issue)",
+                    # An auto-balancing (Imbalance/Orphan) account with a
+                    # non-zero balance is ambiguous: GnuCash may have parked
+                    # an unbalanced remainder, or the user may be holding an
+                    # unclassified item on purpose. Flag it for attention
+                    # without implying the book is corrupted.
+                    f"{name}: {balance} "
+                    f"(uncleared suspense balance — review or reclassify)",
                 ))
         integrity.sort(key=lambda pair: pair[0], reverse=True)
         integrity = [msg for _, msg in integrity]

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -2090,7 +2090,7 @@ class TestGetBookSummaryWarnings:
         warnings_block = result.split("Warnings:")[1].split("\n")
         joined = "\n".join(warnings_block)
         assert "Imbalance-USD" in joined
-        assert "data integrity issue" in joined
+        assert "uncleared suspense balance" in joined
         assert "⚠" in joined
 
     def test_orphan_account_with_balance_warns(self, test_book: Path):
@@ -2125,7 +2125,7 @@ class TestGetBookSummaryWarnings:
         warnings_block = result.split("Warnings:")[1].split("\n")
         joined = "\n".join(warnings_block)
         assert "Orphan-USD" in joined
-        assert "data integrity issue" in joined
+        assert "uncleared suspense balance" in joined
 
     def test_zero_balance_imbalance_does_not_warn(
         self, test_book: Path,

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -409,6 +409,35 @@ class TestAutoBalancingAccountDetection:
             )
 
 
+    def test_detects_newly_covered_locales(self, tmp_path):
+        """Locks the full-catalog expansion (every shipped GnuCash
+        locale). A regression to a smaller prefix table fails here.
+        """
+        path = tmp_path / "bal3.gnucash"
+        self._make_book(path, [
+            ("Açık-TRY", "BANK", None),        # tr imbalance/orphan
+            ("貸借不一致", "BANK", None),  # ja imbalance, unsuffixed
+            ("عدم تناسب-PKR", "BANK", None),  # ur imbalance
+            ("Osierocone-PLN", "BANK", None),             # pl orphan
+            ("Tagesgeld", "BANK", None),                  # ordinary root bank
+        ])
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            root = b.root_account
+            by_name = {a.name: a for a in b.accounts}
+            for nm in (
+                "Açık-TRY",
+                "貸借不一致",
+                "عدم تناسب-PKR",
+                "Osierocone-PLN",
+            ):
+                assert gb._is_auto_balancing_account(by_name[nm], root), nm
+            assert not gb._is_auto_balancing_account(
+                by_name["Tagesgeld"], root
+            )
+
+
+
 class TestLoanTermLocaleRobust:
     """Tier B: ``debt_payoff_plan`` must not guess a loan's
     amortization term from an English "mortgage" substring, and must

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -335,6 +335,38 @@ class TestBookLocaleInference:
         )
 
 
+    def test_infers_and_names_newly_added_locale(self, tmp_path):
+        # A locale added by the catalog-completion expansion (Turkish).
+        # Build the book from the table's own structural words (no
+        # transcription drift), then prove inference detects it AND the
+        # naming table returns a localized FX leaf — i.e. inference and
+        # naming moved together past the original 12. A revert to the
+        # smaller tables fails here.
+        words = GnuCashBook._STRUCTURAL_TYPE_NAMES["tr"]
+        path = tmp_path / "tr.gnucash"
+        book = piecash.create_book(str(path), currency="EUR", overwrite=True)
+        root = book.root_account
+        cur = book.default_currency
+        for atype, name in words.items():
+            piecash.Account(name=name, type=atype, parent=root,
+                            commodity=cur, placeholder=True)
+        book.save()
+        book.close()
+
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            assert gb._infer_book_locale(b) == "tr"
+        expected = GnuCashBook._LOCALIZED_ACCOUNT_NAMES["fx_gain_loss"]["tr"]
+        assert (
+            gb._locale_account_name(
+                "fx_gain_loss", "Foreign Exchange Gain/Loss", "tr"
+            )
+            == expected
+        )
+        assert expected != "Foreign Exchange Gain/Loss"  # genuinely localized
+
+
+
 class TestAutoBalancingAccountDetection:
     """Tier C: GnuCash localizes the "Imbalance"/"Orphan" leading word,
     so the old English-prefix check went dark on localized books. The


### PR DESCRIPTION
## Summary

Completes locale coverage for the Imbalance/Orphan integrity warning and the FX-account paths, plus softens the warning wording. All source-verified from GnuCash's `po/<lang>.po` catalogs; existing entries reproduce byte-identically (regression-checked).

**1. Imbalance/Orphan detection → all shipped locales (13 → 101 prefixes)**
- `_BALANCING_ACCOUNT_NAME_PREFIXES`: 51 `Imbalance` + 51 `Orphan` forms. The dashboard's integrity warning now fires on a localized book in every shipped locale (Urdu, Turkish, …), not just the original 13. Strict superset.

**2. FX-account inference + naming → 12 → 47 locales (Tier-D)**
- `_STRUCTURAL_TYPE_NAMES` (locale inference) and `_LOCALIZED_ACCOUNT_NAMES["fx_gain_loss"]` both extended to the same 47 languages — complete entries only (all five structural words + a `Realized Gain/Loss` name), so a detected locale always has a leaf name. Collision-safe keys (`pt_BR`→`pt`, `zh_CN`→`zh`). Existing 12 pinned, byte-identical. Cosmetic only — resolution stays GUID-based via the Layer-0 slot.

**3. Warning wording — soften "(data integrity issue)"**
- An auto-balancing account with a non-zero balance is ambiguous: GnuCash may have parked an unbalanced remainder, or the user may be holding an unclassified item on purpose. Reworded to `(uncleared suspense balance — review or reclassify)` — flags it and says what to do without implying corruption. Surfaced by bookkeeper review of the German SKR03 sample, where the warning correctly fires on `Ausgleichskonto-EUR`.

## Not in scope
FX-account **keyword matching** (`_FX_NAME_KEYWORDS`) is unchanged — that was attempted and dropped (no native gains account to reuse on an invoice-only book). Discount-account naming is unchanged (GnuCash ships no translation).

## Test plan
- [x] Balancing table 101 distinct prefixes; superset of original 13 (`test_detects_newly_covered_locales`)
- [x] Inference + naming tables both 47 langs, lockstep, 5 words each; new-locale round trip (`test_infers_and_names_newly_added_locale`)
- [x] Existing 12 reproduce byte-identical from po (regression guard)
- [x] Imbalance/Orphan warning asserts the new wording (`test_book.py`)
- [x] Full suite green (1761)