### PR TITLE
feat: pay_invoice memo and desktop-compatible account notes

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -318,7 +318,7 @@ class StaleFXRateError(ValueError):
 
 def _account_to_dict(account: piecash.Account) -> dict:
     """Convert a piecash Account to a serializable dict."""
-    return {
+    result = {
         "guid": account.guid,
         "name": account.name,
         "fullname": account.fullname,
@@ -327,6 +327,16 @@ def _account_to_dict(account: piecash.Account) -> dict:
         "description": account.description or "",
         "placeholder": bool(account.placeholder),
     }
+    # Account notes live in the "notes" slot — the same key GnuCash
+    # desktop's account editor reads/writes. Conditional so
+    # note-less accounts keep their original shape.
+    try:
+        notes = _slot_value_str(account["notes"])
+    except KeyError:
+        notes = ""
+    if notes:
+        result["notes"] = notes
+    return result
 
 
 # Default type per conventional top-level name — used by

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -5499,11 +5499,17 @@ class BusinessMixin:
         apply_discount: bool = False,
         discount_account: str | None = None,
         force: bool = False,
+        memo: str = "",
     ) -> dict:
         """Record a payment against a posted invoice or bill.
 
         Creates a payment transaction and assigns the A/R or A/P
         split to the invoice's lot. Partial payments are supported.
+
+        ``memo`` lands on the bank-account split (check number, wire
+        reference). The A/R//A/P split keeps its ``action="Payment"``
+        convention, and server-authored memos (FX drift, discount)
+        are untouched.
 
         ``amount`` is always in the **invoice's currency**. For
         cross-currency payments the pay account's quantity comes
@@ -5881,7 +5887,7 @@ class BusinessMixin:
                     account=pay_acct,
                     value=-payment_amount,
                     quantity=-pay_quantity,
-                    memo="",
+                    memo=memo,
                 )
             else:
                 # Receive customer payment (or refund-in from a
@@ -5897,7 +5903,7 @@ class BusinessMixin:
                     account=pay_acct,
                     value=payment_amount,
                     quantity=pay_quantity,
-                    memo="",
+                    memo=memo,
                 )
 
             # Realized FX gain/loss on post→pay rate drift, factored

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -32,6 +32,7 @@ from gnucash_mcp.book._base import (
     _is_market_price,
     _is_unreconciled,
     _is_voided,
+    _slot_value_str,
     _split_to_compact_dict,
     _split_to_dict,
     _to_decimal,
@@ -3467,6 +3468,22 @@ class CoreMixin:
                 f"Got: {name!r}."
             )
 
+    # UTF-8 byte cap for the account "notes" slot — same limit as
+    # customer/vendor notes in the business module (kept as a local
+    # constant: core must not depend on BusinessMixin, which may not
+    # be composed into the book class).
+    _ACCOUNT_NOTES_MAX_BYTES = 4096
+
+    @classmethod
+    def _validate_account_notes(cls, notes: str) -> None:
+        byte_len = len(notes.encode("utf-8"))
+        if byte_len > cls._ACCOUNT_NOTES_MAX_BYTES:
+            raise ValueError(
+                f"notes exceeds {cls._ACCOUNT_NOTES_MAX_BYTES}-byte "
+                f"cap ({byte_len} bytes supplied). Shorten the value "
+                f"and retry."
+            )
+
     def create_account(
         self,
         name: str,
@@ -3476,6 +3493,7 @@ class CoreMixin:
         placeholder: bool = False,
         commodity: str | None = None,
         commodity_namespace: str = "CURRENCY",
+        notes: str = "",
     ) -> dict:
         """Create a new account in the chart of accounts.
 
@@ -3490,6 +3508,8 @@ class CoreMixin:
                        Defaults to book's default currency.
             commodity_namespace: Commodity namespace for non-currency commodities.
                                 Default "CURRENCY".
+            notes: Optional free-text notes, stored in the "notes"
+                   slot GnuCash desktop's account editor reads.
 
         Returns:
             Dict with guid, fullname, and status. Includes a warning if
@@ -3509,6 +3529,8 @@ class CoreMixin:
         # Validate the account name (shared chokepoint with
         # update_account's rename branch).
         self._validate_account_name(name)
+        if notes:
+            self._validate_account_notes(notes)
 
         with self.open(readonly=False) as book:
             # Determine parent account
@@ -3552,6 +3574,8 @@ class CoreMixin:
                 description=description,
                 placeholder=placeholder,
             )
+            if notes:
+                new_account["notes"] = notes
 
             book.save()
 
@@ -3596,6 +3620,7 @@ class CoreMixin:
         description: str | None = None,
         placeholder: bool | None = None,
         account_type: str | None = None,
+        notes: str | None = None,
     ) -> dict:
         """Update an existing account's properties.
 
@@ -3607,6 +3632,9 @@ class CoreMixin:
             account_type: New account type (e.g., "CREDIT", "BANK"). Only
                 changes within the same debit/credit polarity family are
                 allowed (e.g., LIABILITY to CREDIT, ASSET to BANK).
+            notes: New notes ("notes" slot, shared with GnuCash
+                desktop's account editor). Pass "" to clear — the
+                slot is deleted, matching a desktop-cleared field.
 
         Returns:
             Dict with updated account details.
@@ -3650,6 +3678,19 @@ class CoreMixin:
             if placeholder is not None and bool(placeholder) != bool(account.placeholder):
                 account.placeholder = placeholder
                 changed["placeholder"] = bool(placeholder)
+
+            if notes is not None:
+                self._validate_account_notes(notes)
+                try:
+                    current_notes = _slot_value_str(account["notes"])
+                except KeyError:
+                    current_notes = ""
+                if notes == "" and current_notes:
+                    del account["notes"]
+                    changed["notes"] = ""
+                elif notes and notes != current_notes:
+                    account["notes"] = notes
+                    changed["notes"] = notes
 
             if account_type is not None:
                 new_type = account_type.upper()

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -769,6 +769,9 @@ def _fmt_account_create(entry: dict) -> list[str]:
         desc = after.get("description", params.get("description", ""))
         if desc:
             lines.append(f'{_INDENT}Description: "{desc}"')
+        notes = after.get("notes", params.get("notes", ""))
+        if notes:
+            lines.append(f'{_INDENT}Notes: "{notes}"')
     return lines
 
 
@@ -791,6 +794,16 @@ def _fmt_account_update(entry: dict) -> list[str]:
         new_desc = after.get("description", "")
         if old_desc != new_desc:
             lines.append(f'{_INDENT}Description: "{old_desc}" → "{new_desc}"')
+        # ``notes`` is a diff-echo key: present in after_state only
+        # when the update changed it ("" = cleared).
+        if "notes" in after:
+            old_notes = before.get("notes", "")
+            if after["notes"]:
+                lines.append(
+                    f'{_INDENT}Notes: "{old_notes}" → "{after["notes"]}"'
+                )
+            else:
+                lines.append(f'{_INDENT}Notes: "{old_notes}" → (cleared)')
     return lines
 
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1406,6 +1406,9 @@ def _fmt_invoice_pay(entry: dict) -> list[str]:
         lines.append(
             f"{_INDENT}from: {params.get('payment_account', '')}  txn:{txn_guid}"
         )
+    memo = params.get("memo", "")
+    if memo:
+        lines.append(f"{_INDENT}memo: {memo}")
     lines += _fx_stale_lines(entry)
     return lines
 

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1147,6 +1147,7 @@ def register(mcp, get_book) -> None:
         apply_discount: bool = False,
         discount_account: str | None = None,
         force: bool = False,
+        memo: str = "",
     ) -> str:
         """Record a payment against a posted invoice or bill.
 
@@ -1203,6 +1204,10 @@ def register(mcp, get_book) -> None:
                 is refused with ``stale_fx_rate`` unless ``force=True``
                 (the override is recorded as ``fx_stale``/"forced").
                 A rate beyond the 90-day cap cannot be forced.
+            memo: Optional memo for the bank-account split (e.g.,
+                check number or wire reference). ``description``
+                names the whole transaction; ``memo`` annotates the
+                cash movement.
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -1217,6 +1222,7 @@ def register(mcp, get_book) -> None:
             apply_discount=apply_discount,
             discount_account=discount_account,
             force=force,
+            memo=memo,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -401,6 +401,7 @@ def register(mcp, get_book) -> None:
         placeholder: bool = False,
         commodity: str | None = None,
         commodity_namespace: str = "CURRENCY",
+        notes: str = "",
     ) -> str:
         """Create a new account in the chart of accounts.
 
@@ -418,6 +419,8 @@ def register(mcp, get_book) -> None:
             commodity_namespace: "CURRENCY" (default), "FUND", or an
                 exchange ("NASDAQ", "NYSE"). Required with non-currency
                 commodities.
+            notes: Optional free-text notes (max 4096 bytes). Shows in
+                GnuCash desktop's account editor Notes field.
         """
         book = get_book()
         result = book.create_account(
@@ -428,6 +431,7 @@ def register(mcp, get_book) -> None:
             placeholder=placeholder,
             commodity=commodity,
             commodity_namespace=commodity_namespace,
+            notes=notes,
         )
         return _json(result)
 
@@ -440,6 +444,7 @@ def register(mcp, get_book) -> None:
         description: str | None = None,
         placeholder: bool | None = None,
         account_type: str | None = None,
+        notes: str | None = None,
     ) -> str:
         """Update an existing account's properties.
 
@@ -452,6 +457,8 @@ def register(mcp, get_book) -> None:
                 within the same debit/credit polarity are allowed — e.g.,
                 LIABILITY to CREDIT, ASSET to BANK. Cross-polarity changes
                 (e.g., ASSET to LIABILITY) are blocked.
+            notes: New notes (max 4096 bytes; shared with GnuCash
+                desktop's Notes field). Pass "" to clear.
         """
         book = get_book()
         result = book.update_account(
@@ -460,6 +467,7 @@ def register(mcp, get_book) -> None:
             description=description,
             placeholder=placeholder,
             account_type=account_type,
+            notes=notes,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -5902,6 +5902,99 @@ class TestSearchTransactions:
         assert "limit capped at 250" in result.split("\n")[0]
 
 
+class TestAccountNotes:
+    """Account notes via the desktop-compatible "notes" slot."""
+
+    def test_create_with_notes_round_trip(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Chase Sapphire",
+            account_type="EXPENSE",
+            parent="Expenses",
+            notes="Closed to new charges 2026-07; autopay off",
+        )
+        account = gc_book.get_account("Expenses:Chase Sapphire")
+        assert account["notes"] == (
+            "Closed to new charges 2026-07; autopay off"
+        )
+
+        # Stored under the flat "notes" slot key — the one GnuCash
+        # desktop's account editor reads.
+        import sqlite3
+        conn = sqlite3.connect(str(test_book))
+        row = conn.execute(
+            "SELECT s.string_val FROM slots s "
+            "JOIN accounts a ON a.guid = s.obj_guid "
+            "WHERE a.name = 'Chase Sapphire' AND s.name = 'notes'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "Closed to new charges 2026-07; autopay off"
+
+    def test_create_without_notes_keeps_shape(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Plain", account_type="EXPENSE", parent="Expenses",
+        )
+        account = gc_book.get_account("Expenses:Plain")
+        assert "notes" not in account
+
+    def test_update_sets_changes_and_clears(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Annotated", account_type="EXPENSE", parent="Expenses",
+        )
+
+        r1 = gc_book.update_account(
+            "Expenses:Annotated", notes="first note",
+        )
+        assert r1["notes"] == "first note"
+        assert gc_book.get_account("Expenses:Annotated")["notes"] == (
+            "first note"
+        )
+
+        r2 = gc_book.update_account(
+            "Expenses:Annotated", notes="second note",
+        )
+        assert r2["notes"] == "second note"
+
+        # "" clears: the slot row is deleted, not left empty.
+        r3 = gc_book.update_account("Expenses:Annotated", notes="")
+        assert r3["notes"] == ""
+        assert "notes" not in gc_book.get_account("Expenses:Annotated")
+
+        import sqlite3
+        conn = sqlite3.connect(str(test_book))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM slots s "
+            "JOIN accounts a ON a.guid = s.obj_guid "
+            "WHERE a.name = 'Annotated' AND s.name = 'notes'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_update_unchanged_notes_not_echoed(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="Stable", account_type="EXPENSE", parent="Expenses",
+            notes="same",
+        )
+        result = gc_book.update_account("Expenses:Stable", notes="same")
+        assert "notes" not in result  # diff-style echo: no change
+
+    def test_notes_byte_cap(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="notes exceeds"):
+            gc_book.create_account(
+                name="Chatty", account_type="EXPENSE", parent="Expenses",
+                notes="x" * 5000,
+            )
+        gc_book.create_account(
+            name="Chatty", account_type="EXPENSE", parent="Expenses",
+        )
+        with pytest.raises(ValueError, match="notes exceeds"):
+            gc_book.update_account("Expenses:Chatty", notes="x" * 5000)
+
+
 class TestCreateAccount:
     """Tests for create_account method."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -7218,6 +7218,34 @@ class TestPayInvoice:
         )
         assert Decimal(result["remaining_balance"]) == Decimal("300")
 
+    def test_memo_lands_on_bank_split_only(self, business_book):
+        """User memo annotates the cash movement; the A/R//A/P split
+        keeps its action='Payment' convention with an empty memo."""
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+            memo="check #1042",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        memos = {s["account"]: s.get("memo", "") for s in txn["splits"]}
+        assert memos["Assets:Checking"] == "check #1042"
+        assert memos["Assets:Accounts Receivable"] == ""
+
+    def test_no_memo_keeps_prior_shape(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_bill(gb, "50.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="50",
+            owner_type="vendor",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert all(not s.get("memo") for s in txn["splits"])
+
     def test_multiple_payments(self, business_book):
         gb = GnuCashBook(str(business_book))
         self._post_invoice(gb, "500.00")


### PR DESCRIPTION
## Summary
- `pay_invoice` gains an optional `memo` applied to the bank-account split (check number, wire reference). The A/R//A/P split keeps its `action="Payment"` convention; server-authored memos (FX drift, early-payment discount) are untouched. Rendered in the `PAY INVOICE` audit entry.
- `create_account` / `update_account` gain `notes`, stored in the flat `notes` slot GnuCash desktop's account editor reads. `""` clears (slot deleted, matching a desktop-cleared field); unchanged values aren't echoed per the diff-style convention. `get_account` surfaces notes conditionally; CREATE/UPDATE ACCOUNT audit entries render the value and diff. 4096-byte cap kept local to core (business's identical cap lives on a mixin that may not be composed).

## Test plan
- [x] Full suite: 1805/1805 (7 new: memo-on-bank-split-only, no-memo shape, notes round-trip + slot-key check via sqlite, set/change/clear, diff-echo suppression, byte cap both paths)
- [x] Bookkeeper round (combined with #128): payment memos land on bank splits, audit records them, backward compatibility holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)