### PR TITLE
feat(logging): per-book .mcp subdirs under GNUCASH_LOG_DIR

### DIFF
--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -173,8 +173,21 @@ def redact_paths(text: str) -> str:
 def resolve_mcp_dir(book_path: Path | str) -> Path:
     """Resolve the ``.mcp`` directory for audit / debug / backup storage.
 
-    ``GNUCASH_LOG_DIR`` set → that path is used directly, bypassing
-    all checks (explicit user opt-in). Otherwise the directory is
+    ``GNUCASH_LOG_DIR`` set → a PER-BOOK subdirectory under it:
+    ``{GNUCASH_LOG_DIR}/{book_filename}.mcp`` — the default layout,
+    relocated. The subdir is what makes the override safe for
+    multi-book: a flat shared directory interleaved two books' audit
+    entries in one daily file under one book's header. Always
+    per-book, never sniffed from what exists on disk — a
+    conditional "reuse the flat layout if present" rule can never
+    decide which book owns the flat files, so every book would
+    match and the interleave would persist. v1.4.0-and-earlier flat
+    files (``{GNUCASH_LOG_DIR}/audit`` …) stay on disk untouched;
+    move them into the book's subdir manually to keep old history
+    attached. Permission checks are bypassed under the override
+    (explicit user opt-in), as before.
+
+    Otherwise the directory is
     ``book_path.parent / f"{book_path.name}.mcp"`` and two POSIX
     sanity checks fire:
 
@@ -198,7 +211,8 @@ def resolve_mcp_dir(book_path: Path | str) -> Path:
     """
     env_override = os.environ.get("GNUCASH_LOG_DIR")
     if env_override:
-        return Path(env_override).expanduser()
+        base = Path(env_override).expanduser()
+        return base / f"{Path(book_path).name}.mcp"
 
     book_path = Path(book_path)
     parent = book_path.parent

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -1085,8 +1085,10 @@ Environment variables:
                              --modules (e.g. "bookkeeper" or "core,reporting")
   GNUCASH_MCP_DEBUG=1        Enable debug logging
   GNUCASH_MCP_NOAUDIT=1      Disable audit logging
-  GNUCASH_LOG_DIR            Override the .mcp storage directory (audit,
-                             debug, backups). Default: {book_path}.mcp
+  GNUCASH_LOG_DIR            Relocate .mcp storage (audit, debug, backups).
+                             Each book gets its own subdirectory:
+                             {GNUCASH_LOG_DIR}/{book}.mcp
+                             Default location: {book_path}.mcp
   GNUCASH_REDACT_PATHS=1     Collapse absolute paths to basenames in tool
                              responses and error messages (safe to share)
   GNUCASH_FX_GUARD_DAYS      Refuse a cross-currency invoice/bill post or pay
@@ -1102,7 +1104,7 @@ Environment variables:
                              (default 10; applies only when the rate is set)
 
 Logs and backups live under the .mcp directory — beside the book file by
-default, or at GNUCASH_LOG_DIR if set:
+default, or per-book under GNUCASH_LOG_DIR if set:
   {book_path}.mcp/audit/YYYY-MM-DD.txt
   {book_path}.mcp/debug/YYYY-MM-DD.log   (when debug enabled)
   {book_path}.mcp/backups/               (auto + manual snapshots)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1380,18 +1380,23 @@ class TestResolveMcpDir:
         assert result == tmp_path / "alex.gnucash.mcp"
 
     def test_env_override_used(self, tmp_path, monkeypatch):
-        """GNUCASH_LOG_DIR takes precedence over derivation."""
+        """GNUCASH_LOG_DIR takes precedence over derivation — and
+        yields a PER-BOOK subdir under it, so two books sharing the
+        override never interleave audit files or backup state."""
         override = tmp_path / "elsewhere"
         monkeypatch.setenv("GNUCASH_LOG_DIR", str(override))
         result = resolve_mcp_dir(tmp_path / "alex.gnucash")
-        assert result == override
+        assert result == override / "alex.gnucash.mcp"
+        other = resolve_mcp_dir(tmp_path / "linwei.gnucash")
+        assert other == override / "linwei.gnucash.mcp"
+        assert result != other
 
     def test_env_override_expands_tilde(self, monkeypatch):
         """GNUCASH_LOG_DIR=~/foo expands to the user's home."""
         monkeypatch.setenv("GNUCASH_LOG_DIR", "~/my-logs")
         result = resolve_mcp_dir("/anywhere/book.gnucash")
         assert "~" not in str(result)
-        assert str(result).endswith("my-logs")
+        assert str(result).endswith("my-logs/book.gnucash.mcp")
 
     @pytest.mark.skipif(
         os.name != "posix",
@@ -1474,7 +1479,7 @@ class TestResolveMcpDir:
             # Should not raise despite the world-writable
             # parent — env override bypasses the check.
             result = resolve_mcp_dir(tmp_path / "alex.gnucash")
-            assert result == override
+            assert result == override / "alex.gnucash.mcp"
         finally:
             if os.name == "posix":
                 os.chmod(tmp_path, 0o755)


### PR DESCRIPTION
## Summary
- GNUCASH_LOG_DIR now resolves to a per-book subdirectory ({log_dir}/{book}.mcp) — retires the v1.4 review's MB-3 (two books interleaving audit entries in one daily file under one book's header)
- Always per-book by rule, never sniffed from existing disk layout (a conditional reuse rule can never decide which book owns the flat files)
- Legacy flat files stay on disk untouched; --help documents the layout
- Implements the maintainer's 2026-07-07 design ruling from the v1.4 review triage

## Test plan
- [x] resolve_mcp_dir tests updated to the subdir contract (distinct dirs for distinct books under one override)
- [x] Live smoke: two books, one GNUCASH_LOG_DIR — separate audit dailies, separate backup chains, per-book state
- [x] Full suite green (1,786)