### PR TITLE
Memoize price lookups and preload the split graph for get_book_summary

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1630,6 +1630,37 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         return guids
 
     @staticmethod
+    def _preload_split_graph(book) -> None:
+        """Bulk-load accounts, transactions and their split collections,
+        so that later traversals of ``txn.splits``, ``split.transaction``
+        and ``split.account`` resolve in memory instead of lazy-loading
+        per row. Intended for whole-book reports; a single-account lookup
+        would load rows it never touches.
+
+        The loaded rows are parked on the book deliberately: SQLAlchemy's
+        identity map holds them only weakly, so without a strong
+        reference they would be collected immediately and every traversal
+        would query again. The reference lives as long as the book, i.e.
+        one ``open()`` context.
+        """
+        from piecash.core.account import Account
+        from piecash.core.transaction import Transaction
+        from sqlalchemy.orm import selectinload
+
+        if getattr(book, "_gnucash_mcp_split_graph", None) is not None:
+            return
+
+        accounts = (
+            book.session.query(Account).options(selectinload(Account.splits)).all()
+        )
+        transactions = (
+            book.session.query(Transaction)
+            .options(selectinload(Transaction.splits))
+            .all()
+        )
+        book._gnucash_mcp_split_graph = (accounts, transactions)
+
+    @staticmethod
     def _is_template_transaction(txn, template_guids: set) -> bool:
         """True iff ``txn`` is a scheduled-transaction template recipe.
 

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -170,6 +170,27 @@ class CurrencyMixin:
     the reporting mixin is absent.
     """
 
+    # These caches are hung on the piecash Book as plain Python
+    # attributes. They are not mapped columns, so they are never
+    # persisted. A Book instance only exists for the duration of a
+    # single ``open()`` context — one tool call — so a cache cannot
+    # go stale across calls; ``_invalidate_price_caches`` covers the
+    # one path that mutates prices mid-call.
+    _PRICE_LOOKUPS_ATTR = "_gnucash_mcp_price_lookups"
+    _PRICE_COMMODITIES_ATTR = "_gnucash_mcp_price_commodities"
+
+    @staticmethod
+    def _invalidate_price_caches(book: piecash.Book) -> None:
+        """Drop the memoized price lookups. Call this after adding or
+        deleting a Price so that a later lookup in the same call sees
+        the change."""
+        for attr in (
+            CurrencyMixin._PRICE_LOOKUPS_ATTR,
+            CurrencyMixin._PRICE_COMMODITIES_ATTR,
+        ):
+            if hasattr(book, attr):
+                delattr(book, attr)
+
     @staticmethod
     def _find_prices(
         book: piecash.Book,
@@ -184,24 +205,48 @@ class CurrencyMixin:
         ``commodity_guid`` filters the held instrument,
         ``currency_guid`` the quote side; ``market_only`` (default)
         skips ``type='transaction'`` auto-placeholders.
-        """
-        from piecash.core.commodity import Price
 
-        q = book.session.query(Price)
-        if commodity_guid is not None:
-            q = q.filter(Price.commodity_guid == commodity_guid)
-        if currency_guid is not None:
-            q = q.filter(Price.currency_guid == currency_guid)
-        q = q.order_by(Price.date.desc())
-        prices = list(q)
+        Memoized per ``(commodity_guid, currency_guid)`` on the open
+        book: the first request for a pair runs one indexed query,
+        and every repeat is a dict hit. The pivot search requests the
+        same handful of pairs once per candidate leg per commodity,
+        so without the memo a whole-book report re-runs identical
+        queries thousands of times; with it the query count is
+        bounded by the number of DISTINCT pairs requested, not by the
+        number of calls. Empty results are memoized too — most
+        candidate pivot legs have no prices, and re-discovering that
+        per leg is most of the repetition. A one-shot caller still
+        costs exactly one indexed query.
+        """
+        lookups = getattr(book, CurrencyMixin._PRICE_LOOKUPS_ATTR, None)
+        if lookups is None:
+            lookups = {}
+            setattr(book, CurrencyMixin._PRICE_LOOKUPS_ATTR, lookups)
+
+        key = (commodity_guid, currency_guid)
+        prices = lookups.get(key)
+        if prices is None:
+            from piecash.core.commodity import Price
+
+            q = book.session.query(Price)
+            if commodity_guid is not None:
+                q = q.filter(Price.commodity_guid == commodity_guid)
+            if currency_guid is not None:
+                q = q.filter(Price.currency_guid == currency_guid)
+            prices = list(q)
+            # Newest first, with same-date ties resolved by
+            # _price_tie_rank rather than row order (see its
+            # docstring for the rule). Sorted once, at memoization
+            # time, so every consumer sees the same ordering.
+            prices.sort(
+                key=lambda p: (_to_date(p.date), _price_tie_rank(p)),
+                reverse=True,
+            )
+            lookups[key] = prices
+
         if market_only:
-            prices = [p for p in prices if _is_market_price(p)]
-        # Same-date ties resolve by _price_tie_rank, not row order.
-        prices.sort(
-            key=lambda p: (_to_date(p.date), _price_tie_rank(p)),
-            reverse=True,
-        )
-        return prices
+            return [p for p in prices if _is_market_price(p)]
+        return list(prices)
 
     @staticmethod
     def _anchor_for_as_of(as_of: date) -> date:
@@ -308,16 +353,25 @@ class CurrencyMixin:
         and still needs chaining. Returned in a stable order (by
         namespace then mnemonic) so the chain pass is deterministic.
         """
+        cached = getattr(book, CurrencyMixin._PRICE_COMMODITIES_ATTR, None)
+        if cached is not None:
+            return cached
+
         seen: dict[str, piecash.Commodity] = {}
         for p in book.prices:
             if not _is_market_price(p):
                 continue
             for c in (p.commodity, p.currency):
                 seen.setdefault(c.guid, c)
-        return sorted(
+        result = sorted(
             seen.values(),
             key=lambda c: (c.namespace or "", c.mnemonic or ""),
         )
+        # Memoized because the pivot search would otherwise recompute
+        # this full-price-walk once per candidate leg, and the result
+        # only depends on the book.
+        setattr(book, CurrencyMixin._PRICE_COMMODITIES_ATTR, result)
+        return result
 
     def _pivot_currencies(
         self,
@@ -822,42 +876,54 @@ class CurrencyMixin:
                 return days < best[0]
             return rank > best[1]
 
-        for p in book.prices:
-            if not _is_market_price(p):
-                continue
+        # Only prices quoting this exact pair can match, so fetch
+        # just the two pair lists (direct, then inverse) rather than
+        # walking every price in the book: the pivot search calls
+        # this once per candidate leg, and a full walk here would
+        # re-read the whole price table per leg.
+        for p in CurrencyMixin._find_prices(
+            book,
+            commodity_guid=from_commodity.guid,
+            currency_guid=to_commodity.guid,
+        ):
             p_date = _to_date(p.date)
-            if p.commodity == from_commodity and p.currency == to_commodity:
-                days = (as_of - p_date).days
-                if days < 0 and not allow_after:
-                    continue
-                if cap_enabled and abs(days) > cap:
-                    continue
-                rate = Decimal(str(p.value))
-                if rate <= 0:
-                    continue
-                rank = _price_tie_rank(p)
-                if days >= 0:
-                    if _better(days, rank, best_before_direct):
-                        best_before_direct = (days, rank, rate, p_date)
-                else:
-                    if _better(-days, rank, best_after_direct):
-                        best_after_direct = (-days, rank, rate, p_date)
-            elif p.commodity == to_commodity and p.currency == from_commodity:
-                days = (as_of - p_date).days
-                if days < 0 and not allow_after:
-                    continue
-                if cap_enabled and abs(days) > cap:
-                    continue
-                if Decimal(str(p.value)) <= 0:
-                    continue
-                rate = Decimal("1") / Decimal(str(p.value))
-                rank = _price_tie_rank(p)
-                if days >= 0:
-                    if _better(days, rank, best_before_inverse):
-                        best_before_inverse = (days, rank, rate, p_date)
-                else:
-                    if _better(-days, rank, best_after_inverse):
-                        best_after_inverse = (-days, rank, rate, p_date)
+            days = (as_of - p_date).days
+            if days < 0 and not allow_after:
+                continue
+            if cap_enabled and abs(days) > cap:
+                continue
+            rate = Decimal(str(p.value))
+            if rate <= 0:
+                continue
+            rank = _price_tie_rank(p)
+            if days >= 0:
+                if _better(days, rank, best_before_direct):
+                    best_before_direct = (days, rank, rate, p_date)
+            else:
+                if _better(-days, rank, best_after_direct):
+                    best_after_direct = (-days, rank, rate, p_date)
+
+        for p in CurrencyMixin._find_prices(
+            book,
+            commodity_guid=to_commodity.guid,
+            currency_guid=from_commodity.guid,
+        ):
+            p_date = _to_date(p.date)
+            days = (as_of - p_date).days
+            if days < 0 and not allow_after:
+                continue
+            if cap_enabled and abs(days) > cap:
+                continue
+            if Decimal(str(p.value)) <= 0:
+                continue
+            rate = Decimal("1") / Decimal(str(p.value))
+            rank = _price_tie_rank(p)
+            if days >= 0:
+                if _better(days, rank, best_before_inverse):
+                    best_before_inverse = (days, rank, rate, p_date)
+            else:
+                if _better(-days, rank, best_after_inverse):
+                    best_after_inverse = (-days, rank, rate, p_date)
 
         for candidate in (
             best_before_direct,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2008,6 +2008,10 @@ class CoreMixin:
         from piecash.core.transaction import ScheduledTransaction
 
         with self.open(readonly=True) as book:
+            # Whole-book report: every pass below traverses splits, so
+            # load the graph once instead of lazily per traversal.
+            self._preload_split_graph(book)
+
             default_currency = self._require_default_currency(book)
             currency = default_currency.mnemonic
 

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -304,6 +304,7 @@ class InvestmentsMixin:
                 )
 
             book.save()
+            self._invalidate_price_caches(book)
 
             result = {
                 "commodity": commodity,
@@ -399,6 +400,7 @@ class InvestmentsMixin:
 
             book.session.delete(target)
             book.save()
+            self._invalidate_price_caches(book)
 
             return result
 

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -416,3 +416,73 @@ class TestSameDatePriceTieBreak:
             )
             rates = gc._rates_as_of(book, d)
             assert rates[eur.guid] == Decimal("1.10")
+
+
+class TestPriceLookupMemo:
+    """_find_prices memoizes each (commodity_guid, currency_guid)
+    lookup on the open book: the first request queries, repeats are
+    dict hits. The memoized result must match a fresh query exactly,
+    including the same-date tie-break (bookkeeper finding F3, see
+    TestSameDatePriceTieBreak above) — a memo sorted on date alone
+    would put same-date ties back to depending on row order, which
+    is the bug F3 fixed."""
+
+    def test_repeat_lookups_agree_and_are_memoized(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 3, 31)
+        gc.create_price("EUR", "CURRENCY", "1.30", price_date=d,
+                        source="user:market-data")
+        gc.create_price("EUR", "CURRENCY", "1.10", price_date=d,
+                        source="user:price")
+
+        with gc.open(readonly=True) as book:
+            eur = book.commodities(mnemonic="EUR")
+            usd = book.default_currency
+
+            first = gc._find_prices(book, commodity_guid=eur.guid,
+                                    currency_guid=usd.guid)
+            # The pair is memoized now; the repeat is a dict hit.
+            memo = getattr(book, gc._PRICE_LOOKUPS_ATTR)
+            assert (eur.guid, usd.guid) in memo
+            repeat = gc._find_prices(book, commodity_guid=eur.guid,
+                                     currency_guid=usd.guid)
+
+            assert [p.guid for p in first] == [p.guid for p in repeat], (
+                "memoized lookups must return the same prices "
+                "in the same order as the first query"
+            )
+            # The manual quote wins the same-date tie on both.
+            assert first[0].value == Decimal("1.10")
+            assert repeat[0].value == Decimal("1.10")
+
+    def test_price_written_mid_call_is_visible_after_invalidation(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 4, 30)
+
+        with gc.open(readonly=False) as book:
+            eur = book.commodities(mnemonic="EUR")
+            usd = book.default_currency
+
+            # Memoize the pair, so a later read would be served
+            # from the memo.
+            before = gc._find_prices(book, commodity_guid=eur.guid,
+                                     currency_guid=usd.guid)
+
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd, date=d,
+                value=Decimal("1.42"), source="user:price",
+            ))
+            book.save()
+            gc._invalidate_price_caches(book)
+
+            after = gc._find_prices(book, commodity_guid=eur.guid,
+                                    currency_guid=usd.guid)
+            assert len(after) == len(before) + 1
+            assert after[0].value == Decimal("1.42"), (
+                "a price added mid-call must be visible once the "
+                "caches are invalidated"
+            )


### PR DESCRIPTION
## Summary

- On a large real book (509 accounts, 14,466 transactions, 32,976 splits, 10,718 prices, GBP default, 10 commodities needing an FX pivot), `get_book_summary` never completed - killed after 6 minutes at 100% CPU. Profiling put nearly all of the time in two places: price-history scans and lazy split loading. One commit each.
- Price scans: each rate lookup walked the whole stored price history, and pivot triangulation repeated that walk once per candidate leg, so the cost grew as (prices x commodities x legs). `_find_prices` now memoizes each `(commodity_guid, currency_guid)` lookup on the open book - the first ask runs one indexed query (so a one-shot caller is unchanged), every repeat is a dict hit. Empty results are memoized too, since most candidate legs have none. Query count is then bounded by distinct pairs asked (~300 here), not calls made (tens of thousands). `_find_exchange_rate_aged` asks for the direct and inverse pairs instead of filtering the whole table, and `_commodities_with_market_prices` is memoised per book.
- Split loading: each report pass fetched a transaction's splits with its own query, tens of thousands of round-trips per run. `_preload_split_graph` bulk-loads accounts and transactions with `selectinload` on their splits, called only from the whole-book report. Together the two commits take a `get_book_summary` run on that book from not completing to under 10 s (1,040 SQL statements); the preload alone does not finish, so the commit order matters.
- Selection semantics are unchanged, including the F3 same-date tie-break from 8e0114d - the memo sorts each pair's list on the same key.
- The memo is a plain attribute on the `Book`, never persisted, and a `Book` lasts one `open()` context, so it cannot go stale across calls. `create_price` and `delete_price` - the only paths that add or remove a `Price` - invalidate it for reads later in the same call.

## Test plan

- [x] Full suite passes: `uv run --extra dev pytest -q` - 1,795 passed (the prior 1,793 plus the two new tests below).
- [x] `get_book_summary` output is byte-identical before and after on all three sample oracles (Alex, Lin Wei, Sabine), captured back-to-back so date-relative content cannot drift.
- [x] New regression test: a repeated `_find_prices` lookup is served from the memo and matches the first query exactly, F3 tie-break included.
- [x] New regression test: a `Price` written mid-call is visible to a later `_find_prices` once `_invalidate_price_caches` has run.
- [x] A single cold `_find_prices` lookup measures ~4 ms before and after.
- [x] Live validation against a real server on the feature branch (test copy of a large multi-currency book): `get_book_summary` returns in seconds where it previously never completed, balance sheet / net worth / flow reports agree with pre-change values, and a `create_price` -> `get_latest_price` -> `delete_price` round trip behaves correctly.
