### PR TITLE
fix(core): validate every batch header column by name

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -213,57 +213,68 @@ _BATCH_SPLIT_TOKENS = {
     "qty": "quantity", "quantity": "quantity",
 }
 
-# The legacy positional shape, used whenever the header doesn't
-# declare an extension token (memo/qty) — pre-extension headers were
-# purely decorative, so anything non-declaring parses as pairs.
+# Fallback shape for the audit log's display parser when a stored
+# submission's header no longer validates (it renders rows as
+# pairs rather than crashing log rendering).
 _BATCH_LEGACY_GROUP = ("amount", "account")
 
 
 def _batch_tsv_layout(header_line: str) -> dict:
     """Column layout of a batch-entry TSV, derived from its header.
 
-    The original format ignored the header entirely (positional
-    ``(amount, account)`` pairs). Extensions are header-declared so
-    legacy submissions parse byte-identically:
+    Fixed prefix ``ref, date, description``, an optional ``notes``
+    column, then split columns. The split-group field sequence is
+    whatever the header's FIRST group declares (``amt, acct`` pairs;
+    ``amt, acct, memo`` triples; ``amt, acct, qty``;
+    ``amt, acct, memo, qty`` — in any intra-group order): the header
+    is the schema, for field order too.
 
-    - a ``notes`` token in column 4 → a per-transaction notes column
-      sits between ``description`` and the split columns
-    - a ``memo`` and/or ``qty`` token among the split columns →
-      each split group widens to include that field, in the order
-      the header's FIRST group declares (e.g. ``amt, acct, memo,
-      qty`` or ``amt, acct, qty`` — the header is the schema, for
-      field order too)
+    EVERY column name is validated. Now that the header is
+    load-bearing, an unknown or typo'd token (``meno1``,
+    ``currency2``) must fail on the format — silently falling back
+    to positional pairs would misparse the row and surface a raw
+    decimal error on whatever landed in an amount slot (bookkeeper
+    finding, 1.4.1 validation round).
 
-    Returns ``{"has_notes": bool, "group": tuple[str, ...]}`` where
-    ``group`` is the per-split field sequence in canonical names
-    (``amount`` / ``account`` / ``memo`` / ``quantity``).
+    Returns ``{"has_notes": bool, "group": tuple[str, ...]}`` with
+    ``group`` in canonical names (``amount`` / ``account`` /
+    ``memo`` / ``quantity``).
 
-    Raises ValueError when an extension is declared but the first
-    group is malformed (unknown token mixed in, duplicate field, or
-    missing amount/account).
+    Raises ValueError naming the offending column on any unknown
+    token, a wrong fixed prefix, or a first group missing
+    amount/account.
     """
-    tokens = [
-        t.strip().lower().rstrip("0123456789")
-        for t in header_line.split("\t")
-    ]
+    raw_tokens = [t.strip().lower() for t in header_line.split("\t")]
+    # Tolerate trailing empty cells (a trailing tab on the header).
+    while raw_tokens and not raw_tokens[-1]:
+        raw_tokens.pop()
+    tokens = [t.rstrip("0123456789") for t in raw_tokens]
+
+    if len(tokens) < 3 or tokens[0] != "ref" or tokens[1] != "date" \
+            or tokens[2] not in ("description", "desc"):
+        raise ValueError(
+            "batch header must start with ref, date, description "
+            f"— got {', '.join(raw_tokens[:3]) or '(empty header)'}"
+        )
     has_notes = len(tokens) > 3 and tokens[3] == "notes"
-    split_tokens = tokens[4:] if has_notes else tokens[3:]
+    start = 4 if has_notes else 3
 
-    canonical = [_BATCH_SPLIT_TOKENS.get(t) for t in split_tokens]
-    if not ({"memo", "quantity"} & set(canonical)):
-        # No extension declared — legacy positional pairs, header
-        # content otherwise irrelevant.
-        return {"has_notes": has_notes, "group": _BATCH_LEGACY_GROUP}
-
-    # Extension mode: the first group runs until a field repeats.
-    group: list[str] = []
-    for raw, name in zip(split_tokens, canonical):
+    canonical: list[str] = []
+    for raw, token in zip(raw_tokens[start:], tokens[start:]):
+        name = _BATCH_SPLIT_TOKENS.get(token)
         if name is None:
             raise ValueError(
-                f"unrecognized split column {raw!r} in a header that "
-                f"declares memo/qty columns — split columns must be "
-                f"amt, acct, memo, or qty"
+                f"unrecognized column {raw!r} in batch header — "
+                f"columns are ref, date, description, notes, then "
+                f"amt, acct, memo, qty split groups"
             )
+        canonical.append(name)
+
+    # The first group runs until a field repeats; later groups are
+    # not order-checked (rows are chunked by the first group's
+    # shape), but every token was validated above.
+    group: list[str] = []
+    for name in canonical:
         if name in group:
             break
         group.append(name)

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -23,12 +23,13 @@ from gnucash_mcp.tools._helpers import (
 def _parse_transactions_tsv(tsv: str) -> list[dict]:
     """Parse the batch-entry TSV into structured transactions.
 
-    The header row is load-bearing (see ``_batch_tsv_layout``): a
-    legacy header parses as positional ``(amount, account)`` pairs
-    exactly as before; a header declaring ``memo`` and/or ``qty``
-    split columns widens each split group accordingly (field order
-    per the header's first group), and a ``notes`` token in column 4
-    inserts a per-transaction notes column after ``description``.
+    The header row is load-bearing (see ``_batch_tsv_layout``): the
+    documented base header parses as positional ``(amount, account)``
+    pairs exactly as before; ``memo`` and/or ``qty`` split columns
+    widen each split group accordingly (field order per the header's
+    first group); a ``notes`` token in column 4 inserts a
+    per-transaction notes column after ``description``. Unknown or
+    typo'd column names reject with the offending name.
 
     Rows may be ragged (2 splits vs 3). Raises ValueError on a
     missing header, too-few columns, or a split count that doesn't

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -72,17 +72,46 @@ class TestBatchTsvParser:
         ]
         assert "notes" not in rows[0]
 
-    def test_arbitrary_legacy_header_still_pairs(self):
-        """Pre-extension callers could put anything in the header
-        (it was purely decorative) — those parse as pairs still."""
+    def test_unknown_header_columns_reject_by_name(self):
+        """6c (bookkeeper finding): now that the header is load-
+        bearing, unknown columns must fail on the FORMAT with the
+        offending name — falling back to positional pairs misparsed
+        rows into raw decimal errors."""
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tcurrency1"
+            "\tamt2\tacct2\tcurrency2\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\tUSD"
+            "\t5.00\tExpenses:Groceries\tUSD"
+        )
+        with pytest.raises(ValueError, match="unrecognized column 'currency1'"):
+            _parse_transactions_tsv(tsv)
+
+    def test_typoed_memo_token_rejects_instead_of_misparsing(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tmeno1\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\toops"
+            "\t5.00\tExpenses:Groceries\t"
+        )
+        with pytest.raises(ValueError, match="unrecognized column 'meno1'"):
+            _parse_transactions_tsv(tsv)
+
+    def test_wrong_fixed_prefix_rejects(self):
         tsv = (
             "col_a\tcol_b\tcol_c\tcol_d\tcol_e\n"
             "1\t2026-05-21\tGas\t-5.00\tAssets:Checking"
             "\t5.00\tExpenses:Groceries"
         )
+        with pytest.raises(ValueError, match="must start with ref, date"):
+            _parse_transactions_tsv(tsv)
+
+    def test_trailing_header_tab_tolerated(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\t\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking"
+            "\t5.00\tExpenses:Groceries"
+        )
         rows = _parse_transactions_tsv(tsv)
         assert len(rows[0]["splits"]) == 2
-        assert "memo" not in rows[0]["splits"][0]
 
     def test_memo_header_switches_to_triples(self):
         tsv = (
@@ -194,7 +223,7 @@ class TestBatchTsvParser:
             "ref\tdate\tdescription\tamt\tacct\tmemo\tcurrency\n"
             "1\t2026-07-01\tX\t-1\tA\tm\tEUR\t1\tB\t\t"
         )
-        with pytest.raises(ValueError, match="unrecognized split column"):
+        with pytest.raises(ValueError, match="unrecognized column"):
             _parse_transactions_tsv(tsv)
 
     def test_triple_count_mismatch_names_the_tab(self):


### PR DESCRIPTION
## Summary
- Bookkeeper finding 6c from the batch validation round: unknown header columns only rejected when a memo/qty token was also present — a header of pure unknowns (`currency1`) fell into legacy pairs mode and surfaced a raw ConversionSyntax. The same hole meant a typo (`meno1`) silently misparsed.
- Every column now validates: fixed `ref, date, description` prefix, optional `notes`, then known split tokens only. Unknown names reject naming the offending column. Trailing header tabs tolerated.
- Drops the arbitrary-header tolerance, which protected no documented caller — the docstring has always specified the header.

## Test plan
- [x] Full suite: 1832/1832 (4 new: currency1 rejection by name, meno1 typo rejection, wrong-prefix rejection, trailing-tab tolerance)
- [x] Bookkeeper 6c scenario reproduced as a test before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)