### PR TITLE
feat(core): splitless batch rows auto-fill from history

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -270,6 +270,12 @@ def _batch_tsv_layout(header_line: str) -> dict:
             )
         canonical.append(name)
 
+    if not canonical:
+        # No split columns declared at all — the natural header for
+        # an all-auto-fill batch (``ref, date, description``). Rows
+        # that do carry splits chunk as legacy pairs.
+        return {"has_notes": has_notes, "group": _BATCH_LEGACY_GROUP}
+
     # The first group runs until a field repeats; later groups are
     # not order-checked (rows are chunked by the first group's
     # shape), but every token was validated above.

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3111,7 +3111,11 @@ class CoreMixin:
         splits: [{account, amount, memo (optional),
         quantity (optional)}]}`` — quantity per the
         ``_validate_transaction_splits`` contract (required iff the
-        account commodity differs from the book default).
+        account commodity differs from the book default). An EMPTY
+        splits list is an auto-fill request: the row reproduces the
+        most recent matching-description transaction (splits, memos,
+        quantities), marked ``auto_filled_from:<guid>`` in the
+        results ``reason`` column; no match rejects the row.
 
         Three phases under one book-open: validate all structurally,
         screen each against existing-book duplicates, then build every
@@ -3148,6 +3152,26 @@ class CoreMixin:
                 ref = txn["ref"]
                 try:
                     splits = txn["splits"]
+                    auto_filled_from = None
+                    auto_fill_warnings: list[dict] = []
+                    if not splits:
+                        # A splitless row is an auto-fill request —
+                        # same contract as create_transaction with
+                        # ``splits`` omitted: reproduce the most
+                        # recent matching-description transaction.
+                        preflight = self._collect_create_signals(
+                            book, txn["description"], txn["date"],
+                            proposed_amounts=[],
+                            want_auto_fill=True, want_stability=True,
+                            want_duplicates=False, want_recent=False,
+                        )
+                        if preflight.auto_fill is None:
+                            raise ValueError(
+                                "no matching transaction to auto-fill "
+                                "from — provide explicit splits"
+                            )
+                        splits, auto_filled_from = preflight.auto_fill
+                        auto_fill_warnings = preflight.stability_warnings
                     if len(splits) < 2:
                         raise ValueError("at least 2 splits required")
                     validated = self._validate_transaction_splits(
@@ -3168,6 +3192,8 @@ class CoreMixin:
                         "proposed_amounts": [
                             abs(_to_decimal(s["amount"])) for s in splits
                         ],
+                        "auto_filled_from": auto_filled_from,
+                        "auto_fill_warnings": auto_fill_warnings,
                     })
                 except (ValueError, KeyError) as e:
                     by_ref[ref] = {
@@ -3209,10 +3235,25 @@ class CoreMixin:
             # so a decimal slip in a bulk import is caught too.
             warn_rows: list = []
             for p, _dc in accepted:
+                for w in p["auto_fill_warnings"]:
+                    warn_rows.append((p["ref"], w["message"]))
                 for w in self._fx_sanity_warnings(
                     book, p["validated"], default_currency, p["trans_date"],
                 ):
                     warn_rows.append((p["ref"], w["message"]))
+
+            # Auto-fill must be loud in the results: a row that
+            # ACCIDENTALLY lost its splits either rejects (no match)
+            # or lands here, visibly marked with its source.
+            def _fill_marker(p) -> dict:
+                if p["auto_filled_from"]:
+                    return {
+                        "reason": (
+                            f"auto_filled_from:"
+                            f"{p['auto_filled_from']['guid']}"
+                        ),
+                    }
+                return {}
 
             # --- Phase 3: build all accepted rows, one save ---
             if dry_run:
@@ -3220,6 +3261,7 @@ class CoreMixin:
                     by_ref[p["ref"]] = {
                         "ref": p["ref"], "status": "would_create",
                         "dup_count": dup_count,
+                        **_fill_marker(p),
                     }
                 return self._batch_envelope(
                     transactions, by_ref, dup_rows, warn_rows,
@@ -3241,7 +3283,7 @@ class CoreMixin:
                     post_date=p["trans_date"],
                     splits=piecash_splits,
                 )
-                built.append((p["ref"], txn_obj, dup_count))
+                built.append((p, txn_obj, dup_count))
 
             # Single flush for the whole batch — per the "don't flush
             # mid-build" rule, every Transaction is fully constructed
@@ -3249,11 +3291,12 @@ class CoreMixin:
             book.save()
 
             all_guids = [t.guid for t in book.transactions]
-            for ref, txn_obj, dup_count in built:
-                by_ref[ref] = {
-                    "ref": ref, "status": "created",
+            for p, txn_obj, dup_count in built:
+                by_ref[p["ref"]] = {
+                    "ref": p["ref"], "status": "created",
                     "txn_guid": _unique_prefix(txn_obj.guid, all_guids),
                     "dup_count": dup_count,
+                    **_fill_marker(p),
                 }
 
             return self._batch_envelope(

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -653,6 +653,14 @@ def _fmt_transaction_create_batch(entry: dict) -> list[str]:
         )
         if src.get("notes"):
             lines.append(f"{_INDENT_SPLITS}notes: {src['notes']}")
+        reason = r.get("reason", "")
+        if reason.startswith("auto_filled_from:"):
+            # Splitless submission — the source guid is the trail to
+            # what actually got booked.
+            source = reason.split(":", 1)[1]
+            lines.append(
+                f"{_INDENT_SPLITS}auto-filled from guid:{source}"
+            )
         splits = src.get("splits") or []
         if splits:
             lines.append(_format_splits_text(splits, _INDENT_SPLITS))

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -43,30 +43,39 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
     layout = _batch_tsv_layout(lines[0])
     group = layout["group"]
     fixed = 4 if layout["has_notes"] else 3
-    shape = f"({', '.join(group)}) group"
     out: list[dict] = []
     for i, ln in enumerate(lines[1:], start=1):
         fields = ln.split("\t")
-        if len(fields) < fixed + len(group):
-            notes_part = ", notes" if layout["has_notes"] else ""
+        # Trailing empty cells carry nothing in any position —
+        # stripping them makes "row ends after description" (the
+        # auto-fill request) robust to stray trailing tabs.
+        while fields and not fields[-1].strip():
+            fields.pop()
+        if len(fields) < 3:
             raise ValueError(
-                f"row {i}: expected ref, date, description"
-                f"{notes_part}, and at least one {shape}"
+                f"row {i}: expected at least ref, date, description"
             )
         ref, dt, desc = fields[0].strip(), fields[1].strip(), fields[2]
         if not ref:
             raise ValueError(f"row {i}: empty ref (each row needs a key)")
-        try:
-            splits = _batch_row_splits(fields[fixed:], group)
-        except ValueError as e:
-            raise ValueError(f"row {i} (ref {ref!r}): {e}")
+        if len(fields) <= fixed:
+            # No split cells at all: an auto-fill request — the book
+            # layer reproduces the most recent matching-description
+            # transaction (create_transaction's omitted-splits
+            # contract), or rejects the row when nothing matches.
+            splits: list[dict] = []
+        else:
+            try:
+                splits = _batch_row_splits(fields[fixed:], group)
+            except ValueError as e:
+                raise ValueError(f"row {i} (ref {ref!r}): {e}")
         txn = {
             "ref": ref,
             "date": _parse_iso_date(dt) or date.today(),
             "description": desc,
             "splits": splits,
         }
-        if layout["has_notes"] and fields[3].strip():
+        if layout["has_notes"] and len(fields) > 3 and fields[3].strip():
             txn["notes"] = fields[3].strip()
         out.append(txn)
     return out
@@ -371,6 +380,22 @@ def register(mcp, get_book) -> None:
         All extensions combine; when several split fields are
         declared, the header's FIRST group fixes their order (e.g.
         ``amt, acct, memo, qty``).
+
+        AUTO-FILL — a row with NO split cells at all (ends right
+        after ``description``/``notes``) reproduces the most recent
+        transaction with the same description — splits, memos, and
+        quantities included — exactly like calling
+        ``create_transaction`` without ``splits``::
+
+            1<TAB>2026-07-01<TAB>Rent
+            2<TAB>2026-07-01<TAB>Netflix
+
+        Auto-filled rows are marked ``auto_filled_from:<guid>`` in
+        the results ``reason`` column; a row whose description
+        matches nothing rejects ("no matching transaction to
+        auto-fill from"). Use ``dry_run=true`` to preview what a
+        batch of auto-fills would book. Perfect for recurring
+        monthly entries.
 
         - ``ref``: YOUR correlation key per row (e.g. 1, 2, 3), unique
           within the batch. It is echoed back so you can match results

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -282,6 +282,39 @@ class TestBatchTsvParser:
             "quantity": "0.153",
         }
 
+    def test_splitless_row_parses_as_auto_fill_request(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-07-01\tRent\n"
+            "2\t2026-07-01\tNetflix\t\t"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == []
+        # Stray trailing tabs stripped — still an auto-fill request.
+        assert rows[1]["splits"] == []
+
+    def test_minimal_header_for_all_autofill_batch(self):
+        """ref/date/description with no split columns at all — the
+        natural header for a pure auto-fill batch (found live: the
+        layout validator used to reject the empty split region)."""
+        tsv = (
+            "ref\tdate\tdescription\n"
+            "1\t2026-08-01\tMortgage Payment\n"
+            "2\t2026-08-01\tNetflix"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert [r["splits"] for r in rows] == [[], []]
+
+    def test_splitless_row_with_notes_column(self):
+        tsv = (
+            "ref\tdate\tdescription\tnotes\tamt\tacct\n"
+            "1\t2026-07-01\tRent\tJuly\n"
+            "2\t2026-07-01\tNetflix"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"] == [] and rows[0]["notes"] == "July"
+        assert rows[1]["splits"] == [] and "notes" not in rows[1]
+
     def test_omitting_required_fields_still_rejects(self):
         # Row ends after an amount — the account is missing; that's
         # a misalignment, not an optional-cell shorthand.
@@ -430,6 +463,86 @@ class TestBatchCreate:
         rows = _parse(env["results"])
         assert rows[0]["status"] == "rejected"
         assert "quantity" in rows[0]["reason"].lower()
+
+    def test_auto_fill_reproduces_last_shape(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        gc.create_transaction(
+            description="Rent",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-1800",
+                 "memo": "unit 4B"},
+                {"account": "Expenses:Groceries", "amount": "1800"},
+            ],
+            trans_date=date(2026, 5, 20),
+        )
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 6, 20),
+            "description": "Rent", "splits": [],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+        assert rows[0]["reason"].startswith("auto_filled_from:")
+
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        by_acct = {s["account"]: s for s in txn["splits"]}
+        assert by_acct["Assets:Checking"]["value"].startswith("-1800")
+        assert by_acct["Assets:Checking"]["memo"] == "unit 4B"
+        assert txn["date"] == "2026-06-20"
+
+    def test_auto_fill_no_match_rejects_row(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([
+            {"ref": "1", "date": date(2026, 6, 20),
+             "description": "Nothing like this exists", "splits": []},
+            _txn(2, "Real one", "25.00"),
+        ], on_error="skip")
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["1"]["status"] == "rejected"
+        assert "auto-fill" in rows["1"]["reason"]
+        assert rows["2"]["status"] == "created"
+
+    def test_auto_fill_no_match_aborts_batch_by_default(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([
+            {"ref": "1", "date": date(2026, 6, 20),
+             "description": "Nothing like this exists", "splits": []},
+            _txn(2, "Casualty", "25.00"),
+        ])
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["2"]["reason"] == "batch_aborted"
+        assert "Casualty" not in _descriptions(gc)
+
+    def test_auto_fill_dry_run_carries_marker(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        before = len(
+            gc.list_transactions(compact=False)["transactions"]
+        )
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 6, 20),
+            "description": "Rent", "splits": [],
+        }], dry_run=True)
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "would_create"
+        assert rows[0]["reason"].startswith("auto_filled_from:")
+        after = len(
+            gc.list_transactions(compact=False)["transactions"]
+        )
+        assert after == before  # nothing written
+
+    def test_auto_fill_still_screened_for_duplicates(self, test_book):
+        """Auto-filling 'Rent' dated within the duplicate window of
+        the source rejects like any other duplicate — auto-fill is
+        not a bypass."""
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)  # 2026-05-20
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 5, 21),
+            "description": "Rent", "splits": [],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert rows[0]["reason"] == "duplicate_detected"
 
     def test_checksum_dupcount_equals_table_rows(self, test_book):
         gc = GnuCashBook(str(test_book))


### PR DESCRIPTION
## Summary
- A batch row ending right after `description`/`notes` carries zero splits, and zero splits is the auto-fill request: reproduce the most recent matching-description transaction (splits, memos, quantities) — the same contract as `create_transaction` with `splits` omitted. Twelve recurring bills become twelve ref-date-description rows.
- Auto-fill is loud: rows carry `auto_filled_from:<guid>` in the results `reason` column, the audit batch block renders the source, no-match rejects the row (also catching accidentally-truncated rows), stability warnings join the warnings table, and filled rows still pass the duplicate screen with their filled amounts.
- The minimal `ref/date/description` header (no split columns) now parses — found via live smoke; the header validator rejected the empty split region.

## Test plan
- [x] Full suite: 1856/1856 (8 new: parser splitless forms + minimal header, shape reproduction incl. memo, no-match under abort and skip, dry-run marker, duplicate screening of filled rows)
- [x] Live smoke: Alex's real mortgage history — 3-split shape reproduced to the penny, source guid in results and audit
- [x] Bookkeeper round: passed; dry-run-first entry workflow validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)