### PR TITLE
feat(business): per-line notes and action on add_*_entry tools

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1756,6 +1756,12 @@ class BusinessMixin:
             "price": str(price),
             "total": str(total),
         }
+        # Conditional keys — plain entries keep their shape.
+        if entry_row.notes:
+            result["notes"] = entry_row.notes
+        if entry_row.action:
+            result["action"] = entry_row.action
+
         if account_paths is not None and acct_guid:
             # Surface the readable path. Falls back to the
             # raw GUID when a stale entry references a deleted account.
@@ -4287,6 +4293,8 @@ class BusinessMixin:
         owner_type: str | None = None,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> dict:
         """Add a line item to a credit note.
 
@@ -4316,6 +4324,8 @@ class BusinessMixin:
             price=price,
             taxtable=taxtable,
             tax_included=tax_included,
+            notes=notes,
+            action=action,
         )
         # Re-key invoice_id/bill_id → credit_note_id for clarity.
         legacy_key = (
@@ -4413,6 +4423,8 @@ class BusinessMixin:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> dict:
         """Write a line-item entry on an invoice, bill, voucher, or
         credit note.
@@ -4421,6 +4433,10 @@ class BusinessMixin:
         ``_ENTRY_CONFIG``: which entries-table column side gets the
         price/account, the allowed account types, and the response
         id key.
+
+        ``notes`` is per-line free text (same 4096-byte cap as
+        customer/vendor notes); ``action`` is GnuCash's line-type
+        label (desktop suggests "Hours", "Material", "Project").
 
         Taxtable wire-up: ``taxtable`` marks the entry taxable and
         writes the resolved GUID to ``i_taxtable``/``b_taxtable``;
@@ -4441,6 +4457,7 @@ class BusinessMixin:
                 "tax_included=True requires a taxtable. Specify "
                 "which taxtable applies, or omit tax_included."
             )
+        self._validate_business_freetext(notes=notes)
 
         cfg = self._ENTRY_CONFIG[owner_type]
         # Bills (4) and vouchers (5) share the ``b_*`` / ``bill``
@@ -4538,8 +4555,8 @@ class BusinessMixin:
                     date=datetime.now(),
                     date_entered=datetime.now(),
                     description=description,
-                    action="",
-                    notes="",
+                    action=action,
+                    notes=notes,
                     quantity_num=q_num,
                     quantity_denom=q_denom,
                     i_discount_num=0,
@@ -4569,7 +4586,7 @@ class BusinessMixin:
 
             total = qty * unit_price
             # Entry ``guid`` omitted — no standalone tool surface.
-            return {
+            result = {
                 cfg["id_param"]: doc_id,
                 "description": description,
                 "quantity": str(qty),
@@ -4577,6 +4594,12 @@ class BusinessMixin:
                 "total": str(total),
                 "status": "created",
             }
+            # Conditional keys — plain entries keep their shape.
+            if notes:
+                result["notes"] = notes
+            if action:
+                result["action"] = action
+            return result
 
     def add_invoice_entry(
         self,
@@ -4587,6 +4610,8 @@ class BusinessMixin:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> dict:
         """Add a line item entry to a customer invoice.
 
@@ -4596,6 +4621,7 @@ class BusinessMixin:
             description: Line item description.
             quantity: Quantity as string (e.g., '1', '2.5').
             price: Unit price as string (e.g., '100.00').
+            taxtable, tax_included, notes, action: See ``_add_entry``.
 
         Returns:
             Dict with guid, invoice_id, total, status.
@@ -4609,6 +4635,8 @@ class BusinessMixin:
             price=price,
             taxtable=taxtable,
             tax_included=tax_included,
+            notes=notes,
+            action=action,
         )
 
     def add_bill_entry(
@@ -4620,6 +4648,8 @@ class BusinessMixin:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> dict:
         """Add a line item entry to a vendor bill.
 
@@ -4629,7 +4659,7 @@ class BusinessMixin:
             description: Line item description.
             quantity: Quantity as string (e.g., '1', '2.5').
             price: Unit price as string (e.g., '50.00').
-            taxtable, tax_included: See ``_add_entry``.
+            taxtable, tax_included, notes, action: See ``_add_entry``.
 
         Returns:
             Dict with bill_id, total, status.
@@ -4643,6 +4673,8 @@ class BusinessMixin:
             price=price,
             taxtable=taxtable,
             tax_included=tax_included,
+            notes=notes,
+            action=action,
         )
 
     def add_voucher_entry(
@@ -4654,6 +4686,8 @@ class BusinessMixin:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> dict:
         """Add a line item entry to an employee expense voucher.
 
@@ -4667,7 +4701,7 @@ class BusinessMixin:
             description: Line item description.
             quantity: Quantity as string (e.g., '1').
             price: Unit price as string (e.g., '42.50').
-            taxtable, tax_included: See ``_add_entry``.
+            taxtable, tax_included, notes, action: See ``_add_entry``.
 
         Returns:
             Dict with voucher_id, total, status.
@@ -4681,6 +4715,8 @@ class BusinessMixin:
             price=price,
             taxtable=taxtable,
             tax_included=tax_included,
+            notes=notes,
+            action=action,
         )
 
     def list_invoices(

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1649,10 +1649,20 @@ def _fmt_entry_create(entry: dict) -> list[str]:
         or params.get("voucher_id", "")
         or params.get("credit_note_id", "")
     )
-    return [
+    lines = [
         f"{time_part}  CREATE ENTRY",
         f'{_INDENT}"{desc}"  total: {total}  on: {inv_id}',
     ]
+    action = after.get("action", params.get("action", ""))
+    notes = after.get("notes", params.get("notes", ""))
+    if action or notes:
+        detail = []
+        if action:
+            detail.append(f"action: {action}")
+        if notes:
+            detail.append(f"notes: {notes}")
+        lines.append(f"{_INDENT}{'  '.join(detail)}")
+    return lines
 
 
 # ── Budget handlers ────────────────────────────────────────────────

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -625,6 +625,8 @@ def register(mcp, get_book) -> None:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> str:
         """Add a line item to a customer invoice.
 
@@ -644,12 +646,17 @@ def register(mcp, get_book) -> None:
             tax_included: If true, ``price`` is the gross (tax-included)
                 value; pretax extracted at posting. If false (default),
                 ``price`` is pre-tax and tax adds on top.
+            notes: Optional per-line notes (max 4096 bytes) — detail
+                that doesn't belong on the printed description line.
+            action: Optional line-type label (GnuCash convention:
+                "Hours", "Material", "Project").
         """
         book = get_book()
         result = book.add_invoice_entry(
             invoice_id=invoice_id, account=account,
             description=description, quantity=quantity, price=price,
             taxtable=taxtable, tax_included=tax_included,
+            notes=notes, action=action,
         )
         return _json(result)
 
@@ -664,6 +671,8 @@ def register(mcp, get_book) -> None:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> str:
         """Add a line item to a vendor bill.
 
@@ -682,12 +691,16 @@ def register(mcp, get_book) -> None:
                 entries.
             tax_included: If true, ``price`` is gross; pretax extracted
                 at posting. If false (default), tax adds on top.
+            notes: Optional per-line notes (max 4096 bytes).
+            action: Optional line-type label (GnuCash convention:
+                "Hours", "Material", "Project").
         """
         book = get_book()
         result = book.add_bill_entry(
             bill_id=bill_id, account=account,
             description=description, quantity=quantity, price=price,
             taxtable=taxtable, tax_included=tax_included,
+            notes=notes, action=action,
         )
         return _json(result)
 
@@ -740,6 +753,8 @@ def register(mcp, get_book) -> None:
         price: str,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> str:
         """Add a line item to an employee expense voucher.
 
@@ -758,12 +773,17 @@ def register(mcp, get_book) -> None:
                 ``add_bill_entry``.
             tax_included: If true, ``price`` is gross; pretax extracted
                 at posting.
+            notes: Optional per-line notes (max 4096 bytes) — e.g.
+                receipt reference or attendee list.
+            action: Optional line-type label (GnuCash convention:
+                "Hours", "Material", "Project").
         """
         book = get_book()
         result = book.add_voucher_entry(
             voucher_id=voucher_id, account=account,
             description=description, quantity=quantity, price=price,
             taxtable=taxtable, tax_included=tax_included,
+            notes=notes, action=action,
         )
         return _json(result)
 
@@ -866,6 +886,8 @@ def register(mcp, get_book) -> None:
         owner_type: str | None = None,
         taxtable: str | None = None,
         tax_included: bool = False,
+        notes: str = "",
+        action: str = "",
     ) -> str:
         """Add a line item to a credit note.
 
@@ -893,6 +915,10 @@ def register(mcp, get_book) -> None:
                 account.
             tax_included: If true, ``price`` is gross; pretax
                 extracted at posting.
+            notes: Optional per-line notes (max 4096 bytes) — e.g.
+                the reason this line is being credited.
+            action: Optional line-type label (GnuCash convention:
+                "Hours", "Material", "Project").
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -905,6 +931,8 @@ def register(mcp, get_book) -> None:
             owner_type=owner_type,
             taxtable=taxtable,
             tax_included=tax_included,
+            notes=notes,
+            action=action,
         )
         return _json(result)
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -5852,6 +5852,112 @@ class TestCreditNoteDisplayPolish:
         assert ar_balance == Decimal("400.00")
 
 
+class TestEntryNotesAction:
+    """Per-line ``notes`` and ``action`` on the add_*_entry paths.
+
+    All four tools route through ``_add_entry``, which previously
+    hardcoded both columns to "" — the schema had the fields, the
+    caller couldn't reach them.
+    """
+
+    def test_invoice_entry_notes_action_round_trip(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        result = gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="April retainer",
+            quantity="10",
+            price="150.00",
+            notes="PO #2231, contact: J. Doe",
+            action="Hours",
+        )
+        assert result["notes"] == "PO #2231, contact: J. Doe"
+        assert result["action"] == "Hours"
+
+        entry = gb.get_invoice("000001")["entries"][0]
+        assert entry["notes"] == "PO #2231, contact: J. Doe"
+        assert entry["action"] == "Hours"
+
+    def test_plain_entry_shape_unchanged(self, business_book):
+        """Entries without notes/action keep their exact key set —
+        conditional emission, not new always-present fields."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        result = gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Service",
+            quantity="1",
+            price="100.00",
+        )
+        assert "notes" not in result
+        assert "action" not in result
+        entry = gb.get_invoice("000001")["entries"][0]
+        assert "notes" not in entry
+        assert "action" not in entry
+
+    def test_notes_byte_cap_enforced(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="notes exceeds"):
+            gb.add_invoice_entry(
+                invoice_id="000001",
+                account="Income:Sales",
+                description="Too chatty",
+                quantity="1",
+                price="100.00",
+                notes="x" * 5000,
+            )
+
+    def test_bill_and_voucher_entries_carry_notes(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Vendor One")
+        gb.create_bill(vendor_id="000001")
+        bill_result = gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="2",
+            price="25.00",
+            notes="restock for Q3",
+            action="Material",
+        )
+        assert bill_result["notes"] == "restock for Q3"
+        assert bill_result["action"] == "Material"
+
+        gb.create_employee(name="Field Tech")
+        voucher = gb.create_voucher(employee_id="000001")
+        voucher_result = gb.add_voucher_entry(
+            voucher_id=voucher["id"],
+            account="Expenses:Office Supplies",
+            description="Client lunch",
+            quantity="1",
+            price="42.50",
+            notes="attendees: 3, receipt #881",
+        )
+        assert voucher_result["notes"] == "attendees: 3, receipt #881"
+        assert "action" not in voucher_result
+
+    def test_credit_note_entry_carries_notes(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_credit_note(owner_id="000001", owner_type="customer")
+        result = gb.add_credit_note_entry(
+            credit_note_id="000001",
+            account="Income:Sales",
+            description="Overbilled hours",
+            quantity="2",
+            price="150.00",
+            notes="per 2026-07-01 email thread",
+        )
+        assert result["notes"] == "per 2026-07-01 email thread"
+        assert result["credit_note_id"] == "000001"
+
+
 class TestAddInvoiceEntry:
     """Tests for add_invoice_entry."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -732,6 +732,47 @@ class TestBudgetAndScheduledAuditHandlers:
         assert 'CREATE FROM SCHEDULED  "Car Insurance" (2026-08-01)' in rendered
         assert "rejected: equivalent transaction already exists" in rendered
 
+    def test_entry_create_renders_notes_and_action(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "entry",
+            "operation": "create",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"invoice_id": "000001"},
+            "after_state": {
+                "invoice_id": "000001",
+                "description": "April retainer",
+                "total": "1500.00",
+                "notes": "PO #2231",
+                "action": "Hours",
+                "status": "created",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert '"April retainer"  total: 1500.00  on: 000001' in rendered
+        assert "action: Hours  notes: PO #2231" in rendered
+
+    def test_entry_create_plain_has_no_detail_line(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "entry",
+            "operation": "create",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"bill_id": "000001"},
+            "after_state": {
+                "bill_id": "000001",
+                "description": "Paper",
+                "total": "50.00",
+                "status": "created",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert '"Paper"  total: 50.00  on: 000001' in rendered
+        assert "notes:" not in rendered
+        assert "action:" not in rendered
+
 
 class TestBudgetAndScheduledStaging:
     """Verify the book methods actually stage before-state.


### PR DESCRIPTION
## Summary
- All four `add_*_entry` tools (invoice, bill, voucher, credit note) gain `notes` and `action` parameters, threaded through the single `_add_entry` chokepoint that previously hardcoded both entries-table columns to `""`.
- `notes` shares the 4096-byte cap with customer/vendor notes; `action` is GnuCash's line-type label ("Hours", "Material", "Project").
- Both surface as conditional keys on `get_invoice` entries and in the `CREATE ENTRY` audit line — plain entries keep their exact response shape (locked by the existing key-set test).

## Test plan
- [x] Full suite: 1805/1805 (7 new: round-trip, shape-unchanged, byte cap, bill/voucher/credit-note paths, two audit formatter shapes)
- [x] Live smoke on scratch copy of Alex's book: notes + action through response, get_invoice, and raw entries table; EUR invoice posted cleanly after
- [x] Bookkeeper round: all six checks pass, including oversize rejection and clean audit rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)