### PR TITLE
fix: truthful bulk-reconcile audit entries + fake example GUIDs

### DIFF
--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -404,8 +404,9 @@ class ReconciliationMixin:
 
             book.save()
 
-            # Computed info only — the audit log reads the inputs
-            # from tool params.
+            # Computed info only — the audit log reads the statement
+            # inputs from tool params and the reconciled-split list
+            # from the staged before-state above.
             return {
                 "splits_reconciled": len(splits_to_reconcile),
                 "new_reconciled_balance": str(new_balance),

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -911,37 +911,49 @@ def _fmt_split_reconcile(entry: dict) -> list[str]:
     params = entry.get("params") or {}
     before = entry.get("before_state")
     split_details = (before or {}).get("splits", []) if before else []
-    split_guids = params.get("split_guids", []) or []
+
+    # The staged before-state lists the splits ACTUALLY reconciled —
+    # the only source in bulk mode, where reconcile_all=true sends no
+    # split_guids at all (reading only the param rendered
+    # "Splits reconciled (0):" on a 51-split sweep). Params remain the
+    # fallback for entries logged without a before-state.
+    if split_details:
+        reconciled = split_details
+    else:
+        reconciled = [{"guid": g} for g in (params.get("split_guids") or [])]
 
     lines = [
         f"{time_part}  RECONCILE  {params.get('account', '')}",
         f"{_INDENT}Statement date: {params.get('statement_date', '')}",
         f"{_INDENT}Statement balance: {_format_amount(params.get('statement_balance'))}",
-        f"{_INDENT}Splits reconciled ({len(split_guids)}):",
     ]
+    if params.get("reconcile_all"):
+        mode = "bulk (reconcile_all)"
+        if params.get("through_date"):
+            mode += f", through {params['through_date']}"
+        lines.append(f"{_INDENT}Mode: {mode}")
+    lines.append(f"{_INDENT}Splits reconciled ({len(reconciled)}):")
 
-    # First 10 splits with context. GUID matching tolerates prefix
-    # vs full forms (params may carry prefixes; before_state full).
-    for guid in split_guids[:10]:
-        split_info = next(
-            (
-                s for s in split_details
-                if s and (
-                    s.get("guid") == guid
-                    or s.get("guid", "").startswith(guid)
-                    or guid.startswith(s.get("guid", ""))
-                )
-            ),
-            None,
-        )
-        if split_info:
-            desc = split_info.get("transaction_description", "")
+    for split_info in reconciled[:10]:
+        guid = split_info.get("guid", "")
+        desc = split_info.get("transaction_description")
+        if desc is None:
+            lines.append(f"{_INDENT}  guid:{guid}")
+        else:
             amount = _format_amount(split_info.get("amount"))
             lines.append(f'{_INDENT}  guid:{guid}  "{desc}"  {amount:>10}')
-        else:
-            lines.append(f"{_INDENT}  guid:{guid}")
-    if len(split_guids) > 10:
-        lines.append(f"{_INDENT}  ... and {len(split_guids) - 10} more")
+    if len(reconciled) > 10:
+        lines.append(f"{_INDENT}  ... and {len(reconciled) - 10} more")
+
+    # Exclusions are part of "what happened": a bulk sweep that
+    # skipped a pending ACH should say so. Rendered as the caller
+    # supplied them (prefixes that didn't resolve were ignored).
+    excluded = params.get("except_guids") or []
+    if excluded:
+        lines.append(
+            f"{_INDENT}Excluded ({len(excluded)}): "
+            + ", ".join(f"guid:{g}" for g in excluded)
+        )
     return lines
 
 
@@ -2098,7 +2110,7 @@ def _extract_after_state(result: str, entity_type: str | None) -> dict | None:
             return data
 
         # reconcile_account returns a summary
-        if "reconciled_splits" in data:
+        if "splits_reconciled" in data:
             return data
 
         return data if data else None

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -48,8 +48,8 @@ ORIENTATION:
 - Use search_transactions before creating to avoid duplicates.
 - Every transaction has splits that MUST sum to zero.
 ACCOUNT REFERENCES:
-- Tools accept full paths ("Expenses:Groceries"), short GUIDs ("%2e78c86"), or full 32-char GUIDs.
-- list_accounts emits short GUIDs at line start: "%2e78c86\\tAssets:Savings [BANK]". Reuse them — ~80% smaller than paths.
+- Tools accept full paths ("Expenses:Groceries"), short GUIDs ("%xxxxxxx" form), or full 32-char GUIDs.
+- list_accounts emits short GUIDs at line start: "%xxxxxxx\\tAssets:Savings [BANK]" (x's are a placeholder — copy real GUIDs from list_accounts output). Reuse them — ~80% smaller than paths.
 - Paths are colon-delimited, case-sensitive. Use paths when naming new accounts or reasoning about hierarchy; short GUIDs for everything else.
 - Account short GUIDs: 7+ hex chars with leading "%". Transaction/split GUIDs: 8+ bare hex prefix, no marker.
 DOUBLE-ENTRY SIGN CONVENTION:

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -169,7 +169,8 @@ class SplitInput(BaseModel):
         Field(
             description=(
                 "Account ref: full path (e.g. 'Expenses:Rent'), "
-                "%short GUID (e.g. '%2e78c86'), or full 32-char GUID"
+                "%short GUID (e.g. '%xxxxxxx' — 7+ hex chars copied "
+                "from list_accounts), or full 32-char GUID"
             )
         ),
     ]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1129,6 +1129,173 @@ class TestAuditBeforeStateLeak:
         assert "this call's own description" in content
 
 
+class TestReconcileAuditRendering:
+    """The RECONCILE formatter must render the splits that were
+    ACTUALLY reconciled, sourced from the staged before-state.
+
+    Pre-fix it counted ``params["split_guids"]`` — absent in bulk
+    mode (``reconcile_all=true``), so a 51-split sweep logged
+    "Splits reconciled (0):" with an empty list. The book method
+    stages ``{"splits": [...]}`` in both modes; that list is the
+    authoritative record.
+    """
+
+    def _run(self, temp_book_path, staged: dict | None, result: dict,
+             **params) -> None:
+        """Run an audit-decorated fake reconcile_account with the
+        given staged before-state, JSON result, and tool params."""
+        book = _StagedBook(staged)
+        setup_logging(
+            book_path=str(temp_book_path),
+            debug=False,
+            get_book=lambda: book,
+        )
+
+        @audit_log(
+            classification="write", operation="reconcile",
+            entity_type="split",
+        )
+        def reconcile_account(**kwargs) -> str:
+            return json.dumps(result)
+
+        reconcile_account(**params)
+
+    def _read_log(self, temp_log_dir) -> str:
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        return (temp_log_dir / "audit" / f"{today}.txt").read_text()
+
+    def test_bulk_mode_renders_splits_from_before_state(
+        self, temp_book_path, temp_log_dir,
+    ):
+        """reconcile_all=true sends no split_guids; the count and
+        split lines must come from the staged before-state."""
+        staged = {
+            "splits": [
+                {
+                    "guid": f"{i:032x}",
+                    "account": "Assets:Checking",
+                    "amount": f"-{i + 1}.00",
+                    "reconcile_state": "n",
+                    "reconcile_date": None,
+                    "transaction_description": f"Payment {i + 1}",
+                    "transaction_date": "2026-07-01",
+                }
+                for i in range(12)
+            ]
+        }
+        self._run(
+            temp_book_path,
+            staged,
+            {"splits_reconciled": 12,
+             "new_reconciled_balance": "2089.42",
+             "status": "reconciled"},
+            account="Assets:Checking",
+            statement_date="2026-07-19",
+            statement_balance="2089.42",
+            reconcile_all=True,
+        )
+        content = self._read_log(temp_log_dir)
+
+        assert "Splits reconciled (12):" in content
+        assert "Splits reconciled (0):" not in content
+        assert '"Payment 1"' in content
+        assert f"guid:{0:032x}" in content
+        # Only the first 10 render; the rest collapse to a count.
+        assert "... and 2 more" in content
+        assert "Mode: bulk (reconcile_all)" in content
+
+    def test_bulk_mode_renders_through_date_and_exclusions(
+        self, temp_book_path, temp_log_dir,
+    ):
+        """through_date and except_guids are part of what happened
+        and must appear in the entry."""
+        staged = {
+            "splits": [{
+                "guid": "a" * 32,
+                "account": "Assets:Checking",
+                "amount": "-45.67",
+                "reconcile_state": "n",
+                "reconcile_date": None,
+                "transaction_description": "Groceries",
+                "transaction_date": "2026-06-30",
+            }]
+        }
+        self._run(
+            temp_book_path,
+            staged,
+            {"splits_reconciled": 1,
+             "new_reconciled_balance": "100.00",
+             "status": "reconciled"},
+            account="Assets:Checking",
+            statement_date="2026-07-19",
+            statement_balance="100.00",
+            reconcile_all=True,
+            through_date="2026-07-01",
+            except_guids=["cafe1234", "beef5678"],
+        )
+        content = self._read_log(temp_log_dir)
+
+        assert "Mode: bulk (reconcile_all), through 2026-07-01" in content
+        assert "Excluded (2): guid:cafe1234, guid:beef5678" in content
+        assert "Splits reconciled (1):" in content
+
+    def test_targeted_mode_details_from_before_state(
+        self, temp_book_path, temp_log_dir,
+    ):
+        """Targeted mode renders the same before-state details."""
+        staged = {
+            "splits": [{
+                "guid": "b" * 32,
+                "account": "Assets:Checking",
+                "amount": "-12.50",
+                "reconcile_state": "n",
+                "reconcile_date": None,
+                "transaction_description": "Lunch",
+                "transaction_date": "2026-07-10",
+            }]
+        }
+        self._run(
+            temp_book_path,
+            staged,
+            {"splits_reconciled": 1,
+             "new_reconciled_balance": "50.00",
+             "status": "reconciled"},
+            account="Assets:Checking",
+            statement_date="2026-07-19",
+            statement_balance="50.00",
+            split_guids=["b" * 8],
+        )
+        content = self._read_log(temp_log_dir)
+
+        assert "Splits reconciled (1):" in content
+        assert '"Lunch"' in content
+        assert f"guid:{'b' * 32}" in content
+        # No bulk-mode line for targeted reconciliation.
+        assert "Mode: bulk" not in content
+
+    def test_params_fallback_without_before_state(
+        self, temp_book_path, temp_log_dir,
+    ):
+        """Entries logged without a staged before-state fall back to
+        the split_guids param — bare guid lines, correct count."""
+        self._run(
+            temp_book_path,
+            None,
+            {"splits_reconciled": 2,
+             "new_reconciled_balance": "75.00",
+             "status": "reconciled"},
+            account="Assets:Checking",
+            statement_date="2026-07-19",
+            statement_balance="75.00",
+            split_guids=["cafe1234", "beef5678"],
+        )
+        content = self._read_log(temp_log_dir)
+
+        assert "Splits reconciled (2):" in content
+        assert "guid:cafe1234" in content
+        assert "guid:beef5678" in content
+
+
 class TestAuditLogIntegration:
     """Integration tests for the complete audit trail."""
 


### PR DESCRIPTION
## Summary
- The RECONCILE audit formatter counted `params["split_guids"]`, which `reconcile_all=true` never sends — bulk sweeps logged `Splits reconciled (0):` with an empty list (found live on the real book, 2026-07-19). The split list now comes from the staged before-state (authoritative in both modes, params as legacy fallback), and the entry renders the bulk mode, `through_date`, and `except_guids` exclusions. Also fixes the stale `reconciled_splits` key check in `_extract_after_state` (the book returns `splits_reconciled`).
- Model-facing example GUIDs (`%2e78c86`) replaced with the `%xxxxxxx` placeholder form in the server instructions and the shared account-ref `Field` description — a live session pasted the docs example into a real call and got "Account not found".

## Test plan
- [x] Full suite green: 1,860 passed, 0 failed
- [x] New `TestReconcileAuditRendering` coverage: bulk mode from before-state, through_date + exclusions, targeted mode
- [x] Live validation on a scratch copy of Alex: 67-split bulk sweep renders real count, `Mode: bulk (reconcile_all), through 2025-04-30`, and `Excluded (1)`; statement balance tied at 22,584.81
- [x] `grep` confirms no realistic example GUIDs remain in model-facing text (the one survivor is a human-facing code comment)