### PR TITLE
fix(i18n): FX/discount resolver collision safety + notice accuracy

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1072,7 +1072,7 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
     _STRUCTURAL_TYPE_NAMES = {
         "ar": {"ASSET": "الأصول", "LIABILITY": "الالتزامات", "INCOME": "الدخل", "EXPENSE": "المصروفات", "EQUITY": "حقوق الملكية"},
         "as": {"ASSET": "সম্পত্তিবোৰ", "LIABILITY": "বিশ্বাসযোগ্যতাবোৰ", "INCOME": "উপাৰ্জন", "EXPENSE": "ব্যয়বোৰ", "EQUITY": "সাধাৰণ অংশ"},
-        "bg": {"ASSET": "Активи:", "LIABILITY": "Пасиви", "INCOME": "Доход", "EXPENSE": "Разходи", "EQUITY": "Собствен капитал"},
+        "bg": {"ASSET": "Активи", "LIABILITY": "Пасиви", "INCOME": "Доход", "EXPENSE": "Разходи", "EQUITY": "Собствен капитал"},
         "brx": {"ASSET": "सम्पति", "LIABILITY": "दाहार", "INCOME": "आय", "EXPENSE": "खरसा", "EQUITY": "बन्दक"},
         "ca": {"ASSET": "Actiu", "LIABILITY": "Passiu", "INCOME": "Ingressos", "EXPENSE": "Despeses", "EQUITY": "Patrimoni"},
         "cs": {"ASSET": "Aktiva", "LIABILITY": "Pasiva", "INCOME": "Příjmy", "EXPENSE": "Náklady", "EQUITY": "Vlastní jmění"},
@@ -1085,7 +1085,7 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         "fr": {"ASSET": "Actifs (avoirs)", "LIABILITY": "Passifs (dettes)", "INCOME": "Revenus", "EXPENSE": "Dépenses", "EQUITY": "Capitaux propres"},
         "gu": {"ASSET": "સંપત્તિઓ", "LIABILITY": "જવાબદારી", "INCOME": "આવક", "EXPENSE": "ખર્ચ", "EQUITY": "હિસ્સો"},
         "he": {"ASSET": "נכסים", "LIABILITY": "התחייבויות", "INCOME": "הכנסות", "EXPENSE": "הוצאות", "EQUITY": "הון"},
-        "hi": {"ASSET": "संपत्तियां ", "LIABILITY": "देयताएं ", "INCOME": "आय", "EXPENSE": "खर्चे", "EQUITY": "इक्विटी"},
+        "hi": {"ASSET": "संपत्तियां", "LIABILITY": "देयताएं", "INCOME": "आय", "EXPENSE": "खर्चे", "EQUITY": "इक्विटी"},
         "hr": {"ASSET": "Imovina", "LIABILITY": "Obveze", "INCOME": "Prihod", "EXPENSE": "Rashod", "EQUITY": "Kapital"},
         "hu": {"ASSET": "Eszközök", "LIABILITY": "Kötelezettségek", "INCOME": "Bevétel", "EXPENSE": "Kiadások", "EQUITY": "Saját tőke"},
         "id": {"ASSET": "Aset", "LIABILITY": "Liabilitas", "INCOME": "Pendapatan", "EXPENSE": "Pengeluaran", "EQUITY": "Ekuitas"},
@@ -1222,10 +1222,18 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
 
         best_lang, best_score = None, 0
         for lang, type_words in self._STRUCTURAL_TYPE_NAMES.items():
+            # Normalize BOTH sides the same way (strip + lower) —
+            # account names are stripped above; a table entry carrying
+            # extraction residue (trailing space/colon) would
+            # otherwise be unmatchable in every book, silently
+            # weakening that locale's vote.
             score = sum(
                 1
                 for atype, word in type_words.items()
-                if any(n == word.lower() for n in names_by_type.get(atype, ()))
+                if any(
+                    n == word.strip().lower()
+                    for n in names_by_type.get(atype, ())
+                )
             )
             if score > best_score:
                 best_lang, best_score = lang, score

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -486,9 +486,19 @@ class BusinessMixin:
         if slotted is not None:
             return slotted, None
 
-        # Layer 2: fuzzy match by leaf-name substring. Only
+        # Layer 2: fuzzy match by leaf-name substring, plus exact
+        # match against every shipped localization of the FX leaf —
+        # the machinery must be able to re-find names it generates
+        # itself (a stale slot on a German book would otherwise miss
+        # "Realisierter Gewinn/Verlust" and collide at Layer 3). Only
         # default-currency candidates qualify — see the commodity
         # rationale on the explicit-account path above.
+        localized_fx_leaves = {
+            n.lower()
+            for n in self._LOCALIZED_ACCOUNT_NAMES.get(
+                "fx_gain_loss", {}
+            ).values()
+        }
         template_guids = self._template_account_guids(book)
         candidates = []
         for account in book.accounts:
@@ -499,36 +509,67 @@ class BusinessMixin:
             if account.commodity != default_currency:
                 continue
             name_lower = account.name.lower()
-            if any(kw in name_lower for kw in self._FX_NAME_KEYWORDS):
+            if (
+                name_lower in localized_fx_leaves
+                or any(kw in name_lower for kw in self._FX_NAME_KEYWORDS)
+            ):
                 candidates.append(account)
 
-        notice = None
         if len(candidates) == 1:
-            return candidates[0], None
-        if len(candidates) > 1:
-            sorted_paths = sorted(c.fullname for c in candidates)
-            notice = {
+            only = candidates[0]
+            # A fuzzy keyword match stays per-call (don't permanently
+            # designate a guess), but an EXACT match on a leaf this
+            # machinery generates itself is the resolver re-finding
+            # its own account — designate it so the next call hits
+            # Layer 0 and the healed slot survives renames.
+            if only.name.lower() in localized_fx_leaves:
+                self._store_designated_account(
+                    book, self._FX_ACCOUNT_SLOT_KEY, only
+                )
+            return only, None
+
+        # Multi-candidate ambiguity: fall through to the canonical
+        # default and report where the split actually went. The
+        # message is built AFTER resolution — on a localized book the
+        # destination is the localized leaf under the type-resolved
+        # income root, not the English canonical path.
+        ambiguous_paths = (
+            sorted(c.fullname for c in candidates)
+            if len(candidates) > 1 else None
+        )
+
+        def _ambiguity_notice(destination: str) -> dict | None:
+            if ambiguous_paths is None:
+                return None
+            return {
                 "type": "ambiguous_fx_account",
-                "candidates": sorted_paths,
+                "candidates": ambiguous_paths,
                 "message": (
-                    f"Found {len(candidates)} candidate FX accounts "
-                    f"({', '.join(sorted_paths)}). Routed to "
-                    f"{self.FX_GAIN_LOSS_PATH} as the canonical "
-                    f"default; pass fx_account explicitly to "
-                    f"disambiguate."
+                    f"Found {len(ambiguous_paths)} candidate FX "
+                    f"accounts ({', '.join(ambiguous_paths)}). Routed "
+                    f"to {destination} as the default; pass fx_account "
+                    f"explicitly to disambiguate."
                 ),
             }
-            # Fall through to canonical default below.
 
-        # Layer 3: canonical default (existing or auto-create).
+        # Layer 3: canonical default (existing or auto-create). An
+        # existing canonical account is adopted only if it passes the
+        # same gates Layers 0 and 1 enforce — adopting (and slotting)
+        # e.g. a EUR-denominated account here would book a
+        # default-currency delta as EUR (silent corruption) and store
+        # a designation Layer 0 rejects on every later call.
         fx_acct = self._find_account(book, self.FX_GAIN_LOSS_PATH)
-        if fx_acct is not None:
+        if (
+            fx_acct is not None
+            and fx_acct.type in {"INCOME", "EXPENSE"}
+            and fx_acct.commodity == default_currency
+        ):
             # Lock in the designation so the next call hits Layer 0
             # directly — even on a book that already had this account.
             self._store_designated_account(
                 book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
             )
-            return fx_acct, notice
+            return fx_acct, _ambiguity_notice(fx_acct.fullname)
 
         # Resolve the parent by TYPE, not the English name "Income".
         # On a localized book the income root is "Erträge"/"Ingresos"/…,
@@ -547,15 +588,7 @@ class BusinessMixin:
                 commodity=default_currency,
                 placeholder=1,
             )
-        if notice is None:
-            notice = parent_notice
 
-        # Construct — piecash.Account auto-adds to the session via the
-        # parent linkage. Don't flush here: the caller is still building
-        # the payment transaction, and orphan Split objects already in
-        # the session would trip a NOT NULL on splits.tx_guid. The
-        # final book.save() at the end of pay_invoice flushes everything
-        # together with their now-set tx_guids.
         # Localize the leaf on a non-English book (§6.3). Cosmetic only:
         # the slot write below makes the next resolve GUID-based, so the
         # localized name never has to be matched again.
@@ -563,6 +596,47 @@ class BusinessMixin:
             "fx_gain_loss", "Foreign Exchange Gain/Loss",
             self._infer_book_locale(book),
         )
+
+        # Sibling-collision check BEFORE constructing: if the intended
+        # leaf already exists under this parent, adopt it when it
+        # passes the gates — otherwise raise a clear error instead of
+        # letting book.save() fail with piecash's opaque "two children
+        # with the same name". That failure never persisted anything,
+        # so the slot never self-healed and every retry failed
+        # identically — a permanently wedged cross-currency pay path.
+        existing = next(
+            (c for c in income.children if c.name == fx_leaf), None
+        )
+        if existing is not None:
+            if (
+                existing.type in {"INCOME", "EXPENSE"}
+                and existing.commodity == default_currency
+                and existing.guid not in template_guids
+            ):
+                self._store_designated_account(
+                    book, self._FX_ACCOUNT_SLOT_KEY, existing
+                )
+                adopted_notice = _ambiguity_notice(existing.fullname)
+                return existing, (
+                    adopted_notice if adopted_notice is not None
+                    else parent_notice
+                )
+            raise ValueError(
+                f"An account named {fx_leaf!r} already exists under "
+                f"{income.name!r} but cannot receive realized FX "
+                f"gain/loss (type {existing.type}, denominated "
+                f"{existing.commodity.mnemonic}; needs INCOME/EXPENSE "
+                f"in the book default currency "
+                f"{default_currency.mnemonic}). Pass fx_account "
+                f"explicitly to choose a different account."
+            )
+
+        # Construct — piecash.Account auto-adds to the session via the
+        # parent linkage. Don't flush here: the caller is still building
+        # the payment transaction, and orphan Split objects already in
+        # the session would trip a NOT NULL on splits.tx_guid. The
+        # final book.save() at the end of pay_invoice flushes everything
+        # together with their now-set tx_guids.
         fx_acct = piecash.Account(
             name=fx_leaf,
             type="INCOME",
@@ -577,7 +651,8 @@ class BusinessMixin:
         self._store_designated_account(
             book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
         )
-        return fx_acct, notice
+        notice = _ambiguity_notice(fx_acct.fullname)
+        return fx_acct, notice if notice is not None else parent_notice
 
     def _get_or_create_discount_account(
         self, book, owner_type_is_bill: bool,
@@ -649,28 +724,43 @@ class BusinessMixin:
             if any(kw in name_lower for kw in keywords):
                 candidates.append(account)
 
-        notice = None
         if len(candidates) == 1:
             return candidates[0], None
-        if len(candidates) > 1:
-            sorted_paths = sorted(c.fullname for c in candidates)
-            notice = {
+
+        # Multi-candidate ambiguity: fall through to the canonical
+        # default; the message names the ACTUAL destination, built
+        # after resolution (parallel to the FX resolver).
+        ambiguous_paths = (
+            sorted(c.fullname for c in candidates)
+            if len(candidates) > 1 else None
+        )
+
+        def _ambiguity_notice(destination: str) -> dict | None:
+            if ambiguous_paths is None:
+                return None
+            return {
                 "type": "ambiguous_discount_account",
-                "candidates": sorted_paths,
+                "candidates": ambiguous_paths,
                 "message": (
-                    f"Found {len(candidates)} candidate {side_label} "
-                    f"accounts ({', '.join(sorted_paths)}). Routed to "
-                    f"{canonical_path} as the canonical default; pass "
+                    f"Found {len(ambiguous_paths)} candidate "
+                    f"{side_label} accounts "
+                    f"({', '.join(ambiguous_paths)}). Routed to "
+                    f"{destination} as the default; pass "
                     f"discount_account explicitly to disambiguate."
                 ),
             }
-            # Fall through to canonical default below.
 
-        # Layer 3: canonical default (existing or auto-create).
+        # Layer 3: canonical default (existing or auto-create). Adopt
+        # only a type-valid account — the discount side deliberately
+        # has no commodity gate (the discount split converts via
+        # _convert), so type is the one invariant to enforce.
         disc_acct = self._find_account(book, canonical_path)
-        if disc_acct is not None:
+        if (
+            disc_acct is not None
+            and disc_acct.type in {"INCOME", "EXPENSE"}
+        ):
             self._store_designated_account(book, slot_key, disc_acct)
-            return disc_acct, notice
+            return disc_acct, _ambiguity_notice(disc_acct.fullname)
 
         # Resolve the parent by TYPE (INCOME/EXPENSE), not the English
         # name "Income"/"Expenses" — locale-robust and rename-proof.
@@ -688,8 +778,6 @@ class BusinessMixin:
                 commodity=default_currency,
                 placeholder=1,
             )
-        if notice is None:
-            notice = parent_notice
 
         # Don't flush here; the caller is still building the payment
         # transaction. Same rationale as the FX-account auto-create.
@@ -700,6 +788,35 @@ class BusinessMixin:
             concept, canonical_path.split(":")[-1],
             self._infer_book_locale(book),
         )
+
+        # Sibling-collision check BEFORE constructing — same wedge as
+        # the FX resolver: an unadoptable same-named child would make
+        # book.save() fail with piecash's opaque duplicate-children
+        # error on every retry. Matters today for an English book
+        # whose canonical account exists with a non-INCOME/EXPENSE
+        # type, and future-proofs the day discount leaf translations
+        # ship.
+        existing = next(
+            (c for c in parent.children if c.name == leaf_name), None
+        )
+        if existing is not None:
+            if (
+                existing.type in {"INCOME", "EXPENSE"}
+                and existing.guid not in template_guids
+            ):
+                self._store_designated_account(book, slot_key, existing)
+                adopted_notice = _ambiguity_notice(existing.fullname)
+                return existing, (
+                    adopted_notice if adopted_notice is not None
+                    else parent_notice
+                )
+            raise ValueError(
+                f"An account named {leaf_name!r} already exists under "
+                f"{parent.name!r} but is type {existing.type}; the "
+                f"{side_label} account must be INCOME or EXPENSE. "
+                f"Pass discount_account explicitly to choose a "
+                f"different account."
+            )
         disc_acct = piecash.Account(
             name=leaf_name,
             type=canonical_type,
@@ -713,7 +830,8 @@ class BusinessMixin:
             ),
         )
         self._store_designated_account(book, slot_key, disc_acct)
-        return disc_acct, notice
+        notice = _ambiguity_notice(disc_acct.fullname)
+        return disc_acct, notice if notice is not None else parent_notice
 
     def _get_invoice_billterm(self, book, inv):
         """Return the piecash Billterm linked to the invoice, or None.

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -336,7 +336,12 @@ def setup_logging(
         # Write header if file is new
         write_header = not audit_file.exists()
 
-        audit_handler = logging.FileHandler(audit_file)
+        # Explicit UTF-8: under a C/POSIX locale (common for
+        # daemonized MCP servers) the platform default encoding is
+        # ASCII, and audit lines carrying localized account names
+        # ("已实现获利(亏损)", "Erträge:…") would hit UnicodeEncodeError
+        # inside the handler and be dropped to stderr.
+        audit_handler = logging.FileHandler(audit_file, encoding="utf-8")
         audit_handler.setFormatter(logging.Formatter("%(message)s"))
         audit_handler.stream.reconfigure(line_buffering=True)
         audit_logger.addHandler(audit_handler)
@@ -370,7 +375,9 @@ def setup_logging(
         debug_logger.setLevel(logging.DEBUG)
         debug_logger.propagate = False
 
-        debug_handler = logging.FileHandler(debug_dir / f"{today}.log")
+        debug_handler = logging.FileHandler(
+            debug_dir / f"{today}.log", encoding="utf-8",
+        )
         debug_handler.setFormatter(
             logging.Formatter(
                 "%(asctime)s [%(levelname)s] %(message)s",

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 
 import piecash
 import pytest
+from piecash import factories
 
 from gnucash_mcp.book import GnuCashBook
 
@@ -135,6 +136,126 @@ class TestLocalizedHelperAccounts:
             assert purchase.type == "INCOME"
             assert purchase.parent.fullname == "Erträge"
             b.save()
+
+
+class TestFxAccountCollisionSafety:
+    """v1.4 review I18N-1 / I18N-2: the resolver must re-find (or
+    refuse loudly) an existing account bearing the exact name it
+    would create, and must never adopt-and-designate an account the
+    Layer-0 gates reject.
+
+    Pre-fix wedge: a German book with a pre-existing
+    ``Erträge:Realisierter Gewinn/Verlust`` and no designation slot
+    hit Layer 3's construct, ``book.save()`` failed with piecash's
+    opaque "two children with the same name", nothing persisted, and
+    every cross-currency ``pay_invoice`` retry failed identically.
+    """
+
+    def test_adopts_preexisting_localized_fx_account(
+        self, localized_book,
+    ):
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            income = gb._find_account(b, "Erträge")
+            piecash.Account(
+                name="Realisierter Gewinn/Verlust",
+                type="INCOME",
+                parent=income,
+                commodity=b.default_currency,
+            )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            acct, _ = gb._get_or_create_fx_account(b)
+            assert acct.fullname == "Erträge:Realisierter Gewinn/Verlust"
+            b.save()  # pre-fix: ValueError (duplicate children)
+
+        # The adoption self-healed the designation: Layer 0 now
+        # resolves the same account directly.
+        with gb.open(readonly=True) as b:
+            slotted = gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY,
+            )
+            assert slotted is not None
+            assert slotted.fullname == "Erträge:Realisierter Gewinn/Verlust"
+
+    def test_unadoptable_same_named_sibling_raises_clearly(
+        self, localized_book,
+    ):
+        """A same-named sibling that fails the gates (wrong
+        commodity) must produce an explanatory error naming
+        ``fx_account`` — not a save-time duplicate-children crash."""
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            usd = factories.create_currency_from_ISO("USD")
+            income = gb._find_account(b, "Erträge")
+            piecash.Account(
+                name="Realisierter Gewinn/Verlust",
+                type="INCOME",
+                parent=income,
+                commodity=usd,
+            )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            with pytest.raises(ValueError, match="fx_account"):
+                gb._get_or_create_fx_account(b)
+
+    def test_invalid_canonical_account_never_designated(
+        self, test_book,
+    ):
+        """An account sitting at the English canonical path but
+        denominated in a foreign currency must not be adopted: the FX
+        split books a default-currency quantity, so adopting it would
+        record $X as €X — and storing its designation would create a
+        permanent store/reject disagreement with Layer 0."""
+        gb = GnuCashBook(str(test_book))
+        with gb.open(readonly=False) as b:
+            eur = factories.create_currency_from_ISO("EUR")
+            income = gb._find_account(b, "Income")
+            piecash.Account(
+                name="Foreign Exchange Gain/Loss",
+                type="INCOME",
+                parent=income,
+                commodity=eur,
+            )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            with pytest.raises(ValueError, match="fx_account"):
+                gb._get_or_create_fx_account(b)
+            # And nothing was designated on the failure path.
+            assert gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY,
+            ) is None
+
+    def test_ambiguity_notice_names_actual_destination(
+        self, localized_book,
+    ):
+        """With multiple fuzzy candidates the resolver falls back to
+        the default destination — and the notice must name the REAL
+        destination (the localized leaf under the type-resolved
+        income root), not the English canonical path that does not
+        exist on this book."""
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            income = gb._find_account(b, "Erträge")
+            for name in ("FX Adjustments", "Forex Rounding"):
+                piecash.Account(
+                    name=name,
+                    type="INCOME",
+                    parent=income,
+                    commodity=b.default_currency,
+                )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            acct, notice = gb._get_or_create_fx_account(b)
+            assert notice is not None
+            assert notice["type"] == "ambiguous_fx_account"
+            assert acct.fullname in notice["message"]
+            assert "Income:Foreign Exchange Gain/Loss" \
+                not in notice["message"]
 
 
 class TestDesignatedAccountSlotLayer0:


### PR DESCRIPTION
## Summary
- The FX resolver checked the ENGLISH canonical path but created a LOCALIZED leaf: a German book with a pre-existing `Erträge:Realisierter Gewinn/Verlust` failed at save with piecash's opaque duplicate-children error, nothing persisted, and every cross-currency pay_invoice retry failed identically (review I18N-1, high — reproduced)
- Layer 2 now also exact-matches the 47 self-generated localized FX leaves and designates on such a match (the machinery re-finds its own names)
- Layer 3 validates a canonical-path account with the same type/commodity gates Layer 0 enforces before adopting/designating (I18N-2: adopting a EUR-denominated account booked $X as €X and stored a designation Layer 0 rejects forever)
- Sibling-collision check before constructing, in BOTH resolvers: adopt a passing same-named child or raise an error naming fx_account/discount_account
- Ambiguity notices name the actual destination, built after resolution (I18N-6)
- Locale-table hygiene (bg/hi entries with extraction residue) + UTF-8 log handlers (I18N-4, I18N-7)

## Test plan
- [x] New TestFxAccountCollisionSafety class; all four tests verified to FAIL pre-fix
- [x] Full suite green (1,768); existing 507 i18n/business tests unchanged