### PR TITLE
fix: bulk reconcile bounded by statement date; error ergonomics

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1649,6 +1649,72 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         guids.update(a.guid for a in descendants)
         return guids
 
+    def _account_suggestions(
+        self, book: piecash.Book, ref: str, limit: int = 3,
+    ) -> list[str]:
+        """Closest real account fullnames to a failed ref.
+
+        Prefix/substring hits rank first — the common near-miss is
+        the right branch with a wrong or truncated leaf
+        ("Expenses:Insurance:Auto" for
+        "Expenses:Insurance:Auto Insurance") — then difflib
+        similarity for typos. Error-path only: costs nothing on
+        successful resolution.
+        """
+        import difflib
+
+        template_guids = self._template_account_guids(book)
+        names = [
+            a.fullname for a in book.accounts
+            if a.guid not in template_guids
+        ]
+        ref_l = ref.lower()
+        subs = [
+            n for n in names
+            if n.lower().startswith(ref_l) or ref_l in n.lower()
+        ]
+        close = difflib.get_close_matches(ref, names, n=limit, cutoff=0.6)
+        out: list[str] = []
+        for n in subs + close:
+            if n not in out:
+                out.append(n)
+        return out[:limit]
+
+    def _account_not_found_error(
+        self, book: piecash.Book, ref: str,
+    ) -> ValueError:
+        """`Account not found` with did-you-mean suggestions.
+
+        Every wrong path guess in a batch is a rejected row and a
+        retry round-trip (live bookkeeper friction, 2026-07-24);
+        three candidates turn the retry into a one-shot correction.
+        """
+        msg = f"Account not found: {ref}"
+        suggestions = self._account_suggestions(book, ref)
+        if suggestions:
+            listed = ", ".join(f"'{s}'" for s in suggestions)
+            msg += (
+                f". Did you mean: {listed}? "
+                f"(list_accounts(query=...) to browse.)"
+            )
+        return ValueError(msg)
+
+    @staticmethod
+    def _placeholder_error(account) -> ValueError:
+        """Placeholder rejection that names postable children."""
+        kids = [
+            c.fullname for c in account.children if not c.placeholder
+        ]
+        msg = (
+            f"Account '{account.fullname}' is a placeholder and "
+            f"cannot receive splits"
+        )
+        if kids:
+            shown = ", ".join(f"'{k}'" for k in kids[:3])
+            more = f" (+{len(kids) - 3} more)" if len(kids) > 3 else ""
+            msg += f" — post to one of its children: {shown}{more}"
+        return ValueError(msg)
+
     @staticmethod
     def _is_template_transaction(txn, template_guids: set) -> bool:
         """True iff ``txn`` is a scheduled-transaction template recipe.

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2407,7 +2407,7 @@ class CoreMixin:
         with self.open(readonly=True) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             return self._own_splits_balance(account, as_of=as_of_date)
 
@@ -2965,7 +2965,7 @@ class CoreMixin:
             ref = split["account"]
             account = self._resolve_account(book, ref)
             if not account:
-                raise ValueError(f"Account not found: {ref}")
+                raise self._account_not_found_error(book, ref)
 
             value = _to_decimal(split["amount"])
             if account.commodity == trans_currency:
@@ -3353,10 +3353,7 @@ class CoreMixin:
                     )
                     for v in validated:
                         if v["account"].placeholder:
-                            raise ValueError(
-                                f"account '{v['account'].fullname}' is a "
-                                f"placeholder and cannot receive splits"
-                            )
+                            raise self._placeholder_error(v["account"])
                     prepared.append({
                         "ref": ref,
                         "description": txn["description"],
@@ -4570,11 +4567,11 @@ class CoreMixin:
                 account_name = split_data["account"]
                 account = self._resolve_account(book, account_name)
                 if not account:
-                    raise ValueError(f"Account not found: {account_name}")
-                if account.placeholder:
-                    raise ValueError(
-                        f"Cannot use placeholder account: {account_name}"
+                    raise self._account_not_found_error(
+                        book, account_name,
                     )
+                if account.placeholder:
+                    raise self._placeholder_error(account)
                 resolved_accounts.append((account, split_data))
 
             # 4a. Voided transactions are immutable — same

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -259,13 +259,19 @@ class ReconciliationMixin:
         - **Targeted** (``split_guids=[...]``): reconcile exactly
           the listed splits.
         - **Bulk** (``reconcile_all=True``): reconcile every
-          unreconciled split on the account — the OFX-import common
-          case. ``through_date`` optionally bounds the sweep; the
-          default is NO date filter (defaulting to statement_date
-          would silently exclude payments dated after the
-          statement). ``except_guids`` excludes named splits ("the
-          statement covers everything except this pending ACH");
-          non-resolving prefixes are silently ignored.
+          unreconciled split on the account dated on or before
+          ``through_date``, which DEFAULTS TO ``statement_date`` —
+          a statement reconciliation is bounded by the statement.
+          (The old no-filter default made multi-month entry
+          unreconcilable in bulk: later months broke the balance
+          tie, forcing a targeted GUID-picking dance per statement
+          — live bookkeeper finding, 2026-07-24. Nothing is
+          silently excluded either way: the tie check rejects with
+          the discrepancy when the window and the statement
+          disagree.) Pass a later ``through_date`` explicitly to
+          widen the sweep. ``except_guids`` excludes named splits
+          ("the statement covers everything except this pending
+          ACH"); non-resolving prefixes are silently ignored.
 
         The two modes are mutually exclusive, and both verify the
         resulting reconciled balance ties to ``statement_balance``
@@ -292,6 +298,9 @@ class ReconciliationMixin:
                 "Use either bulk mode (reconcile_all=True) or targeted "
                 "mode (split_guids=[...]), not both."
             )
+        if reconcile_all and through_date is None:
+            through_date = statement_date
+
         if not reconcile_all and not split_guids:
             raise ValueError(
                 "Must provide split_guids for targeted reconciliation, "
@@ -385,10 +394,18 @@ class ReconciliationMixin:
                 reconciled_balance + reconciling_total
             ).quantize(quantum)
             if new_balance != expected_q:
+                hint = ""
+                if reconcile_all:
+                    hint = (
+                        " Bulk mode swept splits through "
+                        f"{through_date.isoformat()}; if the statement "
+                        "includes later-dated items (e.g. a payoff "
+                        "payment), pass through_date past them."
+                    )
                 raise ValueError(
                     f"Balance mismatch: reconciled balance would be {new_balance}, "
                     f"but statement balance is {expected_q}. "
-                    f"Difference: {expected_q - new_balance}"
+                    f"Difference: {expected_q - new_balance}.{hint}"
                 )
 
             # Audit before-state in the multi-split shape the

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -94,9 +94,10 @@ def register(mcp, get_book) -> None:
             list[str] | None,
             Field(
                 description=(
-                    "List of split GUIDs to reconcile (8+ char prefixes "
-                    "accepted). Required for targeted mode; omit when "
-                    "using reconcile_all=true."
+                    "List of SPLIT GUIDs to reconcile (8+ char prefixes "
+                    "accepted). These are NOT transaction GUIDs — get "
+                    "them from get_unreconciled_splits. Required for "
+                    "targeted mode; omit when using reconcile_all=true."
                 ),
                 default=None,
             ),
@@ -106,11 +107,12 @@ def register(mcp, get_book) -> None:
             Field(
                 description=(
                     "When true, reconcile every unreconciled split on "
-                    "the account. Avoids the ~300-token GUID round-"
-                    "trip for OFX-import workflows. Pass through_date "
-                    "to add an upper-date filter; by default no date "
-                    "filter is applied. Mutually exclusive with "
-                    "split_guids."
+                    "the account dated on or before through_date "
+                    "(default: statement_date). Avoids the ~300-token "
+                    "GUID round-trip for statement workflows — enter "
+                    "several months of transactions, then reconcile "
+                    "each statement with just its date and balance. "
+                    "Mutually exclusive with split_guids."
                 ),
                 default=False,
             ),
@@ -119,11 +121,11 @@ def register(mcp, get_book) -> None:
             str | None,
             Field(
                 description=(
-                    "Optional upper-date filter for reconcile_all "
-                    "(YYYY-MM-DD). When set, only splits with "
-                    "post_date <= through_date are included. Default "
-                    "is no filter — every unreconciled split is "
-                    "reconciled regardless of date."
+                    "Upper-date bound for reconcile_all (YYYY-MM-DD); "
+                    "only splits with post_date <= through_date are "
+                    "swept. DEFAULTS TO statement_date — pass a later "
+                    "date explicitly to widen the sweep past the "
+                    "statement."
                 ),
                 default=None,
             ),
@@ -146,20 +148,32 @@ def register(mcp, get_book) -> None:
     ) -> str:
         """Reconcile splits against a statement balance.
 
+        SIGN CONVENTION: statement_balance is the ACCOUNT's balance
+        in GnuCash's signs — for liability accounts (credit cards)
+        a $5,000 owed balance is "-5000", not "5000".
+
         Two modes:
 
         - **Targeted** (`split_guids=[...]`): reconcile exactly the
-          listed splits. Use when statement and book disagree and
-          you need to pick a subset.
+          listed splits (SPLIT guids from get_unreconciled_splits,
+          not transaction guids). Use when statement and book
+          disagree and you need to pick a subset.
         - **Bulk** (`reconcile_all=true`): reconcile every
-          unreconciled split on the account. One call, no GUID
-          round-trip — the common case for OFX-import workflows.
-          By default no date filter is applied; pass through_date
-          to restrict to splits on or before a specific date.
+          unreconciled split dated on or before through_date
+          (default: statement_date — a statement reconciliation is
+          bounded by the statement). One call, no GUID round-trip.
 
         Both modes verify the resulting reconciled balance ties to
         statement_balance before mutating; mismatch rejects with
         the discrepancy amount.
+
+        TYPICAL STATEMENT FLOW (credit card or bank): batch-enter
+        the statement's transactions (create_transactions), then
+        reconcile_all with the statement's closing date and balance.
+        Multi-month catch-up: enter all months in one batch, then
+        one reconcile_all per statement, oldest first — the
+        through_date default keeps each sweep inside its own
+        statement.
 
         Args:
             account: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -7384,7 +7384,7 @@ class TestReplaceSplits:
         guid = transactions[0]["guid"]
 
         # Expenses is a placeholder in test_book
-        with pytest.raises(ValueError, match="placeholder account"):
+        with pytest.raises(ValueError, match="is a placeholder.*post to one of its children"):
             gc_book.replace_splits(
                 guid=guid,
                 splits=[
@@ -12436,3 +12436,74 @@ class TestSplitAction:
             if s["account"] == "Assets:Checking"
         )
         assert chk["action"] == "Wire"
+
+
+class TestAccountErrorSuggestions:
+    """Account-resolution failures teach instead of just rejecting.
+
+    Every wrong path guess in a batch was a rejected row and a
+    retry round-trip (bookkeeper friction, 2026-07-24): near-miss
+    paths get did-you-mean candidates, placeholder rejections name
+    postable children. Error-path only — success costs nothing."""
+
+    def test_truncated_leaf_suggests_full_path(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError) as e:
+            gc.create_transaction(
+                description="x",
+                splits=[
+                    {"account": "Expenses:Grocer", "amount": "5.00"},
+                    {"account": "Assets:Checking", "amount": "-5.00"},
+                ],
+            )
+        assert "Did you mean" in str(e.value)
+        assert "Expenses:Groceries" in str(e.value)
+
+    def test_nonsense_ref_stays_plain(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        with pytest.raises(ValueError) as e:
+            gc.get_balance("Zzz:Qqqqq:Wwww")
+        assert "Account not found" in str(e.value)
+        assert "Did you mean" not in str(e.value)
+
+    def test_placeholder_rejection_names_children(
+        self, test_book: Path,
+    ):
+        gc = GnuCashBook(str(test_book))
+        gc.create_account(
+            name="Utilities", account_type="EXPENSE",
+            parent="Expenses", placeholder=True,
+        )
+        gc.create_account(
+            name="Water", account_type="EXPENSE",
+            parent="Expenses:Utilities",
+        )
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 1),
+            "description": "Water bill",
+            "splits": [
+                {"account": "Expenses:Utilities", "amount": "50.00"},
+                {"account": "Assets:Checking", "amount": "-50.00"},
+            ],
+        }], on_error="skip")
+        rows = _parse_results_tsv(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "placeholder" in rows[0]["reason"]
+        assert "Expenses:Utilities:Water" in rows[0]["reason"]
+
+    def test_batch_row_rejection_carries_suggestion(
+        self, test_book: Path,
+    ):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([{
+            "ref": "1", "date": date(2026, 7, 1),
+            "description": "x",
+            "splits": [
+                {"account": "Expenses:Grocery", "amount": "5.00"},
+                {"account": "Assets:Checking", "amount": "-5.00"},
+            ],
+        }], on_error="skip")
+        rows = _parse_results_tsv(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "Did you mean" in rows[0]["reason"]
+        assert "Expenses:Groceries" in rows[0]["reason"]

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -8027,48 +8027,102 @@ class TestReconcileAccount:
         )
         assert unreconciled_after["splits"] == []
 
-    def test_reconcile_all_no_default_date_filter(self, test_book: Path):
-        """Bulk mode must NOT default to a date filter — the
-        bookkeeper's CareCredit payoff scenario had payment splits
-        dated AFTER the statement_date, and the test fixture's
-        analogue is splits across Jan 1 / 15 / 20 reconciled against
-        a Jan 10 statement. Pre-fix the default ``through_date =
-        statement_date`` excluded Jan 15 and Jan 20 splits silently;
-        post-fix every unreconciled split is included regardless of
-        date when no ``through_date`` is passed.
+    def test_bulk_default_bounded_by_statement_date(self, test_book: Path):
+        """Bulk mode defaults ``through_date`` to ``statement_date``.
+
+        This default has now flipped once in each direction — read
+        both incidents before flipping it a third time:
+
+        - **CareCredit payoff (2026-05, shaped the original
+          no-filter default):** a final statement plus a payoff
+          payment dated AFTER the statement date needed one sweep.
+          Under the bounded default that flow passes an explicit
+          later ``through_date`` (see
+          ``test_reconcile_all_respects_through_date``), and the
+          bulk balance-mismatch error hints exactly that.
+        - **Multi-month catch-up (2026-07, flipped it to bounded):**
+          enter several months of card transactions, reconcile each
+          statement in turn. Under no-filter, every statement but
+          the last broke the balance tie, forcing a per-statement
+          GUID-picking dance (live bookkeeper finding, four cards
+          in one night). Statement reconciliation is definitionally
+          bounded by the statement; the frequent case wins the
+          default and the rare payoff case pays one parameter.
+
+        Fixture has splits on 2024-01-01, 01-15, 01-20: the Jan-10
+        statement sweeps only Jan 1; the Jan-31 statement then
+        sweeps the rest — two bare calls, no GUIDs.
         """
         gc_book = GnuCashBook(str(test_book))
 
         unreconciled_all = gc_book.get_unreconciled_splits(
             "Assets:Checking", compact=False,
         )
-        total = sum(
-            (Decimal(s["amount"]) for s in unreconciled_all["splits"]),
-            Decimal("0"),
-        )
-        expected_count = len(unreconciled_all["splits"])
-        # The test fixture has at least one split AFTER the early
-        # statement date; if not, this assertion documents the gap.
-        early_cutoff = date(2024, 1, 10)
-        after_cutoff = [
-            s for s in unreconciled_all["splits"]
-            if date.fromisoformat(s["date"]) > early_cutoff
+        all_splits = unreconciled_all["splits"]
+        cutoff = date(2024, 1, 10)
+        early = [
+            s for s in all_splits
+            if date.fromisoformat(s["date"]) <= cutoff
         ]
-        assert after_cutoff, (
-            "Test setup: expected at least one split after the "
-            "early statement date to exercise the no-default-filter "
-            "behavior."
+        late = [
+            s for s in all_splits
+            if date.fromisoformat(s["date"]) > cutoff
+        ]
+        assert early and late, (
+            "Test setup: need splits on both sides of the early "
+            "statement date."
+        )
+        early_total = sum(
+            (Decimal(s["amount"]) for s in early), Decimal("0"),
         )
 
-        # statement_date is BEFORE some splits, but no through_date
-        # is passed — every unreconciled split must be included.
+        # Statement 1: bare bulk call sweeps ONLY through Jan 10.
         result = gc_book.reconcile_account(
             account_name="Assets:Checking",
-            statement_date=early_cutoff,
-            statement_balance=str(total),
+            statement_date=cutoff,
+            statement_balance=str(early_total),
             reconcile_all=True,
         )
-        assert result["splits_reconciled"] == expected_count
+        assert result["splits_reconciled"] == len(early)
+        remaining = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )["splits"]
+        assert len(remaining) == len(late)
+
+        # Statement 2: the next bare call finishes the catch-up.
+        full_total = sum(
+            (Decimal(s["amount"]) for s in all_splits), Decimal("0"),
+        )
+        result = gc_book.reconcile_account(
+            account_name="Assets:Checking",
+            statement_date=date(2024, 1, 31),
+            statement_balance=str(full_total),
+            reconcile_all=True,
+        )
+        assert result["splits_reconciled"] == len(late)
+
+    def test_bulk_mismatch_error_hints_through_date(
+        self, test_book: Path,
+    ):
+        """The payoff shape fails the tie loudly WITH the fix named:
+        the bulk mismatch error tells the caller to widen
+        through_date."""
+        gc_book = GnuCashBook(str(test_book))
+        all_splits = gc_book.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )["splits"]
+        full_total = sum(
+            (Decimal(s["amount"]) for s in all_splits), Decimal("0"),
+        )
+        # Statement balance includes post-statement items, but the
+        # bounded sweep can't reach them.
+        with pytest.raises(ValueError, match="pass through_date"):
+            gc_book.reconcile_account(
+                account_name="Assets:Checking",
+                statement_date=date(2024, 1, 10),
+                statement_balance=str(full_total),
+                reconcile_all=True,
+            )
 
     def test_reconcile_all_respects_through_date(self, test_book: Path):
         """When ``through_date`` is set, ``reconcile_all`` only touches


### PR DESCRIPTION
## Summary
- **`reconcile_all` is bounded by the statement by default** — `through_date` now defaults to `statement_date`. The tool docstring had promised this since day one while the book layer deliberately implemented no filter; the contradiction survived because agents absorbed the friction (a per-statement GUID-picking dance across four cards in one live night) instead of filing it. Statement reconciliation is definitionally bounded by the statement: multi-month catch-up becomes one bare call per statement, and the payoff-shaped sweep passes an explicit later `through_date` — which the bulk balance-mismatch error now names.
- The regression test records **both incidents** (the 2026-05 CareCredit payoff that shaped the original no-filter default, and the 2026-07 multi-month finding that flipped it) so a third flip has to read about the first two.
- `reconcile_account` docstrings gain the liability sign convention, the split-vs-transaction GUID warning, and the statement workflow sketch.
- **Did-you-mean suggestions on account resolution failure** — prefix/substring matches first, difflib for typos, wired at the shared split validator, `replace_splits`, the batch placeholder gate (which now names postable children), and `get_balance`. Error-path only.

## Test plan
- [x] Full suite green (multi-month regression, payoff-hint test, suggestion quality/fallback tests)
- [x] Live smoke on scratch Alex: two statements, two bare calls, 125+58 swept, balances tied, voided zombie correctly skipped — and the failed first attempt live-validated the new mismatch hint
- [x] Bookkeeper round (T1–T6 all ✅): Apr/May/Jun statements swept 68/57/58 with zero GUIDs; payoff shape failed with the fix named; Chase Sapphire liability signs tied; suggestions correct, placeholder children named, no bogus suggestions on nonsense