### PR TITLE
feat(core): batch entry memos, notes, and cross-commodity qty

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -196,6 +196,77 @@ def _format_grouped_tsv(
     return out
 
 
+# ── Batch-entry TSV layout ─────────────────────────────────────────
+#
+# Shared by the tool-layer parser (tools/core.py) and the audit-log
+# display parser (logging_config.py) so the two can never drift on
+# what a submitted batch means.
+
+
+def _batch_tsv_layout(header_line: str) -> dict:
+    """Column layout of a batch-entry TSV, derived from its header.
+
+    The original format ignored the header entirely (positional
+    ``(amount, account)`` pairs). Extensions are header-declared so
+    legacy submissions parse byte-identically:
+
+    - a ``notes`` token in column 4 → a per-transaction notes column
+      sits between ``description`` and the split columns
+    - any ``memo`` token among the split columns → splits are
+      ``(amount, account, memo)`` TRIPLES instead of pairs
+
+    Tokens match case-insensitively with trailing digits stripped
+    (``amt1`` / ``acct2`` / ``memo3`` → ``amt`` / ``acct`` /
+    ``memo``), so numbered and unnumbered headers both work.
+
+    Returns ``{"has_notes": bool, "has_memos": bool}``.
+    """
+    tokens = [
+        t.strip().lower().rstrip("0123456789")
+        for t in header_line.split("\t")
+    ]
+    has_notes = len(tokens) > 3 and tokens[3] == "notes"
+    split_tokens = tokens[4:] if has_notes else tokens[3:]
+    return {
+        "has_notes": has_notes,
+        "has_memos": "memo" in split_tokens,
+    }
+
+
+def _batch_row_splits(rest: list[str], has_memos: bool) -> list[dict]:
+    """Chunk a batch row's trailing fields into split dicts.
+
+    Pairs mode: ``(amount, account)``. Triples mode (header declared
+    memos): ``(amount, account, memo)`` — empty memo cells are fine,
+    and the ``memo`` key appears only when non-empty so plain splits
+    keep their shape downstream.
+
+    Raises ValueError when the count doesn't divide evenly; the
+    triples-mode message calls out the likely culprit (a dropped
+    trailing tab on an empty final memo).
+    """
+    width = 3 if has_memos else 2
+    if len(rest) % width != 0:
+        if has_memos:
+            raise ValueError(
+                f"trailing fields must be (amount, account, memo) "
+                f"triples per the memo-declaring header — got "
+                f"{len(rest)} fields. A split with an empty memo "
+                f"still needs the memo cell's tab."
+            )
+        raise ValueError(
+            f"trailing fields must be (amount, account) pairs — "
+            f"got an odd count ({len(rest)})"
+        )
+    splits: list[dict] = []
+    for j in range(0, len(rest), width):
+        split = {"account": rest[j + 1], "amount": rest[j]}
+        if has_memos and rest[j + 2].strip():
+            split["memo"] = rest[j + 2].strip()
+        splits.append(split)
+    return splits
+
+
 # ── Numeric formatting ─────────────────────────────────────────────
 
 

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -203,6 +203,22 @@ def _format_grouped_tsv(
 # what a submitted batch means.
 
 
+# Canonical names for split-column header tokens. Trailing digits
+# are stripped before lookup (``amt1`` → ``amt``), so numbered and
+# unnumbered headers both work.
+_BATCH_SPLIT_TOKENS = {
+    "amt": "amount", "amount": "amount",
+    "acct": "account", "account": "account", "acc": "account",
+    "memo": "memo",
+    "qty": "quantity", "quantity": "quantity",
+}
+
+# The legacy positional shape, used whenever the header doesn't
+# declare an extension token (memo/qty) — pre-extension headers were
+# purely decorative, so anything non-declaring parses as pairs.
+_BATCH_LEGACY_GROUP = ("amount", "account")
+
+
 def _batch_tsv_layout(header_line: str) -> dict:
     """Column layout of a batch-entry TSV, derived from its header.
 
@@ -212,14 +228,19 @@ def _batch_tsv_layout(header_line: str) -> dict:
 
     - a ``notes`` token in column 4 → a per-transaction notes column
       sits between ``description`` and the split columns
-    - any ``memo`` token among the split columns → splits are
-      ``(amount, account, memo)`` TRIPLES instead of pairs
+    - a ``memo`` and/or ``qty`` token among the split columns →
+      each split group widens to include that field, in the order
+      the header's FIRST group declares (e.g. ``amt, acct, memo,
+      qty`` or ``amt, acct, qty`` — the header is the schema, for
+      field order too)
 
-    Tokens match case-insensitively with trailing digits stripped
-    (``amt1`` / ``acct2`` / ``memo3`` → ``amt`` / ``acct`` /
-    ``memo``), so numbered and unnumbered headers both work.
+    Returns ``{"has_notes": bool, "group": tuple[str, ...]}`` where
+    ``group`` is the per-split field sequence in canonical names
+    (``amount`` / ``account`` / ``memo`` / ``quantity``).
 
-    Returns ``{"has_notes": bool, "has_memos": bool}``.
+    Raises ValueError when an extension is declared but the first
+    group is malformed (unknown token mixed in, duplicate field, or
+    missing amount/account).
     """
     tokens = [
         t.strip().lower().rstrip("0123456789")
@@ -227,42 +248,67 @@ def _batch_tsv_layout(header_line: str) -> dict:
     ]
     has_notes = len(tokens) > 3 and tokens[3] == "notes"
     split_tokens = tokens[4:] if has_notes else tokens[3:]
-    return {
-        "has_notes": has_notes,
-        "has_memos": "memo" in split_tokens,
-    }
+
+    canonical = [_BATCH_SPLIT_TOKENS.get(t) for t in split_tokens]
+    if not ({"memo", "quantity"} & set(canonical)):
+        # No extension declared — legacy positional pairs, header
+        # content otherwise irrelevant.
+        return {"has_notes": has_notes, "group": _BATCH_LEGACY_GROUP}
+
+    # Extension mode: the first group runs until a field repeats.
+    group: list[str] = []
+    for raw, name in zip(split_tokens, canonical):
+        if name is None:
+            raise ValueError(
+                f"unrecognized split column {raw!r} in a header that "
+                f"declares memo/qty columns — split columns must be "
+                f"amt, acct, memo, or qty"
+            )
+        if name in group:
+            break
+        group.append(name)
+    if "amount" not in group or "account" not in group:
+        raise ValueError(
+            "split columns must include both an amount and an "
+            "account column"
+        )
+    return {"has_notes": has_notes, "group": tuple(group)}
 
 
-def _batch_row_splits(rest: list[str], has_memos: bool) -> list[dict]:
+def _batch_row_splits(rest: list[str], group: tuple[str, ...]) -> list[dict]:
     """Chunk a batch row's trailing fields into split dicts.
 
-    Pairs mode: ``(amount, account)``. Triples mode (header declared
-    memos): ``(amount, account, memo)`` — empty memo cells are fine,
-    and the ``memo`` key appears only when non-empty so plain splits
-    keep their shape downstream.
+    ``group`` is the per-split field sequence from
+    ``_batch_tsv_layout``. ``amount`` and ``account`` are always
+    present; ``memo`` / ``quantity`` cells may be empty (the key is
+    included only when non-empty, so plain splits keep their shape
+    downstream — and an empty qty means "account commodity equals
+    the transaction currency", the same-currency default).
 
     Raises ValueError when the count doesn't divide evenly; the
-    triples-mode message calls out the likely culprit (a dropped
-    trailing tab on an empty final memo).
+    message names the declared shape and calls out the likely
+    culprit (a dropped trailing tab on an empty final cell).
     """
-    width = 3 if has_memos else 2
+    width = len(group)
     if len(rest) % width != 0:
-        if has_memos:
-            raise ValueError(
-                f"trailing fields must be (amount, account, memo) "
-                f"triples per the memo-declaring header — got "
-                f"{len(rest)} fields. A split with an empty memo "
-                f"still needs the memo cell's tab."
-            )
+        shape = ", ".join(group)
+        hint = (
+            " A split with an empty trailing cell still needs "
+            "its tab." if width > 2 else ""
+        )
         raise ValueError(
-            f"trailing fields must be (amount, account) pairs — "
-            f"got an odd count ({len(rest)})"
+            f"trailing fields must be ({shape}) groups per the "
+            f"header — got {len(rest)} fields.{hint}"
         )
     splits: list[dict] = []
     for j in range(0, len(rest), width):
-        split = {"account": rest[j + 1], "amount": rest[j]}
-        if has_memos and rest[j + 2].strip():
-            split["memo"] = rest[j + 2].strip()
+        split: dict = {}
+        for k, field in enumerate(group):
+            cell = rest[j + k]
+            if field in ("amount", "account"):
+                split[field] = cell
+            elif cell.strip():
+                split[field] = cell.strip()
         splits.append(split)
     return splits
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3091,7 +3091,10 @@ class CoreMixin:
 
         Spec: specs/BATCH_TRANSACTION_ENTRY_SPEC.md. Each entry is
         ``{ref, date (date), description, notes (optional),
-        splits: [{account, amount, memo (optional)}]}``.
+        splits: [{account, amount, memo (optional),
+        quantity (optional)}]}`` — quantity per the
+        ``_validate_transaction_splits`` contract (required iff the
+        account commodity differs from the book default).
 
         Three phases under one book-open: validate all structurally,
         screen each against existing-book duplicates, then build every
@@ -3102,9 +3105,11 @@ class CoreMixin:
 
         Returns a thin envelope: ``results`` TSV (always) and
         ``duplicates`` TSV (only when a match exists; otherwise empty,
-        which ``_strip_noise`` drops). v1 is same-currency (book
-        default) with no intra-batch dedup — cross-currency and
-        investment entries use ``create_transaction``.
+        which ``_strip_noise`` drops). The transaction currency is
+        always the book default (a differently-denominated
+        transaction needs ``create_transaction``'s ``currency``
+        parameter); splits on non-default-commodity accounts carry
+        an explicit ``quantity``. No intra-batch dedup.
         """
         if on_error not in ("abort", "skip"):
             raise ValueError("on_error must be 'abort' or 'skip'")

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3090,7 +3090,8 @@ class CoreMixin:
         """Create multiple transactions in one atomic save.
 
         Spec: specs/BATCH_TRANSACTION_ENTRY_SPEC.md. Each entry is
-        ``{ref, date (date), description, splits: [{account, amount}]}``.
+        ``{ref, date (date), description, notes (optional),
+        splits: [{account, amount, memo (optional)}]}``.
 
         Three phases under one book-open: validate all structurally,
         screen each against existing-book duplicates, then build every
@@ -3102,8 +3103,8 @@ class CoreMixin:
         Returns a thin envelope: ``results`` TSV (always) and
         ``duplicates`` TSV (only when a match exists; otherwise empty,
         which ``_strip_noise`` drops). v1 is same-currency (book
-        default), no per-split memo, no intra-batch dedup — exotic cases
-        use ``create_transaction``.
+        default) with no intra-batch dedup — cross-currency and
+        investment entries use ``create_transaction``.
         """
         if on_error not in ("abort", "skip"):
             raise ValueError("on_error must be 'abort' or 'skip'")
@@ -3139,6 +3140,7 @@ class CoreMixin:
                     prepared.append({
                         "ref": ref,
                         "description": txn["description"],
+                        "notes": txn.get("notes") or "",
                         "trans_date": txn["date"],
                         "validated": validated,
                         "proposed_amounts": [
@@ -3213,6 +3215,7 @@ class CoreMixin:
                 txn_obj = piecash.Transaction(
                     currency=default_currency,
                     description=p["description"],
+                    notes=p["notes"] or None,
                     post_date=p["trans_date"],
                     splits=piecash_splits,
                 )

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -589,13 +589,22 @@ def _parse_batch_submission(tsv: str) -> dict:
     display-only (a row the chunker rejects renders without its
     splits — the write path rejected such rows anyway).
     """
-    from gnucash_mcp._format import _batch_row_splits, _batch_tsv_layout
+    from gnucash_mcp._format import (
+        _BATCH_LEGACY_GROUP,
+        _batch_row_splits,
+        _batch_tsv_layout,
+    )
 
     out: dict = {}
     lines = tsv.split("\n") if tsv else []
     if not lines:
         return out
-    layout = _batch_tsv_layout(lines[0])
+    try:
+        layout = _batch_tsv_layout(lines[0])
+    except ValueError:
+        # Malformed extension header — the write path rejected the
+        # whole submission; render rows in the legacy shape.
+        layout = {"has_notes": False, "group": _BATCH_LEGACY_GROUP}
     fixed = 4 if layout["has_notes"] else 3
     for ln in lines[1:]:
         if not ln.strip():
@@ -604,7 +613,7 @@ def _parse_batch_submission(tsv: str) -> dict:
         if len(f) < 3:
             continue
         try:
-            splits = _batch_row_splits(f[fixed:], layout["has_memos"])
+            splits = _batch_row_splits(f[fixed:], layout["group"])
         except ValueError:
             splits = []
         entry = {

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -451,7 +451,10 @@ def _format_splits_text(splits: list[dict], indent: str = "          ") -> str:
         account = split.get("account", "Unknown")
         short_name = account.split(":")[-1]
         amount = _format_amount(split.get("amount") or split.get("value"))
-        lines.append(f"{indent}{short_name:<{max_name_len}}  {amount:>12}")
+        line = f"{indent}{short_name:<{max_name_len}}  {amount:>12}"
+        if split.get("memo"):
+            line += f"  {split['memo']}"
+        lines.append(line)
 
     return "\n".join(lines)
 
@@ -579,24 +582,37 @@ def _parse_audit_tsv_rows(tsv: str) -> list[dict]:
 
 
 def _parse_batch_submission(tsv: str) -> dict:
-    """ref -> {description, date, splits} from the submitted batch TSV.
-    Positional parse mirroring the tool layer; tolerant of ragged rows
-    since this is display-only."""
+    """ref -> {description, date, notes?, splits} from the submitted
+    batch TSV. Layout comes from the shared header reader
+    (``_batch_tsv_layout``) so this display parse can't drift from
+    the tool-layer parse; tolerant of malformed rows since this is
+    display-only (a row the chunker rejects renders without its
+    splits — the write path rejected such rows anyway).
+    """
+    from gnucash_mcp._format import _batch_row_splits, _batch_tsv_layout
+
     out: dict = {}
-    for ln in (tsv.split("\n")[1:] if tsv else []):
+    lines = tsv.split("\n") if tsv else []
+    if not lines:
+        return out
+    layout = _batch_tsv_layout(lines[0])
+    fixed = 4 if layout["has_notes"] else 3
+    for ln in lines[1:]:
         if not ln.strip():
             continue
         f = ln.split("\t")
         if len(f) < 3:
             continue
-        rest = f[3:]
-        splits = [
-            {"account": rest[j + 1], "amount": rest[j]}
-            for j in range(0, len(rest) - 1, 2)
-        ]
-        out[f[0].strip()] = {
+        try:
+            splits = _batch_row_splits(f[fixed:], layout["has_memos"])
+        except ValueError:
+            splits = []
+        entry = {
             "description": f[2], "date": f[1].strip(), "splits": splits,
         }
+        if layout["has_notes"] and len(f) > 3 and f[3].strip():
+            entry["notes"] = f[3].strip()
+        out[f[0].strip()] = entry
     return out
 
 
@@ -626,6 +642,8 @@ def _fmt_transaction_create_batch(entry: dict) -> list[str]:
         lines.append(
             f'{_INDENT}CREATE  guid:{guid}  "{desc}" ({date_str})'
         )
+        if src.get("notes"):
+            lines.append(f"{_INDENT_SPLITS}notes: {src['notes']}")
         splits = src.get("splits") or []
         if splits:
             lines.append(_format_splits_text(splits, _INDENT_SPLITS))

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -8,6 +8,7 @@ way (pure lazy-load orchestration, no hardcoded imports).
 
 from datetime import date
 
+from gnucash_mcp._format import _batch_row_splits, _batch_tsv_layout
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     SplitInput,
@@ -22,43 +23,53 @@ from gnucash_mcp.tools._helpers import (
 def _parse_transactions_tsv(tsv: str) -> list[dict]:
     """Parse the batch-entry TSV into structured transactions.
 
-    Header row + one row per transaction; positional parse so rows may
-    be ragged. First three fields are ref / date / description; the rest
-    are ``(amount, account)`` pairs. Raises ValueError on a missing
-    header, too-few columns, or an odd trailing count.
+    The header row is load-bearing (see ``_batch_tsv_layout``): a
+    legacy header parses as positional ``(amount, account)`` pairs
+    exactly as before; a header declaring ``memo`` split columns
+    switches splits to triples, and a ``notes`` token in column 4
+    inserts a per-transaction notes column after ``description``.
+
+    Rows may be ragged (2 splits vs 3). Raises ValueError on a
+    missing header, too-few columns, or a split count that doesn't
+    match the declared shape.
     """
     lines = [ln for ln in tsv.splitlines() if ln.strip()]
     if len(lines) < 2:
         raise ValueError(
             "transactions TSV needs a header row and at least one data row"
         )
+    layout = _batch_tsv_layout(lines[0])
+    fixed = 4 if layout["has_notes"] else 3
+    width = 3 if layout["has_memos"] else 2
+    shape = (
+        "(amount, account, memo) triple" if layout["has_memos"]
+        else "(amount, account) pair"
+    )
     out: list[dict] = []
     for i, ln in enumerate(lines[1:], start=1):
         fields = ln.split("\t")
-        if len(fields) < 5:
+        if len(fields) < fixed + width:
+            notes_part = ", notes" if layout["has_notes"] else ""
             raise ValueError(
-                f"row {i}: expected ref, date, description, and at least "
-                f"one (amount, account) pair"
+                f"row {i}: expected ref, date, description"
+                f"{notes_part}, and at least one {shape}"
             )
         ref, dt, desc = fields[0].strip(), fields[1].strip(), fields[2]
         if not ref:
             raise ValueError(f"row {i}: empty ref (each row needs a key)")
-        rest = fields[3:]
-        if len(rest) % 2 != 0:
-            raise ValueError(
-                f"row {i} (ref {ref!r}): trailing fields must be "
-                f"(amount, account) pairs — got an odd count"
-            )
-        splits = [
-            {"account": rest[j + 1], "amount": rest[j]}
-            for j in range(0, len(rest), 2)
-        ]
-        out.append({
+        try:
+            splits = _batch_row_splits(fields[fixed:], layout["has_memos"])
+        except ValueError as e:
+            raise ValueError(f"row {i} (ref {ref!r}): {e}")
+        txn = {
             "ref": ref,
             "date": _parse_iso_date(dt) or date.today(),
             "description": desc,
             "splits": splits,
-        })
+        }
+        if layout["has_notes"] and fields[3].strip():
+            txn["notes"] = fields[3].strip()
+        out.append(txn)
     return out
 
 
@@ -308,11 +319,31 @@ def register(mcp, get_book) -> None:
         """Create MANY transactions in one atomic command (bulk entry).
 
         INPUT — ``transactions`` is a TSV block: a header row, then one
-        row per transaction. Splits are ``(amount, account)`` column
-        PAIRS, repeated as wide as a transaction needs::
+        row per transaction. The HEADER DECLARES THE LAYOUT. Base form:
+        splits are ``(amount, account)`` column PAIRS, repeated as wide
+        as a transaction needs::
 
             ref<TAB>date<TAB>description<TAB>amt1<TAB>acct1<TAB>amt2<TAB>acct2...
             1<TAB>2026-05-21<TAB>Gas<TAB>-54.19<TAB>Assets:Checking<TAB>54.19<TAB>Expenses:Auto:Fuel
+
+        Two opt-in extensions, each activated by naming it in the
+        header (legacy headers parse exactly as before):
+
+        - PER-SPLIT MEMOS — declare ``memo`` split columns; splits
+          become ``(amount, account, memo)`` TRIPLES::
+
+              ref<TAB>date<TAB>description<TAB>amt1<TAB>acct1<TAB>memo1<TAB>amt2<TAB>acct2<TAB>memo2
+              1<TAB>2026-05-21<TAB>Gas<TAB>-54.19<TAB>Assets:Checking<TAB>card #4471<TAB>54.19<TAB>Expenses:Auto:Fuel<TAB>
+
+          An empty memo cell is fine, but every split is a FULL
+          triple — keep the tab even when the memo is blank.
+        - PER-TRANSACTION NOTES — declare a ``notes`` column directly
+          after ``description``::
+
+              ref<TAB>date<TAB>description<TAB>notes<TAB>amt1<TAB>acct1...
+
+        Both extensions combine (ref, date, description, notes, then
+        triples).
 
         - ``ref``: YOUR correlation key per row (e.g. 1, 2, 3), unique
           within the batch. It is echoed back so you can match results
@@ -320,9 +351,9 @@ def register(mcp, get_book) -> None:
         - ``date``: ISO YYYY-MM-DD. ``amount``: decimal STRING (never a
           raw JSON number). Each transaction needs >=2 splits balancing
           to zero. Rows may differ in width (2 splits vs 3).
-        - v1 is same-currency (book default) with no per-split memo —
-          use ``create_transaction`` for cross-currency, investment, or
-          memo-bearing entries.
+        - v1 is same-currency (book default) — use
+          ``create_transaction`` for cross-currency or investment
+          entries.
 
         BEHAVIOR — one book-open, one atomic save:
         - A STRUCTURAL error (unbalanced, unknown account, bad pairs)

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -25,8 +25,9 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
 
     The header row is load-bearing (see ``_batch_tsv_layout``): a
     legacy header parses as positional ``(amount, account)`` pairs
-    exactly as before; a header declaring ``memo`` split columns
-    switches splits to triples, and a ``notes`` token in column 4
+    exactly as before; a header declaring ``memo`` and/or ``qty``
+    split columns widens each split group accordingly (field order
+    per the header's first group), and a ``notes`` token in column 4
     inserts a per-transaction notes column after ``description``.
 
     Rows may be ragged (2 splits vs 3). Raises ValueError on a
@@ -39,31 +40,13 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
             "transactions TSV needs a header row and at least one data row"
         )
     layout = _batch_tsv_layout(lines[0])
-    # Forward-compat guard: qty columns are the planned cross-currency
-    # extension, not yet implemented. Without this check a qty header
-    # falls into pairs mode and rejects rows with a bewildering
-    # "Account not found: <number>" — fail on the format instead.
-    header_tokens = {
-        t.strip().lower().rstrip("0123456789")
-        for t in lines[0].split("\t")
-    }
-    if header_tokens & {"qty", "quantity"}:
-        raise ValueError(
-            "qty columns are not supported yet — batch entry is "
-            "same-currency (quantity always equals amount). Use "
-            "create_transaction for cross-currency or investment "
-            "entries."
-        )
+    group = layout["group"]
     fixed = 4 if layout["has_notes"] else 3
-    width = 3 if layout["has_memos"] else 2
-    shape = (
-        "(amount, account, memo) triple" if layout["has_memos"]
-        else "(amount, account) pair"
-    )
+    shape = f"({', '.join(group)}) group"
     out: list[dict] = []
     for i, ln in enumerate(lines[1:], start=1):
         fields = ln.split("\t")
-        if len(fields) < fixed + width:
+        if len(fields) < fixed + len(group):
             notes_part = ", notes" if layout["has_notes"] else ""
             raise ValueError(
                 f"row {i}: expected ref, date, description"
@@ -73,7 +56,7 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
         if not ref:
             raise ValueError(f"row {i}: empty ref (each row needs a key)")
         try:
-            splits = _batch_row_splits(fields[fixed:], layout["has_memos"])
+            splits = _batch_row_splits(fields[fixed:], group)
         except ValueError as e:
             raise ValueError(f"row {i} (ref {ref!r}): {e}")
         txn = {
@@ -357,19 +340,34 @@ def register(mcp, get_book) -> None:
 
               ref<TAB>date<TAB>description<TAB>notes<TAB>amt1<TAB>acct1...
 
-        Both extensions combine (ref, date, description, notes, then
-        triples).
+        - PER-SPLIT QUANTITY — declare ``qty`` split columns for
+          splits whose ACCOUNT commodity differs from the book
+          default (investment shares, foreign-currency accounts)::
+
+              ref<TAB>date<TAB>description<TAB>amt1<TAB>acct1<TAB>qty1<TAB>amt2<TAB>acct2<TAB>qty2
+              1<TAB>2026-07-01<TAB>VFIFX Purchase<TAB>-505.17<TAB>Assets:Checking<TAB><TAB>505.17<TAB>Assets:401k:VFIFX<TAB>7.7936
+
+          ``amount`` stays in the book's default currency (the
+          transaction currency — batch never changes that); ``qty``
+          is the amount in the account's own commodity. An EMPTY qty
+          cell means the account uses the default currency
+          (quantity == amount). A non-default-commodity account with
+          an empty qty rejects that row.
+
+        All extensions combine; when several split fields are
+        declared, the header's FIRST group fixes their order (e.g.
+        ``amt, acct, memo, qty``).
 
         - ``ref``: YOUR correlation key per row (e.g. 1, 2, 3), unique
           within the batch. It is echoed back so you can match results
           to what you sent; the server never reuses or interprets it.
-        - ``date``: ISO YYYY-MM-DD. ``amount``: decimal STRING (never a
-          raw JSON number). Each transaction needs >=2 splits balancing
-          to zero. Rows may differ in width (2 splits vs 3).
-        - v1 is same-currency (book default) — use
-          ``create_transaction`` for cross-currency or investment
-          entries. ``qty`` columns are a planned extension and are
-          rejected explicitly for now, not misparsed.
+        - ``date``: ISO YYYY-MM-DD. ``amount``/``qty``: decimal
+          STRINGS (never raw JSON numbers). Each transaction needs
+          >=2 splits balancing to zero in the default currency. Rows
+          may differ in width (2 splits vs 3).
+        - The transaction currency is always the book default — for
+          a transaction denominated in another currency, use
+          ``create_transaction`` with its ``currency`` parameter.
 
         BEHAVIOR — one book-open, one atomic save:
         - A STRUCTURAL error (unbalanced, unknown account, bad pairs)

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -39,6 +39,21 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
             "transactions TSV needs a header row and at least one data row"
         )
     layout = _batch_tsv_layout(lines[0])
+    # Forward-compat guard: qty columns are the planned cross-currency
+    # extension, not yet implemented. Without this check a qty header
+    # falls into pairs mode and rejects rows with a bewildering
+    # "Account not found: <number>" — fail on the format instead.
+    header_tokens = {
+        t.strip().lower().rstrip("0123456789")
+        for t in lines[0].split("\t")
+    }
+    if header_tokens & {"qty", "quantity"}:
+        raise ValueError(
+            "qty columns are not supported yet — batch entry is "
+            "same-currency (quantity always equals amount). Use "
+            "create_transaction for cross-currency or investment "
+            "entries."
+        )
     fixed = 4 if layout["has_notes"] else 3
     width = 3 if layout["has_memos"] else 2
     shape = (
@@ -353,7 +368,8 @@ def register(mcp, get_book) -> None:
           to zero. Rows may differ in width (2 splits vs 3).
         - v1 is same-currency (book default) — use
           ``create_transaction`` for cross-currency or investment
-          entries.
+          entries. ``qty`` columns are a planned extension and are
+          rejected explicitly for now, not misparsed.
 
         BEHAVIOR — one book-open, one atomic save:
         - A STRUCTURAL error (unbalanced, unknown account, bad pairs)

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -5,6 +5,7 @@ method directly (the tool wrapper + audit are tested separately).
 """
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -137,18 +138,63 @@ class TestBatchTsvParser:
         assert len(rows[1]["splits"]) == 3
         assert rows[1]["splits"][2]["memo"] == "c"
 
-    def test_qty_columns_rejected_clearly(self):
-        """qty is the planned 1.5 cross-currency extension. Until it
-        exists, a qty header must fail on the FORMAT — falling into
-        pairs mode would reject rows with a bewildering
-        'Account not found: <number>' instead."""
+    def test_qty_header_switches_to_quantity_groups(self):
         tsv = (
             "ref\tdate\tdescription\tamt1\tacct1\tqty1"
             "\tamt2\tacct2\tqty2\n"
             "1\t2026-07-01\tVFIFX Purchase\t-505.17\tAssets:Checking\t"
             "\t505.17\tAssets:401k:VFIFX\t7.7936"
         )
-        with pytest.raises(ValueError, match="qty columns are not supported"):
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == [
+            # empty qty cell → same-currency split, no quantity key
+            {"account": "Assets:Checking", "amount": "-505.17"},
+            {
+                "account": "Assets:401k:VFIFX", "amount": "505.17",
+                "quantity": "7.7936",
+            },
+        ]
+
+    def test_quad_group_memo_and_qty(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\tqty\n"
+            "1\t2026-07-01\tShares\t-10.00\tAssets:Checking\tsettle\t"
+            "\t10.00\tAssets:401k:VFIFX\t\t0.153"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][0] == {
+            "account": "Assets:Checking", "amount": "-10.00",
+            "memo": "settle",
+        }
+        assert rows[0]["splits"][1] == {
+            "account": "Assets:401k:VFIFX", "amount": "10.00",
+            "quantity": "0.153",
+        }
+
+    def test_header_first_group_fixes_field_order(self):
+        """qty-before-memo in the header → qty-before-memo in rows.
+        The header is the schema for ORDER, not just presence."""
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tqty\tmemo\n"
+            "1\t2026-07-01\tShares\t10.00\tAssets:401k:VFIFX"
+            "\t0.153\tbuy\t-10.00\tAssets:Checking\t\tsettle"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][0] == {
+            "account": "Assets:401k:VFIFX", "amount": "10.00",
+            "quantity": "0.153", "memo": "buy",
+        }
+        assert rows[0]["splits"][1] == {
+            "account": "Assets:Checking", "amount": "-10.00",
+            "memo": "settle",
+        }
+
+    def test_unknown_split_token_in_extension_header_rejects(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\tcurrency\n"
+            "1\t2026-07-01\tX\t-1\tA\tm\tEUR\t1\tB\t\t"
+        )
+        with pytest.raises(ValueError, match="unrecognized split column"):
             _parse_transactions_tsv(tsv)
 
     def test_triple_count_mismatch_names_the_tab(self):
@@ -158,7 +204,7 @@ class TestBatchTsvParser:
             "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\tcard"
             "\t5.00\tExpenses:Groceries"
         )
-        with pytest.raises(ValueError, match="memo cell's tab"):
+        with pytest.raises(ValueError, match="still needs\\s+its tab"):
             _parse_transactions_tsv(tsv)
 
 
@@ -253,6 +299,52 @@ class TestBatchCreate:
         txn = gc.get_transaction(rows[0]["txn_guid"])
         assert "notes" not in txn
         assert all(not s.get("memo") for s in txn["splits"])
+
+    def test_cross_commodity_quantity_round_trip(self, multi_currency_book):
+        """A batch row with an explicit quantity on a non-default-
+        commodity account books value in the transaction currency
+        and quantity in the account's commodity — same contract as
+        create_transaction, same validation chokepoint."""
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1",
+            "date": date(2026, 7, 1),
+            "description": "EUR top-up",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-1100.00"},
+                {
+                    "account": "Assets:Euro Savings",
+                    "amount": "1100.00",
+                    "quantity": "1000.00",
+                    "memo": "wire ref 4471",
+                },
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        eur = [s for s in txn["splits"]
+               if s["account"] == "Assets:Euro Savings"][0]
+        assert Decimal(eur["value"]) == Decimal("1100.00")
+        assert Decimal(eur["quantity"]) == Decimal("1000.00")
+        assert eur["memo"] == "wire ref 4471"
+
+    def test_missing_quantity_on_foreign_account_rejects_row(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1",
+            "date": date(2026, 7, 1),
+            "description": "EUR top-up sans qty",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-1100.00"},
+                {"account": "Assets:Euro Savings", "amount": "1100.00"},
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "quantity" in rows[0]["reason"].lower()
 
     def test_checksum_dupcount_equals_table_rows(self, test_book):
         gc = GnuCashBook(str(test_book))

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -9,6 +9,7 @@ from datetime import date
 import pytest
 
 from gnucash_mcp.book import GnuCashBook
+from gnucash_mcp.tools.core import _parse_transactions_tsv
 
 
 def _parse(tsv: str) -> list[dict]:
@@ -46,6 +47,105 @@ def _seed_rent(gc):
 
 def _descriptions(gc):
     return {t["description"] for t in gc.list_transactions(compact=False)["transactions"]}
+
+
+class TestBatchTsvParser:
+    """Header-driven layout of the batch TSV (tool-layer parser).
+
+    The header declares the shape: legacy headers parse as
+    positional (amount, account) pairs exactly as before; ``memo``
+    split columns switch to triples; a ``notes`` token in column 4
+    inserts a per-transaction notes column.
+    """
+
+    def test_legacy_pairs_unchanged(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-05-21\tGas\t-54.19\tAssets:Checking"
+            "\t54.19\tExpenses:Auto:Fuel"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == [
+            {"account": "Assets:Checking", "amount": "-54.19"},
+            {"account": "Expenses:Auto:Fuel", "amount": "54.19"},
+        ]
+        assert "notes" not in rows[0]
+
+    def test_arbitrary_legacy_header_still_pairs(self):
+        """Pre-extension callers could put anything in the header
+        (it was purely decorative) — those parse as pairs still."""
+        tsv = (
+            "col_a\tcol_b\tcol_c\tcol_d\tcol_e\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking"
+            "\t5.00\tExpenses:Groceries"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert len(rows[0]["splits"]) == 2
+        assert "memo" not in rows[0]["splits"][0]
+
+    def test_memo_header_switches_to_triples(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tmemo1"
+            "\tamt2\tacct2\tmemo2\n"
+            "1\t2026-05-21\tGas\t-54.19\tAssets:Checking\tcard #4471"
+            "\t54.19\tExpenses:Auto:Fuel\t"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == [
+            {
+                "account": "Assets:Checking", "amount": "-54.19",
+                "memo": "card #4471",
+            },
+            # empty memo cell → no memo key
+            {"account": "Expenses:Auto:Fuel", "amount": "54.19"},
+        ]
+
+    def test_notes_column(self):
+        tsv = (
+            "ref\tdate\tdescription\tnotes\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-05-21\tGas\tfrom July statement\t-5.00"
+            "\tAssets:Checking\t5.00\tExpenses:Groceries\n"
+            "2\t2026-05-22\tCoffee\t\t-4.00\tAssets:Checking"
+            "\t4.00\tExpenses:Groceries"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["notes"] == "from July statement"
+        assert "notes" not in rows[1]  # empty cell → absent
+
+    def test_notes_and_memos_combined(self):
+        tsv = (
+            "ref\tdate\tdescription\tnotes\tamt\tacct\tmemo"
+            "\tamt\tacct\tmemo\n"
+            "1\t2026-05-21\tGas\tstatement p.2\t-5.00"
+            "\tAssets:Checking\tcard #4471\t5.00"
+            "\tExpenses:Groceries\t"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["notes"] == "statement p.2"
+        assert rows[0]["splits"][0]["memo"] == "card #4471"
+
+    def test_ragged_rows_with_triples(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\n"
+            "1\t2026-05-21\tTwo splits\t-5.00\tAssets:Checking\ta"
+            "\t5.00\tExpenses:Groceries\tb\n"
+            "2\t2026-05-21\tThree splits\t-9.00\tAssets:Checking\t"
+            "\t4.00\tExpenses:Groceries\t\t5.00\tExpenses:Dining\tc"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert len(rows[0]["splits"]) == 2
+        assert len(rows[1]["splits"]) == 3
+        assert rows[1]["splits"][2]["memo"] == "c"
+
+    def test_triple_count_mismatch_names_the_tab(self):
+        # Last memo cell's tab dropped — THE likely mistake.
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\tcard"
+            "\t5.00\tExpenses:Groceries"
+        )
+        with pytest.raises(ValueError, match="memo cell's tab"):
+            _parse_transactions_tsv(tsv)
 
 
 class TestBatchCreate:
@@ -116,6 +216,29 @@ class TestBatchCreate:
         rows = _parse(env["results"])
         assert rows[0]["status"] == "would_create"
         assert "Preview" not in _descriptions(gc)
+
+    def test_notes_and_memos_round_trip(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        t = _txn(1, "Gas fill-up", "54.19")
+        t["notes"] = "from July statement, p.2"
+        t["splits"][0]["memo"] = "card #4471"
+        env = gc.create_transactions([t])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        assert txn["notes"] == "from July statement, p.2"
+        memos = {s["account"]: s.get("memo", "") for s in txn["splits"]}
+        assert memos["Assets:Checking"] == "card #4471"
+        assert memos["Expenses:Groceries"] == ""
+
+    def test_plain_batch_shape_unchanged(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([_txn(1, "Plain", "10.00")])
+        rows = _parse(env["results"])
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        assert "notes" not in txn
+        assert all(not s.get("memo") for s in txn["splits"])
 
     def test_checksum_dupcount_equals_table_rows(self, test_book):
         gc = GnuCashBook(str(test_book))

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -137,6 +137,20 @@ class TestBatchTsvParser:
         assert len(rows[1]["splits"]) == 3
         assert rows[1]["splits"][2]["memo"] == "c"
 
+    def test_qty_columns_rejected_clearly(self):
+        """qty is the planned 1.5 cross-currency extension. Until it
+        exists, a qty header must fail on the FORMAT — falling into
+        pairs mode would reject rows with a bewildering
+        'Account not found: <number>' instead."""
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tqty1"
+            "\tamt2\tacct2\tqty2\n"
+            "1\t2026-07-01\tVFIFX Purchase\t-505.17\tAssets:Checking\t"
+            "\t505.17\tAssets:401k:VFIFX\t7.7936"
+        )
+        with pytest.raises(ValueError, match="qty columns are not supported"):
+            _parse_transactions_tsv(tsv)
+
     def test_triple_count_mismatch_names_the_tab(self):
         # Last memo cell's tab dropped — THE likely mistake.
         tsv = (

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -732,6 +732,60 @@ class TestBudgetAndScheduledAuditHandlers:
         assert 'CREATE FROM SCHEDULED  "Car Insurance" (2026-08-01)' in rendered
         assert "rejected: equivalent transaction already exists" in rendered
 
+    def test_batch_create_renders_notes_and_memos(self):
+        """The batch audit block re-parses the submitted TSV via the
+        shared header-aware layout — memo-declaring headers render
+        per-split memos, and the notes column gets its own line."""
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        submitted = (
+            "ref\tdate\tdescription\tnotes\tamt\tacct\tmemo\n"
+            "1\t2026-07-15\tGas\tstatement p.2\t-54.19"
+            "\tAssets:Checking\tcard #4471"
+            "\t54.19\tExpenses:Auto:Fuel\t"
+        )
+        entry = {
+            "classification": "write",
+            "entity_type": "transaction",
+            "operation": "create_batch",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"transactions": submitted},
+            "after_state": {
+                "results": (
+                    "ref\tstatus\ttxn_guid\tdup_count\treason\n"
+                    "1\tcreated\tabcd1234\t\t"
+                ),
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'CREATE  guid:abcd1234  "Gas" (2026-07-15)' in rendered
+        assert "notes: statement p.2" in rendered
+        assert "card #4471" in rendered
+
+    def test_legacy_batch_submission_renders_as_before(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        submitted = (
+            "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-07-15\tGas\t-54.19\tAssets:Checking"
+            "\t54.19\tExpenses:Auto:Fuel"
+        )
+        entry = {
+            "classification": "write",
+            "entity_type": "transaction",
+            "operation": "create_batch",
+            "timestamp": "2026-07-15T18:00:00",
+            "params": {"transactions": submitted},
+            "after_state": {
+                "results": (
+                    "ref\tstatus\ttxn_guid\tdup_count\treason\n"
+                    "1\tcreated\tabcd1234\t\t"
+                ),
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert 'CREATE  guid:abcd1234  "Gas" (2026-07-15)' in rendered
+        assert "notes:" not in rendered
+        assert "Checking" in rendered
+
     def test_entry_create_renders_notes_and_action(self):
         from gnucash_mcp.logging_config import _format_audit_entry_text
         entry = {


### PR DESCRIPTION
## Summary
- The `create_transactions` TSV header row now declares the layout: legacy headers parse as positional (amount, account) pairs byte-identically; `memo` and/or `qty` split columns widen each split group (field order per the header's first group); a `notes` token after `description` adds per-transaction notes.
- qty brings cross-commodity splits to batch (promoted from the 1.5 backlog): the book layer supported per-split quantity all along via the shared `_validate_transaction_splits` chokepoint — the restriction was parser-only. Transaction currency remains the book default.
- Layout detection lives once in `_format.py`, shared by the tool parser and the audit log's display parser. Batch audit blocks render notes and per-split memos; `_format_splits_text` appends memos everywhere.

## Test plan
- [x] Full suite: 1829/1829 (18 new: parser layouts incl. header-order variation, book round-trips incl. cross-commodity qty + missing-qty rejection, audit formatter shapes, legacy locks)
- [x] Live smoke on scratch Alex: legacy identical; notes+memo+qty quad bought 3.8127 VTSAX shares correctly; dry_run clean
- [x] Bookkeeper round (specs/BOOKKEEPER_TEST_PLAN_BATCH_MEMO.md): 8 steps pass incl. the 3-split distinct-memo/qty association check; one finding (unknown header columns surface a raw decimal error) accepted as a follow-up fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)