### PR TITLE
feat(summary): dashboard clarity - five review-driven fixes

### DIFF
--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1535,7 +1535,7 @@ class CoreMixin:
         """
         if not monthly:
             return []
-        out = ["Monthly net (last 6 months):"]
+        out = ["Monthly net (income - expenses, last 6 months):"]
         for entry in monthly:
             label = entry["label"]
             if entry["is_mtd"]:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1843,7 +1843,9 @@ class CoreMixin:
         accounts. The action-signal suffix (``N invoice(s),
         M overdue``) lets the LLM see "2 overdue" and ask about
         collections without us having to spell that out
-        explicitly.
+        explicitly. The "included in ..." note prevents the
+        breakout from being double-counted against the Assets /
+        Liabilities headline totals, which already fold these in.
         """
         lines: list[str] = []
         if data.receivable_accts:
@@ -1852,8 +1854,8 @@ class CoreMixin:
             signal = (
                 f" ({inv_n} invoice"
                 f"{'s' if inv_n != 1 else ''}, "
-                f"{overdue} overdue)"
-            ) if inv_n else ""
+                f"{overdue} overdue; included in Assets total)"
+            ) if inv_n else " (included in Assets total)"
             lines.append(
                 f"Receivables: {len(data.receivable_accts)} "
                 f"account"
@@ -1874,8 +1876,8 @@ class CoreMixin:
             signal = (
                 f" ({bill_n} bill"
                 f"{'s' if bill_n != 1 else ''}, "
-                f"{overdue} overdue)"
-            ) if bill_n else ""
+                f"{overdue} overdue; included in Liabilities total)"
+            ) if bill_n else " (included in Liabilities total)"
             lines.append(
                 f"Payables: {len(data.payable_accts)} "
                 f"account"

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -594,11 +594,74 @@ class CoreMixin:
     # quotes are likely skewing net-worth and runway numbers.
     _STALE_PRICE_DAYS = 30
 
+    def _overdue_scheduled_warnings(
+        self, book: piecash.Book, today: date,
+    ) -> list[str]:
+        """Overdue-scheduled warning strings, most overdue first.
+
+        Requires SchedulingMixin's helpers (_next_occurrence,
+        RECURRENCE_TO_FREQUENCY). When that module isn't loaded,
+        the attribute lookup degrades gracefully via getattr and
+        this returns []. Shared between the Warnings section and
+        the Scheduled line's overdue count so the two surfaces
+        agree by construction.
+        """
+        next_occ_fn = getattr(self, "_next_occurrence", None)
+        rec_to_freq = getattr(self, "RECURRENCE_TO_FREQUENCY", None)
+        if next_occ_fn is None or rec_to_freq is None:
+            return []
+        try:
+            from piecash.core.transaction import ScheduledTransaction
+            overdue_entries: list[tuple[int, str]] = []
+            for sx in book.session.query(ScheduledTransaction).all():
+                if not sx.enabled:
+                    continue
+                try:
+                    rec = sx.recurrence
+                    key = (
+                        rec.recurrence_period_type,
+                        rec.recurrence_mult,
+                    )
+                    frequency = rec_to_freq.get(key)
+                    if not frequency:
+                        continue
+                    start = sx.start_date
+                    if isinstance(start, datetime):
+                        start = start.date()
+                    end = sx.end_date
+                    if isinstance(end, datetime):
+                        end = end.date()
+                    last = sx.last_occur
+                    if isinstance(last, datetime):
+                        last = last.date()
+                    # Search relative to "yesterday" so today's
+                    # occurrence isn't classified as overdue
+                    # before the user has a chance to enter it.
+                    next_occ = next_occ_fn(
+                        start, frequency,
+                        after=start - timedelta(days=1),
+                        end_date=end, last_occur=last,
+                    )
+                    if next_occ and next_occ < today:
+                        days_overdue = (today - next_occ).days
+                        overdue_entries.append((
+                            days_overdue,
+                            f"Overdue scheduled: {sx.name} "
+                            f"due {next_occ.isoformat()}",
+                        ))
+                except Exception:
+                    continue
+            overdue_entries.sort(reverse=True)
+            return [msg for _, msg in overdue_entries]
+        except Exception:
+            return []
+
     def _collect_warnings(
         self,
         book: piecash.Book,
         transactions: list,
         accounts: list,
+        overdue_scheduled: list[str] | None = None,
     ) -> list[str]:
         """Collect warnings for the consolidated Warnings section.
 
@@ -617,6 +680,10 @@ class CoreMixin:
         Each per-category collector swallows its own exceptions — a
         failed check in one category never breaks the rest. Category
         specifics are commented at each collector below.
+
+        ``overdue_scheduled`` lets get_book_summary pass the list it
+        already computed (shared with the Scheduled line); ``None``
+        computes it here for direct callers.
         """
         today = date.today()
         default_currency = self._require_default_currency(book)
@@ -910,58 +977,10 @@ class CoreMixin:
             pass
 
         # ── 5. Overdue scheduled transactions ──
-        # Requires SchedulingMixin's helpers (_next_occurrence,
-        # RECURRENCE_TO_FREQUENCY). When that module isn't loaded,
-        # the attribute lookup degrades gracefully via getattr.
-        overdue_scheduled: list[str] = []
-        next_occ_fn = getattr(self, "_next_occurrence", None)
-        rec_to_freq = getattr(self, "RECURRENCE_TO_FREQUENCY", None)
-        if next_occ_fn is not None and rec_to_freq is not None:
-            try:
-                from piecash.core.transaction import ScheduledTransaction
-                overdue_entries: list[tuple[int, str]] = []
-                for sx in book.session.query(ScheduledTransaction).all():
-                    if not sx.enabled:
-                        continue
-                    try:
-                        rec = sx.recurrence
-                        key = (
-                            rec.recurrence_period_type,
-                            rec.recurrence_mult,
-                        )
-                        frequency = rec_to_freq.get(key)
-                        if not frequency:
-                            continue
-                        start = sx.start_date
-                        if isinstance(start, datetime):
-                            start = start.date()
-                        end = sx.end_date
-                        if isinstance(end, datetime):
-                            end = end.date()
-                        last = sx.last_occur
-                        if isinstance(last, datetime):
-                            last = last.date()
-                        # Search relative to "yesterday" so today's
-                        # occurrence isn't classified as overdue
-                        # before the user has a chance to enter it.
-                        next_occ = next_occ_fn(
-                            start, frequency,
-                            after=start - timedelta(days=1),
-                            end_date=end, last_occur=last,
-                        )
-                        if next_occ and next_occ < today:
-                            days_overdue = (today - next_occ).days
-                            overdue_entries.append((
-                                days_overdue,
-                                f"Overdue scheduled: {sx.name} "
-                                f"due {next_occ.isoformat()}",
-                            ))
-                    except Exception:
-                        continue
-                overdue_entries.sort(reverse=True)
-                overdue_scheduled = [msg for _, msg in overdue_entries]
-            except Exception:
-                pass
+        if overdue_scheduled is None:
+            overdue_scheduled = self._overdue_scheduled_warnings(
+                book, today,
+            )
 
         # ── 6. Backup health ──
         # Auto-backup chain breaks render next to integrity issues:
@@ -1959,18 +1978,25 @@ class CoreMixin:
         total_txns: int,
         enabled_sx: int,
         currency: str,
+        overdue_count: int = 0,
     ) -> list[str]:
         """Render the Transactions count + Scheduled line.
 
-        Scheduled folds in the "due in next 7 days" stat — turns
-        the dashboard from "what is the state" into "what do I
-        need to do next" without a second tool call. Uses
+        Scheduled folds in the overdue count and the "due in next
+        7 days" stat — turns the dashboard from "what is the
+        state" into "what do I need to do next" without a second
+        tool call. The overdue bucket must agree with the Warnings
+        section (same underlying list) — "10 overdue" in Warnings
+        next to a bare "none due in next 7 days" here read as a
+        contradiction, since overdue items ARE due. Uses
         ``hasattr`` to skip the upcoming-line render cleanly on
         book classes built without scheduling.
         """
         lines = [f"Transactions: {total_txns}"]
         if enabled_sx > 0:
             line = f"Scheduled: {enabled_sx} recurring"
+            if overdue_count > 0:
+                line += f", {overdue_count} overdue ⚠"
             if hasattr(self, "_upcoming_within_days"):
                 upcoming = self._upcoming_within_days(book, days=7)
                 if upcoming["count"] > 0:
@@ -2153,9 +2179,16 @@ class CoreMixin:
             )
 
             # Warnings near the top — integrity/stale-price issues
-            # inform how the LLM reads the numbers below.
+            # inform how the LLM reads the numbers below. Overdue
+            # scheduled computes once here and feeds BOTH the
+            # Warnings section and the Scheduled line's overdue
+            # count, so the two can't disagree.
+            overdue_sched = self._overdue_scheduled_warnings(
+                book, date.today(),
+            )
             warnings = self._collect_warnings(
                 book, transactions, accounts,
+                overdue_scheduled=overdue_sched,
             )
             if warnings:
                 lines.append("Warnings:")
@@ -2219,6 +2252,7 @@ class CoreMixin:
             lines.extend(
                 self._render_transactions_scheduled(
                     book, total_txns, enabled_sx, currency,
+                    overdue_count=len(overdue_sched),
                 )
             )
             lines.extend(

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1155,6 +1155,30 @@ class CoreMixin:
             "variance_pct": variance_pct,
         }
 
+    def _burn_window_days(
+        self, transactions: list, days: int | None = None,
+    ) -> int:
+        """Actual burn-averaging window in days.
+
+        Book-age clamp: ``_RUNWAY_BURN_DAYS`` is a MAX, not a fixed
+        denominator — dividing by 180 on a 19-day-old book
+        overstates runway ~10×. The 1-day floor avoids
+        divide-by-zero. Shared between ``_daily_expense_burn`` (the
+        divisor) and the Runway render (the label) so the displayed
+        window always matches the math.
+        """
+        if days is None:
+            days = self._RUNWAY_BURN_DAYS
+        today = date.today()
+        dated = [
+            t.post_date for t in transactions
+            if t.post_date is not None  # old-book artifact
+        ]
+        if dated:
+            book_age_days = max(1, (today - min(dated)).days)
+            days = min(days, book_age_days)
+        return days
+
     def _daily_expense_burn(
         self,
         book: piecash.Book,
@@ -1172,21 +1196,8 @@ class CoreMixin:
         book default currency — raw ``split.value`` would mix
         currencies on books with foreign-currency expenses.
         """
-        if days is None:
-            days = self._RUNWAY_BURN_DAYS
+        days = self._burn_window_days(transactions, days)
         today = date.today()
-        # Book-age clamp: the window is a MAX, not a fixed
-        # denominator — dividing by 180 on a 19-day-old book
-        # overstates runway ~10×. The 1-day floor avoids
-        # divide-by-zero.
-        dated = [
-            t.post_date for t in transactions
-            if t.post_date is not None  # old-book artifact
-        ]
-        if dated:
-            first_txn_date = min(dated)
-            book_age_days = max(1, (today - first_txn_date).days)
-            days = min(days, book_age_days)
         window_start = today - timedelta(days=days)
         # "Now" burn signal — anchor factors to today.
         factors = self._account_conversion_factors(book, today)
@@ -1280,6 +1291,9 @@ class CoreMixin:
         daily_burn = self._daily_expense_burn(
             book, transactions, days=self._RUNWAY_BURN_DAYS,
         )
+        burn_window = self._burn_window_days(
+            transactions, self._RUNWAY_BURN_DAYS,
+        )
 
         if daily_burn <= 0:
             return None
@@ -1289,6 +1303,7 @@ class CoreMixin:
                 "negative_liquid": True,
                 "liquid": liquid.quantize(Decimal("1")),
                 "daily_burn": daily_burn.quantize(Decimal("1")),
+                "burn_window_days": burn_window,
             }
 
         runway_days = int(liquid / daily_burn)
@@ -1297,6 +1312,7 @@ class CoreMixin:
             "runway_days": runway_days,
             "liquid": liquid.quantize(Decimal("1")),
             "daily_burn": daily_burn.quantize(Decimal("1")),
+            "burn_window_days": burn_window,
         }
 
     def _monthly_net_income(
@@ -1547,11 +1563,13 @@ class CoreMixin:
         days = runway["runway_days"]
         liquid = int(runway["liquid"])
         burn = int(runway["daily_burn"])
+        window = runway["burn_window_days"]
         warn = " ⚠" if days < self._RUNWAY_WARN_DAYS else ""
         return [
             f"Runway: {days} days{warn} "
             f"({currency} {liquid:,} liquid / "
-            f"{currency} {burn:,}/day burn)"
+            f"{currency} {burn:,}/day burn, "
+            f"{window}-day avg)"
         ]
 
     # ── Summary collector / section renderers ────────────────────

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1331,6 +1331,12 @@ class CoreMixin:
         for the current (partial) month. Empty list when the window
         has no activity → caller omits the section.
 
+        The MTD entry additionally carries ``mtd_comparable``:
+        the prior month's net over the SAME day window (day 1
+        through today's day-of-month, clamped to the prior
+        month's length) — a partial month next to full months
+        misleads without a like-for-like anchor.
+
         Each split converts to the book default at the most recent
         market rate — raw ``split.value`` sums mix currencies.
         """
@@ -1372,6 +1378,16 @@ class CoreMixin:
         window_end = month_ends[-1]
         has_activity = False
 
+        # Prior-month same-day-window accumulator for the MTD
+        # comparable (clamped: Jul 30 compares against Jun 30, and
+        # Mar 30 against Feb 28).
+        prior_idx = len(month_starts) - 2
+        prior_cutoff_day = (
+            min(today.day, month_ends[prior_idx].day)
+            if prior_idx >= 0 else None
+        )
+        prior_window_net = Decimal("0")
+
         # Single pass; bucket index = months-from-window-start.
         for txn in transactions:
             d = txn.post_date
@@ -1385,6 +1401,9 @@ class CoreMixin:
             )
             if idx < 0 or idx >= len(nets):
                 continue
+            in_prior_window = (
+                idx == prior_idx and d.day <= prior_cutoff_day
+            )
             for s in txn.splits:
                 atype = s.account.type
                 if atype not in ("INCOME", "EXPENSE"):
@@ -1392,12 +1411,14 @@ class CoreMixin:
                 amt = self._split_in_default_currency(
                     s, s.account, factors.get(s.account.guid),
                 )
-                if atype == "INCOME":
-                    # INCOME stored negative (credit-natural); flip
-                    # to positive contribution to monthly net.
-                    nets[idx] += -amt
-                else:  # EXPENSE
-                    nets[idx] -= amt
+                # INCOME is stored negative (credit-natural) and
+                # flips to a positive contribution; EXPENSE is
+                # stored positive and subtracts. Both reduce to
+                # negating the raw amount.
+                contribution = -amt
+                nets[idx] += contribution
+                if in_prior_window:
+                    prior_window_net += contribution
                 has_activity = True
 
         if not has_activity:
@@ -1407,11 +1428,21 @@ class CoreMixin:
         result: list[dict] = []
         for i in range(len(month_starts) - 1, -1, -1):
             start = month_starts[i]
-            result.append({
+            entry = {
                 "label": start.strftime("%b %Y"),
                 "net": nets[i].quantize(Decimal("1")),
                 "is_mtd": start == today_month_start,
-            })
+            }
+            if entry["is_mtd"] and prior_idx >= 0:
+                prior_start = month_starts[prior_idx]
+                entry["mtd_comparable"] = {
+                    "label": (
+                        f"{prior_start.strftime('%b')} "
+                        f"1-{prior_cutoff_day}"
+                    ),
+                    "net": prior_window_net.quantize(Decimal("1")),
+                }
+            result.append(entry)
         return result
 
     @staticmethod
@@ -1531,18 +1562,28 @@ class CoreMixin:
 
         Surfaces seasonality and recent anomalies. Empty list = no
         income/expense activity in the window → omit the section.
-        MTD entries get a "(MTD)" suffix on the label.
+        MTD entries get a "(MTD)" suffix plus the prior month's
+        net over the same day window — without the like-for-like
+        anchor, a partial month reads as a collapse next to full
+        months.
         """
         if not monthly:
             return []
         out = ["Monthly net (income - expenses, last 6 months):"]
         for entry in monthly:
             label = entry["label"]
+            suffix = ""
             if entry["is_mtd"]:
                 label += " (MTD)"
+                comparable = entry.get("mtd_comparable")
+                if comparable is not None:
+                    suffix = (
+                        f" (vs {comparable['label']}: "
+                        f"{int(comparable['net']):+,})"
+                    )
             # Always shows explicit sign + thousands separator;
             # whole dollars (cents would noise up the summary).
-            out.append(f"  {label}: {int(entry['net']):+,}")
+            out.append(f"  {label}: {int(entry['net']):+,}{suffix}")
         return out
 
     def _render_runway(

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1444,6 +1444,65 @@ class TestGetBookSummaryMonthlyNet:
         rows = section.split("\n")[:6]
         assert not any("999,999" in r for r in rows)
 
+    @staticmethod
+    def _prior_month_last_day() -> int:
+        """Length of last month in days."""
+        first_of_current = date.today().replace(day=1)
+        return (first_of_current - timedelta(days=1)).day
+
+    def test_mtd_row_carries_prior_month_comparable(
+        self, test_book: Path,
+    ):
+        """The MTD row shows the prior month's net over the same
+        day window: '(vs <Mon> 1-<day>: <net>)'."""
+        gc = GnuCashBook(str(test_book))
+        self._seed_income(gc, "1000", date.today())
+        prior_first = self._months_ago(1)
+        self._seed_income(gc, "700", prior_first)
+
+        result = gc.get_book_summary()
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
+        mtd_row = section.split("\n", 1)[0]
+        cutoff = min(date.today().day, self._prior_month_last_day())
+        expected = (
+            f"(vs {prior_first.strftime('%b')} 1-{cutoff}: +700)"
+        )
+        assert expected in mtd_row
+
+    def test_comparable_excludes_prior_month_tail(
+        self, test_book: Path,
+    ):
+        """Activity after the cutoff day counts toward the prior
+        month's full-month row but not the MTD comparable."""
+        prior_len = self._prior_month_last_day()
+        if date.today().day >= prior_len:
+            pytest.skip(
+                "run-date is past the prior month's length — "
+                "no tail exists to exclude"
+            )
+        gc = GnuCashBook(str(test_book))
+        self._seed_income(gc, "1000", date.today())
+        prior_first = self._months_ago(1)
+        self._seed_income(gc, "700", prior_first)
+        # Tail: last day of prior month, beyond today's day-of-month.
+        tail_day = date(
+            prior_first.year, prior_first.month, prior_len,
+        )
+        self._seed_income(gc, "111", tail_day)
+
+        result = gc.get_book_summary()
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
+        rows = section.split("\n")[:6]
+        mtd_row = rows[0]
+        # Comparable holds only the in-window 700.
+        assert ": +700)" in mtd_row
+        # Full prior-month row still carries the whole 811.
+        prior_row = next(
+            r for r in rows
+            if prior_first.strftime("%b %Y") in r
+        )
+        assert "+811" in prior_row
+
 
 class TestGetBookSummaryRunway:
     """Runway section in get_book_summary.

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3184,6 +3184,64 @@ class TestGetBookSummaryUpcomingScheduled:
             or "none due in next 7 days" in sched_line
         )
 
+    def test_scheduled_line_carries_overdue_count(
+        self, scheduled_book: Path,
+    ):
+        """An overdue SX shows on the Scheduled line as
+        "N overdue ⚠", and the count agrees with the number of
+        Overdue-scheduled entries in Warnings — pre-fix the line
+        could say "none due in next 7 days" while Warnings showed
+        10 overdue, a flat contradiction."""
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="Overdue Rent",
+            description="Rent",
+            splits=[
+                {"account": "Expenses:Rent", "amount": "1850.00"},
+                {"account": "Assets:Checking", "amount": "-1850.00"},
+            ],
+            start_date=(date.today() - timedelta(days=400)).isoformat(),
+            frequency="monthly",
+        )
+        result = gc.get_book_summary()
+        sched_line = next(
+            l for l in result.splitlines()
+            if l.startswith("Scheduled:")
+        )
+        warning_count = sum(
+            1 for l in result.splitlines()
+            if "Overdue scheduled:" in l
+        )
+        assert warning_count >= 1
+        assert f"{warning_count} overdue ⚠" in sched_line
+
+    def test_scheduled_line_omits_overdue_when_none(
+        self, scheduled_book: Path,
+    ):
+        """No overdue SX → no overdue bucket on the line
+        (absence-as-signal, matching the section conventions)."""
+        from datetime import date as _date, timedelta as _td
+        gc = GnuCashBook(str(scheduled_book))
+        gc.create_scheduled_transaction(
+            name="Far Future Yearly",
+            description="Yearly",
+            start_date=(
+                _date.today() + _td(days=180)
+            ).isoformat(),
+            frequency="yearly",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-100"},
+                {"account": "Expenses:Rent", "amount": "100"},
+            ],
+        )
+        result = gc.get_book_summary()
+        sched_line = next(
+            l for l in result.splitlines()
+            if l.startswith("Scheduled:")
+        )
+        if "Overdue scheduled:" not in result:
+            assert "overdue" not in sched_line
+
 
 class TestGetBookSummaryReconciliationSplitCount:
     """Stale reconciliation lines carry "47 splits unreconciled

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1509,6 +1509,9 @@ class TestGetBookSummaryRunway:
         assert "USD" in runway_line
         assert "liquid" in runway_line
         assert "/day burn" in runway_line
+        # Burn-averaging window is disclosed (book-age clamped,
+        # so the exact day count varies with the fixture's age).
+        assert "-day avg)" in runway_line
         # Comma-separated for the liquid (2,670).
         assert "2,670" in runway_line
         # No decimals.

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -3346,6 +3346,7 @@ class TestGetBookSummaryBusinessSignals:
         )
         assert "1 invoice" in recv
         assert "1 overdue" in recv
+        assert "included in Assets total" in recv
 
     def test_payables_signal_shows_open_count(
         self, business_book: Path,
@@ -3359,6 +3360,7 @@ class TestGetBookSummaryBusinessSignals:
         )
         assert "1 bill" in pay
         assert "0 overdue" in pay
+        assert "included in Liabilities total" in pay
 
     def test_jobs_line_present_when_active(
         self, business_book: Path,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -1329,7 +1329,7 @@ class TestGetBookSummaryMonthlyNet:
         gc = GnuCashBook(str(test_book))
         self._seed_income(gc, "1000", date.today())
         result = gc.get_book_summary()
-        assert "Monthly net (last 6 months):" in result
+        assert "Monthly net (income - expenses, last 6 months):" in result
 
     def test_six_months_emitted_oldest_to_newest(
         self, test_book: Path,
@@ -1339,7 +1339,7 @@ class TestGetBookSummaryMonthlyNet:
         gc = GnuCashBook(str(test_book))
         self._seed_income(gc, "1000", date.today())
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         # Section runs until the next non-indented line.
         rows = []
         for line in section.split("\n"):
@@ -1362,7 +1362,7 @@ class TestGetBookSummaryMonthlyNet:
         gc = GnuCashBook(str(test_book))
         self._seed_income(gc, "1000", date.today())
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         first_row = section.split("\n", 1)[0]
         assert "(MTD)" in first_row
 
@@ -1375,7 +1375,7 @@ class TestGetBookSummaryMonthlyNet:
         self._seed_income(gc, "1000", date.today())
         # No activity 3 months ago.
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         three_ago_label = self._months_ago(3).strftime("%b %Y")
         three_ago_row = next(
             line for line in section.split("\n")
@@ -1397,7 +1397,7 @@ class TestGetBookSummaryMonthlyNet:
         self._seed_expense(gc, "300", one_ago_mid)
 
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         rows = section.split("\n")[:6]
 
         # Current month: +1500
@@ -1420,7 +1420,7 @@ class TestGetBookSummaryMonthlyNet:
         self._seed_expense(gc, "200", d, "groceries 2")
         # Net: 6000 - 1700 = 4300
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         first_row = section.split("\n", 1)[0]
         assert "+4,300" in first_row
 
@@ -1439,7 +1439,7 @@ class TestGetBookSummaryMonthlyNet:
         self._seed_income(gc, "999999", old_mid)
 
         result = gc.get_book_summary()
-        section = result.split("Monthly net (last 6 months):\n", 1)[1]
+        section = result.split("Monthly net (income - expenses, last 6 months):\n", 1)[1]
         # No row should contain the old amount.
         rows = section.split("\n")[:6]
         assert not any("999,999" in r for r in rows)


### PR DESCRIPTION
## Summary
- Receivables/Payables headline lines note their inclusion in the Assets/Liabilities totals, preventing double-counting on read
- Runway line discloses the burn-averaging window ("180-day avg", book-age clamped); the clamp moved into a shared `_burn_window_days` helper so the label always matches the divisor
- Monthly net header defines the number inline: "(income - expenses, last 6 months)"
- MTD row carries a prior-month same-day-window comparable — "Jul 2026 (MTD): +17,478 (vs Jun 1-22: +19,191)" — accumulated in the existing single pass
- Scheduled line carries the overdue count from the same list the Warnings section renders, ending the "10 overdue" / "none due in next 7 days" contradiction

Items 1–4 originate from a GPT dashboard review triaged by a Claude second pass; item 5 was reshaped to keep per-item overdue detail in Warnings while making the two surfaces agree by construction.

## Test plan
- [x] Full suite green: 1,881 passed
- [x] New regression tests: A/R-A/P inclusion notes, burn-window disclosure, MTD comparable value + tail exclusion, Scheduled-line/Warnings overdue agreement
- [x] Before/after capture on all three sample oracles (Alex, Lin Wei, Sabine): diff shows only the five intended additive changes, all existing numbers byte-identical
- [x] Bookkeeper loop on the live branch: signoff, zero findings