### PR TITLE
fix(i18n): Imbalance/Orphan matcher requires the exact word or -CUR shape

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1034,22 +1034,34 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         A non-zero balance on one of these is a structural defect the
         dashboard surfaces. Locale-robust: match by **structure** —
         type ``BANK``, a direct child of root (both invariants of how
-        GnuCash hangs these accounts) — plus a leading word from the
-        known Imbalance/Orphan catalog translations. Unknown locales
-        degrade to the English forms; the structural gate keeps false
-        positives off ordinary user accounts. (``Orphaned Gains`` is
-        deliberately excluded — it is type ``INCOME``, a legitimate
-        account, not a defect.)
+        GnuCash hangs these accounts) — plus the NAME SHAPE GnuCash
+        actually emits: a catalog word exactly, or the word plus a
+        ``-<CUR>`` mnemonic suffix (Scrub.cpp writes
+        ``_("Imbalance")-<currency>``). A bare prefix match is too
+        loose across ~100 pooled locale words: a legitimate root
+        BANK account named with an ordinary word from ANY locale
+        ("Açık Hesap", "Thừa kế…") was misclassified as suspense —
+        warned about on the dashboard and silently excluded from
+        runway/low-cash liquidity. The suffix is shape-checked
+        (short, no spaces), not compared to the account's own
+        commodity: real books contain e.g. an EUR-book
+        ``Imbalance-USD``. (``Orphaned Gains`` is deliberately
+        excluded — it is type ``INCOME``, a legitimate account, not
+        a defect.)
         """
         if account.type != "BANK":
             return False
         if account.parent is None or account.parent.guid != root.guid:
             return False
-        leaf = account.name.lower()
-        return any(
-            leaf.startswith(p)
-            for p in self._BALANCING_ACCOUNT_NAME_PREFIXES
-        )
+        leaf = account.name.strip().lower()
+        for p in self._BALANCING_ACCOUNT_NAME_PREFIXES:
+            if leaf == p:
+                return True
+            if leaf.startswith(p + "-"):
+                suffix = leaf[len(p) + 1:]
+                if 0 < len(suffix) <= 10 and suffix.isalnum():
+                    return True
+        return False
 
     # ── Book-locale inference + localized account names (§6.3) ────────
     #

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -630,6 +630,34 @@ class TestAutoBalancingAccountDetection:
                 by_name["Tagesgeld"], root
             )
 
+    def test_ordinary_word_prefix_not_misclassified(self, tmp_path):
+        """v1.4 review I18N-5: the pooled locale catalog contains
+        ordinary words ("Açık" is Turkish for open/deficit; "Thừa"
+        Vietnamese for surplus). A legitimate root BANK account merely
+        STARTING with one must not be classified as suspense — that
+        excluded it from runway/low-cash and warned on the dashboard.
+        Only the exact word or the word-<CUR> shape GnuCash emits
+        qualifies."""
+        path = tmp_path / "tr.gnucash"
+        self._make_book(path, [
+            ("Açık Hesap", "BANK", None),      # ordinary Turkish name
+            ("Thừa kế Fonu", "BANK", None),    # ordinary Vietnamese name
+            ("Açık", "BANK", None),            # exact catalog word: flagged
+            ("Açık-TRY", "BANK", None),        # GnuCash shape: flagged
+        ])
+        gb = GnuCashBook(str(path))
+        with gb.open() as b:
+            root = b.root_account
+            by_name = {a.name: a for a in b.accounts}
+            assert not gb._is_auto_balancing_account(
+                by_name["Açık Hesap"], root,
+            )
+            assert not gb._is_auto_balancing_account(
+                by_name["Thừa kế Fonu"], root,
+            )
+            assert gb._is_auto_balancing_account(by_name["Açık"], root)
+            assert gb._is_auto_balancing_account(by_name["Açık-TRY"], root)
+
     def test_structural_gate_excludes_nested_and_nonbank(self, tmp_path):
         path = tmp_path / "bal2.gnucash"
         self._make_book(path, [


### PR DESCRIPTION
## Summary
- Retires v1.4 review I18N-5: the pooled locale catalog's bare prefix match misclassified ordinary accounts (Turkish 'Açık Hesap', Vietnamese 'Thừa kế…') as suspense — dashboard warning + silent exclusion from runway/low-cash
- Match is now the exact catalog word or the word-<CUR> shape GnuCash emits; suffix shape-checked, not tied to the account's own commodity (EUR books legitimately carry Imbalance-USD)
- Implements the maintainer's 2026-07-07 ruling from the review triage

## Test plan
- [x] New regression: ordinary prefix names not flagged; exact word and word-CUR still flagged
- [x] All three sample oracles byte-identical across seven report surfaces
- [x] Full suite green (1,787)