### PR TITLE
feat(core): batch rows may end once required fields are present

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -296,21 +296,35 @@ def _batch_row_splits(rest: list[str], group: tuple[str, ...]) -> list[dict]:
     downstream — and an empty qty means "account commodity equals
     the transaction currency", the same-currency default).
 
-    Raises ValueError when the count doesn't divide evenly; the
-    message names the declared shape and calls out the likely
-    culprit (a dropped trailing tab on an empty final cell).
+    A row may end mid-group once the final split's REQUIRED fields
+    are present: omitted trailing cells are read as empty, so a
+    quad-header row can end right after its last account with no
+    placeholder tabs. Rows are still rejected when the omission
+    would swallow an amount or account — that's a misalignment, not
+    a shorthand.
     """
     width = len(group)
-    if len(rest) % width != 0:
-        shape = ", ".join(group)
-        hint = (
-            " A split with an empty trailing cell still needs "
-            "its tab." if width > 2 else ""
-        )
-        raise ValueError(
-            f"trailing fields must be ({shape}) groups per the "
-            f"header — got {len(rest)} fields.{hint}"
-        )
+    # Index just past the last required field — a trailing group
+    # shorter than this is missing amount/account, not merely
+    # skipping optional cells.
+    required_span = max(
+        i for i, f in enumerate(group) if f in ("amount", "account")
+    ) + 1
+    remainder = len(rest) % width
+    if remainder:
+        if remainder < required_span:
+            shape = ", ".join(group)
+            missing = ", ".join(
+                f for f in group[remainder:]
+                if f in ("amount", "account")
+            )
+            raise ValueError(
+                f"row ends mid-group: the last ({shape}) group has "
+                f"only {remainder} cell(s) and is missing {missing}. "
+                f"Optional trailing cells (memo/qty) may be omitted; "
+                f"amount and account may not."
+            )
+        rest = list(rest) + [""] * (width - remainder)
     splits: list[dict] = []
     for j in range(0, len(rest), width):
         split: dict = {}

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -332,10 +332,12 @@ def register(mcp, get_book) -> None:
           become ``(amount, account, memo)`` TRIPLES::
 
               ref<TAB>date<TAB>description<TAB>amt1<TAB>acct1<TAB>memo1<TAB>amt2<TAB>acct2<TAB>memo2
-              1<TAB>2026-05-21<TAB>Gas<TAB>-54.19<TAB>Assets:Checking<TAB>card #4471<TAB>54.19<TAB>Expenses:Auto:Fuel<TAB>
+              1<TAB>2026-05-21<TAB>Gas<TAB>-54.19<TAB>Assets:Checking<TAB>card #4471<TAB>54.19<TAB>Expenses:Auto:Fuel
 
-          An empty memo cell is fine, but every split is a FULL
-          triple — keep the tab even when the memo is blank.
+          Empty memo cells mid-row keep their tabs; a row may simply
+          END once its last split's amount and account are present
+          (trailing memo/qty cells are read as empty — no
+          placeholder tabs needed, as above).
         - PER-TRANSACTION NOTES — declare a ``notes`` column directly
           after ``description``::
 

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -226,14 +226,70 @@ class TestBatchTsvParser:
         with pytest.raises(ValueError, match="unrecognized column"):
             _parse_transactions_tsv(tsv)
 
-    def test_triple_count_mismatch_names_the_tab(self):
-        # Last memo cell's tab dropped — THE likely mistake.
+    def test_row_may_end_after_last_required_field(self):
+        """Trailing optional cells may be omitted — a triple-header
+        row ending right after its last account parses with an empty
+        memo (was THE most common formatting mistake; now shorthand)."""
         tsv = (
             "ref\tdate\tdescription\tamt\tacct\tmemo\n"
             "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\tcard"
             "\t5.00\tExpenses:Groceries"
         )
-        with pytest.raises(ValueError, match="still needs\\s+its tab"):
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == [
+            {
+                "account": "Assets:Checking", "amount": "-5.00",
+                "memo": "card",
+            },
+            {"account": "Expenses:Groceries", "amount": "5.00"},
+        ]
+
+    def test_quad_row_may_omit_both_trailing_optionals(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\tqty\n"
+            "1\t2026-05-21\tCoffee\t-4.50\tAssets:Checking\t\t"
+            "\t4.50\tExpenses:Dining"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][1] == {
+            "account": "Expenses:Dining", "amount": "4.50",
+        }
+
+    def test_quad_row_may_omit_just_the_final_optional(self):
+        # Ends after memo — only qty omitted.
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\tqty\n"
+            "1\t2026-05-21\tCoffee\t-4.50\tAssets:Checking\t\t"
+            "\t4.50\tExpenses:Dining\ttip included"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][1] == {
+            "account": "Expenses:Dining", "amount": "4.50",
+            "memo": "tip included",
+        }
+
+    def test_omission_respects_header_field_order(self):
+        # qty before memo in the header → ending after qty omits
+        # only the memo.
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tqty\tmemo\n"
+            "1\t2026-07-01\tShares\t-10.00\tAssets:Checking\t\tsettle"
+            "\t10.00\tAssets:401k:VFIFX\t0.153"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][1] == {
+            "account": "Assets:401k:VFIFX", "amount": "10.00",
+            "quantity": "0.153",
+        }
+
+    def test_omitting_required_fields_still_rejects(self):
+        # Row ends after an amount — the account is missing; that's
+        # a misalignment, not an optional-cell shorthand.
+        tsv = (
+            "ref\tdate\tdescription\tamt\tacct\tmemo\n"
+            "1\t2026-05-21\tGas\t-5.00\tAssets:Checking\tcard\t5.00"
+        )
+        with pytest.raises(ValueError, match="missing account"):
             _parse_transactions_tsv(tsv)
 
 


### PR DESCRIPTION
## Summary
- Trailing optional cells (memo/qty) in a batch row's last split group may be omitted — the parser pads them as empty, so a quad-header row can end right after its final account with no placeholder tabs. This removes the most common formatting mistake (the dropped trailing tab) by making it valid shorthand.
- Omissions that would swallow an amount or account still reject, naming the missing field — that's a misalignment, not shorthand. The cutoff respects header-declared field order (required span computed from the group).
- Interior empty cells keep their tabs; interior tab-drops remain caught by downstream account/decimal/balance validation.

## Test plan
- [x] Full suite: 1843/1843 (5 new: triple/quad omission, partial omission, header-order-aware omission, required-field rejection)
- [x] Bookkeeper live pass on the updated step 6 (shorthand accepted with genuinely-empty fields; amount-truncated row rejected by name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)