### PR TITLE
feat: split action field on all transaction create paths

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -211,6 +211,7 @@ _BATCH_SPLIT_TOKENS = {
     "acct": "account", "account": "account", "acc": "account",
     "memo": "memo",
     "qty": "quantity", "quantity": "quantity",
+    "act": "action", "action": "action",
 }
 
 # Fallback shape for the audit log's display parser when a stored

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -417,6 +417,7 @@ def _split_to_dict(
         "value": str(split.value),
         "quantity": str(split.quantity),
         "memo": split.memo or "",
+        "action": split.action or "",
         "reconcile_state": split.reconcile_state,
         "reconcile_date": rec_date.isoformat() if rec_date else None,
         "lot_guid": lot_guid,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2991,6 +2991,7 @@ class CoreMixin:
                 "value": value,
                 "quantity": quantity,
                 "memo": split.get("memo"),
+                "action": split.get("action"),
                 "original_ref": ref,
             })
 
@@ -3167,6 +3168,7 @@ class CoreMixin:
                             value=v["value"],
                             quantity=v["quantity"],
                             memo=v["memo"] or "",
+                            action=v["action"] or "",
                         )
                     )
 
@@ -3447,6 +3449,7 @@ class CoreMixin:
                     piecash.Split(
                         account=v["account"], value=v["value"],
                         quantity=v["quantity"], memo=v["memo"] or "",
+                        action=v["action"] or "",
                     )
                     for v in p["validated"]
                 ]
@@ -4595,6 +4598,7 @@ class CoreMixin:
                     "value": s.value,
                     "quantity": s.quantity,
                     "memo": s.memo or "",
+                    "action": s.action or "",
                     "state": s.reconcile_state,
                     "rdate": s.reconcile_date,
                     "claimed": False,
@@ -4705,8 +4709,9 @@ class CoreMixin:
                 fx_check_splits.append({
                     "account": account, "value": amount, "quantity": quantity,
                 })
-                # Unchanged leg: keep its memo (caller-supplied memo
-                # wins) and its reconciliation, verbatim.
+                # Unchanged leg: keep its memo and action (caller-
+                # supplied values win) and its reconciliation,
+                # verbatim.
                 match = _claim(carryover, account.guid, amount, quantity)
                 new_split = piecash.Split(
                     account=account,
@@ -4715,6 +4720,10 @@ class CoreMixin:
                     memo=(
                         split_data.get("memo")
                         or (match["memo"] if match else "")
+                    ),
+                    action=(
+                        split_data.get("action")
+                        or (match["action"] if match else "")
                     ),
                     transaction=transaction,
                 )

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -394,10 +394,16 @@ class SchedulingMixin:
                         "amount": str(_to_decimal(s["amount"])),
                         "memo": s.get("memo", ""),
                         # Cross-commodity legs replay their stored
-                        # quantity at every instantiation.
+                        # quantity at every instantiation; actions
+                        # (Buy/Sell on investment templates) replay
+                        # the same way.
                         **(
                             {"quantity": str(_to_decimal(s["quantity"]))}
                             if s.get("quantity") is not None else {}
+                        ),
+                        **(
+                            {"action": s["action"]}
+                            if s.get("action") else {}
                         ),
                     }
                     for s in splits

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -457,6 +457,8 @@ def _format_splits_text(splits: list[dict], indent: str = "          ") -> str:
         short_name = account.split(":")[-1]
         amount = _format_amount(split.get("amount") or split.get("value"))
         line = f"{indent}{short_name:<{max_name_len}}  {amount:>12}"
+        if split.get("action"):
+            line += f"  [{split['action']}]"
         if split.get("memo"):
             line += f"  {split['memo']}"
         lines.append(line)

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -192,6 +192,18 @@ class SplitInput(BaseModel):
         str | None,
         Field(default=None, description="Optional split memo."),
     ] = None
+    action: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Optional split action — GnuCash's typed movement "
+                "tag (free text; register conventions: 'Buy', "
+                "'Sell', 'Dividend' on investment legs, 'Wire', "
+                "'ATM', 'Interest' on bank legs)."
+            ),
+        ),
+    ] = None
 
 
 def _splits_to_dicts(

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -286,11 +286,12 @@ def register(mcp, get_book) -> None:
         Each split: ``account`` (full path, required), ``amount``
         (required, in transaction currency), ``quantity`` (required
         when account commodity differs from transaction currency),
-        ``memo`` (optional). ``amount`` and ``quantity`` are decimal
-        strings (e.g. "94.87") — never raw JSON numbers, which would
-        lose precision on non-dyadic decimals.
+        ``memo`` (optional), ``action`` (optional). ``amount`` and
+        ``quantity`` are decimal strings (e.g. "94.87") — never raw
+        JSON numbers, which would lose precision on non-dyadic
+        decimals.
 
-        FIELD TARGETING — three annotation fields, three jobs, in
+        FIELD TARGETING — the annotation fields, one job each, in
         GnuCash-register visibility order:
 
         - ``description``: the clean name ("Chevron 0090706
@@ -303,6 +304,11 @@ def register(mcp, get_book) -> None:
           provenance ("Withdrawal ACH TRAVELERS TYPE: PER INSUR…").
           Visible only in expanded split view — evidence, not
           narrative.
+        - split ``action``: the typed KIND of movement, one word.
+          Matters most on investment legs, where desktop convention
+          (and the Advanced Portfolio report) expects "Buy" /
+          "Sell" / "Dividend"; bank legs may use "Wire" / "ATM" /
+          "Interest". Skip it for ordinary spending.
 
         When duplicate detection surfaces candidates (either rejecting
         the write with ``status: "rejected"`` or returning alongside a
@@ -418,6 +424,12 @@ def register(mcp, get_book) -> None:
           cell means the account uses the default currency
           (quantity == amount). A non-default-commodity account with
           an empty qty rejects that row.
+
+        - PER-SPLIT ACTION — declare ``act`` split columns for
+          GnuCash's typed movement tag ("Buy"/"Sell"/"Dividend" on
+          investment legs — desktop convention; "Wire"/"ATM" on
+          bank legs). Same group mechanics as ``memo``/``qty``;
+          empty cells skip it. Rarely needed for plain spending.
 
         All extensions combine; when several split fields are
         declared, the header's FIRST group fixes their order (e.g.

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -762,3 +762,38 @@ class TestBatchCurColumn:
         assert dups[0]["confidence"] == "MEDIUM"
         assert dups[0]["signals"] == "D-D"
         assert dups[0]["cur"] == "EUR"
+
+
+class TestSplitActionColumn:
+    """The ``act`` split column carries GnuCash's typed movement
+    tag (investment-register convention: Buy/Sell/Dividend)."""
+
+    def test_act_column_parses_into_split_dicts(self):
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tact1\tamt2\tacct2\tact2\n"
+            "1\t2026-07-01\tVFIFX Purchase\t-500\tA:Chk\t\t500\tA:VFIFX\tBuy"
+        )
+        rows = _parse_transactions_tsv(tsv)
+        assert rows[0]["splits"][1]["action"] == "Buy"
+        assert "action" not in rows[0]["splits"][0]  # empty cell
+
+    def test_batch_action_lands_on_split(self, multi_currency_book):
+        gc = GnuCashBook(str(multi_currency_book))
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 15),
+            "description": "EUR feed",
+            "splits": [
+                {"account": "Assets:Checking", "amount": "-110.00",
+                 "action": "Wire"},
+                {"account": "Assets:Euro Savings", "amount": "110.00",
+                 "quantity": "100.00"},
+            ],
+        }])
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+        txn = gc.get_transaction(rows[0]["txn_guid"])
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        assert chk["action"] == "Wire"

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12151,3 +12151,54 @@ class TestReplaceSplitsPreservation:
             if s["account"] == "Expenses:Groceries"
         )
         assert memos == ["first twin", "second twin"]
+
+
+class TestSplitAction:
+    """Split ``action`` — native splits.action column, exposed on
+    the create paths and preserved through replace_splits."""
+
+    def test_create_and_read_back(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        result = gc.create_transaction(
+            description="Interest posting",
+            splits=[
+                {"account": "Assets:Checking", "amount": "1.23",
+                 "action": "Interest"},
+                {"account": "Income:Salary", "amount": "-1.23"},
+            ],
+        )
+        txn = gc.get_transaction(result["guid"])
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        assert chk["action"] == "Interest"
+
+    def test_replace_splits_preserves_action_on_unchanged_leg(
+        self, test_book: Path,
+    ):
+        gc = GnuCashBook(str(test_book))
+        gc.create_account(
+            name="Dining", account_type="EXPENSE", parent="Expenses",
+        )
+        result = gc.create_transaction(
+            description="Wire out",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-90.00",
+                 "action": "Wire"},
+                {"account": "Expenses:Groceries", "amount": "90.00"},
+            ],
+        )
+        gc.replace_splits(
+            guid=result["guid"],
+            splits=[
+                {"account": "Assets:Checking", "amount": "-90.00"},
+                {"account": "Expenses:Dining", "amount": "90.00"},
+            ],
+        )
+        txn = gc.get_transaction(result["guid"])
+        chk = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Checking"
+        )
+        assert chk["action"] == "Wire"

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -1083,3 +1083,29 @@ class TestScheduledCurrency:
             stats = gc._upcoming_within_days(book, days=7)
         assert stats["unrated"] == 0
         assert stats["total"] == Decimal("25.00") * Decimal("1.08")
+
+
+class TestScheduledSplitAction:
+    def test_template_action_replays_at_instantiation(
+        self, multi_currency_book,
+    ):
+        """A DCA-style template stamps Buy on every instantiation."""
+        gc = GnuCashBook(str(multi_currency_book))
+        sx = gc.create_scheduled_transaction(
+            name="EUR DCA", description="Monthly EUR feed",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-110.00"},
+                {"account": "Assets:Euro Savings", "amount": "110.00",
+                 "quantity": "100.00", "action": "Buy"},
+            ],
+            start_date="2026-08-01", frequency="monthly",
+        )
+        r = gc.create_transaction_from_scheduled(
+            guid=sx["guid"], transaction_date="2026-08-01",
+        )
+        txn = gc.get_transaction(r["transaction_guid"])
+        eur = next(
+            s for s in txn["splits"]
+            if s["account"] == "Assets:Euro Savings"
+        )
+        assert eur["action"] == "Buy"


### PR DESCRIPTION
## Summary
- Exposes GnuCash's native `splits.action` column (the typed movement tag — Buy/Sell/Dividend by investment-register convention, the one place the community genuinely uses it) on `create_transaction`, the batch TSV (`act` split column, same group mechanics as `memo`/`qty`), and scheduled templates (stored in splits-json, replayed at every instantiation).
- `replace_splits` carry-forward preserves action on unchanged legs, so recategorizing an investment transaction can't strip its Buy stamp.
- Rendered in `get_transaction`/verbose listings (present only when set) and audit split lines (`[Buy]`); field-targeting docstring guidance extended to the annotation quartet, with the honest scoping: investment legs want it, ordinary spending skips it.

## Test plan
- [x] Full suite green (5 new tests: TSV parse, single create, batch e2e, replace-splits preservation, scheduled replay)
- [x] Bookkeeper round on the live server: Buy action on a real VFIFX split renders in the desktop register's Action column; `act` column dry-run verified