### PR TITLE
feat(core): delete_transaction accepts a list of GUIDs

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3833,6 +3833,41 @@ class CoreMixin:
 
             return result
 
+    def _validate_transaction_deletable(
+        self, book, transaction, force: bool,
+    ) -> int:
+        """Shared delete safeguards; returns the reconciled-split
+        count (0 when clean).
+
+        - Refuses an invoice's posting transaction: deleting it
+          orphans the invoice's posted-state metadata, after which
+          the invoice refuses both delete ("posted") and re-post
+          ("already posted") — SQL surgery is the only escape.
+          unpost_invoice clears the metadata properly.
+        - Refuses reconciled splits unless ``force``.
+        """
+        from sqlalchemy import text
+        posting_for = book.session.execute(
+            text("SELECT id FROM invoices WHERE post_txn = :guid"),
+            {"guid": transaction.guid},
+        ).fetchone()
+        if posting_for:
+            raise ValueError(
+                f"Transaction is the posting record for invoice "
+                f"{posting_for[0]}. Use unpost_invoice first."
+            )
+
+        reconciled = [
+            s for s in transaction.splits if s.reconcile_state == "y"
+        ]
+        if reconciled and not force:
+            acct_names = ", ".join(s.account.fullname for s in reconciled)
+            raise ValueError(
+                f"Transaction has reconciled splits in: {acct_names}. "
+                f"Deleting will break reconciliation. Use force=true to override."
+            )
+        return len(reconciled)
+
     def delete_transaction(self, guid: str, force: bool = False) -> dict:
         """Delete a transaction by GUID.
 
@@ -3852,32 +3887,9 @@ class CoreMixin:
             if not transaction:
                 raise ValueError(f"Transaction not found: {guid}")
 
-            # Refuse to delete an invoice's posting transaction: it
-            # orphans the invoice's posted-state metadata, after
-            # which the invoice refuses both delete ("posted") and
-            # re-post ("already posted") — SQL surgery is the only
-            # escape. unpost_invoice clears the metadata properly.
-            from sqlalchemy import text
-            posting_for = book.session.execute(
-                text("SELECT id FROM invoices WHERE post_txn = :guid"),
-                {"guid": transaction.guid},
-            ).fetchone()
-            if posting_for:
-                raise ValueError(
-                    f"Transaction is the posting record for invoice "
-                    f"{posting_for[0]}. Use unpost_invoice first."
-                )
-
-            # Check for reconciled splits
-            reconciled = [
-                s for s in transaction.splits if s.reconcile_state == "y"
-            ]
-            if reconciled and not force:
-                acct_names = ", ".join(s.account.fullname for s in reconciled)
-                raise ValueError(
-                    f"Transaction has reconciled splits in: {acct_names}. "
-                    f"Deleting will break reconciliation. Use force=true to override."
-                )
+            reconciled_count = self._validate_transaction_deletable(
+                book, transaction, force,
+            )
 
             # Stage pre-delete state for the audit log.
             self._stage_audit_before(_transaction_to_dict(transaction))
@@ -3891,14 +3903,92 @@ class CoreMixin:
                 "description": transaction.description,
                 "status": "deleted",
             }
-            if reconciled:
-                result["reconciled_splits_affected"] = len(reconciled)
+            if reconciled_count:
+                result["reconciled_splits_affected"] = reconciled_count
 
             # Delete the transaction
             book.session.delete(transaction)
             book.save()
 
             return result
+
+    def delete_transactions(
+        self, guids: list[str], force: bool = False,
+    ) -> dict:
+        """Delete several transactions in one book open / one save.
+
+        All-or-nothing: every guid must resolve and pass the same
+        safeguards as ``delete_transaction`` (invoice-posting guard,
+        reconciled splits vs ``force``) BEFORE anything is deleted —
+        validate-then-mutate, so a bad guid mid-list can't leave a
+        half-deleted batch.
+
+        Returns:
+            ``{status, count, transactions: [{guid, description,
+            reconciled_splits_affected?}]}`` — a dict envelope (not a
+            bare list) so the response machinery and audit decorator
+            see the same shape every write returns.
+
+        Raises:
+            ValueError: empty list, duplicate guid, any guid not
+                found, or any safeguard failure — nothing deleted.
+        """
+        if not guids:
+            raise ValueError("guids list is empty")
+
+        with self.open(readonly=False) as book:
+            resolved: list[tuple] = []
+            seen: set[str] = set()
+            for ref in guids:
+                transaction = self._find_transaction(book, ref)
+                if not transaction:
+                    raise ValueError(
+                        f"Transaction not found: {ref} (nothing deleted)"
+                    )
+                if transaction.guid in seen:
+                    raise ValueError(
+                        f"Duplicate guid in list: {ref} (nothing deleted)"
+                    )
+                seen.add(transaction.guid)
+                try:
+                    reconciled_count = self._validate_transaction_deletable(
+                        book, transaction, force,
+                    )
+                except ValueError as e:
+                    raise ValueError(f"{e} (nothing deleted)")
+                resolved.append((transaction, reconciled_count))
+
+            # Composite before-state — the audit formatter renders
+            # one block per deleted transaction from this list.
+            self._stage_audit_before({
+                "transactions": [
+                    _transaction_to_dict(t) for t, _ in resolved
+                ],
+            })
+
+            # Everything captured pre-delete: prefixes need the rows
+            # still present, attributes detach after the session
+            # closes.
+            all_guids = [t.guid for t in book.transactions]
+            items = []
+            for transaction, reconciled_count in resolved:
+                item = {
+                    "guid": _unique_prefix(transaction.guid, all_guids),
+                    "description": transaction.description,
+                }
+                if reconciled_count:
+                    item["reconciled_splits_affected"] = reconciled_count
+                items.append(item)
+
+            for transaction, _ in resolved:
+                book.session.delete(transaction)
+            book.save()
+
+            return {
+                "status": "deleted",
+                "count": len(items),
+                "transactions": items,
+            }
 
     def _verify_transaction_state(
         self,

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -736,8 +736,31 @@ def _fmt_transaction_unvoid(entry: dict) -> list[str]:
 def _fmt_transaction_delete(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     before = entry.get("before_state")
-    guid = _transaction_guid(entry)
+    after = entry.get("after_state") or {}
 
+    # Batch form: multi-guid delete_transaction. The response
+    # carries short guids + descriptions; the composite before-state
+    # carries dates and splits, in the same order.
+    if "transactions" in after:
+        after_txns = after.get("transactions") or []
+        before_txns = (before or {}).get("transactions") or []
+        count = after.get("count", len(after_txns))
+        lines = [
+            f"{time_part}  DELETE TRANSACTIONS (batch)  {count} deleted"
+        ]
+        for i, at in enumerate(after_txns):
+            bt = before_txns[i] if i < len(before_txns) else {}
+            lines.append(
+                f'{_INDENT}DELETE  guid:{at.get("guid", "")}  '
+                f'"{at.get("description", "")}" ({bt.get("date", "")})'
+            )
+            if bt.get("splits"):
+                lines.append(
+                    _format_splits_text(bt["splits"], _INDENT_SPLITS)
+                )
+        return lines
+
+    guid = _transaction_guid(entry)
     lines = [f"{time_part}  DELETE TRANSACTION  guid:{guid}"]
     if before:
         desc = before.get("description", "")

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -550,20 +550,32 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="transaction")
     def delete_transaction(
-        guid: TransactionGuid,
+        guid: TransactionGuid | list[TransactionGuid],
         force: bool = False,
     ) -> str:
-        """Delete a transaction by GUID.
+        """Delete one transaction by GUID — or several in one call.
 
-        Safeguards prevent deletion if the transaction has reconciled splits.
-        Use force=true to override.
+        Safeguards prevent deletion if a transaction has reconciled
+        splits (force=true overrides) or is an invoice's posting
+        record (unpost_invoice first).
+
+        Pass a LIST of GUIDs to delete several in one book open /
+        one save. The batch is all-or-nothing: every guid is
+        validated before anything is deleted, so a bad guid rejects
+        the whole call with nothing removed. Response for a list is
+        ``{status, count, transactions: [{guid, description}]}``;
+        a single guid returns the single-object shape as before.
 
         Args:
-            guid: Transaction GUID (32-character hex string, or 8+ char prefix)
-            force: Allow deleting transactions with reconciled splits
+            guid: Transaction GUID (32-char hex or 8+ char prefix),
+                or a list of them.
+            force: Allow deleting transactions with reconciled splits.
         """
         book = get_book()
-        result = book.delete_transaction(guid, force=force)
+        if isinstance(guid, list):
+            result = book.delete_transactions(guid, force=force)
+        else:
+            result = book.delete_transaction(guid, force=force)
         return _json(result)
 
     @mcp.tool()

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -6576,6 +6576,75 @@ class TestDeleteTransaction:
         assert gc_book.get_transaction(guid) is None
 
 
+class TestDeleteTransactions:
+    """Multi-guid delete: one open/save, all-or-nothing."""
+
+    def _make(self, gc_book, description: str) -> str:
+        result = gc_book.create_transaction(
+            description=description,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-10.00"},
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+            ],
+            check_duplicates=False,
+        )
+        return result["guid"]
+
+    def test_deletes_all_in_one_call(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        guids = [self._make(gc_book, f"Cleanup {i}") for i in range(3)]
+
+        result = gc_book.delete_transactions(guids)
+        assert result["status"] == "deleted"
+        assert result["count"] == 3
+        assert [t["description"] for t in result["transactions"]] == [
+            "Cleanup 0", "Cleanup 1", "Cleanup 2",
+        ]
+        for guid in guids:
+            assert gc_book.get_transaction(guid) is None
+
+    def test_bad_guid_aborts_whole_batch(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        guids = [self._make(gc_book, f"Keep {i}") for i in range(2)]
+
+        with pytest.raises(ValueError, match="nothing deleted"):
+            gc_book.delete_transactions(guids + ["deadbeef00000000"])
+        # All-or-nothing: the good guids survived.
+        for guid in guids:
+            assert gc_book.get_transaction(guid) is not None
+
+    def test_reconciled_without_force_aborts_whole_batch(
+        self, test_book: Path,
+    ):
+        gc_book = GnuCashBook(str(test_book))
+        clean = self._make(gc_book, "Clean one")
+        rec = self._make(gc_book, "Reconciled one")
+        txn = gc_book.get_transaction(rec)
+        gc_book.set_reconcile_state(txn["splits"][0]["guid"], "y")
+
+        with pytest.raises(ValueError, match="reconciled splits"):
+            gc_book.delete_transactions([clean, rec])
+        assert gc_book.get_transaction(clean) is not None
+
+        result = gc_book.delete_transactions([clean, rec], force=True)
+        assert result["count"] == 2
+        by_desc = {t["description"]: t for t in result["transactions"]}
+        assert by_desc["Reconciled one"]["reconciled_splits_affected"] == 1
+        assert "reconciled_splits_affected" not in by_desc["Clean one"]
+
+    def test_duplicate_guid_rejects(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        guid = self._make(gc_book, "Once only")
+        with pytest.raises(ValueError, match="Duplicate guid"):
+            gc_book.delete_transactions([guid, guid])
+        assert gc_book.get_transaction(guid) is not None
+
+    def test_empty_list_rejects(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError, match="empty"):
+            gc_book.delete_transactions([])
+
+
 class TestUpdateTransaction:
     """Tests for update_transaction method."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -786,6 +786,46 @@ class TestBudgetAndScheduledAuditHandlers:
         assert "notes:" not in rendered
         assert "Checking" in rendered
 
+    def test_batch_delete_renders_per_transaction_blocks(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "transaction",
+            "operation": "delete",
+            "timestamp": "2026-07-15T20:00:00",
+            "params": {"guid": ["83862278", "d868498f"]},
+            "before_state": {
+                "transactions": [
+                    {
+                        "description": "Test Legacy Coffee",
+                        "date": "2026-07-10",
+                        "splits": [
+                            {"account": "Assets:Checking", "value": "-4.50"},
+                            {"account": "Expenses:Dining", "value": "4.50"},
+                        ],
+                    },
+                    {
+                        "description": "Test Legacy Gas",
+                        "date": "2026-07-11",
+                        "splits": [],
+                    },
+                ],
+            },
+            "after_state": {
+                "status": "deleted",
+                "count": 2,
+                "transactions": [
+                    {"guid": "83862278", "description": "Test Legacy Coffee"},
+                    {"guid": "d868498f", "description": "Test Legacy Gas"},
+                ],
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "DELETE TRANSACTIONS (batch)  2 deleted" in rendered
+        assert 'DELETE  guid:83862278  "Test Legacy Coffee" (2026-07-10)' in rendered
+        assert 'DELETE  guid:d868498f  "Test Legacy Gas" (2026-07-11)' in rendered
+        assert "Checking" in rendered
+
     def test_entry_create_renders_notes_and_action(self):
         from gnucash_mcp.logging_config import _format_audit_entry_text
         entry = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -518,6 +518,25 @@ class TestDeleteTransactionTool:
         get_result = server_module.get_transaction(guid)
         assert "error" in json.loads(get_result)
 
+    def test_delete_list_of_guids(self, setup_book_env):
+        """A list dispatches to the batch path; response is the
+        envelope, and one call removes them all."""
+        transactions = json.loads(
+            server_module.list_transactions(verbose=True)
+        )["transactions"]
+        guids = [t["guid"] for t in transactions[:2]]
+
+        result = server_module.delete_transaction(guids)
+
+        data = json.loads(result)
+        assert data["status"] == "deleted"
+        assert data["count"] == 2
+        assert len(data["transactions"]) == 2
+        for guid in guids:
+            assert "error" in json.loads(
+                server_module.get_transaction(guid)
+            )
+
     def test_delete_reconciled_rejected(self, setup_book_env):
         """Should reject deleting a transaction with reconciled splits."""
         transactions = json.loads(server_module.list_transactions(verbose=True))["transactions"]


### PR DESCRIPTION
## Summary
- Bookkeeper request from the 1.4.1 validation round: cleanup took ten 20-second single-delete calls that should have been one. `delete_transaction` now accepts a list of GUIDs — same tool, same parameter, single-guid behavior byte-identical.
- List input dispatches to a new `delete_transactions` book method: one open, one save, all-or-nothing (validate-then-mutate — every guid resolves and passes the safeguards before anything is deleted). The invoice-posting and reconciled-split guards are extracted into `_validate_transaction_deletable`, shared with single delete.
- List responses use a dict envelope `{status, count, transactions}` (not a bare list) so the audit decorator and response machinery see the standard write shape. The audit log renders a `DELETE TRANSACTIONS (batch)` block with per-transaction detail.

## Test plan
- [x] Full suite: 1839/1839 (7 new: multi-delete, all-or-nothing on bad guid, reconciled abort + force, duplicate guid, empty list, tool-layer list dispatch, batch audit rendering)
- [x] Bookkeeper live round: batch delete works, 6c fix re-verified on the same bounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)