### PR TITLE
feat: per-transaction currency for batch entry and scheduled templates

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -236,9 +236,12 @@ def _batch_tsv_layout(header_line: str) -> dict:
     decimal error on whatever landed in an amount slot (bookkeeper
     finding, 1.4.1 validation round).
 
-    Returns ``{"has_notes": bool, "group": tuple[str, ...]}`` with
-    ``group`` in canonical names (``amount`` / ``account`` /
-    ``memo`` / ``quantity``).
+    Returns ``{"has_notes": bool, "has_cur": bool, "notes_idx":
+    int | None, "cur_idx": int | None, "fixed": int, "group":
+    tuple[str, ...]}`` with ``group`` in canonical names
+    (``amount`` / ``account`` / ``memo`` / ``quantity``).
+    ``fixed`` is the count of fixed-prefix columns; split cells
+    start there.
 
     Raises ValueError naming the offending column on any unknown
     token, a wrong fixed prefix, or a first group missing
@@ -256,8 +259,36 @@ def _batch_tsv_layout(header_line: str) -> dict:
             "batch header must start with ref, date, description "
             f"— got {', '.join(raw_tokens[:3]) or '(empty header)'}"
         )
-    has_notes = len(tokens) > 3 and tokens[3] == "notes"
-    start = 4 if has_notes else 3
+    # Optional per-transaction fixed columns after description, in
+    # either order: ``notes`` and ``cur`` (row's transaction
+    # currency). Exactly ``cur`` — "currency" stays an unknown
+    # token so the typo'd-split-column rejection story
+    # ("currency2") is unchanged.
+    notes_idx: int | None = None
+    cur_idx: int | None = None
+    start = 3
+    while start < len(tokens) and tokens[start] in ("notes", "cur"):
+        name = tokens[start]
+        if (name == "notes" and notes_idx is not None) or (
+            name == "cur" and cur_idx is not None
+        ):
+            raise ValueError(
+                f"duplicate {name!r} column in batch header"
+            )
+        if name == "notes":
+            notes_idx = start
+        else:
+            cur_idx = start
+        start += 1
+    has_notes = notes_idx is not None
+
+    layout_fixed = {
+        "has_notes": has_notes,
+        "has_cur": cur_idx is not None,
+        "notes_idx": notes_idx,
+        "cur_idx": cur_idx,
+        "fixed": start,
+    }
 
     canonical: list[str] = []
     for raw, token in zip(raw_tokens[start:], tokens[start:]):
@@ -265,8 +296,8 @@ def _batch_tsv_layout(header_line: str) -> dict:
         if name is None:
             raise ValueError(
                 f"unrecognized column {raw!r} in batch header — "
-                f"columns are ref, date, description, notes, then "
-                f"amt, acct, memo, qty split groups"
+                f"columns are ref, date, description, notes, cur, "
+                f"then amt, acct, memo, qty split groups"
             )
         canonical.append(name)
 
@@ -274,7 +305,7 @@ def _batch_tsv_layout(header_line: str) -> dict:
         # No split columns declared at all — the natural header for
         # an all-auto-fill batch (``ref, date, description``). Rows
         # that do carry splits chunk as legacy pairs.
-        return {"has_notes": has_notes, "group": _BATCH_LEGACY_GROUP}
+        return layout_fixed | {"group": _BATCH_LEGACY_GROUP}
 
     # The first group runs until a field repeats; later groups are
     # not order-checked (rows are chunked by the first group's
@@ -289,7 +320,7 @@ def _batch_tsv_layout(header_line: str) -> dict:
             "split columns must include both an amount and an "
             "account column"
         )
-    return {"has_notes": has_notes, "group": tuple(group)}
+    return layout_fixed | {"group": tuple(group)}
 
 
 def _batch_row_splits(rest: list[str], group: tuple[str, ...]) -> list[dict]:

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -704,6 +704,10 @@ def _upcoming_to_compact_line(
     occ_date = entry["occurrence_date"]
     days = entry["days_until"]
     amount = entry["amount"]
+    # Foreign-currency templates label their amount — an unlabeled
+    # "2000" from an HKD schedule reads as the book currency.
+    if entry.get("currency"):
+        amount = f"{amount} {entry['currency']}"
     return f"{short}\t{name}\t{occ_date}\t{days} days\t{amount}"
 
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2583,6 +2583,7 @@ class CoreMixin:
         want_stability: bool,
         want_duplicates: bool,
         want_recent: bool,
+        trans_currency: str | None = None,
         duplicate_window_days: int = 30,
         stability_days: int = 90,
         stability_limit: int = 5,
@@ -2742,7 +2743,20 @@ class CoreMixin:
                 # kills the noise without losing real duplicates
                 # (paycheck-vs-paycheck still matches on gross).
                 primary_amount = max(abs(s.value) for s in txn.splits)
-                amount_match = (
+                # Amounts only compare within the same currency
+                # frame: 188 HKD and 188 CNY are not the same money,
+                # and the cross-frame version of a true duplicate
+                # has numerically DIFFERENT values — so cross-
+                # currency amount matches are coincidence by
+                # construction (bookkeeper finding, cur-column
+                # round). Cross-currency candidates can still reach
+                # MEDIUM on description+date, labeled by the cur
+                # column.
+                same_frame = (
+                    trans_currency is None
+                    or txn.currency.mnemonic == trans_currency
+                )
+                amount_match = same_frame and (
                     abs(proposed_primary - primary_amount) <= Decimal("1.00")
                 )
 
@@ -2765,11 +2779,12 @@ class CoreMixin:
                         "date": txn.post_date.isoformat(),
                         "description": txn.description,
                         "amount": str(primary_amount),
-                        # The amount comparison is currency-blind;
-                        # labeling non-default candidates lets the
-                        # caller spot a cross-currency false match
-                        # (CNY 188 vs HKD 188) without a follow-up
-                        # read. Empty = book default.
+                        # Labeling non-default candidates lets the
+                        # caller interpret a cross-currency MEDIUM
+                        # (desc+date) without a follow-up read —
+                        # and explains why equal-looking numbers
+                        # did NOT amount-match. Empty = book
+                        # default.
                         "currency": (
                             txn.currency.mnemonic
                             if txn.currency != book.default_currency
@@ -3070,6 +3085,15 @@ class CoreMixin:
             proposed_amounts = [abs(_to_decimal(s["amount"])) for s in splits]
 
             # --- Preflight pass 2: duplicates + recent matches ---
+            # The frame is passed as a mnemonic (currency resolution
+            # proper happens below and may CREATE the commodity —
+            # mutation stays after the rejection path). A currency
+            # not yet in the book matches no existing transaction's
+            # frame, which is exactly right.
+            frame_code = (
+                currency.upper() if currency
+                else self._require_default_currency(book).mnemonic
+            )
             signals = self._collect_create_signals(
                 book,
                 description,
@@ -3079,6 +3103,7 @@ class CoreMixin:
                 want_stability=False,
                 want_duplicates=check_duplicates,
                 want_recent=True,
+                trans_currency=frame_code,
             )
             duplicates = signals.duplicates
 
@@ -3248,11 +3273,11 @@ class CoreMixin:
         denominate in the book default; rows with it balance in
         that currency instead (splits on accounts of any OTHER
         commodity carry an explicit ``quantity``). The duplicate
-        screen compares amounts numerically without currency
-        awareness — a same-description same-date twin in another
-        currency can false-match; the dup table's ref column makes
-        that visible for review. ``currency`` cannot combine with
-        an auto-fill row (the source transaction's own currency
+        amount signal compares within the same currency frame only
+        (188 HKD is not 188 CNY); a same-description same-date twin
+        in another currency can still surface as a labeled,
+        non-blocking MEDIUM. ``currency`` cannot combine with an
+        auto-fill row (the source transaction's own currency
         governs a reproduction). No intra-batch dedup.
         """
         if on_error not in ("abort", "skip"):
@@ -3366,6 +3391,7 @@ class CoreMixin:
                     p["proposed_amounts"],
                     want_auto_fill=False, want_stability=False,
                     want_duplicates=True, want_recent=False,
+                    trans_currency=p["currency"].mnemonic,
                 )
                 dups = signals.duplicates
                 for d in dups:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2004,9 +2004,18 @@ class CoreMixin:
                         "s" if upcoming["count"] != 1 else ""
                     )
                     total_int = int(upcoming["total"])
+                    amount_part = f"{currency} {total_int:,}"
+                    # Foreign-currency schedules with no market
+                    # rate can't join the sum — say so rather than
+                    # silently understate the week's bills.
+                    if upcoming.get("unrated"):
+                        amount_part += (
+                            f" + {upcoming['unrated']} foreign "
+                            f"w/o rate ⚠"
+                        )
                     line += (
                         f", {upcoming['count']} due in next "
-                        f"7 days ({currency} {total_int:,})"
+                        f"7 days ({amount_part})"
                     )
                 else:
                     line += ", none due in next 7 days"

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2756,6 +2756,16 @@ class CoreMixin:
                         "date": txn.post_date.isoformat(),
                         "description": txn.description,
                         "amount": str(primary_amount),
+                        # The amount comparison is currency-blind;
+                        # labeling non-default candidates lets the
+                        # caller spot a cross-currency false match
+                        # (CNY 188 vs HKD 188) without a follow-up
+                        # read. Empty = book default.
+                        "currency": (
+                            txn.currency.mnemonic
+                            if txn.currency != book.default_currency
+                            else ""
+                        ),
                         "signals": signal_str,
                     })
 
@@ -2820,7 +2830,7 @@ class CoreMixin:
         string (no header — ``create_transaction``'s docstring
         documents the shape)::
 
-            confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+            confidence<TAB>guid<TAB>date<TAB>amount<TAB>cur<TAB>description<TAB>signals
 
         ~40 chars per candidate vs ~120 for list-of-dicts JSON.
         Returns ``""`` for empty input — ``_strip_noise`` drops
@@ -2830,7 +2840,8 @@ class CoreMixin:
         """
         return "\n".join(
             f"{d['confidence']}\t{d['guid']}\t{d['date']}\t"
-            f"{d['amount']}\t{d['description']}\t{d['signals']}"
+            f"{d['amount']}\t{d.get('currency', '')}\t"
+            f"{d['description']}\t{d['signals']}"
             for d in duplicates
         )
 
@@ -2994,7 +3005,7 @@ class CoreMixin:
 
             'duplicates', when present, is newline-separated TSV::
 
-                confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+                confidence<TAB>guid<TAB>date<TAB>amount<TAB>cur<TAB>description<TAB>signals
 
             Confidence is HIGH or MEDIUM; signals is a three-char
             D/A/D code (description / amount / date, dash = no match).
@@ -3477,11 +3488,15 @@ class CoreMixin:
         prepended as the FK. Empty string when no row has a match."""
         if not dup_rows:
             return ""
-        lines = ["ref\tconfidence\tguid\tdate\tamount\tdescription\tsignals"]
+        lines = [
+            "ref\tconfidence\tguid\tdate\tamount\tcur\t"
+            "description\tsignals"
+        ]
         for ref, d in dup_rows:
             lines.append(
                 f"{ref}\t{d['confidence']}\t{d['guid']}\t{d['date']}\t"
-                f"{d['amount']}\t{d['description']}\t{d['signals']}"
+                f"{d['amount']}\t{d.get('currency', '')}\t"
+                f"{d['description']}\t{d['signals']}"
             )
         return "\n".join(lines)
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3203,10 +3203,13 @@ class CoreMixin:
 
         Spec: specs/BATCH_TRANSACTION_ENTRY_SPEC.md. Each entry is
         ``{ref, date (date), description, notes (optional),
+        currency (optional ISO code — the row's transaction
+        currency, defaulting to the book default),
         splits: [{account, amount, memo (optional),
         quantity (optional)}]}`` — quantity per the
         ``_validate_transaction_splits`` contract (required iff the
-        account commodity differs from the book default). An EMPTY
+        account commodity differs from the row's transaction
+        currency). An EMPTY
         splits list is an auto-fill request: the row reproduces the
         most recent matching-description transaction (splits, memos,
         quantities), marked ``auto_filled_from:<guid>`` in the
@@ -3221,11 +3224,16 @@ class CoreMixin:
 
         Returns a thin envelope: ``results`` TSV (always) and
         ``duplicates`` TSV (only when a match exists; otherwise empty,
-        which ``_strip_noise`` drops). The transaction currency is
-        always the book default (a differently-denominated
-        transaction needs ``create_transaction``'s ``currency``
-        parameter); splits on non-default-commodity accounts carry
-        an explicit ``quantity``. No intra-batch dedup.
+        which ``_strip_noise`` drops). Rows without ``currency``
+        denominate in the book default; rows with it balance in
+        that currency instead (splits on accounts of any OTHER
+        commodity carry an explicit ``quantity``). The duplicate
+        screen compares amounts numerically without currency
+        awareness — a same-description same-date twin in another
+        currency can false-match; the dup table's ref column makes
+        that visible for review. ``currency`` cannot combine with
+        an auto-fill row (the source transaction's own currency
+        governs a reproduction). No intra-batch dedup.
         """
         if on_error not in ("abort", "skip"):
             raise ValueError("on_error must be 'abort' or 'skip'")
@@ -3247,6 +3255,30 @@ class CoreMixin:
                 ref = txn["ref"]
                 try:
                     splits = txn["splits"]
+                    # Row's transaction currency (the ``cur``
+                    # column); absent means the book default.
+                    row_currency = default_currency
+                    if txn.get("currency"):
+                        row_currency = self._find_commodity(
+                            book, txn["currency"],
+                        )
+                        if not row_currency:
+                            raise ValueError(
+                                f"currency '{txn['currency']}' not "
+                                f"found in book — create it first "
+                                f"(create_commodity) or record a "
+                                f"transaction in it once"
+                            )
+                        if not splits:
+                            # Auto-fill reproduces a source txn in
+                            # the SOURCE's currency — silently
+                            # re-denominating it would corrupt the
+                            # copied amounts.
+                            raise ValueError(
+                                "cur cannot combine with an "
+                                "auto-fill (splitless) row — supply "
+                                "explicit splits"
+                            )
                     auto_filled_from = None
                     auto_fill_warnings: list[dict] = []
                     if not splits:
@@ -3270,7 +3302,7 @@ class CoreMixin:
                     if len(splits) < 2:
                         raise ValueError("at least 2 splits required")
                     validated = self._validate_transaction_splits(
-                        book, splits, default_currency,
+                        book, splits, row_currency,
                     )
                     for v in validated:
                         if v["account"].placeholder:
@@ -3283,6 +3315,7 @@ class CoreMixin:
                         "description": txn["description"],
                         "notes": txn.get("notes") or "",
                         "trans_date": txn["date"],
+                        "currency": row_currency,
                         "validated": validated,
                         "proposed_amounts": [
                             abs(_to_decimal(s["amount"])) for s in splits
@@ -3333,7 +3366,7 @@ class CoreMixin:
                 for w in p["auto_fill_warnings"]:
                     warn_rows.append((p["ref"], w["message"]))
                 for w in self._fx_sanity_warnings(
-                    book, p["validated"], default_currency, p["trans_date"],
+                    book, p["validated"], p["currency"], p["trans_date"],
                 ):
                     warn_rows.append((p["ref"], w["message"]))
 
@@ -3372,7 +3405,7 @@ class CoreMixin:
                     for v in p["validated"]
                 ]
                 txn_obj = piecash.Transaction(
-                    currency=default_currency,
+                    currency=p["currency"],
                     description=p["description"],
                     notes=p["notes"] or None,
                     post_date=p["trans_date"],

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -231,6 +231,7 @@ class SchedulingMixin:
         end_date: str | None = None,
         enabled: bool = True,
         notes: str | None = None,
+        currency: str | None = None,
     ) -> dict:
         """Create a recurring transaction template.
 
@@ -239,6 +240,10 @@ class SchedulingMixin:
             description: Transaction description when created.
             splits: List of splits, same format as create_transaction:
                 [{"account": "Expenses:Rent", "amount": "1850.00"}, ...]
+                ``quantity`` per the shared contract — required when
+                an account's commodity differs from the template's
+                transaction currency; stored and replayed at every
+                instantiation.
             start_date: First occurrence date (YYYY-MM-DD).
             frequency: How often: "weekly", "biweekly", "monthly",
                       "quarterly", "yearly".
@@ -247,6 +252,16 @@ class SchedulingMixin:
             notes: Transaction-level notes applied to every
                 instantiated transaction (what the purchase is —
                 visible in GnuCash's double-line register view).
+            currency: ISO code denominating every instantiated
+                transaction; defaults to the book default. A
+                template whose legs are all in one foreign currency
+                (Lin Wei's USD-to-USD card payment in a CNY book)
+                needs this — amounts are then that currency's, with
+                no fabricated conversions. Deliberately not
+                updatable after creation: stored amounts are
+                denominated in it, so changing it would silently
+                re-denominate the schedule — delete and recreate
+                instead.
 
         Returns:
             Dict with guid, name, next_occurrence, and status.
@@ -285,12 +300,22 @@ class SchedulingMixin:
         ]
 
         with self.open(readonly=False) as book:
-            for s in splits:
-                acct = self._resolve_account(book, s["account"])
-                if not acct:
+            sx_currency = None
+            if currency:
+                sx_currency = self._find_commodity(book, currency)
+                if not sx_currency:
                     raise ValueError(
-                        f"Account not found: {s['account']}"
+                        f"Currency '{currency}' not found in book — "
+                        f"create it first (create_commodity) or "
+                        f"record a transaction in it once"
                     )
+            frame = sx_currency or self._require_default_currency(book)
+            # Shared split contract (resolution, sum-to-zero,
+            # quantity rules) at CREATE time — a template must
+            # reject here anything instantiation couldn't book.
+            # Pre-fix, an all-foreign-leg template created fine
+            # and then failed at every instantiation forever.
+            self._validate_transaction_splits(book, splits, frame)
 
             for sx in book.session.query(
                 ScheduledTransaction
@@ -368,6 +393,12 @@ class SchedulingMixin:
                         "account": s["account"],
                         "amount": str(_to_decimal(s["amount"])),
                         "memo": s.get("memo", ""),
+                        # Cross-commodity legs replay their stored
+                        # quantity at every instantiation.
+                        **(
+                            {"quantity": str(_to_decimal(s["quantity"]))}
+                            if s.get("quantity") is not None else {}
+                        ),
                     }
                     for s in splits
                 ])
@@ -401,6 +432,24 @@ class SchedulingMixin:
                         book.session, Slot.__table__,
                         {"obj_guid": sx_guid, "name": "description"},
                         f"Description slot for scheduled "
+                        f"transaction '{name}'",
+                    )
+
+                # Instantiation currency — absent slot means the
+                # book default at instantiation time.
+                if sx_currency is not None:
+                    book.session.execute(
+                        Slot.__table__.insert().values(
+                            obj_guid=sx_guid,
+                            name="currency",
+                            slot_type=KVP_Type.KVP_TYPE_STRING,
+                            string_val=sx_currency.mnemonic,
+                        )
+                    )
+                    _verify_composite_write(
+                        book.session, Slot.__table__,
+                        {"obj_guid": sx_guid, "name": "currency"},
+                        f"Currency slot for scheduled "
                         f"transaction '{name}'",
                     )
 
@@ -503,6 +552,11 @@ class SchedulingMixin:
                     )
                     if sx_notes:
                         d["notes"] = sx_notes
+                    sx_cur = self._get_sx_slot_string(
+                        book, sx.guid, "currency",
+                    )
+                    if sx_cur:
+                        d["currency"] = sx_cur
                     d["splits"] = self._get_sx_splits(book, sx)
                 results.append(d)
 
@@ -806,6 +860,9 @@ class SchedulingMixin:
             sx_notes = self._get_sx_slot_string(
                 book, sx.guid, "notes",
             )
+            sx_currency = self._get_sx_slot_string(
+                book, sx.guid, "currency",
+            )
 
         # ── Phase 2: create the transaction (see docstring). ─────
         txn_result = self.create_transaction(
@@ -813,6 +870,7 @@ class SchedulingMixin:
             splits=splits,
             trans_date=txn_date,
             notes=sx_notes,
+            currency=sx_currency,
         )
 
         # ── Phase 3: advance the schedule. ──────────────────────

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -585,20 +585,30 @@ class SchedulingMixin:
         self, book, days: int = 7,
     ) -> dict:
         """Summary stats for scheduled transactions due within
-        ``days`` days: ``{"count": int, "total": Decimal}``.
+        ``days`` days: ``{"count": int, "total": Decimal,
+        "unrated": int}``.
 
         Total = sum of positive split amounts per occurrence (same
-        convention as ``get_upcoming_transactions``). Feeds the
-        get_book_summary Scheduled line; lives here so a book class
-        built without scheduling lacks the method and the summary
-        skips the line via ``hasattr``.
+        convention as ``get_upcoming_transactions``), in the BOOK
+        DEFAULT currency: foreign-currency templates convert at the
+        latest market rate; templates whose currency has no rate on
+        file are counted but excluded from the total (``unrated``
+        reports how many, so the summary line can say so instead of
+        silently understating). Feeds the get_book_summary Scheduled
+        line; lives here so a book class built without scheduling
+        lacks the method and the summary skips the line via
+        ``hasattr``.
         """
 
         today = date.today()
         window_end = today + timedelta(days=days)
 
+        default_currency = self._require_default_currency(book)
+        rates = self._rates_as_of(book, today, default_currency)
+
         count = 0
         total = Decimal("0")
+        unrated = 0
         for sx in book.session.query(ScheduledTransaction).all():
             if not sx.enabled:
                 continue
@@ -630,16 +640,26 @@ class SchedulingMixin:
                 continue
 
             count += 1
-            # splits-json amounts are in the book default currency
-            # by construction (create pins the default; instantiate
-            # passes no override), so no FX conversion is needed. A
-            # foreign-currency SX would be a native-GnuCash template
-            # with no splits-json slot — it contributes nothing here.
+            # splits-json amounts are denominated in the template's
+            # currency (the ``currency`` slot; absent = book
+            # default). Foreign templates convert at the latest
+            # market rate; no rate on file → counted, excluded from
+            # the total, reported via ``unrated``.
+            rate = Decimal("1")
+            sx_cur = self._get_sx_slot_string(book, sx.guid, "currency")
+            if sx_cur and sx_cur != default_currency.mnemonic:
+                commodity = self._find_commodity(book, sx_cur)
+                rate = (
+                    rates.get(commodity.guid) if commodity else None
+                )
+                if rate is None:
+                    unrated += 1
+                    continue
             for s in self._get_sx_splits(book, sx):
                 amt = _to_decimal(s["amount"])
                 if amt > 0:
-                    total += amt
-        return {"count": count, "total": total}
+                    total += amt * rate
+        return {"count": count, "total": total, "unrated": unrated}
 
     def get_upcoming_transactions(
         self,
@@ -722,6 +742,14 @@ class SchedulingMixin:
                         "days_until": (next_occ - today).days,
                         "amount": str(total),
                     }
+                    # Amounts are denominated in the template's
+                    # currency — label foreign ones so the bill
+                    # list never reads HKD numbers as book-default.
+                    sx_cur = self._get_sx_slot_string(
+                        book, sx.guid, "currency",
+                    )
+                    if sx_cur:
+                        entry["currency"] = sx_cur
                     if not compact:
                         entry["splits"] = splits
                     upcoming.append(entry)

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -613,8 +613,12 @@ def _parse_batch_submission(tsv: str) -> dict:
     except ValueError:
         # Malformed extension header — the write path rejected the
         # whole submission; render rows in the legacy shape.
-        layout = {"has_notes": False, "group": _BATCH_LEGACY_GROUP}
-    fixed = 4 if layout["has_notes"] else 3
+        layout = {
+            "has_notes": False, "has_cur": False,
+            "notes_idx": None, "cur_idx": None, "fixed": 3,
+            "group": _BATCH_LEGACY_GROUP,
+        }
+    fixed = layout["fixed"]
     for ln in lines[1:]:
         if not ln.strip():
             continue
@@ -628,8 +632,12 @@ def _parse_batch_submission(tsv: str) -> dict:
         entry = {
             "description": f[2], "date": f[1].strip(), "splits": splits,
         }
-        if layout["has_notes"] and len(f) > 3 and f[3].strip():
-            entry["notes"] = f[3].strip()
+        ni = layout["notes_idx"]
+        if ni is not None and len(f) > ni and f[ni].strip():
+            entry["notes"] = f[ni].strip()
+        ci = layout["cur_idx"]
+        if ci is not None and len(f) > ci and f[ci].strip():
+            entry["currency"] = f[ci].strip().upper()
         out[f[0].strip()] = entry
     return out
 
@@ -657,8 +665,11 @@ def _fmt_transaction_create_batch(entry: dict) -> list[str]:
         guid = r.get("txn_guid", "")
         desc = src.get("description", "")
         date_str = src.get("date", "")
+        when = date_str
+        if src.get("currency"):
+            when = f"{date_str}, {src['currency']}"
         lines.append(
-            f'{_INDENT}CREATE  guid:{guid}  "{desc}" ({date_str})'
+            f'{_INDENT}CREATE  guid:{guid}  "{desc}" ({when})'
         )
         if src.get("notes"):
             lines.append(f"{_INDENT_SPLITS}notes: {src['notes']}")

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1871,6 +1871,9 @@ def _fmt_scheduled_transaction_create(entry: dict) -> list[str]:
     notes = params.get("notes", "")
     if notes:
         lines.append(f"{_INDENT}notes: {notes}")
+    sx_currency = params.get("currency", "")
+    if sx_currency:
+        lines.append(f"{_INDENT}currency: {sx_currency}")
     freq = after.get("frequency", params.get("frequency", ""))
     start = params.get("start_date", "")
     end = params.get("end_date", "")

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -42,7 +42,7 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
         )
     layout = _batch_tsv_layout(lines[0])
     group = layout["group"]
-    fixed = 4 if layout["has_notes"] else 3
+    fixed = layout["fixed"]
     out: list[dict] = []
     for i, ln in enumerate(lines[1:], start=1):
         fields = ln.split("\t")
@@ -75,8 +75,12 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
             "description": desc,
             "splits": splits,
         }
-        if layout["has_notes"] and len(fields) > 3 and fields[3].strip():
-            txn["notes"] = fields[3].strip()
+        ni = layout["notes_idx"]
+        if ni is not None and len(fields) > ni and fields[ni].strip():
+            txn["notes"] = fields[ni].strip()
+        ci = layout["cur_idx"]
+        if ci is not None and len(fields) > ci and fields[ci].strip():
+            txn["currency"] = fields[ci].strip().upper()
         out.append(txn)
     return out
 
@@ -384,6 +388,22 @@ def register(mcp, get_book) -> None:
           is where the RAW statement line goes (provenance, visible
           only in expanded split view). Prefer filling ``notes``
           whenever the description alone doesn't tell the story.
+
+        - PER-TRANSACTION CURRENCY — declare a ``cur`` column after
+          ``description`` (before or after ``notes``); an ISO code
+          cell sets THAT ROW's transaction currency, an empty cell
+          keeps the book default::
+
+              ref<TAB>date<TAB>description<TAB>cur<TAB>amt1<TAB>acct1<TAB>amt2<TAB>acct2
+              1<TAB>2026-07-15<TAB>USD Card Payment<TAB>USD<TAB>-500<TAB>Assets:USD Checking<TAB>500<TAB>Liabilities:USD Card
+
+          With ``cur``, the row's ``amt`` cells are in that
+          currency and must balance in it. Use it when NO leg is in
+          the book's default currency (a USD-to-USD transfer inside
+          a CNY book needs no invented CNY values and no qty).
+          Splits on accounts of any OTHER commodity still need
+          ``qty``. The currency must already exist in the book, and
+          ``cur`` cannot combine with an auto-fill row.
 
         - PER-SPLIT QUANTITY — declare ``qty`` split columns for
           splits whose ACCOUNT commodity differs from the book

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -309,7 +309,7 @@ def register(mcp, get_book) -> None:
         successful create), ``duplicates`` in the response is a
         newline-separated TSV string, not a list of dicts. Columns::
 
-            confidence<TAB>guid<TAB>date<TAB>amount<TAB>description<TAB>signals
+            confidence<TAB>guid<TAB>date<TAB>amount<TAB>cur<TAB>description<TAB>signals
 
         Confidence is ``HIGH`` (all three signals match) or ``MEDIUM``
         (two of three). Signals is a three-char code: position 0

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -25,6 +25,7 @@ def register(mcp, get_book) -> None:
         end_date: str | None = None,
         enabled: bool = True,
         notes: str | None = None,
+        currency: str | None = None,
     ) -> str:
         """Create a recurring transaction template.
 
@@ -33,7 +34,9 @@ def register(mcp, get_book) -> None:
             description: Transaction description at instantiation.
             splits: Same format as create_transaction, e.g.
                 ``[{"account": "Expenses:Rent", "amount": "1850.00"}, ...]``.
-                ``amount`` / ``quantity`` must be decimal strings.
+                ``amount`` / ``quantity`` must be decimal strings;
+                ``quantity`` is required when an account's commodity
+                differs from the template's transaction currency.
             start_date: First occurrence (YYYY-MM-DD).
             frequency: "weekly", "biweekly" (2w), "monthly",
                 "bimonthly" (2mo), "quarterly" (3mo), or "yearly".
@@ -42,6 +45,12 @@ def register(mcp, get_book) -> None:
             notes: Transaction notes applied to every instantiated
                 transaction (what the payment is — visible in
                 GnuCash's double-line register view).
+            currency: ISO code denominating every instantiated
+                transaction; defaults to the book default. Use when
+                no leg is in the book currency (a USD-to-USD card
+                payment scheduled inside a CNY book) so amounts are
+                the foreign currency's own numbers. Not updatable
+                after creation — delete and recreate to change it.
         """
         book = get_book()
         result = book.create_scheduled_transaction(
@@ -53,6 +62,7 @@ def register(mcp, get_book) -> None:
             end_date=end_date,
             enabled=enabled,
             notes=notes,
+            currency=currency,
         )
         return _json(result)
 

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -721,3 +721,37 @@ class TestBatchCurColumn:
             "1\t2026-07-15\tCard Payment\tusd\t-500\tA:U\t500\tL:U"
         )
         assert parsed["1"]["currency"] == "USD"
+
+    def test_dup_table_labels_cross_currency_candidates(
+        self, multi_currency_book,
+    ):
+        """A currency-blind amount match against a foreign-frame
+        transaction is labeled with the candidate's currency in the
+        dup table (empty cell = book default), so a cross-currency
+        false positive is visible without a follow-up read."""
+        gc = GnuCashBook(str(multi_currency_book))
+        gc.create_account(
+            name="EUR Checking", account_type="BANK",
+            parent="Assets", commodity="EUR",
+        )
+        # Existing EUR-frame transaction: 188 EUR.
+        gc.create_transaction(
+            description="Tea House", currency="EUR",
+            splits=[
+                {"account": "Assets:EUR Checking", "amount": "-188.00"},
+                {"account": "Assets:Euro Savings", "amount": "188.00"},
+            ],
+            trans_date=date(2026, 7, 15),
+        )
+        # New default-frame (USD) row, same description/amount/date.
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "Tea House",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-188.00"},
+                {"account": "Expenses:Groceries", "amount": "188.00"},
+            ],
+        }], force=True)
+        dups = _parse(env["duplicates"])
+        assert dups, "expected a cross-currency HIGH/MEDIUM match"
+        assert dups[0]["cur"] == "EUR"

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -559,3 +559,165 @@ class TestBatchCreate:
         gc = GnuCashBook(str(test_book))
         with pytest.raises(ValueError):
             gc.create_transactions([_txn(1, "x", "1")], on_error="bad")
+
+
+class TestBatchCurColumn:
+    """The ``cur`` column sets a ROW's transaction currency.
+
+    Motivating case: a USD-to-USD transfer inside a CNY/USD-default
+    book — with no book-currency leg, the pinned default frame
+    forced fabricated conversion values on both sides of an event
+    containing no conversion at all."""
+
+    def test_cur_parses_after_description(self):
+        tsv = (
+            "ref\tdate\tdescription\tcur\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-07-15\tCard Payment\tUSD\t-500\tA:U\t500\tL:U\n"
+            "2\t2026-07-16\tLocal Rent\t\t-900\tA:C\t900\tE:R"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["currency"] == "USD"
+        assert "currency" not in rows[1]  # empty cell = book default
+
+    def test_cur_and_notes_in_either_order(self):
+        for header in (
+            "ref\tdate\tdescription\tnotes\tcur\tamt1\tacct1\tamt2\tacct2",
+            "ref\tdate\tdescription\tcur\tnotes\tamt1\tacct1\tamt2\tacct2",
+        ):
+            cells = {"notes": "why", "cur": "eur"}
+            order = [t for t in header.split("\t")[3:5]]
+            row = "1\t2026-07-15\tX\t" + "\t".join(
+                cells[c] for c in order
+            ) + "\t-10\tA\t10\tB"
+            rows = _parse_transactions_tsv(header + "\n" + row)
+            assert rows[0]["currency"] == "EUR"
+            assert rows[0]["notes"] == "why"
+
+    def test_duplicate_cur_rejects(self):
+        with pytest.raises(ValueError, match="duplicate 'cur'"):
+            _parse_transactions_tsv(
+                "ref\tdate\tdescription\tcur\tcur\tamt1\tacct1\n"
+                "1\t2026-07-15\tX\tUSD\tUSD\t-10\tA"
+            )
+
+    def test_currency_token_still_rejects(self):
+        """'currency' (and typo'd 'currency2') stay unknown tokens —
+        the 1.4.1 reject-by-name contract is unchanged."""
+        with pytest.raises(ValueError, match="currency"):
+            _parse_transactions_tsv(
+                "ref\tdate\tdescription\tcurrency\tamt1\tacct1\n"
+                "1\t2026-07-15\tX\tUSD\t-10\tA"
+            )
+
+    def test_foreign_pair_books_in_foreign_frame(
+        self, multi_currency_book,
+    ):
+        """EUR->EUR transfer in a USD book: cur=EUR, statement
+        numbers as amounts, no qty, transaction denominated EUR."""
+        gc = GnuCashBook(str(multi_currency_book))
+        gc.create_account(
+            name="EUR Checking", account_type="BANK",
+            parent="Assets", commodity="EUR",
+        )
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "Move to savings", "currency": "EUR",
+            "splits": [
+                {"account": "Assets:EUR Checking", "amount": "-40.00"},
+                {"account": "Assets:Euro Savings", "amount": "40.00"},
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        assert txn["currency"] == "EUR"
+        splits = {s["account"]: s for s in txn["splits"]}
+        sav = splits["Assets:Euro Savings"]
+        assert sav["value"] == "40" and sav["quantity"] == "40"
+
+    def test_cur_row_with_default_commodity_leg_needs_qty(
+        self, multi_currency_book,
+    ):
+        """A USD leg inside a EUR-frame row is the cross-commodity
+        one now — omitting its qty rejects the row."""
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "EUR purchase from USD account",
+            "currency": "EUR",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-40.00"},
+                {"account": "Assets:Euro Savings", "amount": "40.00"},
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "quantity" in rows[0]["reason"]
+
+    def test_mixed_batch_default_and_cur_rows(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        gc.create_account(
+            name="EUR Checking", account_type="BANK",
+            parent="Assets", commodity="EUR",
+        )
+        env = gc.create_transactions([
+            {
+                "ref": "1", "date": date(2026, 7, 15),
+                "description": "USD groceries",
+                "splits": [
+                    {"account": "Assets:Checking", "amount": "-30.00"},
+                    {"account": "Expenses:Groceries", "amount": "30.00"},
+                ],
+            },
+            {
+                "ref": "2", "date": date(2026, 7, 15),
+                "description": "EUR shuffle", "currency": "EUR",
+                "splits": [
+                    {"account": "Assets:EUR Checking", "amount": "-15.00"},
+                    {"account": "Assets:Euro Savings", "amount": "15.00"},
+                ],
+            },
+        ])
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["1"]["status"] == "created"
+        assert rows["2"]["status"] == "created"
+        gc2 = GnuCashBook(str(multi_currency_book))
+        t1 = gc2.get_transaction(rows["1"]["txn_guid"])
+        t2 = gc2.get_transaction(rows["2"]["txn_guid"])
+        assert t1["currency"] == "USD"
+        assert t2["currency"] == "EUR"
+
+    def test_unknown_currency_rejects_row(self, multi_currency_book):
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "X", "currency": "CHF",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-1.00"},
+                {"account": "Expenses:Groceries", "amount": "1.00"},
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "CHF" in rows[0]["reason"]
+
+    def test_cur_with_autofill_row_rejects(self, multi_currency_book):
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "Groceries", "currency": "EUR",
+            "splits": [],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "auto-fill" in rows[0]["reason"]
+
+    def test_audit_submission_parse_carries_currency(self):
+        from gnucash_mcp.logging_config import _parse_batch_submission
+        parsed = _parse_batch_submission(
+            "ref\tdate\tdescription\tcur\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t2026-07-15\tCard Payment\tusd\t-500\tA:U\t500\tL:U"
+        )
+        assert parsed["1"]["currency"] == "USD"

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -722,13 +722,15 @@ class TestBatchCurColumn:
         )
         assert parsed["1"]["currency"] == "USD"
 
-    def test_dup_table_labels_cross_currency_candidates(
+    def test_cross_currency_coincidence_is_nonblocking_and_labeled(
         self, multi_currency_book,
     ):
-        """A currency-blind amount match against a foreign-frame
-        transaction is labeled with the candidate's currency in the
-        dup table (empty cell = book default), so a cross-currency
-        false positive is visible without a follow-up read."""
+        """188 EUR is not 188 USD: the amount signal only fires
+        within the same currency frame, so a cross-currency numeric
+        coincidence lands as a non-blocking MEDIUM (desc+date,
+        'D-D') labeled with the candidate's currency — visible,
+        interpretable, and never forcing a weaker model to refuse
+        a legitimate entry (bookkeeper finding, cur-column round)."""
         gc = GnuCashBook(str(multi_currency_book))
         gc.create_account(
             name="EUR Checking", account_type="BANK",
@@ -743,7 +745,8 @@ class TestBatchCurColumn:
             ],
             trans_date=date(2026, 7, 15),
         )
-        # New default-frame (USD) row, same description/amount/date.
+        # New default-frame (USD) row, same description/amount/date
+        # — creates WITHOUT force: the coincidence is not a HIGH.
         env = gc.create_transactions([{
             "ref": "1", "date": date(2026, 7, 15),
             "description": "Tea House",
@@ -751,7 +754,11 @@ class TestBatchCurColumn:
                 {"account": "Assets:Checking", "amount": "-188.00"},
                 {"account": "Expenses:Groceries", "amount": "188.00"},
             ],
-        }], force=True)
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
         dups = _parse(env["duplicates"])
-        assert dups, "expected a cross-currency HIGH/MEDIUM match"
+        assert dups, "expected a labeled cross-currency MEDIUM"
+        assert dups[0]["confidence"] == "MEDIUM"
+        assert dups[0]["signals"] == "D-D"
         assert dups[0]["cur"] == "EUR"

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -80,8 +80,9 @@ def _parse_duplicates(tsv: str) -> list[dict]:
             "guid": parts[1],
             "date": parts[2],
             "amount": parts[3],
-            "description": parts[4],
-            "signals": parts[5],
+            "cur": parts[4],
+            "description": parts[5],
+            "signals": parts[6],
         })
     return rows
 
@@ -5253,9 +5254,10 @@ class TestDuplicatesTsvShape:
         assert "{" not in result["duplicates"]
 
     def test_tsv_columns_and_order(self, test_book: Path):
-        """Each row is six tab-separated columns in the documented
-        order. The first row is the one with the strongest match
-        (HIGH confidence when all three signals hit)."""
+        """Each row is seven tab-separated columns in the documented
+        order (``cur`` is empty for book-default candidates). The
+        first row is the one with the strongest match (HIGH
+        confidence when all three signals hit)."""
         gc_book = GnuCashBook(str(test_book))
         result = gc_book.create_transaction(
             description="Weekly Groceries",
@@ -5267,14 +5269,15 @@ class TestDuplicatesTsvShape:
         )
         first_line = result["duplicates"].split("\n")[0]
         cols = first_line.split("\t")
-        assert len(cols) == 6
-        confidence, guid, dt, amount, description, signals = cols
+        assert len(cols) == 7
+        confidence, guid, dt, amount, cur, description, signals = cols
         assert confidence == "HIGH"
         assert len(guid) >= 8  # short prefix, never a raw 32-char guid
         assert dt == "2024-01-20"
         # piecash's GncNumeric strips trailing zeros (150, not 150.00),
         # so compare numerically rather than asserting exact text.
         assert Decimal(amount) == Decimal("150")
+        assert cur == ""  # book-default candidate: empty cell
         assert description == "Weekly Groceries"
         assert signals == "DAD"
 

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -908,3 +908,115 @@ class TestScheduledNotes:
         )
         txn = gb.get_transaction(result["transaction_guid"])
         assert txn["notes"] == "new annotation"
+
+
+class TestScheduledCurrency:
+    """Templates denominate their instantiations.
+
+    Pre-fix wedge: an all-foreign-leg template (Lin Wei's USD-to-USD
+    card payment in a CNY book) CREATED fine — the manual account
+    loop never checked quantity rules — then failed at every
+    instantiation forever. Creation now runs the shared split
+    validator against the template's currency, and a ``currency``
+    slot denominates instantiated transactions."""
+
+    def _eur_accounts(self, gc):
+        gc.create_account(
+            name="EUR Checking", account_type="BANK",
+            parent="Assets", commodity="EUR",
+        )
+        # Fixture already has Assets:Euro Savings (EUR).
+
+    def test_foreign_pair_template_instantiates_in_currency(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        self._eur_accounts(gc)
+        sx = gc.create_scheduled_transaction(
+            name="EUR Sweep", description="Monthly EUR sweep",
+            splits=[
+                {"account": "Assets:EUR Checking", "amount": "-25.00"},
+                {"account": "Assets:Euro Savings", "amount": "25.00"},
+            ],
+            start_date="2026-08-01", frequency="monthly",
+            currency="EUR",
+        )
+        r = gc.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-08-01",
+        )
+        assert r["status"] == "created"
+        txn = gc.get_transaction(r["transaction_guid"])
+        assert txn["currency"] == "EUR"
+        sav = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Euro Savings"
+        )
+        assert sav["value"] == "25" and sav["quantity"] == "25"
+
+    def test_all_foreign_template_without_currency_rejects_at_create(
+        self, multi_currency_book,
+    ):
+        gc = GnuCashBook(str(multi_currency_book))
+        self._eur_accounts(gc)
+        with pytest.raises(ValueError, match="quantity"):
+            gc.create_scheduled_transaction(
+                name="Broken Sweep", description="x",
+                splits=[
+                    {"account": "Assets:EUR Checking",
+                     "amount": "-25.00"},
+                    {"account": "Assets:Euro Savings",
+                     "amount": "25.00"},
+                ],
+                start_date="2026-08-01", frequency="monthly",
+            )
+        # Nothing half-created: template list is empty.
+        assert gc.list_scheduled_transactions(
+            enabled_only=False, compact=False,
+        )["total"] == 0
+
+    def test_cross_commodity_template_replays_quantity(
+        self, multi_currency_book,
+    ):
+        """Default-frame template with a EUR leg + qty: stored and
+        replayed at instantiation (paycheck-with-401k shape)."""
+        gc = GnuCashBook(str(multi_currency_book))
+        sx = gc.create_scheduled_transaction(
+            name="EUR Savings Feed", description="Monthly EUR feed",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-110.00"},
+                {"account": "Assets:Euro Savings", "amount": "110.00",
+                 "quantity": "100.00"},
+            ],
+            start_date="2026-08-01", frequency="monthly",
+        )
+        r = gc.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-08-01",
+        )
+        assert r["status"] == "created"
+        txn = gc.get_transaction(r["transaction_guid"])
+        assert txn["currency"] == "USD"
+        eur_leg = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Euro Savings"
+        )
+        assert eur_leg["value"] == "110"
+        assert eur_leg["quantity"] == "100"
+
+    def test_currency_shown_in_verbose_list(self, multi_currency_book):
+        gc = GnuCashBook(str(multi_currency_book))
+        self._eur_accounts(gc)
+        gc.create_scheduled_transaction(
+            name="EUR Sweep", description="x",
+            splits=[
+                {"account": "Assets:EUR Checking", "amount": "-25.00"},
+                {"account": "Assets:Euro Savings", "amount": "25.00"},
+            ],
+            start_date="2026-08-01", frequency="monthly",
+            currency="EUR",
+        )
+        listed = gc.list_scheduled_transactions(
+            enabled_only=False, compact=False,
+        )["scheduled_transactions"]
+        assert listed[0]["currency"] == "EUR"
+        # Stored splits carry no quantity keys (same-currency legs).
+        assert all("quantity" not in s for s in listed[0]["splits"])

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -1020,3 +1020,66 @@ class TestScheduledCurrency:
         assert listed[0]["currency"] == "EUR"
         # Stored splits carry no quantity keys (same-currency legs).
         assert all("quantity" not in s for s in listed[0]["splits"])
+
+    def test_upcoming_labels_foreign_template_amounts(
+        self, multi_currency_book,
+    ):
+        """A foreign template's bill-list amount carries its
+        currency code — '25.00' from an EUR schedule must not read
+        as a book-default amount."""
+        from datetime import date as _date, timedelta as _td
+
+        gc = GnuCashBook(str(multi_currency_book))
+        self._eur_accounts(gc)
+        gc.create_scheduled_transaction(
+            name="EUR Sweep", description="x",
+            splits=[
+                {"account": "Assets:EUR Checking", "amount": "-25.00"},
+                {"account": "Assets:Euro Savings", "amount": "25.00"},
+            ],
+            start_date=(_date.today() + _td(days=2)).isoformat(),
+            frequency="monthly", currency="EUR",
+        )
+        verbose = gc.get_upcoming_transactions(days=7, compact=False)
+        entry = verbose["upcoming_transactions"][0]
+        assert entry["currency"] == "EUR"
+        compact = gc.get_upcoming_transactions(days=7, compact=True)
+        assert "25 EUR" in compact or "25.00 EUR" in compact
+
+    def test_summary_window_converts_or_flags_foreign(
+        self, multi_currency_book,
+    ):
+        """Dashboard 7-day total: foreign templates convert at the
+        latest market rate; with no rate on file they're counted
+        but flagged unrated instead of silently mixed in."""
+        from datetime import date as _date, timedelta as _td
+
+        gc = GnuCashBook(str(multi_currency_book))
+        self._eur_accounts(gc)
+        gc.create_scheduled_transaction(
+            name="EUR Sweep", description="x",
+            splits=[
+                {"account": "Assets:EUR Checking", "amount": "-25.00"},
+                {"account": "Assets:Euro Savings", "amount": "25.00"},
+            ],
+            start_date=(_date.today() + _td(days=2)).isoformat(),
+            frequency="monthly", currency="EUR",
+        )
+        # The fixture's only EUR price is piecash's auto
+        # type='transaction' placeholder, which the market-rate
+        # chokepoint skips → unrated.
+        with gc.open(readonly=True) as book:
+            stats = gc._upcoming_within_days(book, days=7)
+        assert stats["count"] == 1
+        assert stats["unrated"] == 1
+        assert stats["total"] == 0
+
+        # A real market rate converts the total.
+        gc.create_price(
+            commodity="EUR", namespace="CURRENCY", value="1.08",
+            price_date=_date.today(),
+        )
+        with gc.open(readonly=True) as book:
+            stats = gc._upcoming_within_days(book, days=7)
+        assert stats["unrated"] == 0
+        assert stats["total"] == Decimal("25.00") * Decimal("1.08")


### PR DESCRIPTION
## Summary
- **`cur` column in batch entry** — an optional fixed column (after `description`, before or after `notes`) sets that row's transaction currency; empty cells keep the book default. Closes the zero-book-currency-leg gap: a USD-to-USD card payment inside a CNY-default book (or an HKD card statement) books with the statement's own numbers — no fabricated conversion values. The shared header reader carries the layout, so the audit batch formatter parses and renders row currencies for free.
- **`currency` on scheduled templates** — denominates every instantiated transaction; template splits store per-leg `quantity` for cross-commodity legs. Creation now runs the shared split validator against the template's currency, fixing a live wedge: an all-foreign-leg template previously created fine and then failed at every instantiation forever.
- **Foreign-template display honesty** — `get_upcoming_transactions` labels foreign amounts with their currency code; the dashboard's 7-day total converts at the latest market rate and flags templates whose currency has no rate (`+N foreign w/o rate ⚠`) instead of silently summing HKD as CNY.
- **Duplicates tables label candidate currency** — both single-entry and batch TSVs gain a `cur` column after `amount`, empty for book-default candidates.
- **Frame-aware duplicate amount signal** (bookkeeper-argued): 188 HKD is not 188 CNY, and true cross-frame duplicates have numerically different values — so cross-currency amount matches are coincidence by construction. The amount signal now compares within one currency frame; cross-currency twins surface as labeled, non-blocking MEDIUMs on description+date.

## Test plan
- [x] Full suite green: 1,898 passed, 0 failed (22 new tests across batch parsing, book-layer creation, scheduled currency, display labeling, and dup-signal semantics)
- [x] Live smoke on scratch Lin Wei: HKD card-statement rows via `cur=HKD` — transaction currency HKD, card leg value == quantity, CNY expense leg carrying converted quantity
- [x] Bookkeeper round on the live server: HKD batch entries, empty-cur default, unknown-currency rejection, cur+auto-fill rejection, template create/instantiate in HKD, all-foreign template rejects at create, cross-currency coincidence enters without force as labeled MEDIUM D-D, same-currency HIGH still blocks — all confirmed