### PR TITLE
fix(multi-book): transactional switch_book + path-validation integrity

### DIFF
--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -571,6 +571,17 @@ _server_state: dict = {}
 #                   GUID-prefix caches).
 # - _book:          the CURRENT instance. Resetting it to None is the
 #                   re-init point tests rely on.
+#
+# _book is an UNLOCKED global read by get_book() and written by
+# switch_book. That is safe only while every tool is a sync function
+# and the installed MCP SDK runs sync tools inline on the event loop
+# (mcp's FuncMetadata does; standalone fastmcp 2.x thread-pools them
+# instead). Under that scheduling, a whole tool call — audit staging
+# included — is atomic with respect to switch_book. If a tool ever
+# becomes async, or the SDK changes, reads of _book mid-call can see
+# a different book than the call started on (cross-book audit
+# attribution, wrong-book writes). test_all_tools_are_sync in
+# tests/test_modules.py pins our half of that contract.
 _book_paths: list[Path] = []
 _current_path: Path | None = None
 _book_registry: dict[str, GnuCashBook] = {}
@@ -629,8 +640,13 @@ def _parse_book_paths(value: str | None) -> list[Path]:
         )
     raw = [p.strip() for p in value.split(os.pathsep) if p.strip()]
     if not raw:
-        raise ValueError(
-            "GNUCASH_BOOK_PATH environment variable not set"
+        # Separator-only (e.g. ":") is an invalid VALUE, not an unset
+        # variable — _BookPathError so both fail-fast sites (import
+        # block and main()) catch it instead of an uncaught
+        # ValueError traceback.
+        raise _BookPathError(
+            "Invalid GNUCASH_BOOK_PATH: contains only separators, "
+            "no paths"
         )
 
     paths: list[Path] = []
@@ -646,17 +662,21 @@ def _parse_book_paths(value: str | None) -> list[Path]:
             continue
         paths.append(resolved)
 
-    # Filenames must be unique — switch_book matches on them.
+    # Filenames must be unique — switch_book matches on them, and it
+    # matches case-INSENSITIVELY, so uniqueness must be checked the
+    # same way: Ledger.gnucash + ledger.gnucash would make every
+    # prefix ambiguous and the second book permanently unswitchable.
     seen: dict[str, Path] = {}
     for path in paths:
-        if path.name in seen:
+        if path.name.lower() in seen:
             errors.append(
                 f"  - duplicate book filename {path.name!r}: "
-                f"{seen[path.name]} and {path} (filenames must be "
-                f"unique so switch_book can match by name)"
+                f"{seen[path.name.lower()]} and {path} (filenames "
+                f"must be unique, case-insensitively, so switch_book "
+                f"can match by name)"
             )
         else:
-            seen[path.name] = path
+            seen[path.name.lower()] = path
 
     if errors:
         raise _BookPathError(
@@ -787,16 +807,49 @@ def _switch_book_impl(name: str) -> str:
     previous = _current_path
 
     # No-op switch — already on this book. Don't emit the reset
-    # banner (nothing changed); just reaffirm and reorient.
-    if previous is not None and target == previous:
+    # banner (nothing changed); just reaffirm and reorient. The
+    # identity check on _book (not just _current_path) matters: a
+    # previously-failed switch may have left _current_path pointing
+    # at a book _book never became, and trusting the path alone
+    # would report success while every tool still operates on the
+    # old book. A torn state falls through to the full switch,
+    # which heals it.
+    if (
+        previous is not None
+        and target == previous
+        and _book is not None
+        and _book is _book_registry.get(str(target))
+    ):
         return (
             f"Already on: {target.name}\n"
-            f"{_book_orientation(_book_for(target))}"
+            f"{_book_orientation(_book)}"
         )
 
+    # Transactional order: everything fallible runs BEFORE the
+    # globals move, and they move together. _book_for can raise
+    # (constructor resolves the file strictly — transiently missing
+    # under cloud sync / external drives); _activate_logging can
+    # raise (resolve_mcp_dir refuses unsafe log dirs). A failure at
+    # either point must leave the server fully on the previous
+    # book — never a half-switched state where reads, writes, and
+    # audit logs disagree about which book is current.
+    new_book = _book_for(target)
+    try:
+        _activate_logging(target)  # logs follow the active book
+    except Exception:
+        # setup_logging raises before touching handlers, so logging
+        # still points at the previous book; re-assert anyway in
+        # case a future edit moves the fallible step, and surface
+        # the original error.
+        if previous is not None:
+            try:
+                _activate_logging(previous)
+            except Exception:
+                pass  # original error is the actionable one
+        raise
+
     _current_path = target
-    _book = _book_for(target)
-    _activate_logging(target)  # logs follow the active book
+    _book = new_book
     _server_state["book_path"] = str(target)
     _server_state["current_book"] = target.name
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1024,6 +1024,31 @@ class TestMultiBook:
         with pytest.raises(ValueError, match="GNUCASH_BOOK_PATH"):
             _parse_book_paths("   ")
 
+    def test_parse_separator_only_fails_fast(self):
+        """A separator-only value (":") is an invalid VALUE, not an
+        unset variable — it must raise _BookPathError so main()'s
+        fail-fast catches it instead of an uncaught traceback."""
+        from gnucash_mcp.server import _parse_book_paths, _BookPathError
+        with pytest.raises(_BookPathError, match="only separators"):
+            _parse_book_paths(os.pathsep)
+        with pytest.raises(_BookPathError, match="only separators"):
+            _parse_book_paths(f" {os.pathsep} {os.pathsep} ")
+
+    def test_parse_duplicate_basename_case_insensitive(self, tmp_path):
+        """switch_book matches names case-insensitively, so uniqueness
+        must be checked the same way — otherwise Ledger.gnucash +
+        ledger.gnucash validate but every prefix is ambiguous and the
+        second book is permanently unswitchable."""
+        from gnucash_mcp.server import _parse_book_paths, _BookPathError
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        b1 = _make_min_book(d1 / "Ledger.gnucash")
+        b2 = _make_min_book(d2 / "ledger.gnucash")
+        with pytest.raises(_BookPathError, match="duplicate book filename"):
+            _parse_book_paths(f"{b1}{os.pathsep}{b2}")
+
     # ── switch_book visibility ─────────────────────────────────────
 
     def test_switch_book_present_with_two_books(self, two_books):
@@ -1109,6 +1134,58 @@ class TestMultiBook:
         assert msg.startswith("Already on: alex.gnucash")
         assert "CONTEXT RESET" not in msg
 
+    def test_failed_switch_leaves_state_consistent_and_heals(
+        self, two_books, tmp_path,
+    ):
+        """A switch that fails mid-flight must leave the server fully
+        on the previous book, and a retry after the cause clears must
+        perform a REAL switch — not a no-op that trusts the torn
+        ``_current_path`` and reports "Already on" while every tool
+        still operates on the old book (silent wrong-book writes)."""
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._select(srv, two_books)  # current = alex
+
+        # Transient failure: the book file vanishes (cloud-sync
+        # placeholder / unmounted drive) between validation and switch.
+        beast_bytes = beast.read_bytes()
+        beast.unlink()
+        with pytest.raises(FileNotFoundError):
+            srv._switch_book_impl("beast")
+
+        # Fully on the previous book — both globals agree.
+        assert srv._current_path == alex.resolve()
+        assert srv.get_book().book_path.name == "alex.gnucash"
+
+        # Cause clears; retry must really switch (banner, not noop).
+        beast.write_bytes(beast_bytes)
+        msg = srv._switch_book_impl("beast")
+        assert "Switched to: beast-man.gnucash" in msg
+        assert srv.get_book().book_path.name == "beast-man.gnucash"
+
+    def test_switch_activation_failure_rolls_back(
+        self, two_books, monkeypatch,
+    ):
+        """If logging activation fails AFTER the target book is
+        buildable, the switch must not half-happen: reads/writes and
+        the reported outcome must agree that the server is still on
+        the previous book."""
+        import gnucash_mcp.server as srv
+        self._select(srv, two_books)  # current = alex
+
+        real_activate = srv._activate_logging
+
+        def boom(path):
+            if path.name == "beast-man.gnucash":
+                raise ValueError("unsafe log dir")
+            return real_activate(path)
+
+        monkeypatch.setattr(srv, "_activate_logging", boom)
+        with pytest.raises(ValueError, match="unsafe log dir"):
+            srv._switch_book_impl("beast")
+        assert srv._current_path == two_books[0].resolve()
+        assert srv.get_book().book_path.name == "alex.gnucash"
+
     def test_orientation_reports_currency_and_count(self, two_books):
         import gnucash_mcp.server as srv
         alex, _ = two_books
@@ -1140,6 +1217,24 @@ class TestMultiBook:
         self._select(srv, two_books)
         with pytest.raises(ValueError, match="requires a book name"):
             srv._switch_book_impl("   ")
+
+    def test_all_tools_are_sync(self):
+        """Every registered tool must be a plain sync function. The
+        multi-book design keeps ``_book`` an unlocked global; that is
+        safe only while the MCP SDK runs sync tools inline on the
+        event loop, making each tool call atomic with respect to
+        switch_book. An async tool would break that atomicity —
+        see the comment on ``_book`` in server.py."""
+        import inspect
+        _apply_module_filter("all")
+        async_tools = [
+            name for name, tool in mcp._tool_manager._tools.items()
+            if inspect.iscoroutinefunction(tool.fn)
+        ]
+        assert async_tools == [], (
+            f"Async tools break the unlocked-_book atomicity "
+            f"assumption: {async_tools}"
+        )
 
     # ── get_book cold-start selection ──────────────────────────────
 


### PR DESCRIPTION
## Summary
- switch_book builds and validates everything fallible (book instance, logging activation) before repointing `_current_path` and `_book` together; a failure leaves the server fully on the previous book (review MB-1 — critical — and MB-4)
- The no-op branch verifies `_book` identity instead of trusting `_current_path`, so a previously-torn state heals on retry instead of reporting "Already on" while tools operate on the old book
- Separator-only GNUCASH_BOOK_PATH raises `_BookPathError` so both fail-fast sites catch it (MB-5)
- Duplicate-filename validation is case-insensitive, matching switch_book's matching rule (MB-6)
- `test_all_tools_are_sync` pins the sync-inline SDK scheduling that makes the unlocked `_book` global safe (MB-7)

Findings and repro details: specs/v1.4/review/CODE_REVIEW_v1_4.md

## Test plan
- [x] Four new regression tests, each verified to FAIL on pre-fix code
- [x] Full suite green (1,769)
- [x] Live smoke on sample-book copies: real switch, torn-state heal after transient file loss, retry performs a true switch