### PR TITLE
fix(core): exclude suspense/Imbalance accounts from runway + low-cash

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -651,6 +651,15 @@ class CoreMixin:
                 for account in accounts:
                     if account.type not in ("BANK", "CASH"):
                         continue
+                    if self._is_auto_balancing_account(
+                        account, book.root_account
+                    ):
+                        # A suspense/Imbalance balance isn't spendable
+                        # cash — it's surfaced by the integrity section
+                        # above. Counting it here fires a bogus
+                        # "critically low cash" on a few euros parked
+                        # for clarification.
+                        continue
                     if account.placeholder:
                         continue
                     if account.guid in template_guids:
@@ -1199,6 +1208,10 @@ class CoreMixin:
             if account.placeholder:
                 continue
             if account.type not in self._RUNWAY_LIQUID_TYPES:
+                continue
+            if self._is_auto_balancing_account(account, book.root_account):
+                # Suspense/Imbalance balances aren't runway liquidity —
+                # they're unresolved bookkeeping, not money to live on.
                 continue
             if self._is_in_retirement_subtree(account):
                 # Penalty-locked money isn't runway — see the helper.

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -2507,6 +2507,51 @@ class TestGetBookSummaryWarnings:
             )[0]
             assert "Roth IRA" not in warnings_block
 
+    def test_low_cash_imbalance_account_excluded(self, test_book: Path):
+        """A root-level Imbalance/suspense BANK account is surfaced by the
+        integrity check, NOT the low-cash check (and not counted in
+        runway). A few units parked for clarification aren't a cash-flow
+        emergency."""
+        gc = GnuCashBook(str(test_book))
+        with gc.open(readonly=False) as book:
+            opening = gc._find_account(book, "Equity:Opening Balance")
+            imb = piecash.Account(
+                name="Imbalance-USD", type="BANK",
+                parent=book.root_account,
+                commodity=book.default_currency,
+            )
+            book.session.add(imb)
+            book.session.add(piecash.Transaction(
+                currency=book.default_currency,
+                description="Unbalanced remainder",
+                post_date=date.today() - timedelta(days=10),
+                splits=[
+                    piecash.Split(account=imb, value=Decimal("3")),
+                    piecash.Split(account=opening, value=Decimal("-3")),
+                ],
+            ))
+            book.save()
+        # Burn high enough that the low-cash threshold sits above $3.
+        gc.create_transaction(
+            description="Burn",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "36000"},
+                {"account": "Assets:Checking", "amount": "-36000"},
+            ],
+            trans_date=date.today() - timedelta(days=30),
+            check_duplicates=False,
+        )
+        result = gc.get_book_summary()
+        if "Warnings:" in result:
+            warnings_block = result.split("Warnings:")[1].split(
+                "Accounts:"
+            )[0]
+            # Not a cash-flow alarm...
+            assert "Critically low cash: Imbalance-USD" not in warnings_block
+            # ...but the integrity section DOES surface it.
+            assert "Imbalance-USD" in warnings_block
+            assert "uncleared suspense balance" in warnings_block
+
     def test_low_cash_skipped_when_no_burn(self, test_book: Path):
         """When the book has no expense activity in the burn
         window, there's no daily-burn benchmark. Skip the


### PR DESCRIPTION
## Summary

An auto-balancing account (Imbalance / Orphan / a localized `Ausgleichskonto`) with a non-zero balance was being counted as **operating cash** in two places:

- the per-account **"Critically low cash"** warning (`core.py` cash loop — filtered to BANK/CASH, so suspense passed), and
- the **runway liquid pool** (`_RUNWAY_LIQUID_TYPES` includes BANK).

So a few units parked in a suspense account for clarification fired a bogus "critically low cash" alarm and skewed runway. Both sites now skip `_is_auto_balancing_account` accounts — those balances are unresolved bookkeeping (already surfaced separately by the data-integrity section), not spendable cash.

Surfaced by the **Sabine (SKR03)** sample, the only book carrying a deliberate non-zero suspense balance (`Ausgleichskonto-EUR` €48.50). Pre-existing on `develop`; thin but correct.

## Test plan
- [x] `test_low_cash_imbalance_account_excluded` — root-level Imbalance BANK account is surfaced by the integrity check, NOT the low-cash check
- [x] Existing runway / low-cash tests still pass
- [x] Verified live on Sabine: no false low-cash, runway no longer counts the €48, integrity warning intact
- [x] Full suite green (1764)