### PR TITLE
fix(reporting): mark partial sub-periods in group_by tables

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -83,6 +83,58 @@ def _enumerate_periods(
     return periods
 
 
+def _partial_period_labels(
+    start_date: date, end_date: date, group_by: str
+) -> set[str]:
+    """Labels of sub-periods the report range only partially covers.
+
+    Only the first and last enumerated periods can be partial: the
+    first when ``start_date`` isn't the period's natural first day,
+    the last when ``end_date`` isn't its natural last day. Rendered
+    with a ``*`` marker so a half-month column isn't silently read
+    as a small full month (and so the Avg column's drag from a
+    partial period is visible).
+    """
+    partial: set[str] = set()
+    if group_by == "month":
+        first_start = date(start_date.year, start_date.month, 1)
+        last_end = date(
+            end_date.year, end_date.month,
+            calendar.monthrange(end_date.year, end_date.month)[1],
+        )
+    elif group_by == "quarter":
+        q_start = (start_date.month - 1) // 3
+        first_start = date(start_date.year, q_start * 3 + 1, 1)
+        q_end_month = ((end_date.month - 1) // 3 + 1) * 3
+        last_end = date(
+            end_date.year, q_end_month,
+            calendar.monthrange(end_date.year, q_end_month)[1],
+        )
+    else:  # year
+        first_start = date(start_date.year, 1, 1)
+        last_end = date(end_date.year, 12, 31)
+    if start_date != first_start:
+        partial.add(_period_label(start_date, group_by))
+    if end_date != last_end:
+        partial.add(_period_label(end_date, group_by))
+    return partial
+
+
+def _mark_partial(
+    period_labels: list[str], partial_labels: set[str] | None
+) -> list[str]:
+    """Header labels with ``*`` appended to partial periods."""
+    if not partial_labels:
+        return list(period_labels)
+    return [
+        f"{pl}*" if pl in partial_labels else pl
+        for pl in period_labels
+    ]
+
+
+_PARTIAL_FOOTNOTE = "(* period only partially covered by the date range)"
+
+
 def _strip_common_prefix(names: list[str]) -> list[str]:
     """Drop a shared top-level ``Expenses:`` / ``Income:`` prefix.
 
@@ -107,6 +159,7 @@ def _format_grouped_tsv(
     grand_total: Decimal,
     excluded: list[tuple[str, Decimal]],
     label: str,
+    partial_labels: set[str] | None = None,
 ) -> str:
     """Render an entity × sub-period breakdown as a TSV table.
 
@@ -123,7 +176,8 @@ def _format_grouped_tsv(
     """
     num_periods = len(period_labels)
     leaves = _strip_common_prefix(displayed_names)
-    lines = ["\t".join([label, *period_labels, "Total", "Avg"])]
+    header_labels = _mark_partial(period_labels, partial_labels)
+    lines = ["\t".join([label, *header_labels, "Total", "Avg"])]
     for name, leaf in zip(displayed_names, leaves):
         per = totals.get(name, {})
         cells = [leaf]
@@ -140,6 +194,8 @@ def _format_grouped_tsv(
     lines.append("\t".join(total_cells))
 
     out = "\n".join(lines)
+    if partial_labels:
+        out += f"\n{_PARTIAL_FOOTNOTE}"
     if excluded:
         netted = ", ".join(
             f"{n} {t:,.2f}"

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -31,6 +31,7 @@ from gnucash_mcp._format import (
     _enumerate_periods,
     _format_grouped_tsv,
     _paginate,
+    _partial_period_labels,
     _period_label,
 )
 
@@ -7353,6 +7354,7 @@ class BusinessMixin:
         """
         periods = _enumerate_periods(start_date, end_date, group_by)
         period_labels = [pl for pl, _ in periods]
+        label_set = set(period_labels)
 
         totals: dict[str, dict[str, Decimal]] = {}
         unconverted: dict[str, dict] = {}
@@ -7361,6 +7363,11 @@ class BusinessMixin:
             if posted is None:
                 continue
             plabel = _period_label(posted.date(), group_by)
+            if plabel not in label_set:
+                # The caller filters bills to [start, end]; a stray
+                # label means that invariant broke upstream. Skip
+                # rather than KeyError the period-totals pass below.
+                continue
             total, _paid, _out, unconv = self._bill_amounts_in_default(
                 book, bill, default_currency,
             )
@@ -7403,6 +7410,9 @@ class BusinessMixin:
             grand_total=grand_total,
             excluded=[],
             label="Vendor",
+            partial_labels=_partial_period_labels(
+                start_date, end_date, group_by,
+            ),
         )
         if unconverted:
             mnem = default_currency.mnemonic

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -12,6 +12,7 @@ per-boundary snapshots — O(splits + intervals), not
 O(intervals × splits).
 """
 
+import logging
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
@@ -20,11 +21,16 @@ import piecash
 from gnucash_mcp.book._base import _is_voided, _to_decimal
 from gnucash_mcp._format import (
     _GROUP_BY_VALUES,
+    _PARTIAL_FOOTNOTE,
     _enumerate_periods,
     _format_grouped_tsv,
     _format_number,
+    _mark_partial,
+    _partial_period_labels,
     _period_label,
 )
+
+debug_logger = logging.getLogger("gnucash_mcp.debug")
 
 # Account-type groups shared by the reports' SQL IN() clauses — one
 # canonical definition. RECEIVABLE/PAYABLE are included: A/R is an
@@ -87,6 +93,7 @@ def _format_grouped_cashflow_tsv(
     outflows: dict[str, Decimal],
     account_label: str,
     transfers_excluded: int,
+    partial_labels: set[str] | None = None,
 ) -> str:
     """Render a multi-period cash-flow trend as a TSV table.
 
@@ -109,12 +116,18 @@ def _format_grouped_cashflow_tsv(
 
     lines = [
         account_label,
-        "\t".join(["Cash flow", *period_labels, "Total", "Avg"]),
+        "\t".join([
+            "Cash flow",
+            *_mark_partial(period_labels, partial_labels),
+            "Total", "Avg",
+        ]),
         _row("Inflows", inflows),
         _row("Outflows", outflows),
         _row("Net", net),
     ]
     out = "\n".join(lines)
+    if partial_labels:
+        out += f"\n{_PARTIAL_FOOTNOTE}"
     if transfers_excluded:
         out += (
             f"\n({transfers_excluded} internal transfer txn(s) excluded; "
@@ -278,9 +291,21 @@ class ReportingMixin:
         )
 
         # category fullname → {period_label: signed Decimal}
+        label_set = set(period_labels)
         totals: dict[str, dict[str, Decimal]] = {}
         for split, txn, account in rows:
             plabel = _period_label(txn.post_date, group_by)
+            if plabel not in label_set:
+                # _query_filtered_splits bounds post_date to
+                # [start, end], so every label is enumerated; a stray
+                # one means that invariant broke upstream. Skip with
+                # a trace rather than KeyError-ing the whole report.
+                debug_logger.warning(
+                    f"group_by split outside enumerated periods: "
+                    f"{plabel} not in {period_labels[0]}..."
+                    f"{period_labels[-1]}"
+                )
+                continue
             factor = factors_by_period.get(plabel, {}).get(account.guid)
             amount = sign * self._split_in_default_currency(
                 split, account, factor,
@@ -318,6 +343,9 @@ class ReportingMixin:
             grand_total=grand_total,
             excluded=excluded,
             label=label,
+            partial_labels=_partial_period_labels(
+                start_date, end_date, group_by,
+            ),
         )
 
     def spending_by_category(
@@ -1088,6 +1116,15 @@ class ReportingMixin:
                 transfers_excluded.add(txn.guid)
                 continue
             plabel = _period_label(txn.post_date, group_by)
+            if plabel not in inflows:
+                # Same invariant guard as _grouped_breakdown: the SQL
+                # date bound guarantees containment; don't KeyError
+                # the report if it ever breaks.
+                debug_logger.warning(
+                    f"group_by split outside enumerated periods: "
+                    f"{plabel}"
+                )
+                continue
             amt = self._split_in_default_currency(
                 split, acct, factors_by_period.get(plabel, {}).get(acct.guid)
             )
@@ -1102,6 +1139,9 @@ class ReportingMixin:
             outflows=outflows,
             account_label=account_label,
             transfers_excluded=len(transfers_excluded),
+            partial_labels=_partial_period_labels(
+                start_date, end_date, group_by,
+            ),
         )
 
     def _cashflow_txn_guids(

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8395,7 +8395,8 @@ class TestGroupByBreakdown:
 
     def test_year_two_columns_partial_empty(self, tmp_path: Path):
         """18-month range → 2 year columns; the empty 2025 column
-        still renders as 0.00."""
+        still renders as 0.00, and the half-covered 2026 column is
+        marked partial so it isn't read as a small full year."""
         gc = GnuCashBook(str(self._book(tmp_path)))
         tsv = gc.spending_by_category(
             start_date=date(2025, 1, 1), end_date=date(2026, 6, 30),
@@ -8403,9 +8404,24 @@ class TestGroupByBreakdown:
         )
         rows = self._parse(tsv)
         assert rows["Category"] == [
-            "Category", "2025", "2026", "Total", "Avg",
+            "Category", "2025", "2026*", "Total", "Avg",
         ]
         assert rows["Groceries"][1:] == ["0.00", "1700.00", "1700.00", "850.00"]
+        assert "partially covered" in tsv
+
+    def test_partial_month_marked_with_footnote(self, tmp_path: Path):
+        """A range starting mid-month renders its first column with a
+        ``*`` marker and a footnote — a half month must not read as a
+        small full month (and the Avg drag is visible)."""
+        gc = GnuCashBook(str(self._book(tmp_path)))
+        tsv = gc.spending_by_category(
+            start_date=date(2026, 3, 15), end_date=date(2026, 5, 31),
+            group_by="month",
+        )
+        rows = self._parse(tsv)
+        assert rows["Category"][1] == "2026-03*"
+        assert rows["Category"][2:4] == ["2026-04", "2026-05"]
+        assert "partially covered" in tsv
 
     def test_no_group_by_unchanged(self, tmp_path: Path):
         """Regression guard: omitting group_by keeps the single-period


### PR DESCRIPTION
## Summary
- A range starting or ending mid-period rendered its first/last column indistinguishable from a full period — a half-month read as a small full month, and the Avg run-rate silently dragged (review GB-2)
- Partial columns now carry a `*` marker plus a footnote, across all three grouped surfaces (spending/income breakdown, cash-flow trend, vendor spending); labeling only, numbers unchanged
- Period-bucketing passes guarded against labels outside the enumerated columns — was a latent KeyError crashing the whole report if the upstream date-filter invariant ever broke (GB-3)
- GB-1 (the single-period vs group_by rate-anchor divergence) lands separately per maintainer ruling

## Test plan
- [x] New partial-month test; partial-year test updated to expect the marker
- [x] Calendar-aligned ranges verified to render with no markers
- [x] Full suite green (1,765)