### PR TITLE
chore: GB-1 bookkeeper-loop follow-ups (F2, F3, F5, F6, .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ htmlcov/
 samples/*.generated.gnucash
 samples/*.generated.gnucash.*
 samples/*.gnucash.mcp/
+# piecash writes {book}.<timestamp>.log next to the book on some
+# operations; the bare *.gnucash.log rule above doesn't match the
+# timestamped form under samples/ (where !samples/*.gnucash re-includes).
+samples/*.gnucash.*.log
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -404,8 +404,17 @@ session, the server snapshots your book to
 wrong, you can roll back to a known-good state without
 relying on Time Machine or your own habit. Backups are
 verified with `PRAGMA integrity_check` before being declared
-valid. See [docs/RESTORE_FROM_BACKUP.md](docs/RESTORE_FROM_BACKUP.md)
+valid, and skipped when the book hasn't changed since the
+last snapshot. See [docs/RESTORE_FROM_BACKUP.md](docs/RESTORE_FROM_BACKUP.md)
 for the rollback procedure.
+
+> **Reading timestamps:** backup *filenames* carry UTC
+> timestamps (filesystem-safe and unambiguous across travel
+> and DST); audit and debug logs use *local-dated* daily
+> files, matching how you'd search for "what happened
+> Tuesday." Near midnight these can differ by a day — the
+> `list_backups` tool always reports both the ISO timestamp
+> and a human age, so prefer it over eyeballing filenames.
 
 **Reconciled splits are protected.** The server refuses to
 delete or modify reconciled splits without an explicit
@@ -526,6 +535,17 @@ A condensed changelog of major releases lives in
 - Use full account paths: `Expenses:Groceries`, not just
   `Groceries`.
 - Or ask the assistant to list accounts: "List my accounts."
+
+### Multiple server processes after a client restart
+
+Claude Desktop (and some other MCP clients) may briefly spawn
+two or three copies of the server when relaunching. This is
+client behavior, not a server bug, and it's mostly harmless:
+the server opens your book per-request and releases the file
+lock between calls, so overlapping processes contend only for
+moments. If you see persistent `Lock on the file` errors after
+a client restart, quit the client fully, confirm with
+`pgrep -fl gnucash-mcp` that no strays remain, and relaunch.
 
 ### Something went wrong
 

--- a/specs/v1.5/README.md
+++ b/specs/v1.5/README.md
@@ -18,9 +18,8 @@ before picking it up.
   stem scoping (PR #115, hardened in #119), audit interleave via
   per-book `.mcp` subdirs under `GNUCASH_LOG_DIR` (PR #120). See
   `specs/v1.4/review/CODE_REVIEW_v1_4.md` MB-2/MB-3.
-- **`.gitignore` gap** — `samples/*.gnucash.<timestamp>.log`
-  isn't matched by the current `*.gnucash.log` rule, so those
-  files show as untracked. Tighten to `samples/*.gnucash.*.log`.
+- ~~**`.gitignore` gap**~~ — **CLOSED 2026-07-10** with the loop
+  follow-ups (`samples/*.gnucash.*.log`).
 
 ---
 
@@ -122,27 +121,22 @@ unscheduled.
 
 ## Maintenance / hygiene
 
-- **GB-1 bookkeeper-loop follow-ups** (2026-07-09 report,
-  `specs/v1.5/BOOKKEEPER_TEST_REPORT_GB1.md`; F1 was fixed on the
-  GB-1 branch itself):
-  - **F2** — validate-then-open: a write tool that fails input
-    validation still opened the book readonly=False, consuming the
-    monthly auto-backup trigger on a no-op. Move account/argument
-    resolution ahead of the write-mode open where feasible.
-  - **F3** — same-date price tie-break is undefined/undocumented:
-    two prices on one commodity/currency/date resolve by an
-    accident of query order (observed `user:market_data` beating
-    `user:price`). Define the rule (e.g. source priority, then
-    newest insertion) and document it in `_find_prices`.
-  - **F5** — timestamp conventions differ: backup filenames are
-    UTC, audit/debug day-files are local-dated. Label or unify.
-  - **F6** — README note: Claude Desktop may spawn 2-3 server
-    processes on relaunch; the open-per-request design limits
-    lock exposure, but the behavior should be documented.
-  - Reads-oddly: over-forgiving path normalization (a
-    `Users/...` entry without leading slash loaded), zero-total
-    categories dropped from group_by tables rather than shown as
-    0.00.
+- ~~**GB-1 bookkeeper-loop follow-ups**~~ — **CLOSED 2026-07-10**
+  on `chore/loop-followups` (F1 was fixed on the GB-1 branch
+  itself): **F2** via the identical-content skip (the hook can't
+  validate-then-open without a second book open per write, so an
+  unchanged book now advances the schedule without writing a
+  duplicate snapshot; anchor = book-file sha256 recorded in the
+  state file); **F3** via `_price_tie_rank` (manual quotes beat
+  feed sources on the same date, guid breaks residual ties —
+  applied in `_find_prices`, `_rates_as_of`, and
+  `_find_exchange_rate_aged`); **F5/F6** documented in README
+  (timestamp conventions; client multi-spawn); `.gitignore`
+  tightened for timestamped sample logs. Still open from the
+  reads-oddly ledger: over-forgiving path normalization (a
+  `Users/...` entry without leading slash loaded), zero-total
+  categories dropped from group_by tables rather than shown as
+  0.00.
 - **v1.4 review LOWs deliberately left open** (see
   `specs/v1.4/review/CODE_REVIEW_v1_4.md` for mechanisms): FX-1
   (`allow_after` inconsistency on cost-basis fallback legs — math

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -130,6 +130,24 @@ def _to_date(dt: date | datetime) -> date:
     return dt
 
 
+def _price_tie_rank(price) -> tuple:
+    """Deterministic tie-break key for prices sharing a date
+    (bookkeeper finding F3 — the winner used to be an accident of
+    query/iteration order, so posting math and month-close valuation
+    could flip between runs on books carrying same-date duplicates).
+
+    Higher tuple wins. Rule: a deliberate manual quote
+    (``user:price`` from create_price, ``user:price-editor`` from
+    GnuCash's editor) outranks feed/import sources
+    (``user:market-data``, ``Finance::Quote``, anything else); the
+    guid breaks residual ties — arbitrary but STABLE, which is the
+    property that matters.
+    """
+    source = getattr(price, "source", None) or ""
+    manual = 1 if source in ("user:price", "user:price-editor") else 0
+    return (manual, price.guid or "")
+
+
 def _is_market_price(price) -> bool:
     """True iff ``price`` is a real market quote, not a piecash
     auto-placeholder.
@@ -178,6 +196,11 @@ class CurrencyMixin:
         prices = list(q)
         if market_only:
             prices = [p for p in prices if _is_market_price(p)]
+        # Same-date ties resolve by _price_tie_rank, not row order.
+        prices.sort(
+            key=lambda p: (_to_date(p.date), _price_tie_rank(p)),
+            reverse=True,
+        )
         return prices
 
     @staticmethod
@@ -242,9 +265,13 @@ class CurrencyMixin:
                 continue
             key = p.commodity.guid
             existing = latest.get(key)
-            if existing is None or p_date > existing[0]:
-                latest[key] = (p_date, Decimal(str(p.value)))
-        result = {guid: rate for guid, (_d, rate) in latest.items()}
+            cand = (p_date, _price_tie_rank(p))
+            if existing is None or cand > (existing[0], existing[1]):
+                latest[key] = (p_date, _price_tie_rank(p),
+                               Decimal(str(p.value)))
+        result = {
+            guid: rate for guid, (_d, _rank, rate) in latest.items()
+        }
 
         # Chain pass for commodities the direct pass couldn't rate
         # (only priced commodities are candidates — no price, no leg).
@@ -779,11 +806,21 @@ class CurrencyMixin:
         # staleness window.
         cap_enabled = respect_staleness_cap and cap > 0
 
-        # Each candidate: (abs_age_days, rate, price_date).
-        best_before_direct: tuple[int, Decimal, date] | None = None
-        best_after_direct: tuple[int, Decimal, date] | None = None
-        best_before_inverse: tuple[int, Decimal, date] | None = None
-        best_after_inverse: tuple[int, Decimal, date] | None = None
+        # Each candidate: (abs_age_days, tie_rank, rate, price_date).
+        # Equal-distance candidates resolve by _price_tie_rank (F3) —
+        # a same-date duplicate must not make posting math depend on
+        # iteration order.
+        best_before_direct: tuple | None = None
+        best_after_direct: tuple | None = None
+        best_before_inverse: tuple | None = None
+        best_after_inverse: tuple | None = None
+
+        def _better(days: int, rank: tuple, best: tuple | None) -> bool:
+            if best is None:
+                return True
+            if days != best[0]:
+                return days < best[0]
+            return rank > best[1]
 
         for p in book.prices:
             if not _is_market_price(p):
@@ -798,12 +835,13 @@ class CurrencyMixin:
                 rate = Decimal(str(p.value))
                 if rate <= 0:
                     continue
+                rank = _price_tie_rank(p)
                 if days >= 0:
-                    if best_before_direct is None or days < best_before_direct[0]:
-                        best_before_direct = (days, rate, p_date)
+                    if _better(days, rank, best_before_direct):
+                        best_before_direct = (days, rank, rate, p_date)
                 else:
-                    if best_after_direct is None or -days < best_after_direct[0]:
-                        best_after_direct = (-days, rate, p_date)
+                    if _better(-days, rank, best_after_direct):
+                        best_after_direct = (-days, rank, rate, p_date)
             elif p.commodity == to_commodity and p.currency == from_commodity:
                 days = (as_of - p_date).days
                 if days < 0 and not allow_after:
@@ -813,12 +851,13 @@ class CurrencyMixin:
                 if Decimal(str(p.value)) <= 0:
                     continue
                 rate = Decimal("1") / Decimal(str(p.value))
+                rank = _price_tie_rank(p)
                 if days >= 0:
-                    if best_before_inverse is None or days < best_before_inverse[0]:
-                        best_before_inverse = (days, rate, p_date)
+                    if _better(days, rank, best_before_inverse):
+                        best_before_inverse = (days, rank, rate, p_date)
                 else:
-                    if best_after_inverse is None or -days < best_after_inverse[0]:
-                        best_after_inverse = (-days, rate, p_date)
+                    if _better(-days, rank, best_after_inverse):
+                        best_after_inverse = (-days, rank, rate, p_date)
 
         for candidate in (
             best_before_direct,
@@ -827,6 +866,6 @@ class CurrencyMixin:
             best_after_inverse,
         ):
             if candidate is not None:
-                age_days, rate, p_date = candidate
+                age_days, _rank, rate, p_date = candidate
                 return (rate, age_days, p_date)
         return None

--- a/src/gnucash_mcp/book/backup.py
+++ b/src/gnucash_mcp/book/backup.py
@@ -207,10 +207,27 @@ def _read_state(backups_dir: Path, stem: str) -> dict[str, datetime]:
     return result
 
 
+def _read_book_hash(backups_dir: Path, stem: str) -> str | None:
+    """The ``book_sha256`` recorded by the last auto-backup, or None
+    (pre-upgrade state file, or none recorded). Same file-resolution
+    rules as ``_read_state``."""
+    path = _state_path(backups_dir, stem)
+    if not path.exists() and not os.environ.get("GNUCASH_LOG_DIR"):
+        path = backups_dir / ".state.json"
+    try:
+        with path.open() as f:
+            return json.load(f).get("book_sha256")
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+
 def _write_state(
     backups_dir: Path, stem: str, state: dict[str, datetime],
+    book_sha256: str | None = None,
 ) -> None:
-    """Persist ``last_backup_by_stage`` to disk."""
+    """Persist ``last_backup_by_stage`` (and, when provided, the
+    sha256 of the BOOK file at backup time — the identical-content
+    skip's comparison anchor) to disk."""
     backups_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "version": 1,
@@ -219,6 +236,8 @@ def _write_state(
             for stage, ts in state.items()
         },
     }
+    if book_sha256 is not None:
+        payload["book_sha256"] = book_sha256
     path = _state_path(backups_dir, stem)
     # Write via a temp + rename so a partial write never leaves a
     # corrupted state file.
@@ -380,6 +399,48 @@ class BackupMixin:
         backups dir, so the basename round-trips cleanly.)
         """
         return self._backups_dir() / Path(entry["path"]).name
+
+    def _current_book_hash(self) -> str | None:
+        """sha256 of the book file's bytes right now, or None on any
+        read error (callers fail toward taking a backup)."""
+        import hashlib
+
+        try:
+            return hashlib.sha256(
+                Path(self.book_path).read_bytes()
+            ).hexdigest()
+        except OSError as e:
+            debug_logger.warning(f"Book hash failed: {e}")
+            return None
+
+    def _book_unchanged_since_last_backup(
+        self, current_hash: str | None,
+    ) -> bool:
+        """True iff the book's bytes match the hash the last
+        auto-backup recorded AND at least one snapshot still exists.
+
+        The comparison anchor is the BOOK file's own hash at backup
+        time (recorded in the state file), not the snapshot's bytes —
+        SQLite's online-backup API legitimately produces a different
+        page layout, so book-vs-snapshot comparison always differs.
+        Manual backups don't update the anchor; the cost is one
+        redundant auto snapshot after a manual backup, the safe
+        direction. Missing anchor (pre-upgrade state) reads as
+        "changed".
+        """
+        if current_hash is None:
+            return False
+        try:
+            recorded = _read_book_hash(self._backups_dir(),
+                                       self.book_path.stem)
+            if recorded is None or recorded != current_hash:
+                return False
+            return bool(self.list_backups())
+        except Exception as e:  # noqa: BLE001 — fail toward backing up
+            debug_logger.warning(
+                f"Backup identity check failed (backing up anyway): {e}"
+            )
+            return False
 
     # ── Core primitive: create a backup ──────────────────────────
 
@@ -755,15 +816,36 @@ class BackupMixin:
                 # the chain is healthy and recent.
                 return
 
-            # Take ONE backup tagged with the highest-priority due
-            # stage. Advance every due stage's timestamp so multiple
-            # stages don't each trigger their own separate backup.
-            highest = due_stages[0]
-            self.create_backup(stage=highest.name, label=None)
+            # Content-aware skip (bookkeeper finding F2): the audit
+            # decorator fires this hook before the tool body runs, so
+            # a write that later fails validation still lands here —
+            # and duplicated a multi-MB snapshot for a no-op. True
+            # validate-then-open would need a second book open per
+            # write (the perf sin the project eliminated); instead,
+            # when the book's bytes match the newest existing
+            # snapshot, the protection a new backup would add already
+            # exists — advance the schedule without writing a
+            # duplicate file. Comparison failure of any kind falls
+            # through to a normal backup (today's behavior — the
+            # fail-safe direction).
+            current_hash = self._current_book_hash()
+            if self._book_unchanged_since_last_backup(current_hash):
+                debug_logger.info(
+                    "Auto-backup skipped: book content unchanged "
+                    "since the last snapshot; stages advanced."
+                )
+            else:
+                # Take ONE backup tagged with the highest-priority
+                # due stage. Advance every due stage's timestamp so
+                # multiple stages don't each trigger their own
+                # separate backup.
+                highest = due_stages[0]
+                self.create_backup(stage=highest.name, label=None)
             new_state = dict(state)
             for s in due_stages:
                 new_state[s.name] = now
-            _write_state(backups_dir, stem, new_state)
+            _write_state(backups_dir, stem, new_state,
+                         book_sha256=current_hash)
 
             # Prune each auto stage to its keep_last_n.
             self._prune_auto_stages()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -937,3 +937,62 @@ class TestSharedLogDirScoping:
         created.rename(upper)
         listed = book.list_backups()
         assert len(listed) == 1, "case-flipped stem orphaned the backup"
+
+
+class TestIdenticalContentSkip:
+    """Bookkeeper finding F2: the auto-backup hook fires before the
+    tool body runs, so a write that fails validation still triggered
+    a full snapshot — duplicating multi-MB content for a no-op. When
+    the book's bytes match the newest existing snapshot, the hook now
+    advances the schedule without writing a duplicate file."""
+
+    @staticmethod
+    def _rewind_stages(book, test_book):
+        """Make every stage due again while preserving the recorded
+        book hash — simulating a later process on an unchanged book."""
+        from gnucash_mcp.book.backup import (
+            _read_book_hash, _write_state,
+        )
+        backups_dir = book._backups_dir()
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+        _write_state(
+            backups_dir, test_book.stem,
+            {s: old for s in ("session", "weekly", "monthly")},
+            book_sha256=_read_book_hash(backups_dir, test_book.stem),
+        )
+        book._backup_checked_in_process = False
+
+    def test_identical_content_skips_duplicate_snapshot(
+        self, test_book: Path,
+    ):
+        book = GnuCashBook(str(test_book))
+        # First auto pass takes the real snapshot + records the anchor.
+        book._maybe_auto_backup()
+        assert len(book.list_backups()) == 1
+
+        # Later process, everything due again, content unchanged.
+        self._rewind_stages(book, test_book)
+        book._maybe_auto_backup()
+
+        assert len(book.list_backups()) == 1, (
+            "duplicate snapshot written for unchanged content"
+        )
+        # The schedule still advanced.
+        state = _read_state(book._backups_dir(), test_book.stem)
+        now = datetime.now(timezone.utc)
+        assert all((now - ts).days < 1 for ts in state.values())
+
+    def test_changed_content_still_backs_up(self, test_book: Path):
+        book = GnuCashBook(str(test_book))
+        book._maybe_auto_backup()
+        assert len(book.list_backups()) == 1
+
+        # Mutate the book through the real write path, rewind, retry.
+        book.create_account(
+            name="F2 Probe", account_type="EXPENSE", parent="Expenses",
+        )
+        self._rewind_stages(book, test_book)
+        book._maybe_auto_backup()
+        assert len(book.list_backups()) == 2, (
+            "changed content must still take a real snapshot"
+        )

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -385,3 +385,34 @@ def test_market_value_cost_basis_converts_foreign_purchase(tmp_path):
         assert "no price data" in note
         # 1000 EUR x 1.20 = 1200 USD, not a raw 1000.
         assert value == Decimal("1200.00")
+
+
+class TestSameDatePriceTieBreak:
+    """Bookkeeper finding F3: two prices on the same
+    commodity/currency/date used to resolve by an accident of query
+    order — posting math and month-close valuation could flip between
+    runs. The rule is now deliberate: a manual quote (user:price /
+    user:price-editor) outranks feed sources; guid breaks residual
+    ties (arbitrary but stable)."""
+
+    def test_manual_quote_beats_feed_on_same_date(
+        self, multi_currency_book,
+    ):
+        from datetime import date
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 3, 31)
+        # Insert feed first, manual second AND manual first, feed
+        # second on a different date — order must not matter.
+        gc.create_price("EUR", "CURRENCY", "1.30", price_date=d,
+                        source="user:market-data")
+        gc.create_price("EUR", "CURRENCY", "1.10", price_date=d,
+                        source="user:price")
+        with gc.open(readonly=True) as book:
+            eur = book.commodities(mnemonic="EUR")
+            usd = book.default_currency
+            rate = gc._find_exchange_rate(book, eur, usd, d)
+            assert rate == Decimal("1.10"), (
+                f"manual quote must win the same-date tie, got {rate}"
+            )
+            rates = gc._rates_as_of(book, d)
+            assert rates[eur.guid] == Decimal("1.10")


### PR DESCRIPTION
## Summary
Closes the fixable findings from the 2026-07-09 bookkeeper test report (specs/v1.5/BOOKKEEPER_TEST_REPORT_GB1.md), in value order:
- **F2** — the auto-backup hook fires before tool-body validation, so a failed write duplicated a multi-MB snapshot for a no-op. Validate-then-open would need a second book open per write (the eliminated perf sin); instead the hook records the book file's sha256 at backup time and, when the book is unchanged and a snapshot exists, advances the schedule without writing a duplicate. Anchor is the book's own bytes (the online-backup API legitimately produces different page layout, so book-vs-snapshot comparison is the wrong oracle — learned by test). Any comparison failure falls through to a normal backup.
- **F3** — same-date price ties resolved by an accident of query order (the loop observed a feed price beating the manual quote, 355.29 vs 325.00). Now deliberate and shared via `_price_tie_rank`: manual quotes (user:price, user:price-editor) outrank feed sources; guid breaks residual ties, stably. Applied at all three tie sites (`_find_prices`, `_rates_as_of`, `_find_exchange_rate_aged`).
- **.gitignore** — `samples/*.gnucash.*.log` timestamped piecash logs no longer show untracked
- **F5** — README documents the timestamp conventions (backup filenames UTC, log day-files local-dated) and why
- **F6** — README troubleshooting covers client multi-spawn on relaunch

## Test plan
- [x] F2: identical-content skip + changed-content-still-backs-up tests
- [x] F3: same-date manual-beats-feed regression, insertion-order independent
- [x] All three sample oracles byte-identical across seven report surfaces (F3 tie-break causes zero drift on shipped books)
- [x] Full suite green (1,793)