### PR TITLE
feat: bulk transaction updates — broadcast and per-row TSV

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -626,3 +626,60 @@ def _paginate(
         f"{entity_name}{cap_note}{_range_suffix(page, date_key)}"
     )
     return page, indicator
+
+
+# ── Batch transaction-update TSV ──────────────────────────────────
+
+_UPDATE_TSV_FIELDS = ("description", "notes", "date")
+
+
+def _parse_update_tsv(tsv: str) -> list[dict]:
+    """``update_transactions`` TSV → row dicts.
+
+    Header: ``guid`` then any of ``description``, ``notes``,
+    ``date`` (at least one, any order, no repeats); unknown tokens
+    reject by name. An EMPTY cell leaves that field unchanged — the
+    key is simply absent from the row dict. ``date`` stays an ISO
+    string here (the tool layer parses; the audit display reuses
+    this parser and wants text). Shared with the audit formatter so
+    the display parse can't drift from the tool parse.
+    """
+    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        raise ValueError(
+            "updates TSV needs a header row and at least one data row"
+        )
+    tokens = [t.strip().lower() for t in lines[0].split("\t")]
+    while tokens and not tokens[-1]:
+        tokens.pop()
+    if not tokens or tokens[0] != "guid":
+        raise ValueError("updates header must start with guid")
+    fields = tokens[1:]
+    if not fields:
+        raise ValueError(
+            "updates header needs at least one field column "
+            "(description, notes, date)"
+        )
+    seen: set = set()
+    for tok in fields:
+        if tok not in _UPDATE_TSV_FIELDS:
+            raise ValueError(
+                f"unrecognized column {tok!r} in updates header — "
+                f"columns are guid, then description, notes, date"
+            )
+        if tok in seen:
+            raise ValueError(f"duplicate {tok!r} column in updates header")
+        seen.add(tok)
+
+    out: list[dict] = []
+    for i, ln in enumerate(lines[1:], start=1):
+        cells = ln.split("\t")
+        guid = cells[0].strip() if cells else ""
+        if not guid:
+            raise ValueError(f"row {i}: empty guid")
+        row: dict = {"guid": guid}
+        for j, tok in enumerate(fields, start=1):
+            if j < len(cells) and cells[j].strip():
+                row[tok] = cells[j].strip()
+        out.append(row)
+    return out

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -4350,18 +4350,206 @@ class CoreMixin:
                     )
                 bucket.pop(match_idx)
 
+    def _update_transactions_broadcast(
+        self,
+        guids: list[str],
+        description: str | None = None,
+        trans_date: date | None = None,
+        splits: list[dict] | None = None,
+        notes: str | None = None,
+    ) -> dict:
+        """Apply the same field values to every listed transaction.
+
+        All-or-nothing: every guid resolves and passes the voided
+        gate before anything mutates, mirroring batch delete. Splits
+        are single-transaction territory — a broadcast split edit
+        matched "by account" against N different transactions is a
+        semantic minefield, so it rejects loudly.
+        """
+        if not guids:
+            raise ValueError("guid list is empty")
+        if splits is not None:
+            raise ValueError(
+                "splits updates are single-transaction only — pass "
+                "one guid, or use replace_splits per transaction"
+            )
+        if description is None and trans_date is None and notes is None:
+            raise ValueError(
+                "nothing to update — supply description, "
+                "transaction_date, and/or notes"
+            )
+        with self.open(readonly=False) as book:
+            transactions = []
+            for g in guids:
+                txn = self._find_transaction(book, g)
+                if not txn:
+                    raise ValueError(f"Transaction not found: {g}")
+                if any(_is_voided(sp) for sp in txn.splits):
+                    raise ValueError(
+                        f"Transaction {g} is voided. Use "
+                        f"unvoid_transaction first, then update."
+                    )
+                transactions.append(txn)
+
+            self._stage_audit_before({
+                "transactions": [
+                    _transaction_to_dict(t) for t in transactions
+                ],
+            })
+
+            for txn in transactions:
+                if description is not None:
+                    txn.description = description
+                if notes is not None:
+                    txn.notes = notes if notes else None
+                if trans_date is not None:
+                    txn.post_date = trans_date
+
+            book.save()
+
+            for txn in transactions:
+                self._verify_transaction_state(
+                    book, txn,
+                    expected_description=description,
+                    expected_date=trans_date,
+                    expected_notes=notes,
+                )
+
+            all_guids = [t.guid for t in book.transactions]
+            return {
+                "status": "updated",
+                "count": len(transactions),
+                "transactions": [
+                    {
+                        "guid": _unique_prefix(t.guid, all_guids),
+                        "description": t.description,
+                    }
+                    for t in transactions
+                ],
+            }
+
+    def update_transactions(
+        self,
+        updates: list[dict],
+        on_error: str = "abort",
+    ) -> dict:
+        """Per-row transaction updates in one book-open / one save.
+
+        Each entry: ``{guid, description (optional), notes
+        (optional), date (optional, datetime.date)}`` — absent keys
+        leave the field unchanged (the TSV's empty cells). Clearing
+        a field is deliberately single-tool territory
+        (``update_transaction`` with ``notes=""``) so a sparse batch
+        can never mass-erase.
+
+        ``on_error="abort"`` (default) sinks the batch on any bad
+        row; ``"skip"`` keeps the good rows. Returns ``{"results":
+        TSV}`` keyed by the input guid.
+        """
+        if on_error not in ("abort", "skip"):
+            raise ValueError("on_error must be 'abort' or 'skip'")
+        keys = [u["guid"] for u in updates]
+        if len(set(keys)) != len(keys):
+            raise ValueError(
+                "duplicate guid in batch — each transaction may "
+                "appear once"
+            )
+
+        by_key: dict = {}
+        with self.open(readonly=False) as book:
+            prepared = []
+            for u in updates:
+                key = u["guid"]
+                try:
+                    if not any(
+                        f in u for f in ("description", "notes", "date")
+                    ):
+                        raise ValueError(
+                            "row changes nothing — every cell empty"
+                        )
+                    txn = self._find_transaction(book, key)
+                    if not txn:
+                        raise ValueError(f"Transaction not found: {key}")
+                    if any(_is_voided(sp) for sp in txn.splits):
+                        raise ValueError(
+                            f"Transaction {key} is voided. Use "
+                            f"unvoid_transaction first, then update."
+                        )
+                    prepared.append((u, txn))
+                except (ValueError, KeyError) as e:
+                    by_key[key] = {
+                        "guid": key, "status": "rejected",
+                        "reason": str(e),
+                    }
+
+            if by_key and on_error == "abort":
+                for u, _txn in prepared:
+                    by_key[u["guid"]] = {
+                        "guid": u["guid"], "status": "rejected",
+                        "reason": "batch_aborted",
+                    }
+                return self._updates_envelope(updates, by_key)
+
+            self._stage_audit_before({
+                "transactions": [
+                    _transaction_to_dict(t) for _u, t in prepared
+                ],
+            })
+
+            for u, txn in prepared:
+                if "description" in u:
+                    txn.description = u["description"]
+                if "notes" in u:
+                    txn.notes = u["notes"] or None
+                if "date" in u:
+                    txn.post_date = u["date"]
+
+            if prepared:
+                book.save()
+
+            for u, txn in prepared:
+                self._verify_transaction_state(
+                    book, txn,
+                    expected_description=u.get("description"),
+                    expected_date=u.get("date"),
+                    expected_notes=u.get("notes"),
+                )
+                by_key[u["guid"]] = {
+                    "guid": u["guid"], "status": "updated",
+                    "description": txn.description,
+                }
+
+            return self._updates_envelope(updates, by_key)
+
+    @staticmethod
+    def _updates_envelope(updates: list[dict], by_key: dict) -> dict:
+        lines = ["guid\tstatus\tdescription\treason"]
+        for u in updates:
+            r = by_key.get(u["guid"], {})
+            lines.append(
+                f"{u['guid']}\t{r.get('status', '')}\t"
+                f"{r.get('description', '')}\t{r.get('reason', '')}"
+            )
+        return {"results": "\n".join(lines)}
+
     def update_transaction(
         self,
-        guid: str,
+        guid: str | list[str],
         description: str | None = None,
         trans_date: date | None = None,
         splits: list[dict] | None = None,
         notes: str | None = None,
         force: bool = False,
     ) -> dict:
-        """Update an existing transaction.
+        """Update an existing transaction — or broadcast one change
+        to several.
 
         Args:
+            guid: One GUID, or a LIST of them: the supplied field
+                values apply to EVERY listed transaction (one book
+                open, one save, all-or-nothing). The batch-annotation
+                case — same note on 35 related entries — in one call.
+                ``splits`` is single-transaction only.
             description / trans_date / notes: Optional; ``notes=""``
                 clears.
             splits: Optional split updates matched to existing splits
@@ -4370,13 +4558,20 @@ class CoreMixin:
                 when splits change).
 
         Returns:
-            Thin dict: {guid, date, description, status}.
+            Thin dict: {guid, date, description, status}; for a
+            list, ``{status, count, transactions: [{guid,
+            description}]}``.
 
         Raises:
             ValueError: not found, voided, imbalance, account not in
                 transaction, missing quantity, or reconciled without
                 force.
         """
+        if isinstance(guid, list):
+            return self._update_transactions_broadcast(
+                guid, description=description, trans_date=trans_date,
+                splits=splits, notes=notes,
+            )
         with self.open(readonly=False) as book:
             transaction = self._find_transaction(book, guid)
             if not transaction:

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -689,10 +689,87 @@ def _fmt_transaction_create_batch(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_transaction_update_batch(entry: dict) -> list[str]:
+    """``update_transactions`` (TSV, per-row values) — old→new per
+    touched field, old values from the staged before-state, new
+    from the submitted TSV re-parsed through the SAME parser the
+    tool used (no display drift)."""
+    from gnucash_mcp._format import _parse_update_tsv
+
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    before = entry.get("before_state") or {}
+    befores = {
+        (t.get("guid") or ""): t
+        for t in before.get("transactions") or []
+    }
+    try:
+        rows = _parse_update_tsv(params.get("updates") or "")
+    except ValueError:
+        rows = []
+    lines = [
+        f"{time_part}  UPDATE TRANSACTIONS (batch)  {len(rows)} rows"
+    ]
+    for r in rows[:15]:
+        key = r["guid"]
+        old = next(
+            (
+                b for g, b in befores.items()
+                if g.startswith(key) or key.startswith(g[:8])
+            ),
+            {},
+        )
+        parts = [f"guid:{key}"]
+        if "description" in r:
+            old_d = old.get("description", "")
+            parts.append(f'"{old_d}" → "{r["description"]}"')
+        if "notes" in r:
+            old_n = old.get("notes") or "(none)"
+            parts.append(f"Notes: {old_n} → {r['notes']}")
+        if "date" in r:
+            old_dt = old.get("date", "")
+            parts.append(f"Date: {old_dt} → {r['date']}")
+        lines.append(f"{_INDENT}{'  '.join(parts)}")
+    if len(rows) > 15:
+        lines.append(f"{_INDENT}... and {len(rows) - 15} more")
+    return lines
+
+
 def _fmt_transaction_update(entry: dict) -> list[str]:
     time_part = _extract_time(entry)
     before = entry.get("before_state")
     guid = _transaction_guid(entry)
+
+    # Broadcast form (guid list): one entry, shared values once,
+    # then the touched transactions. Same dispatch key as single
+    # update — the staged shape is the discriminator, mirroring
+    # batch delete.
+    if before and "transactions" in before:
+        params = entry.get("params") or {}
+        touched = before.get("transactions") or []
+        lines = [
+            f"{time_part}  UPDATE TRANSACTIONS (broadcast)  "
+            f"{len(touched)} updated"
+        ]
+        if params.get("description") is not None:
+            lines.append(
+                f'{_INDENT}Description → "{params["description"]}"'
+            )
+        if params.get("transaction_date"):
+            lines.append(
+                f"{_INDENT}Date → {params['transaction_date']}"
+            )
+        if params.get("notes") is not None:
+            new = params["notes"] or "(cleared)"
+            lines.append(f"{_INDENT}Notes → {new}")
+        for t in touched[:10]:
+            lines.append(
+                f'{_INDENT}  guid:{(t.get("guid") or "")[:8]}  '
+                f'"{t.get("description", "")}"'
+            )
+        if len(touched) > 10:
+            lines.append(f"{_INDENT}  ... and {len(touched) - 10} more")
+        return lines
 
     lines = [f"{time_part}  UPDATE TRANSACTION  guid:{guid}"]
     if not before:
@@ -1984,6 +2061,7 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("transaction", "CREATE_FROM_SCHEDULED"):
         _fmt_transaction_create_from_scheduled,
     ("transaction", "CREATE_BATCH"): _fmt_transaction_create_batch,
+    ("transaction", "UPDATE_BATCH"): _fmt_transaction_update_batch,
     ("transaction", "UPDATE"): _fmt_transaction_update,
     ("transaction", "VOID"): _fmt_transaction_void,
     ("transaction", "UNVOID"): _fmt_transaction_unvoid,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -149,6 +149,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "create_transaction",
         "create_transactions",
         "update_transaction",
+        "update_transactions",
         "delete_transaction",
         "replace_splits",
         "search_transactions",

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -8,7 +8,11 @@ way (pure lazy-load orchestration, no hardcoded imports).
 
 from datetime import date
 
-from gnucash_mcp._format import _batch_row_splits, _batch_tsv_layout
+from gnucash_mcp._format import (
+    _batch_row_splits,
+    _batch_tsv_layout,
+    _parse_update_tsv,
+)
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     SplitInput,
@@ -677,17 +681,24 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="update", entity_type="transaction")
     def update_transaction(
-        guid: TransactionGuid,
+        guid: TransactionGuid | list[TransactionGuid],
         description: str | None = None,
         transaction_date: str | None = None,
         splits: list[SplitInput] | None = None,
         notes: str | None = None,
         force: bool = False,
     ) -> str:
-        """Update an existing transaction.
+        """Update an existing transaction — or broadcast to several.
+
+        Pass a LIST of GUIDs to apply the SAME supplied values to
+        every listed transaction in one book open / one save
+        (all-or-nothing) — the batch-annotation case: one note
+        across 35 related entries, one call. ``splits`` stays
+        single-transaction. For per-row DIFFERENT values, use
+        ``update_transactions``.
 
         Args:
-            guid: Transaction GUID to update (32-character hex string, or 8+ char prefix)
+            guid: Transaction GUID (32-character hex string, or 8+ char prefix), or a list of them
             description: New transaction description (optional)
             transaction_date: New date in ISO format YYYY-MM-DD (optional)
             splits: List of split updates with 'account' and 'amount' (optional).
@@ -707,6 +718,47 @@ def register(mcp, get_book) -> None:
             splits=_splits_to_dicts(splits),
             notes=notes,
             force=force,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(
+        classification="write", operation="update_batch",
+        entity_type="transaction",
+    )
+    def update_transactions(
+        updates: str,
+        on_error: str = "abort",
+    ) -> str:
+        """Update MANY transactions with per-row values (bulk edit).
+
+        INPUT — ``updates`` is a TSV block: header ``guid`` plus any
+        of ``description``, ``notes``, ``date`` (at least one), then
+        one row per transaction::
+
+            guid<TAB>description<TAB>notes
+            56926ac2<TAB>PayPal Credit Payment<TAB>Resolved — card payment
+            7f0fc117<TAB><TAB>Netflix subscription, $22.10/mo
+
+        An EMPTY cell leaves that field UNCHANGED — this batch can
+        annotate but never clear (clearing is ``update_transaction``
+        with ``notes=""``, deliberately single-transaction). Splits
+        and memos are not updatable here (``replace_splits``).
+
+        One book open, one save; ``on_error="abort"`` (default)
+        sinks the batch on any bad row, ``"skip"`` keeps good rows.
+        Returns a results TSV keyed by your input guids. For the
+        SAME value across many transactions, ``update_transaction``
+        with a guid list is cheaper than repeating rows.
+        """
+        book = get_book()
+        rows = _parse_update_tsv(updates)
+        for r in rows:
+            if "date" in r:
+                r["date"] = date.fromisoformat(r["date"])
+        result = book.update_transactions(
+            updates=rows, on_error=on_error,
         )
         return _json(result)
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12507,3 +12507,137 @@ class TestAccountErrorSuggestions:
         assert rows[0]["status"] == "rejected"
         assert "Did you mean" in rows[0]["reason"]
         assert "Expenses:Groceries" in rows[0]["reason"]
+
+
+class TestUpdateTransactionBroadcast:
+    """guid-list broadcast: same values to N transactions, one save.
+
+    The 44-identical-notes annotation pass that previously burned
+    three turns of tool-call budget (bookkeeper finding)."""
+
+    def _three(self, gc):
+        guids = []
+        for i in range(3):
+            r = gc.create_transaction(
+                description=f"HoopFest Doughnut {i}",
+                splits=[
+                    {"account": "Assets:Checking", "amount": f"{10 + i}.00"},
+                    {"account": "Income:Salary", "amount": f"-{10 + i}.00"},
+                ],
+            )
+            guids.append(r["guid"])
+        return guids
+
+    def test_broadcast_notes(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        guids = self._three(gc)
+        result = gc.update_transaction(
+            guid=guids, notes="HoopFest 2026 — liability, not income.",
+        )
+        assert result["status"] == "updated"
+        assert result["count"] == 3
+        for g in guids:
+            txn = gc.get_transaction(g)
+            assert txn["notes"] == "HoopFest 2026 — liability, not income."
+            assert txn["description"].startswith("HoopFest Doughnut")
+
+    def test_all_or_nothing_on_bad_guid(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        guids = self._three(gc)
+        with pytest.raises(ValueError, match="not found"):
+            gc.update_transaction(
+                guid=[guids[0], "deadbeef00000000"], notes="x",
+            )
+        assert not gc.get_transaction(guids[0]).get("notes")
+
+    def test_splits_rejected_with_list(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        guids = self._three(gc)
+        with pytest.raises(ValueError, match="single-transaction only"):
+            gc.update_transaction(
+                guid=guids,
+                splits=[{"account": "Assets:Checking", "amount": "1"}],
+            )
+
+    def test_empty_field_set_rejected(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        guids = self._three(gc)
+        with pytest.raises(ValueError, match="nothing to update"):
+            gc.update_transaction(guid=guids)
+
+
+class TestUpdateTransactionsTsv:
+    """Per-row bulk edit: empty cells leave fields unchanged; the
+    batch can annotate but never clear."""
+
+    def _two(self, gc):
+        a = gc.create_transaction(
+            description="PayPal Instant Transfer (investigate)",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-250.00"},
+                {"account": "Expenses:Groceries", "amount": "250.00"},
+            ],
+        )["guid"]
+        b = gc.create_transaction(
+            description="PayPal Purchase (investigate)",
+            notes="original note",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-22.10"},
+                {"account": "Expenses:Groceries", "amount": "22.10"},
+            ],
+        )["guid"]
+        return a, b
+
+    def test_per_row_values_and_empty_cells(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        a, b = self._two(gc)
+        env = gc.update_transactions([
+            {"guid": a, "description": "PayPal Credit Payment",
+             "notes": "Resolved — card payment"},
+            {"guid": b, "description": "Netflix via PayPal"},
+        ])
+        rows = {r["guid"]: r for r in _parse_results_tsv(env["results"])}
+        assert rows[a]["status"] == "updated"
+        assert rows[b]["status"] == "updated"
+        ta, tb = gc.get_transaction(a), gc.get_transaction(b)
+        assert ta["description"] == "PayPal Credit Payment"
+        assert ta["notes"] == "Resolved — card payment"
+        assert tb["description"] == "Netflix via PayPal"
+        # Empty cell left the existing note untouched — never cleared.
+        assert tb["notes"] == "original note"
+
+    def test_abort_and_skip(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        a, _b = self._two(gc)
+        bad = {"guid": "deadbeef00000000", "notes": "x"}
+        good = {"guid": a, "notes": "kept"}
+        env = gc.update_transactions([bad, good])
+        rows = {r["guid"]: r for r in _parse_results_tsv(env["results"])}
+        assert rows[a]["reason"] == "batch_aborted"
+        assert not gc.get_transaction(a).get("notes")
+        env = gc.update_transactions([bad, good], on_error="skip")
+        rows = {r["guid"]: r for r in _parse_results_tsv(env["results"])}
+        assert rows[a]["status"] == "updated"
+        assert gc.get_transaction(a)["notes"] == "kept"
+
+    def test_row_changing_nothing_rejects(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        a, _b = self._two(gc)
+        env = gc.update_transactions(
+            [{"guid": a}], on_error="skip",
+        )
+        rows = _parse_results_tsv(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert "changes nothing" in rows[0]["reason"]
+
+    def test_update_tsv_parser_contract(self):
+        from gnucash_mcp._format import _parse_update_tsv
+
+        with pytest.raises(ValueError, match="unrecognized column 'payee'"):
+            _parse_update_tsv("guid\tpayee\nabc\tX")
+        with pytest.raises(ValueError, match="at least one field"):
+            _parse_update_tsv("guid\nabc")
+        rows = _parse_update_tsv(
+            "guid\tdescription\tnotes\nabc123\t\tonly notes"
+        )
+        assert rows[0] == {"guid": "abc123", "notes": "only notes"}

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,22 +84,22 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_group_resolves_to_29_tools(self):
-        """The ``core`` group expands to 30 tools across its nine
-        sub-modules (summary 1 + accounts 7 + transactions 9 + slots
+        """The ``core`` group expands to 31 tools across its nine
+        sub-modules (summary 1 + accounts 7 + transactions 11 + slots
         3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
         reconciliation 3). Reconciliation joined core in v1.3.1
         per the bookkeeper-driven principle that any configuration
         which handles money must include reconciliation.
         """
-        assert len(_core_tool_names()) == 30
+        assert len(_core_tool_names()) == 31
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 108 —
+        """Total tools across all sub-modules should be 109 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
         1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 108
+        assert total == 109
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -265,7 +265,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 108 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables + 1 batch prices)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 108
+        assert len(self._tool_names()) == 109
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -297,12 +297,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 108
+        assert len(self._tool_names()) == 109
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 108 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 108
+        assert len(self._tool_names()) == 109
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.
@@ -1094,7 +1094,7 @@ class TestMultiBook:
         alex, _ = two_books
         srv._book_paths = [alex.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 108
+        assert len(mcp._tool_manager._tools) == 109
 
     def test_tool_count_multi_book(self, two_books):
         """The lone runtime delta from single-book: switch_book (109).
@@ -1104,7 +1104,7 @@ class TestMultiBook:
         alex, beast = two_books
         srv._book_paths = [alex.resolve(), beast.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 109
+        assert len(mcp._tool_manager._tools) == 110
 
     # ── switch_book matching ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **`update_transaction` accepts a guid LIST**: the supplied values apply to every listed transaction in one book-open / one save, all-or-nothing (batch delete's exact shape). The 44-identical-notes annotation pass that burned three turns of tool budget becomes one call. `splits` stays single-transaction and rejects loudly with a list.
- **`update_transactions` (new tool)**: per-row values via TSV — header `guid` plus any of `description`/`notes`/`date`; an EMPTY cell leaves the field UNCHANGED, so a sparse batch can annotate but never mass-erase (clearing remains a deliberate single-transaction act). `abort`/`skip` per batch convention; the display parser is shared with the audit formatter so the two can't drift.
- Both audit truthfully: broadcast renders shared values once plus the touched transactions; the TSV form renders per-row old→new diffs from the staged before-state.

## Test plan
- [x] Full suite green (broadcast atomicity, splits rejection, empty-cell preservation, abort/skip, parser contract; tool-count contract tests bumped 108→109)
- [x] Bookkeeper round (T7–T9 ✅): 6-transaction broadcast in one call; bad guid rejected atomically with nothing half-applied; TSV empty cells preserved existing notes; routing between the three update shapes judged clear from docstrings alone