### PR TITLE
feat: notes convention — template notes, audit truth, leg preservation

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -4331,11 +4331,19 @@ class CoreMixin:
         Currency, description, date, and notes are preserved; the
         new splits must balance to zero.
 
+        A new split that reproduces an existing one (same account,
+        value, and quantity) is treated as an UNCHANGED leg: it
+        keeps the old split's memo (a caller-supplied memo wins)
+        and its reconcile state — recategorizing one leg doesn't
+        destroy the other leg's provenance or reconciliation.
+
         Args:
             splits: Complete new set — 'account', 'amount', optional
                 'quantity' (cross-currency) and 'memo'.
-            force: Required if existing splits are reconciled or
-                assigned to lots.
+            force: Required if the replacement would CHANGE a
+                reconciled split, or remove splits from lots.
+                Unchanged reconciled legs are preserved and need no
+                override.
 
         Returns:
             Thin dict with guid, status, previous_splits (audit
@@ -4396,18 +4404,78 @@ class CoreMixin:
                     f"unvoid_transaction first, then replace splits."
                 )
 
-            # 4. Check reconciled splits
-            reconciled = [
-                s for s in transaction.splits if s.reconcile_state == "y"
+            # 4. Carry-forward snapshot: a new split that reproduces
+            # an old one (same account, value, and quantity) is an
+            # UNCHANGED leg — recategorizing one side of a
+            # transaction must not destroy the other side's
+            # provenance memo or knock it out of reconciliation.
+            # Greedy one-to-one claim so same-account same-amount
+            # twins each match once.
+            carryover = [
+                {
+                    "account_guid": s.account.guid,
+                    "value": s.value,
+                    "quantity": s.quantity,
+                    "memo": s.memo or "",
+                    "state": s.reconcile_state,
+                    "rdate": s.reconcile_date,
+                    "claimed": False,
+                }
+                for s in transaction.splits
             ]
-            if reconciled and not force:
-                names = ", ".join(s.account.fullname for s in reconciled)
+
+            def _new_split_quantity(account, split_data):
+                """Quantity a new split would carry, or None when a
+                required cross-commodity quantity is absent (step 7
+                rejects that row; the pre-pass just skips it)."""
+                amount = _to_decimal(split_data["amount"])
+                if account.commodity == transaction.currency:
+                    return amount
+                if "quantity" in split_data:
+                    return _to_decimal(split_data["quantity"])
+                return None
+
+            def _claim(pool, account_guid, value, quantity):
+                for c in pool:
+                    if (
+                        not c["claimed"]
+                        and c["account_guid"] == account_guid
+                        and c["value"] == value
+                        and c["quantity"] == quantity
+                    ):
+                        c["claimed"] = True
+                        return c
+                return None
+
+            # Pre-pair on a scratch copy so the force gate applies
+            # only to reconciled legs the replacement would CHANGE —
+            # an unchanged reconciled leg is preserved verbatim and
+            # needs no override.
+            scratch = [dict(c) for c in carryover]
+            for account, split_data in resolved_accounts:
+                quantity = _new_split_quantity(account, split_data)
+                if quantity is not None:
+                    _claim(
+                        scratch, account.guid,
+                        _to_decimal(split_data["amount"]), quantity,
+                    )
+            reconciled_changed = [
+                s for s, c in zip(transaction.splits, scratch)
+                if s.reconcile_state == "y" and not c["claimed"]
+            ]
+            if reconciled_changed and not force:
+                names = ", ".join(
+                    s.account.fullname for s in reconciled_changed
+                )
                 raise ValueError(
-                    f"Transaction has reconciled splits in: {names}. "
+                    f"Transaction has reconciled splits in: {names} "
+                    f"that this replacement would change. "
                     f"Use force=true to override."
                 )
-            if reconciled:
-                names = ", ".join(s.account.fullname for s in reconciled)
+            if reconciled_changed:
+                names = ", ".join(
+                    s.account.fullname for s in reconciled_changed
+                )
                 warnings.append(f"Replaced reconciled splits in: {names}")
 
             # 5. Check lot assignments
@@ -4459,13 +4527,23 @@ class CoreMixin:
                 fx_check_splits.append({
                     "account": account, "value": amount, "quantity": quantity,
                 })
-                piecash.Split(
+                # Unchanged leg: keep its memo (caller-supplied memo
+                # wins) and its reconciliation, verbatim.
+                match = _claim(carryover, account.guid, amount, quantity)
+                new_split = piecash.Split(
                     account=account,
                     value=amount,
                     quantity=quantity,
-                    memo=split_data.get("memo", ""),
+                    memo=(
+                        split_data.get("memo")
+                        or (match["memo"] if match else "")
+                    ),
                     transaction=transaction,
                 )
+                if match and match["state"] in ("y", "c"):
+                    new_split.reconcile_state = match["state"]
+                    if match["rdate"] is not None:
+                        new_split.reconcile_date = match["rdate"]
 
             # Cross-commodity implied-rate sanity (non-blocking) — this
             # path's warnings are plain strings, so emit messages.

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -230,6 +230,7 @@ class SchedulingMixin:
         frequency: str,
         end_date: str | None = None,
         enabled: bool = True,
+        notes: str | None = None,
     ) -> dict:
         """Create a recurring transaction template.
 
@@ -243,6 +244,9 @@ class SchedulingMixin:
                       "quarterly", "yearly".
             end_date: Optional last occurrence date (YYYY-MM-DD).
             enabled: Whether active. Default True.
+            notes: Transaction-level notes applied to every
+                instantiated transaction (what the purchase is —
+                visible in GnuCash's double-line register view).
 
         Returns:
             Dict with guid, name, next_occurrence, and status.
@@ -400,6 +404,24 @@ class SchedulingMixin:
                         f"transaction '{name}'",
                     )
 
+                # Instantiation notes — same lifecycle as the
+                # description slot; absent row means "no notes".
+                if notes:
+                    book.session.execute(
+                        Slot.__table__.insert().values(
+                            obj_guid=sx_guid,
+                            name="notes",
+                            slot_type=KVP_Type.KVP_TYPE_STRING,
+                            string_val=notes,
+                        )
+                    )
+                    _verify_composite_write(
+                        book.session, Slot.__table__,
+                        {"obj_guid": sx_guid, "name": "notes"},
+                        f"Notes slot for scheduled "
+                        f"transaction '{name}'",
+                    )
+
                 book.save()
             except Exception:
                 # Clean up the orphan template; swallow cleanup
@@ -476,6 +498,11 @@ class SchedulingMixin:
                     )
                     if desc and desc != sx.name:
                         d["description"] = desc
+                    sx_notes = self._get_sx_slot_string(
+                        book, sx.guid, "notes",
+                    )
+                    if sx_notes:
+                        d["notes"] = sx_notes
                     d["splits"] = self._get_sx_splits(book, sx)
                 results.append(d)
 
@@ -776,12 +803,16 @@ class SchedulingMixin:
 
             sx_name = sx.name
             sx_description = self._get_sx_description(book, sx)
+            sx_notes = self._get_sx_slot_string(
+                book, sx.guid, "notes",
+            )
 
         # ── Phase 2: create the transaction (see docstring). ─────
         txn_result = self.create_transaction(
             description=sx_description,
             splits=splits,
             trans_date=txn_date,
+            notes=sx_notes,
         )
 
         # ── Phase 3: advance the schedule. ──────────────────────
@@ -832,6 +863,7 @@ class SchedulingMixin:
         guid: str,
         enabled: bool | None = None,
         end_date: str | None = None,
+        notes: str | None = None,
     ) -> dict:
         """Update a scheduled transaction.
 
@@ -843,6 +875,10 @@ class SchedulingMixin:
                 empty-string sentinel exists because ``None``
                 already means "no change" and MCP schemas don't
                 express three-state strings cleanly.
+            notes: Instantiation notes applied to future created
+                transactions. Same three-state convention: text to
+                set, ``""`` to clear, ``None`` to leave unchanged.
+                Does not touch transactions already created.
 
         Raises:
             ValueError: If not found.
@@ -862,6 +898,9 @@ class SchedulingMixin:
                 "end_date": (
                     sx.end_date.isoformat() if sx.end_date else None
                 ),
+                "notes": self._get_sx_slot_string(
+                    book, sx.guid, "notes",
+                ),
             })
 
             if enabled is not None:
@@ -872,6 +911,38 @@ class SchedulingMixin:
                     sx.end_date = None
                 else:
                     sx.end_date = date.fromisoformat(end_date)
+
+            if notes is not None:
+                # Upsert as delete-then-insert: the slot table has
+                # no unique constraint to UPSERT against, and the
+                # polymorphic Slot ORM can't be queried directly.
+                book.session.execute(
+                    Slot.__table__.delete().where(
+                        (Slot.__table__.c.obj_guid == sx.guid)
+                        & (Slot.__table__.c.name == "notes")
+                    )
+                )
+                _verify_delete(
+                    book.session, Slot.__table__,
+                    {"obj_guid": sx.guid, "name": "notes"},
+                    f"Notes slot for scheduled transaction "
+                    f"'{sx.name}'",
+                )
+                if notes != "":
+                    book.session.execute(
+                        Slot.__table__.insert().values(
+                            obj_guid=sx.guid,
+                            name="notes",
+                            slot_type=KVP_Type.KVP_TYPE_STRING,
+                            string_val=notes,
+                        )
+                    )
+                    _verify_composite_write(
+                        book.session, Slot.__table__,
+                        {"obj_guid": sx.guid, "name": "notes"},
+                        f"Notes slot for scheduled transaction "
+                        f"'{sx.name}'",
+                    )
 
             book.save()
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1835,6 +1835,9 @@ def _fmt_scheduled_transaction_create(entry: dict) -> list[str]:
     description = params.get("description", "")
     if description and description != name:
         lines.append(f"{_INDENT}description: {description}")
+    notes = params.get("notes", "")
+    if notes:
+        lines.append(f"{_INDENT}notes: {notes}")
     freq = after.get("frequency", params.get("frequency", ""))
     start = params.get("start_date", "")
     end = params.get("end_date", "")
@@ -1873,6 +1876,13 @@ def _fmt_scheduled_transaction_update(entry: dict) -> list[str]:
         new_str = new or "(cleared)"
         if old != new:
             lines.append(f"{_INDENT}end_date: {old_str} → {new_str}")
+    if "notes" in params and params["notes"] is not None:
+        old = before.get("notes")
+        new = params["notes"] if params["notes"] != "" else None
+        old_str = old or "(none)"
+        new_str = new or "(cleared)"
+        if old != new:
+            lines.append(f"{_INDENT}notes: {old_str} → {new_str}")
     return lines
 
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -532,6 +532,10 @@ def _fmt_transaction_create(entry: dict) -> list[str]:
     date_str = after.get("date") or params.get("transaction_date", "")
     lines.append(f'{_INDENT}"{desc}" ({date_str})')
 
+    notes = after.get("notes") or params.get("notes") or ""
+    if notes:
+        lines.append(f"{_INDENT}notes: {notes}")
+
     # after_state preferred; fall back to params (thin-response case)
     splits = after.get("splits") or params.get("splits") or []
     if splits:
@@ -698,6 +702,19 @@ def _fmt_transaction_update(entry: dict) -> list[str]:
         lines.append(f"{_INDENT}Date: {old_date} → {new_date}")
     else:
         lines.append(f"{_INDENT}Date: {old_date} (unchanged)")
+
+    # Notes are three-state at the tool boundary (text / "" clears /
+    # absent leaves unchanged) — render only when the call carried
+    # the field. Without this, a notes-only update logs as a no-op
+    # entry: every field it DID print marked "(unchanged)".
+    params = entry.get("params") or {}
+    if "notes" in params and params["notes"] is not None:
+        old_notes = before.get("notes") or None
+        new_notes = params["notes"] or None
+        if old_notes != new_notes:
+            old_str = f'"{old_notes}"' if old_notes else "(none)"
+            new_str = f'"{new_notes}"' if new_notes else "(cleared)"
+            lines.append(f"{_INDENT}Notes: {old_str} → {new_str}")
 
     if old_splits != new_splits:
         lines.append(f"{_INDENT}Splits (before):")

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -369,10 +369,15 @@ def setup_logging(
         except OSError:
             pass
 
-        # Write header if needed
+        # Write header if needed. The trailing "\n" (plus the
+        # logger's own newline) leaves a blank line after the
+        # banner — get_audit_log splits entries on blank lines, so
+        # without it the day's first entry glues to the header
+        # block: excluded from the count, rendered on every page,
+        # and leaked through limit=0.
         if write_header:
             header = _format_text_header(today, book_path, tz_name)
-            audit_logger.info(header)
+            audit_logger.info(header + "\n")
             _flush_logger(audit_logger)
     else:
         # Disable audit logging

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -52,6 +52,8 @@ ACCOUNT REFERENCES:
 - list_accounts emits short GUIDs at line start: "%xxxxxxx\\tAssets:Savings [BANK]" (x's are a placeholder — copy real GUIDs from list_accounts output). Reuse them — ~80% smaller than paths.
 - Paths are colon-delimited, case-sensitive. Use paths when naming new accounts or reasoning about hierarchy; short GUIDs for everything else.
 - Account short GUIDs: 7+ hex chars with leading "%". Transaction/split GUIDs: 8+ bare hex prefix, no marker.
+ANNOTATIONS (visibility order in GnuCash's register):
+- description = clean payee/name. notes = what the purchase was, interpreted (double-line view — what humans read). Bank-leg split memo = raw statement line (provenance; only visible in expanded splits).
 DOUBLE-ENTRY SIGN CONVENTION:
 - Positive = debit (increases Asset/Expense, decreases Liability/Income/Equity).
 - Negative = credit (reverse).

--- a/src/gnucash_mcp/tools/admin.py
+++ b/src/gnucash_mcp/tools/admin.py
@@ -20,6 +20,8 @@ from gnucash_mcp.tools._helpers import _json, safe_tool
 # ``*.txt`` files. Prompt injection through any free-text field
 # that surfaces into the audit log is the attack vector.
 _LOG_DATE_RE = re.compile(r"\A\d{4}-\d{2}-\d{2}\Z")
+# An audit entry's first line: "HH:MM:SS  OPERATION ...".
+_AUDIT_ENTRY_TS_RE = re.compile(r"\A\d{2}:\d{2}:\d{2}  ")
 
 
 def register(mcp, get_book) -> None:
@@ -176,6 +178,17 @@ def register(mcp, get_book) -> None:
         header = None
         if blocks and "═" in blocks[0]:
             header, blocks = blocks[0], blocks[1:]
+            # Files written before the banner gained its trailing
+            # blank line glue the day's FIRST entry to the header
+            # block — hiding it from the count, rendering it on
+            # every page, and leaking it through limit=0. Split it
+            # back out at the first timestamped line.
+            header_lines = header.split("\n")
+            for i, ln in enumerate(header_lines):
+                if _AUDIT_ENTRY_TS_RE.match(ln):
+                    header = "\n".join(header_lines[:i]).rstrip()
+                    blocks.insert(0, "\n".join(header_lines[i:]))
+                    break
 
         total = len(blocks)
         # Recency-anchored window: offset counts back from the newest

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -417,7 +417,10 @@ def register(mcp, get_book) -> None:
         matches nothing rejects ("no matching transaction to
         auto-fill from"). Use ``dry_run=true`` to preview what a
         batch of auto-fills would book. Perfect for recurring
-        monthly entries.
+        monthly entries. Transaction ``notes`` are NOT copied from
+        the source (notes are often time-bound — "first
+        appearance, investigate" must not replicate); supply a
+        notes cell when the new instance needs one.
 
         - ``ref``: YOUR correlation key per row (e.g. 1, 2, 3), unique
           within the batch. It is echoed back so you can match results
@@ -689,6 +692,13 @@ def register(mcp, get_book) -> None:
         The transaction's currency, description, date, and notes are preserved.
         New splits must balance to zero.
 
+        A new split that reproduces an existing one (same account,
+        amount, and quantity) is an UNCHANGED leg: it keeps the old
+        split's memo (supply a memo to override) and its reconcile
+        state. So recategorizing the expense leg of a reconciled
+        bank transaction is safe — resubmit the bank leg as-is and
+        only the changed leg resets.
+
         Args:
             guid: Transaction GUID (32-character hex string, or 8+ char prefix)
             splits: Complete new set of splits. Each split needs:
@@ -697,7 +707,9 @@ def register(mcp, get_book) -> None:
                 - 'quantity' (optional): Amount in account's commodity, as a decimal string.
                   Required if account commodity differs from transaction currency.
                 - 'memo' (optional): Split memo
-            force: Allow replacing reconciled splits or splits in lots
+            force: Required only when the replacement would CHANGE a
+                reconciled split (or remove splits from lots) —
+                unchanged reconciled legs are preserved without it.
         """
         book = get_book()
         result = book.replace_splits(

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -286,6 +286,20 @@ def register(mcp, get_book) -> None:
         strings (e.g. "94.87") — never raw JSON numbers, which would
         lose precision on non-dyadic decimals.
 
+        FIELD TARGETING — three annotation fields, three jobs, in
+        GnuCash-register visibility order:
+
+        - ``description``: the clean name ("Chevron 0090706
+          Portland"). Always visible.
+        - ``notes``: what the purchase WAS, when the description
+          alone doesn't say ("Fuel, road trip to Portland").
+          Visible in the register's double-line view — this is the
+          annotation humans read. Interpret; don't transcribe.
+        - split ``memo`` (bank/card leg): the RAW statement line as
+          provenance ("Withdrawal ACH TRAVELERS TYPE: PER INSUR…").
+          Visible only in expanded split view — evidence, not
+          narrative.
+
         When duplicate detection surfaces candidates (either rejecting
         the write with ``status: "rejected"`` or returning alongside a
         successful create), ``duplicates`` in the response is a
@@ -304,7 +318,7 @@ def register(mcp, get_book) -> None:
                 from the most recent matching-description transaction.
             transaction_date: ISO date (YYYY-MM-DD). Defaults to today.
             currency: ISO currency code. Defaults to book's default.
-            notes: Optional free-text annotation.
+            notes: What the purchase was (see FIELD TARGETING above).
             check_duplicates: Run duplicate detection. Default True.
             force_create: Create even if HIGH-confidence duplicates found.
             dry_run: Validate + dupe check only; don't write.
@@ -362,6 +376,14 @@ def register(mcp, get_book) -> None:
           after ``description``::
 
               ref<TAB>date<TAB>description<TAB>notes<TAB>amt1<TAB>acct1...
+
+          FIELD TARGETING for statement entry: ``description`` is
+          the clean name; ``notes`` is what the purchase WAS —
+          interpreted, not transcribed — and is what humans see in
+          GnuCash's double-line register; the bank leg's ``memo``
+          is where the RAW statement line goes (provenance, visible
+          only in expanded split view). Prefer filling ``notes``
+          whenever the description alone doesn't tell the story.
 
         - PER-SPLIT QUANTITY — declare ``qty`` split columns for
           splits whose ACCOUNT commodity differs from the book

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -24,6 +24,7 @@ def register(mcp, get_book) -> None:
         frequency: str,
         end_date: str | None = None,
         enabled: bool = True,
+        notes: str | None = None,
     ) -> str:
         """Create a recurring transaction template.
 
@@ -38,6 +39,9 @@ def register(mcp, get_book) -> None:
                 "bimonthly" (2mo), "quarterly" (3mo), or "yearly".
             end_date: Optional last occurrence (YYYY-MM-DD).
             enabled: Active. Default True.
+            notes: Transaction notes applied to every instantiated
+                transaction (what the payment is — visible in
+                GnuCash's double-line register view).
         """
         book = get_book()
         result = book.create_scheduled_transaction(
@@ -48,6 +52,7 @@ def register(mcp, get_book) -> None:
             frequency=frequency,
             end_date=end_date,
             enabled=enabled,
+            notes=notes,
         )
         return _json(result)
 
@@ -144,6 +149,7 @@ def register(mcp, get_book) -> None:
         guid: ScheduledTransactionGuid,
         enabled: bool | None = None,
         end_date: str | None = None,
+        notes: str | None = None,
     ) -> str:
         """Update a scheduled transaction.
 
@@ -162,12 +168,18 @@ def register(mcp, get_book) -> None:
                 distinct value from "no change supplied" — both
                 arrive as Python ``None``. Empty-string is the
                 explicit "clear it" signal.
+            notes: Instantiation notes applied to transactions
+                created from this schedule going forward (existing
+                transactions untouched). Same three-state
+                convention as end_date: text to set, ``""`` to
+                clear, omit to leave unchanged.
         """
         book = get_book()
         result = book.update_scheduled_transaction(
             guid=guid,
             enabled=enabled,
             end_date=end_date,
+            notes=notes,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7282,7 +7282,12 @@ class TestReplaceSplits:
             )
 
     def test_reconciled_requires_force(self, test_book: Path):
-        """Should reject recategorizing reconciled splits without force."""
+        """Should reject CHANGING reconciled splits without force.
+
+        The amounts differ from the originals so the reconciled leg
+        actually changes — an identical resubmission is an unchanged
+        leg and is preserved without force (covered in
+        TestReplaceSplitsPreservation)."""
         gc_book = GnuCashBook(str(test_book))
 
         # Get a transaction and reconcile one of its splits
@@ -7295,8 +7300,8 @@ class TestReplaceSplits:
             gc_book.replace_splits(
                 guid=guid,
                 splits=[
-                    {"account": "Expenses:Groceries", "amount": "150.00"},
-                    {"account": "Assets:Checking", "amount": "-150.00"},
+                    {"account": "Expenses:Groceries", "amount": "151.00"},
+                    {"account": "Assets:Checking", "amount": "-151.00"},
                 ],
             )
 
@@ -11856,3 +11861,168 @@ class TestIssue94IntermediateCurrencyChain:
             assert by_mnem["UKFUND"] == "via GBP→USD"      # C
             assert by_mnem["LOCALFUND"] is None            # D direct
             assert by_mnem["ORPHANFUND"] is None           # E unreachable
+
+
+class TestReplaceSplitsPreservation:
+    """Unchanged legs survive replace_splits intact.
+
+    A new split reproducing an old one (account, value, quantity)
+    keeps the old memo and reconcile state, and no longer trips the
+    force gate — recategorizing one leg of a reconciled bank
+    transaction must not destroy the other leg's provenance or its
+    reconciliation (found live: five reconciled checking splits,
+    including a $2,243.71 deposit, knocked to 'n' with their
+    statement memos erased by routine recategorization)."""
+
+    PROVENANCE = "Withdrawal ACH PAYPAL TYPE: INST XFER CO: PAYPAL"
+
+    def _make_reconciled(self, gc_book):
+        """Fresh 2-split transaction, checking leg memo'd + reconciled."""
+        gc_book.create_account(
+            name="Dining", account_type="EXPENSE", parent="Expenses",
+        )
+        result = gc_book.create_transaction(
+            description="PayPal Instant Transfer",
+            splits=[
+                {
+                    "account": "Assets:Checking",
+                    "amount": "-250.00",
+                    "memo": self.PROVENANCE,
+                },
+                {"account": "Expenses:Groceries", "amount": "250.00"},
+            ],
+        )
+        txn = gc_book.get_transaction(result["guid"])
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        from datetime import date as _date
+        gc_book.set_reconcile_state(
+            chk["guid"], "y", reconcile_date=_date(2026, 7, 15),
+        )
+        return result["guid"]
+
+    def test_unchanged_leg_keeps_memo_and_reconciliation(
+        self, test_book: Path,
+    ):
+        gc_book = GnuCashBook(str(test_book))
+        guid = self._make_reconciled(gc_book)
+
+        # Recategorize the expense leg only; resubmit the bank leg
+        # as-is, memo-less, and WITHOUT force.
+        result = gc_book.replace_splits(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-250.00"},
+                {"account": "Expenses:Dining", "amount": "250.00"},
+            ],
+        )
+        assert result["status"] == "splits_replaced"
+        assert not any(
+            "reconciled" in w.lower()
+            for w in result.get("warnings", [])
+        )
+
+        txn = gc_book.get_transaction(guid)
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        exp = next(
+            s for s in txn["splits"]
+            if s["account"] == "Expenses:Dining"
+        )
+        assert chk["memo"] == self.PROVENANCE
+        assert chk["reconcile_state"] == "y"
+        assert chk["reconcile_date"].startswith("2026-07-15")
+        assert exp["reconcile_state"] == "n"
+
+    def test_caller_supplied_memo_wins(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        guid = self._make_reconciled(gc_book)
+
+        gc_book.replace_splits(
+            guid=guid,
+            splits=[
+                {
+                    "account": "Assets:Checking",
+                    "amount": "-250.00",
+                    "memo": "corrected memo",
+                },
+                {"account": "Expenses:Dining", "amount": "250.00"},
+            ],
+        )
+        txn = gc_book.get_transaction(guid)
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        assert chk["memo"] == "corrected memo"
+        assert chk["reconcile_state"] == "y"
+
+    def test_changed_reconciled_leg_still_gated_and_reset(
+        self, test_book: Path,
+    ):
+        gc_book = GnuCashBook(str(test_book))
+        guid = self._make_reconciled(gc_book)
+
+        with pytest.raises(ValueError, match="force=true"):
+            gc_book.replace_splits(
+                guid=guid,
+                splits=[
+                    {"account": "Assets:Checking", "amount": "-260.00"},
+                    {"account": "Expenses:Dining", "amount": "260.00"},
+                ],
+            )
+
+        result = gc_book.replace_splits(
+            guid=guid,
+            splits=[
+                {"account": "Assets:Checking", "amount": "-260.00"},
+                {"account": "Expenses:Dining", "amount": "260.00"},
+            ],
+            force=True,
+        )
+        assert any(
+            "reconciled" in w.lower() for w in result["warnings"]
+        )
+        txn = gc_book.get_transaction(guid)
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        assert chk["reconcile_state"] == "n"
+        assert not chk.get("memo")
+
+    def test_twin_splits_each_claim_their_own_memo(
+        self, test_book: Path,
+    ):
+        """Two same-account same-amount legs: greedy one-to-one
+        matching preserves both memos (as a multiset)."""
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Split lunch",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "10.00",
+                 "memo": "first twin"},
+                {"account": "Expenses:Groceries", "amount": "10.00",
+                 "memo": "second twin"},
+                {"account": "Assets:Checking", "amount": "-20.00"},
+            ],
+        )
+        guid = result["guid"]
+        gc_book.replace_splits(
+            guid=guid,
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+                {"account": "Assets:Checking", "amount": "-20.00"},
+            ],
+        )
+        txn = gc_book.get_transaction(guid)
+        memos = sorted(
+            s.get("memo", "") for s in txn["splits"]
+            if s["account"] == "Expenses:Groceries"
+        )
+        assert memos == ["first twin", "second twin"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2139,3 +2139,107 @@ class TestTransactionNotesAuditRendering:
         assert (
             "notes: Celebration dinner. Unreimbursed work expense."
         ) in content
+
+
+class TestAuditHeaderEntrySeparation:
+    """The day banner must be its own blank-line-separated block.
+
+    Pre-fix the banner was written without a trailing blank line, so
+    the day's FIRST entry glued to the header block: excluded from
+    the entry count, rendered on every page regardless of offset,
+    and leaked through limit=0. Writer now emits the separator;
+    reader un-glues files written before the fix."""
+
+    def test_writer_separates_banner_from_first_entry(
+        self, temp_book_path, temp_log_dir,
+    ):
+        book = _StagedBook(None)
+        setup_logging(
+            book_path=str(temp_book_path),
+            debug=False,
+            get_book=lambda: book,
+        )
+
+        @audit_log(
+            classification="write", operation="create",
+            entity_type="transaction",
+        )
+        def create_transaction(**kwargs) -> str:
+            return json.dumps({"guid": "ab" * 8, "status": "created"})
+
+        create_transaction(description="First of the day")
+
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        raw = (temp_log_dir / "audit" / f"{today}.txt").read_text()
+        banner_end = raw.index("═" * 64, raw.index("═" * 64) + 1)
+        after_banner = raw[banner_end + 64:]
+        assert after_banner.startswith("\n\n"), (
+            "banner must be followed by a blank line so the first "
+            "entry forms its own block"
+        )
+
+    @pytest.fixture
+    def audit_tool(self, tmp_path):
+        """get_audit_log tool against a seeded legacy (glued) file."""
+        from gnucash_mcp.server import (
+            _apply_module_filter,
+            _reset_lazy_load_state,
+            mcp,
+        )
+
+        book_path = tmp_path / "glued.gnucash"
+        book_path.touch()
+        setup_logging(book_path=str(book_path), debug=False)
+
+        banner = "═" * 64
+        log_dir = tmp_path / "glued.gnucash.mcp" / "audit"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        # Legacy shape: no blank line between banner and entry one.
+        (log_dir / "2026-07-21.txt").write_text(
+            f"{banner}\n"
+            f"GNUCASH MCP AUDIT LOG — 2026-07-21\n"
+            f"Book: {book_path}\nTimezone: PDT\n"
+            f"{banner}\n"
+            '10:00:00  UPDATE TRANSACTION  guid:aaaaaaaa\n'
+            '          Notes: (none) → "first entry"\n'
+            "\n"
+            '11:00:00  UPDATE TRANSACTION  guid:bbbbbbbb\n'
+            '          Notes: (none) → "second entry"\n'
+            "\n"
+            '12:00:00  UPDATE TRANSACTION  guid:cccccccc\n'
+            '          Notes: (none) → "third entry"\n'
+        )
+
+        original = dict(mcp._tool_manager._tools)
+        try:
+            mcp._tool_manager._tools.clear()
+            _reset_lazy_load_state()
+            _apply_module_filter("audit")
+            yield mcp._tool_manager._tools["get_audit_log"]
+        finally:
+            mcp._tool_manager._tools.clear()
+            mcp._tool_manager._tools.update(original)
+            _reset_lazy_load_state()
+
+    def test_glued_first_entry_is_counted(self, audit_tool):
+        result = audit_tool.fn(log_date="2026-07-21", limit=0)
+        assert "Showing 0 of 3 audit entries" in result
+
+    def test_limit_zero_leaks_no_entries(self, audit_tool):
+        result = audit_tool.fn(log_date="2026-07-21", limit=0)
+        assert "10:00:00" not in result
+        assert "first entry" not in result
+        # The banner itself still renders for context.
+        assert "GNUCASH MCP AUDIT LOG" in result
+
+    def test_glued_first_entry_pages_correctly(self, audit_tool):
+        # Newest page of one: only the third entry.
+        newest = audit_tool.fn(log_date="2026-07-21", limit=1)
+        assert "third entry" in newest
+        assert "first entry" not in newest
+        # Two pages back: the glued-off first entry, exactly once.
+        oldest = audit_tool.fn(log_date="2026-07-21", limit=1, offset=2)
+        assert "first entry" in oldest
+        assert oldest.count("10:00:00") == 1
+        assert "second entry" not in oldest
+        assert "third entry" not in oldest

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2038,3 +2038,104 @@ class TestWriteRateLimiter:
         # Now allowed.
         allowed, _ = limiter.consume()
         assert allowed
+
+
+class TestTransactionNotesAuditRendering:
+    """CREATE and UPDATE TRANSACTION entries must render notes.
+
+    Pre-fix, update_transaction calls that only set notes logged as
+    no-op entries (every printed field "(unchanged)") — a 156-
+    transaction backfill left no trace in the trail. Single create
+    dropped the notes param entirely (batch create rendered it)."""
+
+    def _run(self, temp_book_path, staged, result, operation, **params):
+        book = _StagedBook(staged)
+        setup_logging(
+            book_path=str(temp_book_path),
+            debug=False,
+            get_book=lambda: book,
+        )
+
+        @audit_log(
+            classification="write", operation=operation,
+            entity_type="transaction",
+        )
+        def txn_tool(**kwargs) -> str:
+            return json.dumps(result)
+
+        txn_tool(**params)
+
+    def _read_log(self, temp_log_dir) -> str:
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
+        return (temp_log_dir / "audit" / f"{today}.txt").read_text()
+
+    BEFORE = {
+        "guid": "ab" * 16,
+        "date": "2026-06-27",
+        "description": "HoopFest Doughnut - Sheena",
+        "splits": [],
+    }
+
+    def test_notes_only_update_is_not_a_noop_entry(
+        self, temp_book_path, temp_log_dir,
+    ):
+        self._run(
+            temp_book_path,
+            self.BEFORE,
+            {"guid": "ab" * 8, "status": "updated"},
+            "update",
+            guid="ab" * 8,
+            notes="KK doughnut sale via Cash App. Liability, not income.",
+        )
+        content = self._read_log(temp_log_dir)
+        assert (
+            'Notes: (none) → "KK doughnut sale via Cash App. '
+            'Liability, not income."'
+        ) in content
+
+    def test_update_renders_notes_replacement_and_clear(
+        self, temp_book_path, temp_log_dir,
+    ):
+        before = dict(self.BEFORE, notes="old annotation")
+        self._run(
+            temp_book_path,
+            before,
+            {"guid": "ab" * 8, "status": "updated"},
+            "update",
+            guid="ab" * 8,
+            notes="",
+        )
+        content = self._read_log(temp_log_dir)
+        assert 'Notes: "old annotation" → (cleared)' in content
+
+    def test_update_without_notes_param_stays_silent(
+        self, temp_book_path, temp_log_dir,
+    ):
+        before = dict(self.BEFORE, notes="standing annotation")
+        self._run(
+            temp_book_path,
+            before,
+            {"guid": "ab" * 8, "status": "updated"},
+            "update",
+            guid="ab" * 8,
+            description="New Description",
+        )
+        content = self._read_log(temp_log_dir)
+        assert "Notes:" not in content
+
+    def test_single_create_renders_notes(
+        self, temp_book_path, temp_log_dir,
+    ):
+        self._run(
+            temp_book_path,
+            None,
+            {"guid": "cd" * 8, "status": "created"},
+            "create",
+            description="Fogo de Chao - Bellevue",
+            transaction_date="2026-03-10",
+            notes="Celebration dinner. Unreimbursed work expense.",
+        )
+        content = self._read_log(temp_log_dir)
+        assert (
+            "notes: Celebration dinner. Unreimbursed work expense."
+        ) in content

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -803,3 +803,108 @@ class TestScheduledIntegration:
         assert len(listed) == 5
         freqs = {sx["frequency"] for sx in listed}
         assert freqs == {"weekly", "biweekly", "monthly", "quarterly", "yearly"}
+
+
+class TestScheduledNotes:
+    """Notes ride the template: stored as a slot at create, applied
+    to every instantiated transaction, editable three-state via
+    update. Templates without the slot behave exactly as before."""
+
+    RENT_SPLITS = [
+        {"account": "Expenses:Rent", "amount": "1850.00"},
+        {"account": "Assets:Checking", "amount": "-1850.00"},
+    ]
+
+    def _create(self, gb, **kwargs):
+        return gb.create_scheduled_transaction(
+            name="Monthly Rent",
+            description="Rent",
+            splits=self.RENT_SPLITS,
+            start_date="2026-01-01",
+            frequency="monthly",
+            **kwargs,
+        )
+
+    def test_notes_stored_and_applied_at_instantiation(
+        self, scheduled_book,
+    ):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = self._create(
+            gb, notes="Apartment 4B, includes water surcharge",
+        )
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert txn["notes"] == "Apartment 4B, includes water surcharge"
+
+    def test_without_notes_instantiates_clean(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = self._create(gb)
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert not txn.get("notes")
+
+    def test_list_verbose_shows_notes_only_when_present(
+        self, scheduled_book,
+    ):
+        gb = GnuCashBook(str(scheduled_book))
+        self._create(gb, notes="Apartment 4B")
+        gb.create_scheduled_transaction(
+            name="Electric",
+            description="Seattle City Light",
+            splits=self.RENT_SPLITS,
+            start_date="2026-01-10",
+            frequency="monthly",
+        )
+        listed = {
+            sx["name"]: sx
+            for sx in gb.list_scheduled_transactions(
+                compact=False,
+            )["scheduled_transactions"]
+        }
+        assert listed["Monthly Rent"]["notes"] == "Apartment 4B"
+        assert "notes" not in listed["Electric"]
+
+    def test_update_sets_clears_and_leaves_notes(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = self._create(gb)
+
+        # Set on a template that never had notes.
+        gb.update_scheduled_transaction(
+            guid=sx["guid"], notes="Lease renews each June",
+        )
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert txn["notes"] == "Lease renews each June"
+
+        # Omitting notes leaves them unchanged.
+        gb.update_scheduled_transaction(guid=sx["guid"], enabled=True)
+        listed = gb.list_scheduled_transactions(
+            compact=False,
+        )["scheduled_transactions"]
+        assert listed[0]["notes"] == "Lease renews each June"
+
+        # Empty string clears.
+        gb.update_scheduled_transaction(guid=sx["guid"], notes="")
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-03-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert not txn.get("notes")
+
+    def test_replacing_existing_notes(self, scheduled_book):
+        gb = GnuCashBook(str(scheduled_book))
+        sx = self._create(gb, notes="old annotation")
+        gb.update_scheduled_transaction(
+            guid=sx["guid"], notes="new annotation",
+        )
+        result = gb.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-02-01",
+        )
+        txn = gb.get_transaction(result["transaction_guid"])
+        assert txn["notes"] == "new annotation"


### PR DESCRIPTION
## Summary
- **Field-targeting convention**, stated where models read it (tool docstrings + server instructions): `description` = clean name; `notes` = what the purchase was, interpreted (GnuCash double-line view — what humans read); bank-leg split `memo` = raw statement line as provenance.
- **Scheduled-transaction templates take `notes`** — stored as a slot beside the description slot, applied to every instantiated transaction, three-state editable via `update_scheduled_transaction` (text / `""` clears / omit), surfaced in verbose listing and audit entries. Existing templates annotate retroactively.
- **`replace_splits` preserves unchanged legs**: a new split reproducing an existing one (account, value, quantity) keeps its memo and reconcile state; the force gate applies only to reconciled legs that actually change. Found live — five routine recategorizations wiped provenance memos and de-reconciled checking splits (incl. a 2,243.71 deposit).
- **Audit truthfulness**: notes render in transaction CREATE and UPDATE entries (a 45-entry live backfill had logged as all-"(unchanged)" no-ops); the day banner is separated from the first entry, fixing off-by-one counts, first-entry-on-every-page, and the `limit=0` leak (reader un-glues historical files).
- Batch auto-fill's deliberate non-copying of time-bound notes is now documented.

## Test plan
- [x] Full suite: 1,877 passed, 0 failed (17 new tests: scheduled notes ×5, notes rendering ×4, banner separation ×4, leg preservation ×4)
- [x] Live smoke on scratch Alex: retrofit-annotated a pre-existing template, instantiation carried notes; unannotated templates unchanged
- [x] Void/unvoid round-trip preserves notes and memos (probed); `search_transactions(field='notes')` verified live
- [x] Bookkeeper sign-off on the real book: recategorization without force ✅, memo + reconcile state preserved ✅, four destroyed provenance memos re-attached with reconciliation holding ✅