### PR TITLE
feat: batch price entry and a stale-price work list

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -498,6 +498,11 @@ def _commodity_to_compact_line(namespace: str, entry: dict) -> str:
     lp = entry.get("latest_price")
     if lp:
         parts.append(f"{lp['value']} {lp['currency']} ({lp['date']})")
+    # Work-list markers, present only under the stale_days filter.
+    if entry.get("no_price"):
+        parts.append("no price on file")
+    elif entry.get("days_stale") is not None:
+        parts.append(f"{entry['days_stale']}d stale")
     return "\t".join(parts)
 
 

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -39,11 +39,13 @@ class InvestmentsMixin:
 
     def list_commodities(
         self, compact: bool = True, limit: int = 50, offset: int = 0,
+        stale_days: int | None = None, held_only: bool = False,
     ) -> dict | str:
         """List all commodities in the book with latest prices.
 
         Leads with a ``Showing X-Y of Z commodities`` indicator; page
-        with ``offset``.
+        with ``offset``. With no filter arguments the output is the
+        complete list, unchanged — filters are opt-in and AND-combine.
 
         Args:
             compact: If True (default), return compact one-line-per-commodity
@@ -51,6 +53,15 @@ class InvestmentsMixin:
                      commodities grouped by namespace.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return.
+            stale_days: Only commodities whose latest market price is
+                at least this many days old — INCLUDING commodities
+                with no price at all (undefined staleness is maximal
+                staleness), EXCLUDING the book default currency
+                (its price is trivially 1). Rows gain a staleness
+                marker. The price-update work list is
+                ``stale_days=30, held_only=True``.
+            held_only: Only commodities some real (non-template)
+                account is denominated in.
 
         Returns:
             If compact: indicator + newline-separated commodity lines.
@@ -75,11 +86,41 @@ class InvestmentsMixin:
                 if existing is None or p_date > existing[0]:
                     latest_market[key] = (p_date, p)
 
+            today = date.today()
+            default_commodity = self._require_default_currency(book)
+            in_use_accounts: set | None = None
+            if held_only:
+                # Same in-use definition as the dashboard's stale-
+                # price warning: any non-ROOT, non-template account
+                # denominated in the commodity.
+                template_guids = self._template_account_guids(book)
+                in_use_accounts = {
+                    a.commodity.guid for a in book.accounts
+                    if a.type != "ROOT" and a.guid not in template_guids
+                }
+
             for commodity in book.commodities:
                 ns = commodity.namespace
                 # 'template' = GnuCash's SX-scaffolding pseudo-commodity.
                 if ns.lower() == "template":
                     continue
+                if (
+                    in_use_accounts is not None
+                    and commodity.guid not in in_use_accounts
+                ):
+                    continue
+                days_stale: int | None = None
+                no_price = False
+                if stale_days is not None:
+                    if commodity == default_commodity:
+                        continue
+                    latest = latest_market.get(commodity.guid)
+                    if latest is None:
+                        no_price = True
+                    else:
+                        days_stale = (today - latest[0]).days
+                        if days_stale < stale_days:
+                            continue
                 if ns not in by_namespace:
                     by_namespace[ns] = []
 
@@ -96,6 +137,12 @@ class InvestmentsMixin:
                         "currency": price.currency.mnemonic,
                         "date": _to_date(price.date).isoformat(),
                     }
+                # Staleness markers only under the filter — the
+                # unfiltered listing's shape is unchanged.
+                if days_stale is not None:
+                    entry["days_stale"] = days_stale
+                if no_price:
+                    entry["no_price"] = True
 
                 by_namespace[ns].append(entry)
 
@@ -222,6 +269,213 @@ class InvestmentsMixin:
                 "status": "created",
             }
 
+    @staticmethod
+    def _upsert_price(
+        book, comm, resolved_currency, price_date,
+        value: str, price_type: str, source: str,
+    ) -> str:
+        """Create or update-in-place one price row; NO save.
+
+        Single chokepoint for the same-(commodity, currency, date,
+        source)-updates-in-place semantic, shared by ``create_price``
+        and ``create_prices`` so single and batch entry can't
+        diverge. The caller owns ``book.save()`` — batch saves once
+        for the whole set.
+
+        Returns ``"updated"`` or ``"created"``.
+        """
+        # Indexed query, not a full book.prices walk.
+        candidates = book.session.query(Price).filter_by(
+            commodity_guid=comm.guid,
+            currency_guid=resolved_currency.guid,
+            source=source,
+        ).all()
+        existing = None
+        for p in candidates:
+            if _to_date(p.date) == price_date:
+                existing = p
+                break
+
+        if existing:
+            existing.value = _to_decimal(value)
+            existing.type = price_type
+            return "updated"
+        # piecash expects datetime.date, not datetime.datetime
+        piecash.Price(
+            commodity=comm,
+            currency=resolved_currency,
+            date=price_date,
+            value=_to_decimal(value),
+            type=price_type,
+            source=source,
+        )
+        return "created"
+
+    def _resolve_price_commodity(self, book, mnemonic: str,
+                                 namespace: str | None):
+        """Resolve a batch price row's commodity.
+
+        With ``namespace``: exact lookup. Without: search across
+        namespaces (excluding GnuCash's ``template`` pseudo-
+        commodity); exactly one match resolves, zero or several
+        raise naming the fix — most books have unambiguous
+        mnemonics, so the ns column stays optional.
+        """
+        if namespace:
+            comm = self._find_commodity(book, mnemonic, namespace)
+            if not comm:
+                raise ValueError(
+                    f"Commodity not found: {namespace}:{mnemonic}"
+                )
+            return comm
+        matches = [
+            c for c in book.commodities
+            if c.mnemonic == mnemonic
+            and c.namespace.lower() != "template"
+        ]
+        if not matches:
+            raise ValueError(f"Commodity not found: {mnemonic}")
+        if len(matches) > 1:
+            namespaces = ", ".join(sorted(c.namespace for c in matches))
+            raise ValueError(
+                f"Commodity '{mnemonic}' is ambiguous across "
+                f"namespaces ({namespaces}) — supply the ns column"
+            )
+        return matches[0]
+
+    def create_prices(
+        self,
+        prices: list[dict],
+        on_error: str = "abort",
+        dry_run: bool = False,
+    ) -> dict:
+        """Record MANY prices in one book-open / one save.
+
+        Each entry: ``{ref, commodity, date (date), value,
+        namespace (optional), currency (optional — quote currency,
+        defaults to the book default), source (optional, default
+        "user:price"), price_type (optional, default "nav")}``.
+
+        Per-row semantics are ``create_price``'s exactly (shared
+        upsert chokepoint): same (commodity, currency, date,
+        source) updates in place → ``status: updated``; otherwise
+        ``created``. ``on_error="abort"`` (default) sinks the whole
+        batch on any invalid row; ``"skip"`` keeps the good rows.
+        ``dry_run`` reports ``would_create`` / ``would_update``
+        without writing.
+
+        Returns ``{"results": TSV}`` — columns
+        ``ref, status, commodity, date, value, currency, reason``.
+        """
+        if on_error not in ("abort", "skip"):
+            raise ValueError("on_error must be 'abort' or 'skip'")
+        refs = [p["ref"] for p in prices]
+        if len(set(refs)) != len(refs):
+            raise ValueError(
+                "duplicate ref in batch — each ref must be unique"
+            )
+
+        readonly = dry_run
+        by_ref: dict = {}
+        with self.open(readonly=readonly) as book:
+            prepared = []
+            for p in prices:
+                ref = p["ref"]
+                try:
+                    comm = self._resolve_price_commodity(
+                        book, p["commodity"], p.get("namespace"),
+                    )
+                    cur_code = p.get("currency")
+                    if cur_code is None:
+                        resolved_currency = (
+                            self._require_default_currency(book)
+                        )
+                    elif readonly:
+                        resolved_currency = self._find_commodity(
+                            book, cur_code, "CURRENCY",
+                        )
+                        if not resolved_currency:
+                            raise ValueError(
+                                f"Currency '{cur_code}' not found "
+                                f"in book. Dry run cannot create "
+                                f"new currencies."
+                            )
+                    else:
+                        resolved_currency = (
+                            self._get_or_create_currency(book, cur_code)
+                        )
+                    value = p["value"]
+                    _to_decimal(value)  # reject non-decimal early
+                    prepared.append({
+                        "ref": ref,
+                        "comm": comm,
+                        "currency": resolved_currency,
+                        "date": p["date"],
+                        "value": str(value),
+                        "type": p.get("price_type") or "nav",
+                        "source": p.get("source") or "user:price",
+                    })
+                except (ValueError, KeyError, ArithmeticError) as e:
+                    by_ref[ref] = {
+                        "ref": ref, "status": "rejected",
+                        "reason": str(e),
+                    }
+
+            if by_ref and on_error == "abort":
+                for row in prepared:
+                    by_ref[row["ref"]] = {
+                        "ref": row["ref"], "status": "rejected",
+                        "reason": "batch_aborted",
+                    }
+                return self._prices_envelope(prices, by_ref)
+
+            wrote = False
+            for row in prepared:
+                if dry_run:
+                    # Same detection as the upsert, no mutation.
+                    candidates = book.session.query(Price).filter_by(
+                        commodity_guid=row["comm"].guid,
+                        currency_guid=row["currency"].guid,
+                        source=row["source"],
+                    ).all()
+                    exists = any(
+                        _to_date(c.date) == row["date"]
+                        for c in candidates
+                    )
+                    status = "would_update" if exists else "would_create"
+                else:
+                    status = self._upsert_price(
+                        book, row["comm"], row["currency"],
+                        row["date"], row["value"], row["type"],
+                        row["source"],
+                    )
+                    wrote = True
+                by_ref[row["ref"]] = {
+                    "ref": row["ref"], "status": status,
+                    "commodity": row["comm"].mnemonic,
+                    "date": row["date"].isoformat(),
+                    "value": row["value"],
+                    "currency": row["currency"].mnemonic,
+                }
+
+            if wrote:
+                book.save()
+            return self._prices_envelope(prices, by_ref)
+
+    @staticmethod
+    def _prices_envelope(prices: list[dict], by_ref: dict) -> dict:
+        """Results TSV in submission order, one row per input ref."""
+        lines = ["ref\tstatus\tcommodity\tdate\tvalue\tcurrency\treason"]
+        for p in prices:
+            r = by_ref.get(p["ref"], {})
+            lines.append(
+                f"{r.get('ref', p['ref'])}\t{r.get('status', '')}\t"
+                f"{r.get('commodity', '')}\t{r.get('date', '')}\t"
+                f"{r.get('value', '')}\t{r.get('currency', '')}\t"
+                f"{r.get('reason', '')}"
+            )
+        return {"results": "\n".join(lines)}
+
     def create_price(
         self,
         commodity: str,
@@ -276,32 +530,11 @@ class InvestmentsMixin:
                     book, currency,
                 )
 
-            # Same commodity/currency/date/source → update in place.
-            # Indexed query, not a full book.prices walk.
-            candidates = book.session.query(Price).filter_by(
-                commodity_guid=comm.guid,
-                currency_guid=resolved_currency.guid,
-                source=source,
-            ).all()
-            existing = None
-            for p in candidates:
-                if _to_date(p.date) == price_date:
-                    existing = p
-                    break
-
-            if existing:
-                existing.value = _to_decimal(value)
-                existing.type = price_type
-            else:
-                # piecash expects datetime.date, not datetime.datetime
-                piecash.Price(
-                    commodity=comm,
-                    currency=resolved_currency,
-                    date=price_date,
-                    value=_to_decimal(value),
-                    type=price_type,
-                    source=source,
-                )
+            status = self._upsert_price(
+                book, comm, resolved_currency, price_date,
+                value, price_type, source,
+            )
+            existing = status == "updated"
 
             book.save()
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1399,6 +1399,37 @@ def _fmt_commodity_create(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_price_create_batch(entry: dict) -> list[str]:
+    """Batch price entry — one line per row from the results TSV
+    (which is self-contained: status, commodity, date, value,
+    currency), headlined by the created/updated/rejected counts."""
+    time_part = _extract_time(entry)
+    after = entry.get("after_state") or {}
+    rows = _parse_audit_tsv_rows(after.get("results") or "")
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r.get("status", "")] = counts.get(r.get("status", ""), 0) + 1
+    headline = ", ".join(
+        f"{n} {status}" for status, n in sorted(counts.items())
+    ) or "no rows"
+    lines = [f"{time_part}  CREATE PRICES (batch)  {headline}"]
+    for r in rows:
+        status = r.get("status", "")
+        if status in ("rejected",):
+            lines.append(
+                f"{_INDENT}{r.get('ref', '')}  rejected: "
+                f"{r.get('reason', '')}"
+            )
+        else:
+            cur = r.get("currency", "")
+            lines.append(
+                f"{_INDENT}{r.get('commodity', ''):<8}  "
+                f"{r.get('value', ''):>12} {cur}  "
+                f"({r.get('date', '')})  {status}"
+            )
+    return lines
+
+
 def _fmt_price_create(entry: dict) -> list[str]:
     """``create_price`` returns ``status="updated"`` when a price at
     the same (commodity, currency, date, source) already existed and
@@ -2006,6 +2037,7 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("entry", "CREATE"): _fmt_entry_create,
     ("commodity", "CREATE"): _fmt_commodity_create,
     ("price", "CREATE"): _fmt_price_create,
+    ("price", "CREATE_BATCH"): _fmt_price_create_batch,
     ("price", "DELETE"): _fmt_price_delete,
     ("lot", "CREATE"): _fmt_lot_create,
     ("lot", "UPDATE"): _fmt_lot_update,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -215,6 +215,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "list_commodities",
         "create_commodity",
         "create_price",
+        "create_prices",
         "get_prices",
         "get_latest_price",
         "delete_price",

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -2,6 +2,81 @@
 
 from datetime import date as date_type
 
+# Batch price TSV columns: the required prefix, then optional
+# extensions accepted only in this order (a header may stop at any
+# point). Order-fixed because the columns are scalar per row — no
+# repeating groups to disambiguate, so header freedom buys nothing.
+_PRICE_TSV_REQUIRED = ("ref", "commodity", "date", "value")
+_PRICE_TSV_OPTIONAL = ("ns", "cur", "source", "type")
+_PRICE_KEY_FOR = {
+    "ns": "namespace", "cur": "currency",
+    "source": "source", "type": "price_type",
+}
+
+
+def _parse_prices_tsv(tsv: str) -> list[dict]:
+    """Parse the batch price TSV into the book-layer dict shape.
+
+    Header validated token-by-token (typos reject by name, per the
+    batch-entry convention); rows may end early, empty optional
+    cells take defaults. Dates parse here — the book layer works in
+    ``datetime.date``.
+    """
+    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        raise ValueError(
+            "prices TSV needs a header row and at least one data row"
+        )
+    tokens = [t.strip().lower() for t in lines[0].split("\t")]
+    while tokens and not tokens[-1]:
+        tokens.pop()
+    expected = list(_PRICE_TSV_REQUIRED)
+    for opt in _PRICE_TSV_OPTIONAL:
+        expected.append(opt)
+    if len(tokens) < len(_PRICE_TSV_REQUIRED) or \
+            tokens != expected[:len(tokens)]:
+        for i, tok in enumerate(tokens):
+            if i >= len(expected) or tok != expected[i]:
+                raise ValueError(
+                    f"unrecognized or misplaced column {tok!r} in "
+                    f"prices header — columns are "
+                    f"ref, commodity, date, value, then optional "
+                    f"ns, cur, source, type in that order"
+                )
+        raise ValueError(
+            "prices header must start with ref, commodity, date, value"
+        )
+    out: list[dict] = []
+    for i, ln in enumerate(lines[1:], start=1):
+        fields = ln.split("\t")
+        while fields and not fields[-1].strip():
+            fields.pop()
+        if len(fields) < 4:
+            raise ValueError(
+                f"row {i}: expected at least ref, commodity, date, value"
+            )
+        ref = fields[0].strip()
+        if not ref:
+            raise ValueError(f"row {i}: empty ref (each row needs a key)")
+        try:
+            row_date = date_type.fromisoformat(fields[2].strip())
+        except ValueError as e:
+            raise ValueError(f"row {i} (ref {ref!r}): {e}")
+        entry: dict = {
+            "ref": ref,
+            "commodity": fields[1].strip(),
+            "date": row_date,
+            "value": fields[3].strip(),
+        }
+        for col_idx, tok in enumerate(tokens[4:], start=4):
+            if col_idx < len(fields) and fields[col_idx].strip():
+                cell = fields[col_idx].strip()
+                if tok == "cur":
+                    cell = cell.upper()
+                entry[_PRICE_KEY_FOR[tok]] = cell
+        out.append(entry)
+    return out
+
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     LotGuid,
@@ -21,6 +96,8 @@ def register(mcp, get_book) -> None:
         verbose: bool = False,
         limit: int = 50,
         offset: int = 0,
+        stale_days: int | None = None,
+        held_only: bool = False,
     ) -> str:
         """List all commodities (currencies, stocks, etc.) in the book.
 
@@ -29,14 +106,26 @@ def register(mcp, get_book) -> None:
         ``offset``; ``limit=0`` returns the count only. Use verbose=true
         for full JSON with fraction, latest prices, etc.
 
+        THE PRICE-UPDATE WORK LIST: ``stale_days=30, held_only=true``
+        returns exactly the commodities needing fresh quotes, each
+        marked ``Nd stale`` or ``no price on file``. Look the quotes
+        up, then record them all in one ``create_prices`` call.
+
         Args:
             verbose: If true, return full JSON details for each commodity.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
+            stale_days: Only commodities whose latest market price is
+                at least this many days old, including never-priced
+                ones, excluding the book default currency. Omit for
+                the unfiltered list.
+            held_only: Only commodities some real account is
+                denominated in. Filters AND-combine.
         """
         book = get_book()
         result = book.list_commodities(
-            compact=not verbose, limit=limit, offset=offset
+            compact=not verbose, limit=limit, offset=offset,
+            stale_days=stale_days, held_only=held_only,
         )
         if verbose:
             return _json(result)
@@ -71,6 +160,54 @@ def register(mcp, get_book) -> None:
             namespace=namespace,
             fraction=fraction,
             cusip=cusip,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(
+        classification="write", operation="create_batch",
+        entity_type="price",
+    )
+    def create_prices(
+        prices: str,
+        on_error: str = "abort",
+        dry_run: bool = False,
+    ) -> str:
+        """Record MANY prices in one call (bulk quote entry).
+
+        INPUT — ``prices`` is a TSV block: a header row, then one row
+        per price. Required columns ``ref, commodity, date, value``;
+        optional columns extend the header IN ORDER:
+        ``ns, cur, source, type`` (stop anywhere; rows may end early;
+        empty cells take defaults)::
+
+            ref<TAB>commodity<TAB>date<TAB>value<TAB>cur<TAB>source
+            1<TAB>VTSAX<TAB>2026-07-21<TAB>148.32<TAB><TAB>web:yahoo
+            2<TAB>EUR<TAB>2026-07-21<TAB>1.0845<TAB><TAB>web:ecb
+
+        - ``ref``: your correlation key, echoed in results.
+        - ``ns``: commodity namespace; empty auto-resolves when the
+          symbol is unambiguous across namespaces.
+        - ``cur``: quote currency; empty = book default.
+        - ``source``: where the quote came from (provenance —
+          default "user:price"); ``type``: nav/last/bid/ask.
+
+        Per-row semantics are ``create_price``'s exactly: an existing
+        price with the same commodity/currency/date/source is UPDATED
+        in place (``status: updated``), never duplicated. One book
+        open, one save, ``on_error="abort"`` (default) sinks the
+        whole batch on any bad row; ``dry_run=true`` previews as
+        ``would_create`` / ``would_update``.
+
+        The companion work list: ``list_commodities(stale_days=30,
+        held_only=true)``.
+        """
+        book = get_book()
+        result = book.create_prices(
+            prices=_parse_prices_tsv(prices),
+            on_error=on_error,
+            dry_run=dry_run,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12151,3 +12151,183 @@ class TestReplaceSplitsPreservation:
             if s["account"] == "Expenses:Groceries"
         )
         assert memos == ["first twin", "second twin"]
+
+
+def _parse_results_tsv(tsv: str) -> list[dict]:
+    """Header-bearing TSV → list of dicts (batch results tables)."""
+    lines = tsv.split("\n")
+    header = lines[0].split("\t")
+    return [dict(zip(header, ln.split("\t"))) for ln in lines[1:]]
+
+
+class TestBatchPrices:
+    """create_prices: many quotes, one book-open, one save, with
+    create_price's exact upsert semantics via the shared chokepoint."""
+
+    def _setup(self, gc):
+        gc.create_commodity(mnemonic="VTSAX", fullname="Vanguard Total",
+                            namespace="FUND")
+        gc.create_commodity(mnemonic="VFIFX", fullname="Vanguard 2050",
+                            namespace="FUND")
+
+    def test_creates_then_updates_in_place(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._setup(gc)
+        rows = [
+            {"ref": "1", "commodity": "VTSAX",
+             "date": date(2026, 7, 20), "value": "148.32"},
+            {"ref": "2", "commodity": "VFIFX",
+             "date": date(2026, 7, 20), "value": "66.10"},
+        ]
+        env = gc.create_prices(rows)
+        parsed = {r["ref"]: r for r in _parse_results_tsv(env["results"])}
+        assert parsed["1"]["status"] == "created"
+        assert parsed["2"]["status"] == "created"
+
+        # Same commodity/date/source, new value → updated, not doubled.
+        rows[0]["value"] = "149.01"
+        env = gc.create_prices([rows[0]])
+        assert _parse_results_tsv(env["results"])[0]["status"] == "updated"
+        latest = gc.get_latest_price(commodity="VTSAX", namespace="FUND")
+        assert latest["value"] == "149.01"
+
+    def test_abort_sinks_batch_on_bad_row(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._setup(gc)
+        env = gc.create_prices([
+            {"ref": "1", "commodity": "NOPE",
+             "date": date(2026, 7, 20), "value": "1.00"},
+            {"ref": "2", "commodity": "VTSAX",
+             "date": date(2026, 7, 20), "value": "148.32"},
+        ])
+        parsed = {r["ref"]: r for r in _parse_results_tsv(env["results"])}
+        assert "not found" in parsed["1"]["reason"]
+        assert parsed["2"]["reason"] == "batch_aborted"
+        assert gc.get_latest_price(
+            commodity="VTSAX", namespace="FUND",
+        ) is None
+
+    def test_skip_keeps_good_rows(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._setup(gc)
+        env = gc.create_prices([
+            {"ref": "1", "commodity": "NOPE",
+             "date": date(2026, 7, 20), "value": "1.00"},
+            {"ref": "2", "commodity": "VTSAX",
+             "date": date(2026, 7, 20), "value": "148.32"},
+        ], on_error="skip")
+        parsed = {r["ref"]: r for r in _parse_results_tsv(env["results"])}
+        assert parsed["1"]["status"] == "rejected"
+        assert parsed["2"]["status"] == "created"
+
+    def test_dry_run_writes_nothing(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._setup(gc)
+        env = gc.create_prices([
+            {"ref": "1", "commodity": "VTSAX",
+             "date": date(2026, 7, 20), "value": "148.32"},
+        ], dry_run=True)
+        assert _parse_results_tsv(env["results"])[0]["status"] == "would_create"
+        assert gc.get_latest_price(
+            commodity="VTSAX", namespace="FUND",
+        ) is None
+
+    def test_ambiguous_symbol_requires_ns(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        gc.create_commodity(mnemonic="DUP", fullname="Dup Fund",
+                            namespace="FUND")
+        gc.create_commodity(mnemonic="DUP", fullname="Dup Stock",
+                            namespace="NASDAQ")
+        env = gc.create_prices([
+            {"ref": "1", "commodity": "DUP",
+             "date": date(2026, 7, 20), "value": "10.00"},
+        ], on_error="skip")
+        assert "ambiguous" in _parse_results_tsv(env["results"])[0]["reason"]
+        env = gc.create_prices([
+            {"ref": "1", "commodity": "DUP", "namespace": "FUND",
+             "date": date(2026, 7, 20), "value": "10.00"},
+        ])
+        assert _parse_results_tsv(env["results"])[0]["status"] == "created"
+
+
+class TestPricesTsvParser:
+    def test_minimal_and_extended_headers(self):
+        from gnucash_mcp.tools.investments import _parse_prices_tsv
+
+        rows = _parse_prices_tsv(
+            "ref\tcommodity\tdate\tvalue\n"
+            "1\tVTSAX\t2026-07-21\t148.32"
+        )
+        assert rows[0] == {
+            "ref": "1", "commodity": "VTSAX",
+            "date": date(2026, 7, 21), "value": "148.32",
+        }
+        rows = _parse_prices_tsv(
+            "ref\tcommodity\tdate\tvalue\tns\tcur\tsource\n"
+            "1\tEUR\t2026-07-21\t1.0845\tCURRENCY\tusd\tweb:ecb\n"
+            "2\tVTSAX\t2026-07-21\t148.32"
+        )
+        assert rows[0]["currency"] == "USD"
+        assert rows[0]["source"] == "web:ecb"
+        assert "currency" not in rows[1]  # row ended early
+
+    def test_misplaced_or_unknown_column_rejects_by_name(self):
+        from gnucash_mcp.tools.investments import _parse_prices_tsv
+
+        with pytest.raises(ValueError, match="'source'"):
+            _parse_prices_tsv(
+                "ref\tcommodity\tdate\tvalue\tsource\tcur\n"
+                "1\tVTSAX\t2026-07-21\t148.32\tx\ty"
+            )
+        with pytest.raises(ValueError, match="'valu'"):
+            _parse_prices_tsv(
+                "ref\tcommodity\tdate\tvalu\n1\tV\t2026-07-21\t1"
+            )
+
+    def test_bad_date_names_the_row(self):
+        from gnucash_mcp.tools.investments import _parse_prices_tsv
+
+        with pytest.raises(ValueError, match="row 1"):
+            _parse_prices_tsv(
+                "ref\tcommodity\tdate\tvalue\n1\tVTSAX\tJuly 21\t1"
+            )
+
+
+class TestListCommoditiesStaleFilter:
+    def test_work_list_filters_and_markers(self, multi_currency_book):
+        from datetime import timedelta
+
+        gc = GnuCashBook(str(multi_currency_book))
+        gc.create_commodity(mnemonic="VTSAX", fullname="Vanguard Total",
+                            namespace="FUND")
+        gc.create_price(
+            commodity="VTSAX", namespace="FUND", value="120.00",
+            price_date=date.today() - timedelta(days=200),
+        )
+
+        # Unfiltered: unchanged shape, no staleness markers.
+        full = gc.list_commodities(compact=True, limit=0)
+        assert "stale" not in full and "no price on file" not in full
+
+        # Stale filter: old VTSAX marked with its age; EUR (only a
+        # piecash transaction-type placeholder price from the
+        # fixture's transfer) counts as no market price; USD (book
+        # default) excluded.
+        stale = gc.list_commodities(compact=True, stale_days=30)
+        assert "VTSAX" in stale and "200d stale" in stale
+        assert "EUR" in stale and "no price on file" in stale
+        assert "\tUSD\t" not in stale
+
+        # held_only: VTSAX has no account; EUR does.
+        work = gc.list_commodities(
+            compact=True, stale_days=30, held_only=True,
+        )
+        assert "EUR" in work
+        assert "VTSAX" not in work
+
+        # Fresh price falls off the stale list.
+        gc.create_price(
+            commodity="VTSAX", namespace="FUND", value="148.00",
+        )
+        stale = gc.list_commodities(compact=True, stale_days=30)
+        assert "VTSAX" not in stale

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -94,12 +94,12 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 30
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 107 —
+        """Total tools across all sub-modules should be 108 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
         1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 107
+        assert total == 108
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -263,9 +263,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 107 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables)."""
+        """--modules=all should keep all 108 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables + 1 batch prices)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 107
+        assert len(self._tool_names()) == 108
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -297,12 +297,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 107
+        assert len(self._tool_names()) == 108
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 107 tools."""
+        """'all' mixed with other modules should keep all 108 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 107
+        assert len(self._tool_names()) == 108
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.
@@ -1094,17 +1094,17 @@ class TestMultiBook:
         alex, _ = two_books
         srv._book_paths = [alex.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 107
+        assert len(mcp._tool_manager._tools) == 108
 
     def test_tool_count_multi_book(self, two_books):
-        """The lone runtime delta from single-book: switch_book (108).
+        """The lone runtime delta from single-book: switch_book (109).
         Each filter call relies on switch_book being registered at
         import; the production flow filters once at startup."""
         import gnucash_mcp.server as srv
         alex, beast = two_books
         srv._book_paths = [alex.resolve(), beast.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 108
+        assert len(mcp._tool_manager._tools) == 109
 
     # ── switch_book matching ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **`create_prices`** — bulk quote entry as a TSV (`ref, commodity, date, value` + optional `ns, cur, source, type`): one book-open, one save, per-row `created`/`updated` statuses via a shared upsert chokepoint extracted from `create_price`, so single and batch semantics cannot diverge (same commodity/currency/date/source updates in place — price history never destroyed). `on_error` abort/skip and `dry_run` preview match batch-transaction conventions; namespace auto-resolves when unambiguous; `source` records per-quote provenance.
- **`list_commodities` grows the work list** — opt-in `stale_days` (includes never-priced commodities, excludes the book default) and `held_only` filters, AND-combined, with `Nd stale` / `no price on file` markers under the filter only. The no-argument call is byte-identical to before.
- Together they close the dashboard's stale-price loop with zero new dependencies: the LLM holds the market-data access (its own web search), the server records the ledger — the same doctrine that kept calendar logic out of custom periods. The yfinance maintenance treadmill stays unboarded.
- Audit: `CREATE PRICES (batch)` entries render per-row commodity, value, currency, date, and status.

## Test plan
- [x] Full suite green (9 new tests: upsert-vs-create, abort/skip/dry-run, namespace ambiguity, TSV parser column enforcement, stale/held filters and markers)
- [x] Bookkeeper round on the live book: work list found VFIFX 62d + VTSAX 166d stale → web lookup → `create_prices` with per-source provenance → work list empty → dashboard's oldest standing warnings GONE (VFIFX renders at 65.46)