### PR TITLE
feat(core): is_retirement slot for locale-proof runway classification

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -540,17 +540,50 @@ class CoreMixin:
     # the source of truth.
     _RUNWAY_LIQUID_TYPES = frozenset({"BANK", "CASH", "STOCK", "MUTUAL"})
 
-    @staticmethod
-    def _is_in_retirement_subtree(account) -> bool:
-        """True if any path component of the account's fullname
-        contains "retirement" (case-insensitive).
+    # Bare slot key per the slot-naming convention (a universal
+    # financial concept another tool could plausibly converge on).
+    # Set via set_account_slot on the account or any ancestor:
+    # "1"/"true"/"yes" marks the subtree as retirement (excluded from
+    # runway/low-cash liquidity), "0"/"false"/"no" un-marks it —
+    # nearest ancestor wins, so one flag on the "Retirement"
+    # placeholder covers every account under it, and a child can
+    # opt back in.
+    _RETIREMENT_SLOT_KEY = "is_retirement"
 
-        Structural heuristic for excluding retirement accounts from
-        the runway liquid pool — users typically organize them under
-        a "Retirement" placeholder. A subtree named "Tax-advantaged"
-        slips through; the long-term answer is a slot-based
-        ``is_retirement`` flag.
+    _RETIREMENT_SLOT_TRUE = frozenset({"1", "true", "yes", "y"})
+    _RETIREMENT_SLOT_FALSE = frozenset({"0", "false", "no", "n"})
+
+    def _is_in_retirement_subtree(self, account) -> bool:
+        """True when the account is penalty-locked retirement money
+        that must not count as liquid for runway / low-cash.
+
+        Authoritative signal: the ``is_retirement`` slot on the
+        account or its nearest flagged ancestor (see the key comment
+        above) — locale- and naming-proof. Fallback when no slot is
+        set anywhere on the path: any fullname component containing
+        the English word "retirement" (case-insensitive). The
+        fallback is English-only by construction — a zh_CN
+        ``资产:投资:退休金`` or German ``Altersvorsorge`` is invisible
+        to it, which overstates runway on localized books; set the
+        slot there. A subtree named "Tax-advantaged" has the same
+        gap in any locale.
         """
+        from gnucash_mcp.book._base import _slot_value_str
+
+        node = account
+        while node is not None and node.type != "ROOT":
+            try:
+                raw = node[self._RETIREMENT_SLOT_KEY]
+            except KeyError:
+                raw = None
+            if raw is not None:
+                val = (_slot_value_str(raw) or "").strip().lower()
+                if val in self._RETIREMENT_SLOT_TRUE:
+                    return True
+                if val in self._RETIREMENT_SLOT_FALSE:
+                    return False
+                # Unrecognized value: keep walking rather than guess.
+            node = node.parent
         return any(
             "retirement" in part.lower()
             for part in account.fullname.split(":")

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1803,6 +1803,69 @@ class TestGetBookSummaryRunway:
         assert "7,000" not in runway_line
         assert "2,670" in runway_line
 
+    def test_retirement_slot_marks_foreign_named_subtree(
+        self, test_book: Path,
+    ):
+        """The ``is_retirement`` slot is the locale-proof signal: a
+        subtree with no English "retirement" in any path component
+        (a zh_CN 退休金, a German Altersvorsorge) is excluded from
+        liquid once the flag is set on the parent — and the flag
+        inherits, so children need nothing."""
+        gc = GnuCashBook(str(test_book))
+        gc.create_account(
+            name="Altersvorsorge",
+            account_type="ASSET",
+            parent="Assets",
+            placeholder=True,
+        )
+        gc.create_account(
+            name="Riester-Rente",
+            account_type="BANK",
+            parent="Assets:Altersvorsorge",
+        )
+        gc.set_account_slot(
+            "Assets:Altersvorsorge", "is_retirement", "true",
+        )
+        with gc.open(readonly=False) as book:
+            acct = gc._find_account(
+                book, "Assets:Altersvorsorge:Riester-Rente",
+            )
+            assert gc._is_in_retirement_subtree(acct) is True
+            # The placeholder itself is flagged too.
+            parent = gc._find_account(book, "Assets:Altersvorsorge")
+            assert gc._is_in_retirement_subtree(parent) is True
+
+    def test_retirement_slot_false_overrides_name_fallback(
+        self, test_book: Path,
+    ):
+        """An explicit falsy slot un-marks an account the English
+        name heuristic would otherwise exclude — e.g. an HSA the
+        user keeps under their Retirement placeholder but treats
+        as spendable."""
+        gc = GnuCashBook(str(test_book))
+        gc.create_account(
+            name="Retirement",
+            account_type="ASSET",
+            parent="Assets",
+            placeholder=True,
+        )
+        gc.create_account(
+            name="HSA",
+            account_type="BANK",
+            parent="Assets:Retirement",
+        )
+        gc.set_account_slot(
+            "Assets:Retirement:HSA", "is_retirement", "false",
+        )
+        with gc.open(readonly=False) as book:
+            hsa = gc._find_account(book, "Assets:Retirement:HSA")
+            assert gc._is_in_retirement_subtree(hsa) is False
+            # Nearest-ancestor precedence: siblings without their own
+            # slot still fall back to the name heuristic and stay
+            # excluded.
+            parent = gc._find_account(book, "Assets:Retirement")
+            assert gc._is_in_retirement_subtree(parent) is True
+
     def test_stock_without_price_uses_cost_basis(
         self, test_book: Path,
     ):


### PR DESCRIPTION
## Summary
- The retirement-subtree check keyed solely on the English word "retirement" — invisible on a zh_CN 退休金 or German Altersvorsorge chart, so penalty-locked balances counted as liquid and runway was overstated (review I18N-3)
- The `is_retirement` slot (bare key per the slot convention) is the authoritative signal, checked with nearest-ancestor precedence: truthy marks the subtree, falsy un-marks (an HSA under Retirement can opt back in)
- English keyword remains the no-slot fallback — existing books unaffected

## Test plan
- [x] Two new tests (foreign-named subtree via slot; falsy override with ancestor precedence)
- [x] get_book_summary byte-identical on all three sample oracles (Alex, Lin Wei, Sabine)
- [x] Full suite green (1,766)