### PR TITLE
fix: v1.4 review follow-ups (recovered from failed pushes)

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -18,7 +18,7 @@ Two pieces:
 
 import calendar
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import TypeVar
 
@@ -88,34 +88,23 @@ def _partial_period_labels(
 ) -> set[str]:
     """Labels of sub-periods the report range only partially covers.
 
-    Only the first and last enumerated periods can be partial: the
-    first when ``start_date`` isn't the period's natural first day,
-    the last when ``end_date`` isn't its natural last day. Rendered
-    with a ``*`` marker so a half-month column isn't silently read
-    as a small full month (and so the Avg column's drag from a
-    partial period is visible).
+    Only the first and last enumerated periods can be partial.
+    Derived from ``_period_label`` itself instead of a third copy of
+    the calendar-boundary ladder: the range starts mid-period exactly
+    when the day BEFORE ``start_date`` still carries the same label,
+    and ends mid-period exactly when the day AFTER ``end_date`` does.
+    Provably consistent with the bucketing function by construction —
+    a new ``group_by`` granularity added to ``_period_label`` is
+    covered here with no edit. Rendered with a ``*`` marker so a
+    half-month column isn't silently read as a small full month (and
+    so the Avg column's drag from a partial period is visible).
     """
     partial: set[str] = set()
-    if group_by == "month":
-        first_start = date(start_date.year, start_date.month, 1)
-        last_end = date(
-            end_date.year, end_date.month,
-            calendar.monthrange(end_date.year, end_date.month)[1],
-        )
-    elif group_by == "quarter":
-        q_start = (start_date.month - 1) // 3
-        first_start = date(start_date.year, q_start * 3 + 1, 1)
-        q_end_month = ((end_date.month - 1) // 3 + 1) * 3
-        last_end = date(
-            end_date.year, q_end_month,
-            calendar.monthrange(end_date.year, q_end_month)[1],
-        )
-    else:  # year
-        first_start = date(start_date.year, 1, 1)
-        last_end = date(end_date.year, 12, 31)
-    if start_date != first_start:
+    if _period_label(start_date - timedelta(days=1), group_by) \
+            == _period_label(start_date, group_by):
         partial.add(_period_label(start_date, group_by))
-    if end_date != last_end:
+    if _period_label(end_date + timedelta(days=1), group_by) \
+            == _period_label(end_date, group_by):
         partial.add(_period_label(end_date, group_by))
     return partial
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1223,10 +1223,12 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         best_lang, best_score = None, 0
         for lang, type_words in self._STRUCTURAL_TYPE_NAMES.items():
             # Normalize BOTH sides the same way (strip + lower) —
-            # account names are stripped above; a table entry carrying
-            # extraction residue (trailing space/colon) would
-            # otherwise be unmatchable in every book, silently
-            # weakening that locale's vote.
+            # account names are stripped above; a table entry with
+            # trailing WHITESPACE would otherwise be unmatchable in
+            # every book, silently weakening that locale's vote.
+            # strip() does NOT remove punctuation residue (a trailing
+            # ':' from po-label extraction) — that must be fixed in
+            # the table data itself, per the regeneration recipe.
             score = sum(
                 1
                 for atype, word in type_words.items()

--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -519,7 +519,14 @@ class BackupMixin:
         if not backups_dir.exists():
             return []
 
-        own_stem = self.book_path.stem
+        # Case-INSENSITIVE stem match, consistent with switch_book
+        # matching and the parse-time uniqueness check: on macOS a
+        # user can relaunch with ledger.gnucash after backups were
+        # written as Ledger-<ts>-... (same file — resolve() doesn't
+        # canonicalize case); an exact compare would make every
+        # existing backup invisible to listing, pruning, and the
+        # dashboard's backup-health signal.
+        own_stem = self.book_path.stem.lower()
         entries: list[dict] = []
         now = _now_utc()
         for path in backups_dir.iterdir():
@@ -527,7 +534,7 @@ class BackupMixin:
             if parsed is None:
                 continue
             ts, stage, label, stem = parsed
-            if stem != own_stem:
+            if stem.lower() != own_stem:
                 continue
             try:
                 size = path.stat().st_size

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -14,6 +14,7 @@ in the ORM). All raw inserts are paired with `_verify_write` /
 `_verify_composite_write` from _base.
 """
 
+import logging
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 
@@ -34,6 +35,9 @@ from gnucash_mcp._format import (
     _partial_period_labels,
     _period_label,
 )
+
+
+debug_logger = logging.getLogger("gnucash_mcp.debug")
 
 
 def _commodity_quantum(commodity) -> Decimal:
@@ -7520,7 +7524,14 @@ class BusinessMixin:
             if plabel not in label_set:
                 # The caller filters bills to [start, end]; a stray
                 # label means that invariant broke upstream. Skip
-                # rather than KeyError the period-totals pass below.
+                # rather than KeyError the period-totals pass below —
+                # and leave a trace, matching the sibling guards in
+                # reporting.py: a silently dropped bill is a vendor
+                # total that's short with nothing to debug.
+                debug_logger.warning(
+                    f"group_by bill outside enumerated periods: "
+                    f"{plabel}"
+                )
                 continue
             total, _paid, _out, unconv = self._bill_amounts_in_default(
                 book, bill, default_currency,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -388,6 +388,11 @@ class BusinessMixin:
             return None
         if acct.commodity != self._require_default_currency(book):
             return None
+        # A placeholder can't receive postings (GnuCash's UI treats
+        # them as non-postable organizers); a designation that became
+        # a placeholder falls through and re-resolves.
+        if acct.placeholder:
+            return None
         return acct
 
     def _store_designated_account(self, book, slot_key, account) -> None:
@@ -476,6 +481,13 @@ class BusinessMixin:
                     f"gain/loss account must be in the book default "
                     f"currency ({default_currency.mnemonic})."
                 )
+            if acct.placeholder:
+                raise ValueError(
+                    f"fx_account {acct.fullname!r} is a placeholder; "
+                    f"placeholders organize the tree and cannot "
+                    f"receive postings. Pass a leaf INCOME/EXPENSE "
+                    f"account."
+                )
             return acct, None
 
         # Layer 0: a stored designation wins for the no-explicit-arg
@@ -488,17 +500,24 @@ class BusinessMixin:
             return slotted, None
 
         # Layer 2: fuzzy match by leaf-name substring, plus exact
-        # match against every shipped localization of the FX leaf —
-        # the machinery must be able to re-find names it generates
-        # itself (a stale slot on a German book would otherwise miss
-        # "Realisierter Gewinn/Verlust" and collide at Layer 3). Only
-        # default-currency candidates qualify — see the commodity
+        # match against the leaf THIS BOOK's machinery generates (the
+        # book's inferred-locale translation and the English default)
+        # — a stale slot on a German book would otherwise miss
+        # "Realisierter Gewinn/Verlust" and collide at Layer 3.
+        # Deliberately NOT all 47 shipped localizations: an English
+        # book where the user happens to have a German-named account
+        # is a coincidence, not this machinery re-finding its own
+        # name, and must not be silently adopted — let alone
+        # permanently designated. Only default-currency,
+        # non-placeholder candidates qualify — see the commodity
         # rationale on the explicit-account path above.
-        localized_fx_leaves = {
-            n.lower()
-            for n in self._LOCALIZED_ACCOUNT_NAMES.get(
-                "fx_gain_loss", {}
-            ).values()
+        own_fx_leaf = self._locale_account_name(
+            "fx_gain_loss", "Foreign Exchange Gain/Loss",
+            self._infer_book_locale(book),
+        )
+        own_fx_leaves = {
+            own_fx_leaf.lower(),
+            "foreign exchange gain/loss",
         }
         template_guids = self._template_account_guids(book)
         candidates = []
@@ -509,9 +528,11 @@ class BusinessMixin:
                 continue
             if account.commodity != default_currency:
                 continue
+            if account.placeholder:
+                continue
             name_lower = account.name.lower()
             if (
-                name_lower in localized_fx_leaves
+                name_lower in own_fx_leaves
                 or any(kw in name_lower for kw in self._FX_NAME_KEYWORDS)
             ):
                 candidates.append(account)
@@ -519,11 +540,11 @@ class BusinessMixin:
         if len(candidates) == 1:
             only = candidates[0]
             # A fuzzy keyword match stays per-call (don't permanently
-            # designate a guess), but an EXACT match on a leaf this
-            # machinery generates itself is the resolver re-finding
+            # designate a guess), but an EXACT match on the leaf this
+            # book's machinery generates is the resolver re-finding
             # its own account — designate it so the next call hits
             # Layer 0 and the healed slot survives renames.
-            if only.name.lower() in localized_fx_leaves:
+            if only.name.lower() in own_fx_leaves:
                 self._store_designated_account(
                     book, self._FX_ACCOUNT_SLOT_KEY, only
                 )
@@ -564,6 +585,7 @@ class BusinessMixin:
             fx_acct is not None
             and fx_acct.type in {"INCOME", "EXPENSE"}
             and fx_acct.commodity == default_currency
+            and not fx_acct.placeholder
         ):
             # Lock in the designation so the next call hits Layer 0
             # directly — even on a book that already had this account.
@@ -590,13 +612,11 @@ class BusinessMixin:
                 placeholder=1,
             )
 
-        # Localize the leaf on a non-English book (§6.3). Cosmetic only:
-        # the slot write below makes the next resolve GUID-based, so the
-        # localized name never has to be matched again.
-        fx_leaf = self._locale_account_name(
-            "fx_gain_loss", "Foreign Exchange Gain/Loss",
-            self._infer_book_locale(book),
-        )
+        # Localized leaf (§6.3) — already resolved for the Layer-2
+        # exact-match set above. Cosmetic only: the slot write below
+        # makes the next resolve GUID-based, so the localized name
+        # never has to be matched again.
+        fx_leaf = own_fx_leaf
 
         # Sibling-collision check BEFORE constructing: if the intended
         # leaf already exists under this parent, adopt it when it
@@ -612,6 +632,7 @@ class BusinessMixin:
             if (
                 existing.type in {"INCOME", "EXPENSE"}
                 and existing.commodity == default_currency
+                and not existing.placeholder
                 and existing.guid not in template_guids
             ):
                 self._store_designated_account(
@@ -626,8 +647,10 @@ class BusinessMixin:
                 f"An account named {fx_leaf!r} already exists under "
                 f"{income.name!r} but cannot receive realized FX "
                 f"gain/loss (type {existing.type}, denominated "
-                f"{existing.commodity.mnemonic}; needs INCOME/EXPENSE "
-                f"in the book default currency "
+                f"{existing.commodity.mnemonic}"
+                f"{', placeholder' if existing.placeholder else ''}; "
+                f"needs a non-placeholder INCOME/EXPENSE account in "
+                f"the book default currency "
                 f"{default_currency.mnemonic}). Pass fx_account "
                 f"explicitly to choose a different account."
             )
@@ -705,6 +728,13 @@ class BusinessMixin:
                     f"{acct.type}; must be INCOME or EXPENSE to "
                     f"receive an early-payment-discount split."
                 )
+            if acct.placeholder:
+                raise ValueError(
+                    f"discount_account {acct.fullname!r} is a "
+                    f"placeholder; placeholders organize the tree "
+                    f"and cannot receive postings. Pass a leaf "
+                    f"INCOME/EXPENSE account."
+                )
             return acct, None
 
         # Layer 0: a stored designation wins for the no-explicit-arg
@@ -713,13 +743,16 @@ class BusinessMixin:
         if slotted is not None:
             return slotted, None
 
-        # Layer 2: fuzzy match by leaf-name substring.
+        # Layer 2: fuzzy match by leaf-name substring. Placeholders
+        # are excluded — they can't receive postings.
         template_guids = self._template_account_guids(book)
         candidates = []
         for account in book.accounts:
             if account.guid in template_guids:
                 continue
             if account.type not in {"INCOME", "EXPENSE"}:
+                continue
+            if account.placeholder:
                 continue
             name_lower = account.name.lower()
             if any(kw in name_lower for kw in keywords):
@@ -759,6 +792,7 @@ class BusinessMixin:
         if (
             disc_acct is not None
             and disc_acct.type in {"INCOME", "EXPENSE"}
+            and not disc_acct.placeholder
         ):
             self._store_designated_account(book, slot_key, disc_acct)
             return disc_acct, _ambiguity_notice(disc_acct.fullname)
@@ -803,6 +837,7 @@ class BusinessMixin:
         if existing is not None:
             if (
                 existing.type in {"INCOME", "EXPENSE"}
+                and not existing.placeholder
                 and existing.guid not in template_guids
             ):
                 self._store_designated_account(book, slot_key, existing)
@@ -813,10 +848,11 @@ class BusinessMixin:
                 )
             raise ValueError(
                 f"An account named {leaf_name!r} already exists under "
-                f"{parent.name!r} but is type {existing.type}; the "
-                f"{side_label} account must be INCOME or EXPENSE. "
-                f"Pass discount_account explicitly to choose a "
-                f"different account."
+                f"{parent.name!r} but is "
+                f"{'a placeholder' if existing.placeholder else f'type {existing.type}'}; "
+                f"the {side_label} account must be a non-placeholder "
+                f"INCOME or EXPENSE account. Pass discount_account "
+                f"explicitly to choose a different account."
             )
         disc_acct = piecash.Account(
             name=leaf_name,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -666,17 +666,24 @@ def _parse_book_paths(value: str | None) -> list[Path]:
     # matches case-INSENSITIVELY, so uniqueness must be checked the
     # same way: Ledger.gnucash + ledger.gnucash would make every
     # prefix ambiguous and the second book permanently unswitchable.
+    # STEMS must be unique too (also case-insensitively): backup
+    # state files, retention scoping, and backup filenames are all
+    # keyed by stem, so ledger.gnucash + ledger.xac sharing a
+    # GNUCASH_LOG_DIR would share .state-ledger.json and prune each
+    # other's snapshots — the cross-book data-loss class the stem
+    # scoping exists to prevent.
     seen: dict[str, Path] = {}
     for path in paths:
-        if path.name.lower() in seen:
+        stem_key = path.stem.lower()
+        if stem_key in seen:
             errors.append(
-                f"  - duplicate book filename {path.name!r}: "
-                f"{seen[path.name.lower()]} and {path} (filenames "
-                f"must be unique, case-insensitively, so switch_book "
-                f"can match by name)"
+                f"  - duplicate book filename stem {path.stem!r}: "
+                f"{seen[stem_key]} and {path} (book filename stems "
+                f"must be unique, case-insensitively — switch_book "
+                f"matches by name and backups are scoped by stem)"
             )
         else:
-            seen[path.name.lower()] = path
+            seen[stem_key] = path
 
     if errors:
         raise _BookPathError(
@@ -837,10 +844,11 @@ def _switch_book_impl(name: str) -> str:
     try:
         _activate_logging(target)  # logs follow the active book
     except Exception:
-        # setup_logging raises before touching handlers, so logging
-        # still points at the previous book; re-assert anyway in
-        # case a future edit moves the fallible step, and surface
-        # the original error.
+        # This fallback is LOAD-BEARING, not defensive: setup_logging
+        # clears the audit/debug handlers BEFORE its fallible steps
+        # (mkdir, FileHandler open), so a failure there leaves logging
+        # disabled entirely — re-asserting the previous book is what
+        # keeps its writes audited after a failed switch.
         if previous is not None:
             try:
                 _activate_logging(previous)

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -917,3 +917,23 @@ class TestSharedLogDirScoping:
         a._maybe_auto_backup()
         assert _read_attempt_status(a._backups_dir(), a_path.stem)
         assert _read_attempt_status(b._backups_dir(), b_path.stem) is None
+
+    def test_listing_stem_match_is_case_insensitive(
+        self, test_book: Path, tmp_path, monkeypatch,
+    ):
+        """A case flip in GNUCASH_BOOK_PATH (same file on macOS's
+        case-insensitive filesystem) must not orphan existing
+        backups: the stem filter compares case-insensitively, like
+        switch_book matching and parse-time uniqueness."""
+        import shutil
+        shared = tmp_path / "shared-logs"
+        monkeypatch.setenv("GNUCASH_LOG_DIR", str(shared))
+        book = GnuCashBook(str(test_book))
+        created = Path(book.create_backup(stage="manual", label="x")["path"])
+        # Simulate the pre-flip filename casing on disk.
+        upper = created.with_name(
+            created.name.replace(test_book.stem, test_book.stem.upper(), 1)
+        )
+        created.rename(upper)
+        listed = book.list_backups()
+        assert len(listed) == 1, "case-flipped stem orphaned the backup"

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -258,6 +258,97 @@ class TestFxAccountCollisionSafety:
                 not in notice["message"]
 
 
+class TestFxAdoptionGuards:
+    """Post-review follow-ups: adoption must not silently claim a
+    coincidentally-named account from another locale, and no
+    automatic layer may adopt or designate a placeholder."""
+
+    def test_foreign_locale_name_on_english_book_not_designated(
+        self, test_book,
+    ):
+        """An English book where the user created a German-named
+        income account must NOT have it silently adopted/designated —
+        the exact-match set is the book's OWN locale leaf plus the
+        English default, not all 47 shipped translations."""
+        gb = GnuCashBook(str(test_book))
+        with gb.open(readonly=False) as b:
+            income = gb._find_account(b, "Income")
+            piecash.Account(
+                name="Realisierter Gewinn/Verlust",
+                type="INCOME",
+                parent=income,
+                commodity=b.default_currency,
+            )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            acct, _ = gb._get_or_create_fx_account(b)
+            # Canonical English account created; the German-named
+            # coincidence untouched and undesignated.
+            assert acct.fullname == "Income:Foreign Exchange Gain/Loss"
+            slotted = gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY,
+            )
+            assert slotted is None or (
+                slotted.fullname == "Income:Foreign Exchange Gain/Loss"
+            )
+
+    def test_placeholder_canonical_not_adopted(self, test_book):
+        """A placeholder at the canonical path is not adoptable: the
+        resolver raises the explanatory sibling-collision error
+        rather than designating a non-postable organizer (or crashing
+        at save on the duplicate child it would otherwise create)."""
+        gb = GnuCashBook(str(test_book))
+        with gb.open(readonly=False) as b:
+            income = gb._find_account(b, "Income")
+            piecash.Account(
+                name="Foreign Exchange Gain/Loss",
+                type="INCOME",
+                parent=income,
+                commodity=b.default_currency,
+                placeholder=1,
+            )
+            b.save()
+
+        with gb.open(readonly=False) as b:
+            with pytest.raises(ValueError, match="placeholder"):
+                gb._get_or_create_fx_account(b)
+            assert gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY,
+            ) is None
+
+    def test_explicit_placeholder_fx_account_rejected(self, test_book):
+        gb = GnuCashBook(str(test_book))
+        gb.create_account(
+            name="FX Bucket", account_type="INCOME",
+            parent="Income", placeholder=True,
+        )
+        with gb.open(readonly=False) as b:
+            with pytest.raises(ValueError, match="placeholder"):
+                gb._get_or_create_fx_account(
+                    b, fx_account="Income:FX Bucket",
+                )
+
+    def test_stale_placeholder_designation_falls_through(
+        self, test_book,
+    ):
+        """A designated account later turned into a placeholder must
+        not keep receiving postings via Layer 0 — the designation
+        falls through and re-resolves."""
+        gb = GnuCashBook(str(test_book))
+        with gb.open(readonly=False) as b:
+            acct, _ = gb._get_or_create_fx_account(b)
+            b.save()
+        with gb.open(readonly=False) as b:
+            fx = gb._find_account(b, "Income:Foreign Exchange Gain/Loss")
+            fx.placeholder = 1
+            b.save()
+        with gb.open(readonly=True) as b:
+            assert gb._resolve_designated_account(
+                b, gb._FX_ACCOUNT_SLOT_KEY,
+            ) is None
+
+
 class TestDesignatedAccountSlotLayer0:
     """§6.2 Layer 0: once resolved, the FX/discount account's GUID is
     stored in a root-account slot and every later resolution reads that

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1049,6 +1049,24 @@ class TestMultiBook:
         with pytest.raises(_BookPathError, match="duplicate book filename"):
             _parse_book_paths(f"{b1}{os.pathsep}{b2}")
 
+    def test_parse_duplicate_stem_across_extensions_fails_fast(
+        self, tmp_path,
+    ):
+        """Backup state files, retention scoping, and backup filenames
+        are all keyed by the filename STEM — ledger.gnucash +
+        ledger.xac would share .state-ledger.json under a shared
+        GNUCASH_LOG_DIR and prune each other's snapshots. Uniqueness
+        must therefore be enforced on the stem, not the full name."""
+        from gnucash_mcp.server import _parse_book_paths, _BookPathError
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        b1 = _make_min_book(d1 / "ledger.gnucash")
+        b2 = _make_min_book(d2 / "ledger.xac")
+        with pytest.raises(_BookPathError, match="duplicate book filename"):
+            _parse_book_paths(f"{b1}{os.pathsep}{b2}")
+
     # ── switch_book visibility ─────────────────────────────────────
 
     def test_switch_book_present_with_two_books(self, two_books):


### PR DESCRIPTION
## Summary
Four follow-up commits from the local code review of PRs #114–#118 that were meant to ride those PRs but never reached the remote (`git push | tail` masked a no-upstream failure; the branch heads merged without them):
- Stem uniqueness enforced case-insensitively in GNUCASH_BOOK_PATH validation (ledger.gnucash + ledger.xac would share backup state under a shared log dir)
- Case-insensitive stem matching in list_backups (a macOS case flip orphaned every existing backup)
- FX/discount resolvers: exact-match set narrowed to the book's own locale leaf + English (no more silent permanent designation of coincidentally-named accounts); placeholder accounts excluded at every adoption layer
- Vendor stray-label guard now logs like its reporting.py siblings; _partial_period_labels derived from _period_label (third copy of the calendar ladder removed)
- The switch_book rollback comment corrected: the fallback is load-bearing (setup_logging clears handlers before its fallible steps), not defensive

## Test plan
- [x] Full suite green including the six recovered regression tests (1,786)
- [x] All three sample oracles byte-identical across seven report surfaces on the integrated result