### PR TITLE
fix(scheduling): persist SX description; fix instantiation audit

### DIFF
--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -813,6 +813,7 @@ class SchedulingMixin:
         response = {
             "transaction_guid": txn_result.get("guid"),
             "scheduled_transaction": sx_name,
+            "description": sx_description,
             "transaction_date": txn_date.isoformat(),
             "instance_count": instance_count,
             "status": txn_result.get("status", "created"),

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -165,6 +165,23 @@ class SchedulingMixin:
             "auto_create": bool(sx.auto_create),
         }
 
+    def _get_sx_slot_string(
+        self, book, obj_guid: str, name: str,
+    ) -> str | None:
+        """Read a string slot off a ScheduledTransaction via raw SQL.
+
+        Raw SQL because the Slot ORM has polymorphic-relationship
+        conflicts on reads (see the piecash gotchas in CLAUDE.md).
+        """
+        row = book.session.execute(
+            text(
+                "SELECT string_val FROM slots "
+                "WHERE obj_guid = :guid AND name = :name"
+            ),
+            {"guid": obj_guid, "name": name},
+        ).first()
+        return row[0] if row else None
+
     def _get_sx_splits(self, book, sx) -> list[dict]:
         """Read split templates from the scheduled transaction's slot.
 
@@ -173,16 +190,23 @@ class SchedulingMixin:
         """
         import json
 
-        row = book.session.execute(
-            text(
-                "SELECT string_val FROM slots "
-                "WHERE obj_guid = :guid AND name = :name"
-            ),
-            {"guid": sx.guid, "name": "splits-json"},
-        ).first()
-        if row:
-            return json.loads(row[0])
+        raw = self._get_sx_slot_string(book, sx.guid, "splits-json")
+        if raw:
+            return json.loads(raw)
         return []
+
+    def _get_sx_description(self, book, sx) -> str:
+        """Instantiation description for a scheduled transaction.
+
+        MCP-created templates store it in a ``description`` slot
+        (bare key — universal financial concept). Templates from
+        before the slot existed have no row and fall back to the
+        SX name, which is what instantiation always used to use.
+        """
+        return (
+            self._get_sx_slot_string(book, sx.guid, "description")
+            or sx.name
+        )
 
     def _find_scheduled_transaction(self, book, guid: str):
         """Find a scheduled transaction by GUID (supports partial GUIDs, 8+ chars)."""
@@ -357,6 +381,25 @@ class SchedulingMixin:
                     f"Splits slot for scheduled transaction '{name}'",
                 )
 
+                # Instantiation description — read back by
+                # _get_sx_description, which falls back to the SX
+                # name when the slot is absent (pre-slot templates).
+                if description:
+                    book.session.execute(
+                        Slot.__table__.insert().values(
+                            obj_guid=sx_guid,
+                            name="description",
+                            slot_type=KVP_Type.KVP_TYPE_STRING,
+                            string_val=description,
+                        )
+                    )
+                    _verify_composite_write(
+                        book.session, Slot.__table__,
+                        {"obj_guid": sx_guid, "name": "description"},
+                        f"Description slot for scheduled "
+                        f"transaction '{name}'",
+                    )
+
                 book.save()
             except Exception:
                 # Clean up the orphan template; swallow cleanup
@@ -426,6 +469,13 @@ class SchedulingMixin:
                     continue
                 d = self._sx_to_dict(sx)
                 if not compact:
+                    # Only when a slot exists — echoing the name
+                    # back as "description" would just be noise.
+                    desc = self._get_sx_slot_string(
+                        book, sx.guid, "description",
+                    )
+                    if desc and desc != sx.name:
+                        d["description"] = desc
                     d["splits"] = self._get_sx_splits(book, sx)
                 results.append(d)
 
@@ -725,10 +775,11 @@ class SchedulingMixin:
                 )
 
             sx_name = sx.name
+            sx_description = self._get_sx_description(book, sx)
 
         # ── Phase 2: create the transaction (see docstring). ─────
         txn_result = self.create_transaction(
-            description=sx_name,
+            description=sx_description,
             splits=splits,
             trans_date=txn_date,
         )
@@ -864,18 +915,19 @@ class SchedulingMixin:
                 "status": "deleted",
             }
 
-            # splits-json slot deleted via Core.
+            # All SX-owned slots (splits-json, description) deleted
+            # via Core — the parent row is going away, so anything
+            # left keyed on its GUID would be an orphan.
             book.session.execute(
                 Slot.__table__.delete().where(
-                    (Slot.__table__.c.obj_guid == sx.guid)
-                    & (Slot.__table__.c.name == "splits-json")
+                    Slot.__table__.c.obj_guid == sx.guid
                 )
             )
             _verify_delete(
                 book.session,
                 Slot.__table__,
-                {"obj_guid": sx.guid, "name": "splits-json"},
-                f"Splits slot for scheduled transaction '{result['name']}'",
+                {"obj_guid": sx.guid},
+                f"Slots for scheduled transaction '{result['name']}'",
             )
 
             template_acct = sx.template_account

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1703,6 +1703,9 @@ def _fmt_scheduled_transaction_create(entry: dict) -> list[str]:
     after = entry.get("after_state") or {}
     name = after.get("name", params.get("name", ""))
     lines = [f'{time_part}  CREATE SCHEDULED  "{name}"']
+    description = params.get("description", "")
+    if description and description != name:
+        lines.append(f"{_INDENT}description: {description}")
     freq = after.get("frequency", params.get("frequency", ""))
     start = params.get("start_date", "")
     end = params.get("end_date", "")

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -536,6 +536,39 @@ def _fmt_transaction_create(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_transaction_create_from_scheduled(entry: dict) -> list[str]:
+    """SX instantiation — the response carries ``transaction_guid``
+    (not ``guid``), so the generic transaction handler would fall
+    back to the params GUID, which is the SCHEDULE's. Read the
+    response fields directly instead.
+    """
+    time_part = _extract_time(entry)
+    after = entry.get("after_state") or {}
+    sx_name = after.get("scheduled_transaction", "")
+    date_str = after.get("transaction_date", "")
+
+    if after.get("status") == "rejected":
+        # Duplicate already posted for this period — the schedule
+        # advanced but no transaction was written.
+        return [
+            f"{time_part}  CREATE FROM SCHEDULED  \"{sx_name}\" "
+            f"({date_str})",
+            f"{_INDENT}rejected: equivalent transaction already "
+            f"exists for this period",
+        ]
+
+    guid = after.get("transaction_guid", "")
+    desc = after.get("description", "")
+    lines = [f"{time_part}  CREATE FROM SCHEDULED  guid:{guid}"]
+    lines.append(f'{_INDENT}"{desc}" ({date_str})')
+    detail = f'schedule: "{sx_name}"'
+    instance = after.get("instance_count")
+    if instance:
+        detail += f"  instance #{instance}"
+    lines.append(f"{_INDENT}{detail}")
+    return lines
+
+
 def _parse_audit_tsv_rows(tsv: str) -> list[dict]:
     """Header-bearing TSV string -> row dicts (display-only)."""
     if not tsv:
@@ -1773,6 +1806,8 @@ def _fmt_scheduled_transaction_delete(entry: dict) -> list[str]:
 
 _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("transaction", "CREATE"): _fmt_transaction_create,
+    ("transaction", "CREATE_FROM_SCHEDULED"):
+        _fmt_transaction_create_from_scheduled,
     ("transaction", "CREATE_BATCH"): _fmt_transaction_create_batch,
     ("transaction", "UPDATE"): _fmt_transaction_update,
     ("transaction", "VOID"): _fmt_transaction_void,

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -532,6 +532,7 @@ def register(mcp, get_book) -> None:
             splits: List of split updates with 'account' and 'amount' (optional).
                     Must match existing splits by account name and balance to zero.
                     For cross-currency splits, include 'quantity' (amount in account's commodity).
+                    Include 'memo' to set that split's memo (omit to leave it unchanged).
                     ``amount``/``quantity`` are decimal strings (e.g. "94.87").
             notes: New transaction notes (optional). Pass empty string to clear.
             force: Allow modifying transactions with reconciled splits

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -116,7 +116,10 @@ def register(mcp, get_book) -> None:
 
     @mcp.tool()
     @safe_tool
-    @audit_log(classification="write", operation="create", entity_type="transaction")
+    @audit_log(
+        classification="write", operation="create_from_scheduled",
+        entity_type="transaction",
+    )
     def create_transaction_from_scheduled(
         guid: ScheduledTransactionGuid,
         transaction_date: str | None = None,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -663,6 +663,75 @@ class TestBudgetAndScheduledAuditHandlers:
         assert "frequency: monthly  start: 2026-01-01" in rendered
         assert "had run 4 times" in rendered
 
+    def test_scheduled_create_renders_description(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "scheduled_transaction",
+            "operation": "create",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {
+                "name": "Car Insurance",
+                "description": "Progressive policy #4471",
+                "start_date": "2026-08-01",
+            },
+            "after_state": {
+                "name": "Car Insurance",
+                "frequency": "monthly",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'CREATE SCHEDULED  "Car Insurance"' in rendered
+        assert "description: Progressive policy #4471" in rendered
+
+    def test_create_from_scheduled_shows_txn_guid_and_description(self):
+        """The instantiation response keys the new transaction as
+        ``transaction_guid`` — the generic CREATE handler used to
+        fall back to the params GUID (the SCHEDULE's) and render an
+        empty description. The dedicated handler reads the response."""
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "transaction",
+            "operation": "create_from_scheduled",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"guid": "aaaa1111", "transaction_date": "2026-08-01"},
+            "after_state": {
+                "transaction_guid": "bcd3e6e1",
+                "scheduled_transaction": "Car Insurance",
+                "description": "Progressive policy #4471, autopay",
+                "transaction_date": "2026-08-01",
+                "instance_count": 1,
+                "status": "created",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "CREATE FROM SCHEDULED  guid:bcd3e6e1" in rendered
+        assert "aaaa1111" not in rendered
+        assert '"Progressive policy #4471, autopay" (2026-08-01)' in rendered
+        assert 'schedule: "Car Insurance"  instance #1' in rendered
+
+    def test_create_from_scheduled_rejected_duplicate(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "transaction",
+            "operation": "create_from_scheduled",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"guid": "aaaa1111"},
+            "after_state": {
+                "transaction_guid": None,
+                "scheduled_transaction": "Car Insurance",
+                "description": "Progressive policy #4471, autopay",
+                "transaction_date": "2026-08-01",
+                "instance_count": 2,
+                "status": "rejected",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'CREATE FROM SCHEDULED  "Car Insurance" (2026-08-01)' in rendered
+        assert "rejected: equivalent transaction already exists" in rendered
+
 
 class TestBudgetAndScheduledStaging:
     """Verify the book methods actually stage before-state.

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -215,6 +215,25 @@ class TestListScheduled:
             {"account": "Expenses:Rent", "amount": "1850.00", "memo": ""},
             {"account": "Assets:Checking", "amount": "-1850.00", "memo": ""},
         ]
+        # description == name → suppressed as noise.
+        assert "description" not in result[0]
+
+    def test_verbose_list_shows_distinct_description(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent payment to Lakeview Property Mgmt",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        result = gb.list_scheduled_transactions(compact=False)["scheduled_transactions"]
+        assert result[0]["description"] == (
+            "Rent payment to Lakeview Property Mgmt"
+        )
 
     def test_enabled_only_filter(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
@@ -339,9 +358,44 @@ class TestCreateFromScheduled:
         assert result["transaction_date"] == "2026-02-01"
         assert result["instance_count"] == 1
 
-        # Verify the transaction actually exists
+        # Verify the transaction actually exists, carrying the
+        # template's stored description (not the SX name).
         txn = gb.get_transaction(result["transaction_guid"])
         assert txn is not None
+        assert txn["description"] == "Rent"
+
+    def test_falls_back_to_name_without_description_slot(
+        self, scheduled_book,
+    ):
+        """Templates created before the description slot existed
+        instantiate with the SX name, as they always did."""
+        from sqlalchemy import text
+
+        gb = GnuCashBook(str(scheduled_book))
+        gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date="2026-01-01",
+            frequency="monthly",
+        )
+        # Simulate a pre-slot template by removing the slot.
+        with gb.open(readonly=False) as book:
+            book.session.execute(
+                text("DELETE FROM slots WHERE name = 'description'")
+            )
+            book.save()
+            sx_guid = book.session.execute(
+                text("SELECT guid FROM schedxactions")
+            ).first()[0]
+
+        result = gb.create_transaction_from_scheduled(
+            guid=sx_guid, transaction_date="2026-02-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
         assert txn["description"] == "Monthly Rent"
 
     def test_updates_tracking(self, scheduled_book):
@@ -516,6 +570,17 @@ class TestDeleteScheduled:
         # Verify gone
         listed = gb.list_scheduled_transactions(enabled_only=False, compact=False)["scheduled_transactions"]
         assert len(listed) == 0
+
+        # No orphaned SX slots (splits-json, description) remain.
+        from sqlalchemy import text
+        with gb.open(readonly=True) as book:
+            count = book.session.execute(
+                text(
+                    "SELECT COUNT(*) FROM slots "
+                    "WHERE name IN ('splits-json', 'description')"
+                )
+            ).first()[0]
+        assert count == 0
 
     def test_delete_nonexistent_error(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
@@ -698,9 +763,10 @@ class TestScheduledIntegration:
         )
         assert txn["status"] == "created"
 
-        # Verify transaction exists with correct details
+        # Verify transaction exists with correct details — the
+        # stored description, not the SX name.
         real_txn = gb.get_transaction(txn["transaction_guid"])
-        assert real_txn["description"] == "Monthly Rent"
+        assert real_txn["description"] == "Rent payment"
         assert len(real_txn["splits"]) == 2
 
         # Check amounts in splits


### PR DESCRIPTION
## Summary
- `create_scheduled_transaction` accepted a `description` parameter but never persisted it — instantiation silently used the SX name. The description now lands in a bare `description` slot alongside `splits-json` (write-verified) and `create_transaction_from_scheduled` uses it, falling back to the SX name for templates created before the slot existed (zero behavior change for existing books).
- `delete_scheduled_transaction` clears all SX-owned slots by GUID instead of naming `splits-json`, so the new slot can't orphan.
- Verbose `list_scheduled_transactions` surfaces the stored description when it differs from the name; the audit `CREATE SCHEDULED` entry renders it.
- Bookkeeper finding from the branch validation round: instantiation audit entries showed the SX GUID and an empty description (the response keys the transaction as `transaction_guid`, so the generic handler fell back to the params GUID). Instantiation now audits under its own `create_from_scheduled` operation with a dedicated formatter, and the response includes the instantiated description.
- Passenger: `update_transaction` docstring now documents the split-memo support the book layer already had.

## Test plan
- [x] Full suite: 1798/1798 (two tests that had locked in the name-as-description bug updated; new coverage for fallback, slot cleanup, list surfacing, and all three audit formatter shapes)
- [x] Live smoke on a scratch copy of Alex's book: description + split memo round-trip, delete leaves zero orphan slots
- [x] Bookkeeper round on the live server: create/list/instantiate/fallback/audit/delete all clean; their one finding (instantiation audit GUID) fixed on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)