### PR TITLE
fix: price-cache review follow-ups for PR #126

### DIFF
--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1757,6 +1757,13 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         reference they would be collected immediately and every traversal
         would query again. The reference lives as long as the book, i.e.
         one ``open()`` context.
+
+        Deliberate tradeoff: the whole split graph is held in memory
+        for the duration of the call — tens of MB on a tens-of-
+        thousands-of-splits book. That is the price of the report
+        completing at all at that scale (lazy loading was a query per
+        transaction), and the biggest books are exactly the ones that
+        need it, so there is no size cutoff.
         """
         from piecash.core.account import Account
         from piecash.core.transaction import Transaction

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -175,15 +175,19 @@ class CurrencyMixin:
     # persisted. A Book instance only exists for the duration of a
     # single ``open()`` context — one tool call — so a cache cannot
     # go stale across calls; ``_invalidate_price_caches`` covers the
-    # one path that mutates prices mid-call.
+    # paths that mutate prices mid-call.
     _PRICE_LOOKUPS_ATTR = "_gnucash_mcp_price_lookups"
     _PRICE_COMMODITIES_ATTR = "_gnucash_mcp_price_commodities"
 
     @staticmethod
     def _invalidate_price_caches(book: piecash.Book) -> None:
-        """Drop the memoized price lookups. Call this after adding or
-        deleting a Price so that a later lookup in the same call sees
-        the change."""
+        """Drop the memoized price lookups. Every path that adds or
+        removes a Price row must call this after its save so a later
+        lookup in the same call sees the change — today that is
+        create_price, create_prices, and delete_price. (piecash's
+        auto-created ``type='transaction'`` placeholders on
+        cross-currency saves skip this deliberately: every consumer
+        filters them out via ``market_only``.)"""
         for attr in (
             CurrencyMixin._PRICE_LOOKUPS_ATTR,
             CurrencyMixin._PRICE_COMMODITIES_ATTR,
@@ -208,7 +212,9 @@ class CurrencyMixin:
 
         Memoized per ``(commodity_guid, currency_guid)`` on the open
         book: the first request for a pair runs one indexed query,
-        and every repeat is a dict hit. The pivot search requests the
+        and every repeat is served from memory (``market_only``
+        re-filters the memoized list per call — cheap, since a
+        pair's list is small). The pivot search requests the
         same handful of pairs once per candidate leg per commodity,
         so without the memo a whole-book report re-runs identical
         queries thousands of times; with it the query count is
@@ -236,10 +242,14 @@ class CurrencyMixin:
             prices = list(q)
             # Newest first, with same-date ties resolved by
             # _price_tie_rank rather than row order (see its
-            # docstring for the rule). Sorted once, at memoization
-            # time, so every consumer sees the same ordering.
+            # docstring for the rule), and full-key ties by guid so
+            # the ordering never falls through to arbitrary DB row
+            # order. Sorted once, at memoization time, so every
+            # consumer sees the same ordering.
             prices.sort(
-                key=lambda p: (_to_date(p.date), _price_tie_rank(p)),
+                key=lambda p: (
+                    _to_date(p.date), _price_tie_rank(p), p.guid,
+                ),
                 reverse=True,
             )
             lookups[key] = prices
@@ -885,6 +895,7 @@ class CurrencyMixin:
             book,
             commodity_guid=from_commodity.guid,
             currency_guid=to_commodity.guid,
+            market_only=True,  # load-bearing: skips FX placeholders
         ):
             p_date = _to_date(p.date)
             days = (as_of - p_date).days
@@ -907,6 +918,7 @@ class CurrencyMixin:
             book,
             commodity_guid=to_commodity.guid,
             currency_guid=from_commodity.guid,
+            market_only=True,  # load-bearing: skips FX placeholders
         ):
             p_date = _to_date(p.date)
             days = (as_of - p_date).days

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -460,6 +460,7 @@ class InvestmentsMixin:
 
             if wrote:
                 book.save()
+                self._invalidate_price_caches(book)
             return self._prices_envelope(prices, by_ref)
 
     @staticmethod

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -12895,3 +12895,48 @@ class TestGetReconciliationStatus:
         import re
         m = re.search(r"(\d+) accounts? never reconciled", recon)
         assert (int(m.group(1)) if m else 0) == buckets.get("never", 0)
+
+
+class TestSplitGraphPreload:
+    """_preload_split_graph exists so whole-book reports traverse
+    splits from memory instead of lazy-loading per row — on a large
+    book that is the difference between finishing and hanging. The
+    parked strong reference (``book._gnucash_mcp_split_graph``) looks
+    like dead code but is load-bearing: SQLAlchemy's identity map
+    holds instances only weakly, so deleting it silently restores the
+    per-row queries. This test makes that regression loud instead."""
+
+    def test_preloaded_traversal_issues_no_sql(self, test_book):
+        from sqlalchemy import event
+
+        gc = GnuCashBook(str(test_book))
+        with gc.open(readonly=True) as book:
+            gc._preload_split_graph(book)
+            # Snapshot the object lists BEFORE counting: fetching
+            # them is allowed to query; traversing them is not.
+            accounts = list(book.accounts)
+            transactions = list(book.transactions)
+
+            statements: list[str] = []
+            engine = book.session.get_bind()
+
+            def _record(conn, cursor, statement, parameters,
+                        context, executemany):
+                statements.append(statement)
+
+            event.listen(engine, "before_cursor_execute", _record)
+            try:
+                for acct in accounts:
+                    for s in acct.splits:
+                        _ = s.transaction
+                for txn in transactions:
+                    for s in txn.splits:
+                        _ = s.account
+            finally:
+                event.remove(engine, "before_cursor_execute", _record)
+
+            assert statements == [], (
+                f"split traversal after preload issued "
+                f"{len(statements)} SQL statements — the preload's "
+                f"strong reference has been lost"
+            )

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -486,3 +486,46 @@ class TestPriceLookupMemo:
                 "a price added mid-call must be visible once the "
                 "caches are invalidated"
             )
+
+    def test_every_price_write_path_invalidates_the_memo(
+        self, multi_currency_book, monkeypatch,
+    ):
+        """The cache-safety argument rests on one invariant: every
+        path that adds or removes a Price row invalidates the memo
+        after its save. create_price and delete_price were the only
+        write paths when the memo landed; bulk create_prices shipped
+        separately and silently fell outside the claim. This test
+        turns the invariant into a contract over all three."""
+        gc = GnuCashBook(str(multi_currency_book))
+        cls = type(gc)
+        calls: list[bool] = []
+        real = cls._invalidate_price_caches
+
+        def spy(book):
+            calls.append(True)
+            real(book)
+
+        monkeypatch.setattr(
+            cls, "_invalidate_price_caches", staticmethod(spy),
+        )
+
+        gc.create_price("EUR", "CURRENCY", "1.31",
+                        price_date=date(2026, 5, 1),
+                        source="user:price")
+        assert calls, "create_price must invalidate after its save"
+
+        calls.clear()
+        gc.create_prices([{
+            "ref": "r1", "commodity": "EUR",
+            "namespace": "CURRENCY", "date": date(2026, 5, 2),
+            "value": "1.32",
+        }])
+        assert calls, (
+            "bulk create_prices must invalidate after its save"
+        )
+
+        calls.clear()
+        gc.delete_price("EUR", "CURRENCY",
+                        price_date=date(2026, 5, 2),
+                        source="user:price")
+        assert calls, "delete_price must invalidate after its save"


### PR DESCRIPTION
## Summary
Review follow-ups from the adversarial pass on #126 (merged), closing the gaps the clean merge hid:

- **Bulk `create_prices` now invalidates the price memo after its save.** #126's safety argument named `create_price`/`delete_price` as the only Price write paths — true on its July-15 base, falsified by v1.4.2's bulk tool, which writes through the same `_upsert_price` chokepoint. Latent (nothing reads rates after the bulk save in-call), but the invariant is now enforced by a contract test over all three write paths.
- **SQL-count regression test for `_preload_split_graph`.** The parked strong reference looks like dead code; deleting it silently restores the per-row lazy loading that made large-book `get_book_summary` hang. Traversal after preload must issue zero SQL statements.
- **Deterministic tie-break:** `p.guid` as the final `_find_prices` sort key, so full-key ties never fall through to arbitrary DB row order.
- **Docstring honesty:** explicit `market_only=True` at the aged-rate call sites, invalidation docstring names all three write paths, dict-hit claim softened, preload memory tradeoff recorded (deliberately no size cutoff — the biggest books are the ones that need it).

## Test plan
- [x] Full suite: 1940/1940 (two new tests)
- [x] Both new tests mutation-verified: each fails when the thing it locks is broken (strong ref removed / invalidation call removed)
- [x] Report outputs byte-identical on all three sample oracles (Alex, Lin Wei, Sabine) across #126 and across this branch — independently reproduced the contributor's acceptance claim