### PR TITLE
feat(core): query filter on list_accounts

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2175,6 +2175,7 @@ class CoreMixin:
         compact: bool = True,
         limit: int = 50,
         offset: int = 0,
+        query: str | None = None,
     ) -> dict | str:
         """List all accounts in the chart of accounts.
 
@@ -2185,11 +2186,19 @@ class CoreMixin:
         resolve ``%xxxxxxx``, full GUIDs, and paths interchangeably via
         ``_resolve_account``).
 
+        ``query`` is a case-insensitive substring match against the
+        full path AND the description — the description matters on
+        numbered charts (SKR03 "4930" carries its meaning in the
+        description, not the name). Substring, not word match, so it
+        is locale-neutral by construction. Composes with ``root``.
+
         Args:
             root: Optional subtree filter (path, ``%short``, or GUID).
             compact: If False, return a verbose envelope instead.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return.
+            query: Optional case-insensitive substring filter on
+                path/description.
         """
         with self.open(readonly=True) as book:
             # Template accounts are GnuCash internals, not part of
@@ -2204,6 +2213,7 @@ class CoreMixin:
                 resolved_root = self._resolve_account(book, root)
                 root = resolved_root.fullname if resolved_root else root
 
+            needle = query.lower() if query else None
             filtered = []
             for account in book.accounts:
                 if account.type == "ROOT":
@@ -2213,6 +2223,13 @@ class CoreMixin:
                 if root is not None:
                     fn = account.fullname
                     if fn != root and not fn.startswith(root + ":"):
+                        continue
+                if needle is not None:
+                    haystack = (
+                        f"{account.fullname}\n"
+                        f"{account.description or ''}"
+                    ).lower()
+                    if needle not in haystack:
                         continue
                 filtered.append(account)
 

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -110,6 +110,7 @@ def register(mcp, get_book) -> None:
         verbose: bool = False,
         limit: int = 50,
         offset: int = 0,
+        query: str | None = None,
     ) -> str:
         """List all accounts in the GnuCash chart of accounts.
 
@@ -118,15 +119,25 @@ def register(mcp, get_book) -> None:
         ``limit=0`` returns the count only. Use verbose=true for full
         JSON with guid, type, commodity, etc.
 
+        To FIND an account without paging the whole chart, pass
+        ``query`` — a case-insensitive substring matched against each
+        account's full path and description (e.g. query="grocer" or
+        query="4930" on a numbered chart). Results emit %short GUIDs
+        that every account-taking tool accepts. For searching
+        transactions by text or amount, use ``search_transactions``.
+
         Args:
             root: Filter to a subtree (e.g., "Expenses" for expense accounts only).
             verbose: If true, return full JSON details for each account.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
+            query: Case-insensitive substring filter on account
+                path/description. Combines with ``root``.
         """
         book = get_book()
         result = book.list_accounts(
-            root=root, compact=not verbose, limit=limit, offset=offset
+            root=root, compact=not verbose, limit=limit, offset=offset,
+            query=query,
         )
         if verbose:
             return _json(result)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3471,6 +3471,48 @@ class TestListAccounts:
         assert "Expenses:Groceries" in result
         assert "Income:Salary" in result
 
+    def test_query_matches_path_substring(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.list_accounts(query="grocer")
+        lines = result.strip().split("\n")
+        assert "of 1 accounts" in lines[0]
+        assert "Expenses:Groceries" in lines[1]
+
+    def test_query_is_case_insensitive(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        assert "Expenses:Groceries" in gc_book.list_accounts(query="GROCER")
+
+    def test_query_matches_description_on_numbered_chart(
+        self, test_book: Path,
+    ):
+        """SKR03-style: the name is a number, the meaning lives in
+        the description. query must reach it."""
+        gc_book = GnuCashBook(str(test_book))
+        gc_book.create_account(
+            name="4930", account_type="EXPENSE", parent="Expenses",
+            description="Bürobedarf",
+        )
+        result = gc_book.list_accounts(query="bürobedarf")
+        lines = result.strip().split("\n")
+        assert "of 1 accounts" in lines[0]
+        assert "Expenses:4930" in lines[1]
+        # And the number itself matches too.
+        assert "Expenses:4930" in gc_book.list_accounts(query="4930")
+
+    def test_query_composes_with_root(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        # "s" appears everywhere; scoped to Income it can't match
+        # any Expenses account.
+        result = gc_book.list_accounts(root="Income", query="salary")
+        lines = result.strip().split("\n")
+        assert "of 1 accounts" in lines[0]
+        assert "Income:Salary" in lines[1]
+
+    def test_query_no_match_reports_zero(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.list_accounts(query="zzz-not-there")
+        assert "Showing 0 of 0 accounts" in result
+
     def test_list_accounts_sorted(self, test_book: Path):
         """Compact output lines should be sorted by account name."""
         gc_book = GnuCashBook(str(test_book))


### PR DESCRIPTION
## Summary
- `list_accounts` gains `query`: a case-insensitive substring matched against each account's full path AND description. Finding one account no longer means paging the chart — decisive on numbered charts (SKR03) where meaning lives in the description, not the name.
- A parameter, not a `search_accounts` tool — same capability, zero tool-count cost. Composes with `root` and the pagination envelope; results emit %short GUIDs every account-taking tool accepts.

## Test plan
- [x] Full suite: 1848/1848 (5 new incl. description-match on a numbered account and root+query composition)
- [x] Bookkeeper round: English substring (Alex), SKR03 number and German+root (Sabine), Chinese characters (Lin Wei) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)