### PR TITLE
feat: session vocabulary + reconciliation status drill-down

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -357,6 +357,35 @@ _DEFAULT_TYPES = {
 }
 
 
+_SLOT_BOOL_TRUE = frozenset({"1", "true", "yes", "y", "on"})
+_SLOT_BOOL_FALSE = frozenset({"0", "false", "no", "n", "off", ""})
+
+
+def _slot_bool(entity, key: str) -> bool | None:
+    """Tri-state boolean slot read: True, False, or None (absent /
+    unrecognized).
+
+    THE convention for boolean slots — extracted per the standing
+    backlog note when the third boolean slot (``no_reconcile``)
+    arrived: ``credit-note`` parsed strictly (== "1") while
+    ``is_retirement`` parsed leniently, and a third private
+    convention was the trigger to consolidate. Lenient wins because
+    slot values are user-typed through set_account_slot; an
+    unrecognized value returns None so each caller keeps its own
+    fallback semantics instead of this helper guessing.
+    """
+    try:
+        raw = entity[key]
+    except KeyError:
+        return None
+    val = (_slot_value_str(raw) or "").strip().lower()
+    if val in _SLOT_BOOL_TRUE:
+        return True
+    if val in _SLOT_BOOL_FALSE:
+        return False
+    return None
+
+
 def _account_to_compact_line(account: piecash.Account) -> str:
     """Convert a piecash Account to a compact one-line string.
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -3663,11 +3663,10 @@ class BusinessMixin:
     @staticmethod
     def _get_is_credit_note(invoice) -> bool:
         """Read the GnuCash ``credit-note`` slot. True iff value=1."""
-        try:
-            raw = invoice[BusinessMixin._CREDIT_NOTE_SLOT_KEY]
-        except KeyError:
-            return False
-        return _slot_value_str(raw) == "1"
+        from gnucash_mcp.book._base import _slot_bool
+        return _slot_bool(
+            invoice, BusinessMixin._CREDIT_NOTE_SLOT_KEY,
+        ) is True
 
     @staticmethod
     def _set_is_credit_note(invoice, value: bool = True) -> None:

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -308,6 +308,7 @@ class CoreMixin:
             any_splits = False
             unreconciled_count = 0
             oldest_unreconciled_date = None
+            balance = Decimal("0")
             for s in account.splits:
                 # Voided splits are zombies, not reconcilable
                 # activity — they must not make an account
@@ -315,6 +316,7 @@ class CoreMixin:
                 if _is_voided(s):
                     continue
                 any_splits = True
+                balance += s.quantity
                 rstate = s.reconcile_state
                 if rstate in ("y", "c"):
                     has_yc = True
@@ -373,6 +375,7 @@ class CoreMixin:
                 else:
                     days_behind = (today - latest_y_date).days
                     results.append({
+                        "balance_zero": balance == 0,
                         "account": account.fullname,
                         "status": f"through {latest_y_date.isoformat()}",
                         "days_behind": days_behind,
@@ -1512,11 +1515,28 @@ class CoreMixin:
         stale: list[dict] = []
         current_count = 0
         never_count = 0
+        dormant_count = 0
         for entry in reconciliation:
             if entry["status"] == "never reconciled":
                 never_count += 1
             elif entry["days_behind"] > self._RECONCILE_WARN_DAYS:
-                stale.append(entry)
+                # Fully reconciled + zero balance + no activity =
+                # DORMANT, not behind: nothing owed, nothing
+                # unentered that a statement could reveal. A $0
+                # card idle since March needs no orange badge —
+                # but a CARRIED balance with months of silence
+                # means missing entries (interest posts monthly),
+                # so those stay individually warned. (Bookkeeper
+                # finding: stamped dormant cards kept warning
+                # because "through" tracks the last reconciled
+                # SPLIT, which a 0-split sweep can't advance.)
+                if (
+                    entry["unreconciled_count"] == 0
+                    and entry.get("balance_zero")
+                ):
+                    dormant_count += 1
+                else:
+                    stale.append(entry)
             else:
                 current_count += 1
 
@@ -1548,6 +1568,12 @@ class CoreMixin:
         if current_count:
             plural = "s" if current_count != 1 else ""
             out.append(f"  {current_count} account{plural} current")
+        if dormant_count:
+            plural = "s" if dormant_count != 1 else ""
+            out.append(
+                f"  {dormant_count} account{plural} dormant "
+                f"($0, fully reconciled)"
+            )
         if never_count:
             plural = "s" if never_count != 1 else ""
             out.append(

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1777,6 +1777,54 @@ class CoreMixin:
         )
         return data
 
+    def _frequent_accounts(
+        self, book, transactions, days: int = 180, top: int = 15,
+    ) -> list[str]:
+        """The book's working vocabulary: most-posted accounts.
+
+        Short GUIDs went essentially unused in live bookkeeping
+        because they were never in the model's context at the
+        moment its account vocabulary formed — it paged
+        list_accounts once, or guessed paths. Handing the top
+        accounts (with their ``%short`` refs, in list_accounts'
+        exact line format) to every session at orientation makes
+        the compact refs the path of least resistance, and the
+        list is book-adaptive: each book surfaces its own chart's
+        vocabulary in its own language.
+
+        Placeholders can't receive splits, so posting frequency
+        naturally yields only postable accounts; template
+        recipes are excluded explicitly.
+        """
+        cutoff = date.today() - timedelta(days=days)
+        template_guids = self._template_account_guids(book)
+        counts: dict[str, int] = {}
+        by_guid: dict = {}
+        for txn in transactions:
+            post_date = txn.post_date
+            if isinstance(post_date, datetime):
+                post_date = post_date.date()
+            if post_date is None or post_date < cutoff:
+                continue
+            if self._is_template_transaction(txn, template_guids):
+                continue
+            for s in txn.splits:
+                g = s.account.guid
+                counts[g] = counts.get(g, 0) + 1
+                by_guid[g] = s.account
+        ranked = sorted(
+            counts.items(), key=lambda kv: (-kv[1], by_guid[kv[0]].fullname),
+        )[:top]
+        if not ranked:
+            return []
+        short_map = self._account_short_guid_map(book)
+        lines = [f"Frequently used accounts (last {days} days):"]
+        for g, _n in ranked:
+            lines.append(
+                f"  {short_map[g]}\t{_account_to_compact_line(by_guid[g])}"
+            )
+        return lines
+
     def _render_book_metadata(
         self,
         currency: str,
@@ -2231,6 +2279,10 @@ class CoreMixin:
             lines.append(
                 f"Expenses: {data.expense_active} active "
                 f"({data.expense_total} total)"
+            )
+
+            lines.extend(
+                self._frequent_accounts(book, transactions)
             )
 
             reconciliation = self._account_reconciliation_status(

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -1507,6 +1507,33 @@ class CoreMixin:
     # cross-section state: adding or reordering a section is a
     # one-method change.
 
+    def _classify_reconciliation(self, entry: dict) -> str:
+        """One bucket per reconciliation-status row — the SHARED
+        classification for the dashboard renderer and
+        get_reconciliation_status, so the aggregate counts and the
+        drill-down table agree by construction.
+
+        Buckets: ``excluded`` (no_reconcile opt-out), ``never``,
+        ``behind`` (stale with pending work OR a carried balance —
+        months of silence on a carried balance means missing
+        entries, since interest posts monthly), ``dormant`` (stale
+        but $0 and fully reconciled: nothing owed, nothing a
+        statement could reveal — the bookkeeper's stamped-dormant-
+        cards finding), ``current``.
+        """
+        if entry.get("excluded"):
+            return "excluded"
+        if entry["status"] == "never reconciled":
+            return "never"
+        if entry["days_behind"] > self._RECONCILE_WARN_DAYS:
+            if (
+                entry["unreconciled_count"] == 0
+                and entry.get("balance_zero")
+            ):
+                return "dormant"
+            return "behind"
+        return "current"
+
     def _render_reconciliation(
         self, reconciliation: list[dict],
     ) -> list[str]:
@@ -1525,31 +1552,18 @@ class CoreMixin:
         never_count = 0
         dormant_count = 0
         for entry in reconciliation:
-            if entry.get("excluded"):
+            bucket = self._classify_reconciliation(entry)
+            if bucket == "excluded":
                 # no_reconcile opt-outs: dashboard-silent by the
                 # user's own declaration; get_reconciliation_status
                 # is the honesty backstop.
                 continue
-            if entry["status"] == "never reconciled":
+            if bucket == "never":
                 never_count += 1
-            elif entry["days_behind"] > self._RECONCILE_WARN_DAYS:
-                # Fully reconciled + zero balance + no activity =
-                # DORMANT, not behind: nothing owed, nothing
-                # unentered that a statement could reveal. A $0
-                # card idle since March needs no orange badge —
-                # but a CARRIED balance with months of silence
-                # means missing entries (interest posts monthly),
-                # so those stay individually warned. (Bookkeeper
-                # finding: stamped dormant cards kept warning
-                # because "through" tracks the last reconciled
-                # SPLIT, which a 0-split sweep can't advance.)
-                if (
-                    entry["unreconciled_count"] == 0
-                    and entry.get("balance_zero")
-                ):
-                    dormant_count += 1
-                else:
-                    stale.append(entry)
+            elif bucket == "dormant":
+                dormant_count += 1
+            elif bucket == "behind":
+                stale.append(entry)
             else:
                 current_count += 1
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -26,6 +26,7 @@ from gnucash_mcp._format import _paginate
 _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
 
 from gnucash_mcp.book._base import (
+    _slot_bool,
     _account_to_compact_line,
     _account_to_dict,
     _guid_prefix_map,
@@ -296,6 +297,23 @@ class CoreMixin:
                     and account.type != "ASSET":
                 continue
 
+            # User-declared opt-out: loans, escrow payables, cash
+            # wallets — accounts with no statement to reconcile
+            # against. Reporting-only: reconcile_account and
+            # get_unreconciled_splits still work normally on
+            # flagged accounts. The excluded row keeps the account
+            # visible to get_reconciliation_status (no silent
+            # caps); the dashboard renderer drops it.
+            if _slot_bool(account, "no_reconcile") is True:
+                results.append({
+                    "account": account.fullname,
+                    "status": "excluded (no_reconcile)",
+                    "days_behind": None,
+                    "unreconciled_count": 0,
+                    "excluded": True,
+                })
+                continue
+
             # Single pass over splits derives latest_y_date, has_yc
             # (the ASSET gate), any_splits, unreconciled_count, and
             # oldest_unreconciled_date. ``_is_unreconciled`` is the
@@ -554,9 +572,6 @@ class CoreMixin:
     # opt back in.
     _RETIREMENT_SLOT_KEY = "is_retirement"
 
-    _RETIREMENT_SLOT_TRUE = frozenset({"1", "true", "yes", "y"})
-    _RETIREMENT_SLOT_FALSE = frozenset({"0", "false", "no", "n"})
-
     def _is_in_retirement_subtree(self, account) -> bool:
         """True when the account is penalty-locked retirement money
         that must not count as liquid for runway / low-cash.
@@ -572,21 +587,14 @@ class CoreMixin:
         slot there. A subtree named "Tax-advantaged" has the same
         gap in any locale.
         """
-        from gnucash_mcp.book._base import _slot_value_str
+        from gnucash_mcp.book._base import _slot_bool
 
         node = account
         while node is not None and node.type != "ROOT":
-            try:
-                raw = node[self._RETIREMENT_SLOT_KEY]
-            except KeyError:
-                raw = None
-            if raw is not None:
-                val = (_slot_value_str(raw) or "").strip().lower()
-                if val in self._RETIREMENT_SLOT_TRUE:
-                    return True
-                if val in self._RETIREMENT_SLOT_FALSE:
-                    return False
-                # Unrecognized value: keep walking rather than guess.
+            flag = _slot_bool(node, self._RETIREMENT_SLOT_KEY)
+            if flag is not None:
+                return flag
+            # Absent or unrecognized: keep walking rather than guess.
             node = node.parent
         return any(
             "retirement" in part.lower()
@@ -1517,6 +1525,11 @@ class CoreMixin:
         never_count = 0
         dormant_count = 0
         for entry in reconciliation:
+            if entry.get("excluded"):
+                # no_reconcile opt-outs: dashboard-silent by the
+                # user's own declaration; get_reconciliation_status
+                # is the honesty backstop.
+                continue
             if entry["status"] == "never reconciled":
                 never_count += 1
             elif entry["days_behind"] > self._RECONCILE_WARN_DAYS:

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -127,6 +127,69 @@ class ReconciliationMixin:
                 "status": "updated",
             }
 
+    def get_reconciliation_status(
+        self, compact: bool = True, limit: int = 50, offset: int = 0,
+    ) -> dict | str:
+        """Per-account reconciliation table behind the dashboard's
+        aggregate counts — the drill-down that answers "WHICH five
+        accounts are never reconciled?"
+
+        One row per reconcilable account with activity, bucketed by
+        the same classification the dashboard uses (agree-by-
+        construction): ``behind`` (most-behind first), ``never``,
+        ``current``, ``dormant`` ($0, fully reconciled, idle), and
+        ``excluded`` (the account's ``no_reconcile`` slot — set via
+        set_account_slot — opts it out of dashboard warnings;
+        loans and escrow payables with no statement to reconcile).
+
+        Args:
+            compact: One TSV line per account (default) or the
+                verbose envelope.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
+        """
+        with self.open(readonly=True) as book:
+            accounts = list(book.accounts)
+            rows = self._account_reconciliation_status(book, accounts)
+            for r in rows:
+                r["bucket"] = self._classify_reconciliation(r)
+            bucket_rank = {
+                "behind": 0, "never": 1, "current": 2,
+                "dormant": 3, "excluded": 4,
+            }
+            rows.sort(key=lambda r: (
+                bucket_rank[r["bucket"]],
+                -(r["days_behind"] or 0),
+                r["account"],
+            ))
+
+            page, indicator = _paginate(
+                rows, offset=offset, limit=limit,
+                entity_name="accounts",
+            )
+            if compact:
+                lines = [indicator]
+                for r in page:
+                    cells = [r["account"], r["bucket"], r["status"]]
+                    n = r["unreconciled_count"]
+                    if n:
+                        cell = f"{n} unreconciled"
+                        if r.get("oldest_unreconciled_date"):
+                            cell += (
+                                f" (oldest: "
+                                f"{r['oldest_unreconciled_date']})"
+                            )
+                        cells.append(cell)
+                    lines.append("\t".join(cells))
+                return "\n".join(lines)
+            return {
+                "showing": indicator,
+                "total": len(rows),
+                "offset": offset,
+                "count": len(page),
+                "accounts": page,
+            }
+
     def get_unreconciled_splits(
         self,
         account_name: str,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -183,6 +183,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_server_config",
     ],
     "reconciliation": [
+        "get_reconciliation_status",
         "get_unreconciled_splits",
         "set_reconcile_state",
         "reconcile_account",

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -45,6 +45,41 @@ def register(mcp, get_book) -> None:
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
+    def get_reconciliation_status(
+        verbose: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> str:
+        """Per-account reconciliation table behind the dashboard's
+        aggregate counts — answers "WHICH accounts are never
+        reconciled / dormant / behind?"
+
+        One line per reconcilable account with activity, bucketed
+        exactly as the dashboard classifies them: ``behind``
+        (most-behind first, with pending-split counts), ``never``,
+        ``current``, ``dormant`` ($0, fully reconciled, idle), and
+        ``excluded`` (opted out via the account's ``no_reconcile``
+        slot — the right setting for loans, escrow payables, and
+        other statement-less accounts: set_account_slot(account,
+        "no_reconcile", "1"). Reporting-only; reconcile tools still
+        work on excluded accounts).
+
+        Args:
+            verbose: Full JSON rows instead of compact TSV lines.
+            limit: Page size (default 50, max 250). 0 = count only.
+            offset: 0-indexed first row to return.
+        """
+        book = get_book()
+        result = book.get_reconciliation_status(
+            compact=not verbose, limit=limit, offset=offset,
+        )
+        if verbose:
+            return _json(result)
+        return result
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(classification="read")
     def get_unreconciled_splits(
         account: str,
         as_of_date: str | None = None,

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12693,3 +12693,64 @@ class TestFrequentAccounts:
         gc = GnuCashBook(str(test_book))
         summary = gc.get_book_summary()
         assert "Frequently used accounts" not in summary
+
+
+class TestReconciliationDormancy:
+    """A $0, fully-reconciled, long-idle account is DORMANT — an
+    aggregate line, no orange badge. A CARRIED balance with months
+    of silence stays individually warned: interest posts monthly,
+    so silence means missing entries. (Bookkeeper finding: stamped
+    dormant cards warned forever because a 0-split sweep can't
+    advance the last-reconciled-split date.)"""
+
+    def _card_with_history(self, gc, name, pay_off: bool):
+        from datetime import timedelta as _td
+        gc.create_account(
+            name=name, account_type="CREDIT", parent="Liabilities",
+        )
+        old = date.today() - _td(days=150)
+        r = gc.create_transaction(
+            description=f"{name} purchase",
+            splits=[
+                {"account": f"Liabilities:{name}", "amount": "-500.00"},
+                {"account": "Expenses:Groceries", "amount": "500.00"},
+            ],
+            trans_date=old,
+        )
+        guids = [r["guid"]]
+        if pay_off:
+            r2 = gc.create_transaction(
+                description=f"{name} payoff",
+                splits=[
+                    {"account": f"Liabilities:{name}", "amount": "500.00"},
+                    {"account": "Assets:Checking", "amount": "-500.00"},
+                ],
+                trans_date=old,
+            )
+            guids.append(r2["guid"])
+        # Reconcile every card split (dated 150 days ago).
+        for g in guids:
+            txn = gc.get_transaction(g)
+            for s in txn["splits"]:
+                if name in s["account"]:
+                    gc.set_reconcile_state(s["guid"], "y", reconcile_date=old)
+
+    def test_dormant_zero_card_aggregates_without_warning(
+        self, test_book: Path,
+    ):
+        gc = GnuCashBook(str(test_book))
+        self._card_with_history(gc, "Old Apple Card", pay_off=True)
+        summary = gc.get_book_summary()
+        assert "1 account dormant ($0, fully reconciled)" in summary
+        assert "Old Apple Card" not in summary.split("Reconciliation:")[1]
+
+    def test_carried_balance_stays_warned(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._card_with_history(gc, "Care Credit", pay_off=False)
+        summary = gc.get_book_summary()
+        recon = summary.split("Reconciliation:")[1]
+        assert "Care Credit" in recon
+        assert "⚠" in [
+            ln for ln in recon.split("\n") if "Care Credit" in ln
+        ][0]
+        assert "dormant" not in recon

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12754,3 +12754,75 @@ class TestReconciliationDormancy:
             ln for ln in recon.split("\n") if "Care Credit" in ln
         ][0]
         assert "dormant" not in recon
+
+
+class TestNoReconcileSlot:
+    """The ``no_reconcile`` slot: user-declared 'this account has no
+    statement to reconcile against' (loans, escrow payables). The
+    dashboard drops flagged accounts from warnings and counts;
+    reconciliation TOOLS still work on them (reporting-only flag).
+    Also the third boolean slot — the trigger that consolidated
+    _slot_bool per the standing backlog note."""
+
+    def _never_reconciled_loan(self, gc):
+        # Stamp the fixture's Checking splits first so the loan is
+        # the SOLE never-reconciled account and the aggregate line's
+        # presence/absence is attributable to the flag under test.
+        pending = gc.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )["splits"]
+        for sp in pending:
+            gc.set_reconcile_state(sp["guid"], "y")
+        gc.create_account(
+            name="Navient", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc.create_transaction(
+            description="Loan interest",
+            splits=[
+                {"account": "Liabilities:Navient", "amount": "-55.00"},
+                {"account": "Expenses:Groceries", "amount": "55.00"},
+            ],
+        )
+
+    def test_flag_removes_from_dashboard(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._never_reconciled_loan(gc)
+        before = gc.get_book_summary()
+        assert "never reconciled ⚠" in before
+
+        gc.set_account_slot("Liabilities:Navient", "no_reconcile", "1")
+        after = gc.get_book_summary()
+        recon = after.split("Reconciliation:")[1].split("Net worth")[0]
+        assert "Navient" not in recon
+        # The loan was the only never-reconciled account; its
+        # aggregate line vanishes with it.
+        assert "never reconciled" not in recon
+
+    def test_flag_is_reporting_only(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        self._never_reconciled_loan(gc)
+        gc.set_account_slot("Liabilities:Navient", "no_reconcile", "1")
+        d = gc.get_unreconciled_splits(
+            "Liabilities:Navient", compact=False,
+        )
+        assert d["count"] == 1  # tools unaffected by the flag
+
+    def test_slot_bool_convention(self, test_book: Path):
+        """Lenient parse, tri-state: unrecognized values read as
+        absent so callers keep their own fallbacks."""
+        from gnucash_mcp.book._base import _slot_bool
+
+        gc = GnuCashBook(str(test_book))
+        self._never_reconciled_loan(gc)
+        for raw, expected_hidden in (
+            ("yes", True), ("TRUE", True), ("on", True),
+            ("0", False), ("no", False), ("garbage", False),
+        ):
+            gc.set_account_slot(
+                "Liabilities:Navient", "no_reconcile", raw,
+            )
+            summary = gc.get_book_summary()
+            recon = summary.split("Reconciliation:")[1]
+            hidden = "never reconciled" not in recon
+            assert hidden is expected_hidden, (raw, expected_hidden)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12641,3 +12641,55 @@ class TestUpdateTransactionsTsv:
             "guid\tdescription\tnotes\nabc123\t\tonly notes"
         )
         assert rows[0] == {"guid": "abc123", "notes": "only notes"}
+
+
+class TestFrequentAccounts:
+    """get_book_summary hands each session its working vocabulary:
+    top accounts by recent posting frequency, in list_accounts'
+    exact %short-GUID line format (bookkeeper finding: short GUIDs
+    went unused because they were never in context when the
+    model's account vocabulary formed)."""
+
+    def test_section_present_ordered_and_reusable(
+        self, test_book: Path,
+    ):
+        gc = GnuCashBook(str(test_book))
+        # Groceries gets three recent postings, Salary one.
+        for i in range(3):
+            gc.create_transaction(
+                description=f"G{i}",
+                splits=[
+                    {"account": "Expenses:Groceries", "amount": "5.00"},
+                    {"account": "Assets:Checking", "amount": "-5.00"},
+                ],
+            )
+        summary = gc.get_book_summary()
+        assert "Frequently used accounts (last 180 days):" in summary
+        section = summary.split("Frequently used accounts")[1]
+        lines = [
+            ln.strip() for ln in section.split("\n")[1:]
+            if ln.strip().startswith("%")
+        ]
+        assert lines, "expected %short-GUID vocabulary lines"
+        # list_accounts line format: %short<TAB>fullname [TYPE].
+        first = lines[0]
+        assert "\t" in first
+        short, rest = first.split("\t", 1)
+        assert short.startswith("%") and len(short) >= 8
+        # Ordering: the two most-posted are checking + groceries.
+        top_two = {ln.split("\t", 1)[1].split(" [")[0] for ln in lines[:2]}
+        assert top_two == {"Assets:Checking", "Expenses:Groceries"}
+        # The emitted short ref actually resolves (book-layer
+        # get_balance returns a bare Decimal; an unresolvable ref
+        # raises).
+        assert isinstance(gc.get_balance(short), Decimal)
+
+    def test_old_activity_outside_window_excluded(
+        self, test_book: Path,
+    ):
+        """The fixture's 2024 transactions are outside the 180-day
+        window; with no recent activity the section is absent
+        rather than rendering stale vocabulary."""
+        gc = GnuCashBook(str(test_book))
+        summary = gc.get_book_summary()
+        assert "Frequently used accounts" not in summary

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12826,3 +12826,72 @@ class TestNoReconcileSlot:
             recon = summary.split("Reconciliation:")[1]
             hidden = "never reconciled" not in recon
             assert hidden is expected_hidden, (raw, expected_hidden)
+
+
+class TestGetReconciliationStatus:
+    """The drill-down behind the dashboard aggregates: WHICH
+    accounts are behind / never reconciled / dormant / excluded,
+    bucketed by the same classification the dashboard uses."""
+
+    def test_buckets_named_and_ordered(self, test_book: Path):
+        from datetime import timedelta as _td
+
+        gc = GnuCashBook(str(test_book))
+        # never: a loan with activity, no stamps.
+        gc.create_account(
+            name="Navient", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc.create_transaction(
+            description="Loan interest",
+            splits=[
+                {"account": "Liabilities:Navient", "amount": "-55.00"},
+                {"account": "Expenses:Groceries", "amount": "55.00"},
+            ],
+        )
+        # excluded: same shape, flagged.
+        gc.create_account(
+            name="MOHELA", account_type="LIABILITY",
+            parent="Liabilities",
+        )
+        gc.create_transaction(
+            description="Loan interest 2",
+            splits=[
+                {"account": "Liabilities:MOHELA", "amount": "-10.00"},
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+            ],
+        )
+        gc.set_account_slot("Liabilities:MOHELA", "no_reconcile", "1")
+        # behind: stamp ONE Checking split so the account has
+        # reconcile history plus pending 2024-dated work.
+        pending = gc.get_unreconciled_splits(
+            "Assets:Checking", compact=False,
+        )["splits"]
+        gc.set_reconcile_state(pending[0]["guid"], "y")
+
+        out = gc.get_reconciliation_status(compact=True)
+        lines = out.split("\n")[1:]
+        by_account = {ln.split("\t")[0]: ln for ln in lines}
+        assert "never" in by_account["Liabilities:Navient"]
+        assert "excluded" in by_account["Liabilities:MOHELA"]
+        # Checking: reconciled once, years of pending work — behind,
+        # sorted first with its scope of work.
+        assert lines[0].startswith("Assets:Checking")
+        assert "behind" in lines[0]
+        assert "unreconciled" in lines[0]
+        # Excluded sorts last.
+        assert "excluded" in lines[-1]
+
+    def test_dashboard_and_drilldown_agree(self, test_book: Path):
+        """Aggregate counts in the summary equal the bucket counts
+        in the drill-down — agree-by-construction check."""
+        gc = GnuCashBook(str(test_book))
+        out = gc.get_reconciliation_status(compact=False)
+        buckets: dict = {}
+        for r in out["accounts"]:
+            buckets[r["bucket"]] = buckets.get(r["bucket"], 0) + 1
+        summary = gc.get_book_summary()
+        recon = summary.split("Reconciliation:")[1].split("Net worth")[0]
+        import re
+        m = re.search(r"(\d+) accounts? never reconciled", recon)
+        assert (int(m.group(1)) if m else 0) == buckets.get("never", 0)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,22 +84,22 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_group_resolves_to_29_tools(self):
-        """The ``core`` group expands to 31 tools across its nine
+        """The ``core`` group expands to 32 tools across its nine
         sub-modules (summary 1 + accounts 7 + transactions 11 + slots
         3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
-        reconciliation 3). Reconciliation joined core in v1.3.1
+        reconciliation 4). Reconciliation joined core in v1.3.1
         per the bookkeeper-driven principle that any configuration
         which handles money must include reconciliation.
         """
-        assert len(_core_tool_names()) == 31
+        assert len(_core_tool_names()) == 32
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 109 —
+        """Total tools across all sub-modules should be 110 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
         1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 109
+        assert total == 110
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -265,7 +265,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 108 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables + 1 batch prices)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 109
+        assert len(self._tool_names()) == 110
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -297,12 +297,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 109
+        assert len(self._tool_names()) == 110
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 108 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 109
+        assert len(self._tool_names()) == 110
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.
@@ -1094,7 +1094,7 @@ class TestMultiBook:
         alex, _ = two_books
         srv._book_paths = [alex.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 109
+        assert len(mcp._tool_manager._tools) == 110
 
     def test_tool_count_multi_book(self, two_books):
         """The lone runtime delta from single-book: switch_book (109).
@@ -1104,7 +1104,7 @@ class TestMultiBook:
         alex, beast = two_books
         srv._book_paths = [alex.resolve(), beast.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 110
+        assert len(mcp._tool_manager._tools) == 111
 
     # ── switch_book matching ───────────────────────────────────────
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1465,6 +1465,7 @@ _PAGINATED_TOOLS = [
     ("list_budgets", {}, "budgets"),
     ("list_backups", {}, None),
     ("get_audit_log", {}, None),
+    ("get_reconciliation_status", {}, None),
 ]
 
 


### PR DESCRIPTION
## Summary
- `get_book_summary` now hands each session its working vocabulary: top 15 accounts by posting frequency over the last 180 days, rendered in `list_accounts`' exact `%short-GUID` line format — so compact refs are in context at the moment the model's account vocabulary forms (bookkeeper finding: short GUIDs went unused because they never were). Book-adaptive: each book surfaces its own chart in its own language.
- Dormant accounts stop warning forever: fully-reconciled, zero-balance accounts idle past the warning window collapse into one aggregate line (`N dormant ($0, fully reconciled)`). A carried balance with months of silence stays individually warned — interest posts monthly, so silence there means missing entries.
- New `no_reconcile` account slot opts statement-less accounts (loans, escrow payables, cash wallets) out of dashboard reconciliation nagging. Reporting-only — reconcile tools keep working, and flipping the flag back is free. Third boolean slot triggered consolidation: `_slot_bool` in `_base.py` is now THE tri-state boolean-slot convention (credit-note's strict parser and `is_retirement`'s private frozensets folded in).
- New `get_reconciliation_status` read tool: the per-account table behind the dashboard's aggregate counts, bucketed by a classification chokepoint (`_classify_reconciliation`) extracted from the renderer so the counts and the drill-down agree by construction. Buckets: behind (most-behind first, with scope of work), never, current, dormant, excluded (opt-outs stay visible here — the honesty backstop for their dashboard silence).

## Test plan
- [x] Full suite: 1936/1936 passing (254 new test lines in `tests/test_book.py`)
- [x] `TestToolFileVsModulesMapping` contract holds (`get_reconciliation_status` registered in `TOOL_MODULES["reconciliation"]`)
- [x] Live smoke on committed sample oracles (Alex + Lin Wei copies): frequent-accounts section renders 15 `%ref` lines in `list_accounts` format on both books (incl. zh_CN chart); dashboard aggregate counts equal drill-down bucket counts on both; `no_reconcile` round trip (set → excluded in drill-down + dropped from dashboard warnings → unset → original bucket restored)
- [x] Dormant classification unit-covered (`test_dormant_zero_card_aggregates_without_warning`)
- [x] Live bookkeeping ran on the branch with no issues surfaced (light pass — accounts already in the accountant thread's vocabulary)