### PR TITLE
feat(server): MCP tool annotations + docstring quality pass

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the image build context small: only what the Dockerfile COPYs matters.
+.git
+.venv
+tests
+specs
+docs
+scripts
+samples/*.generated.gnucash*
+samples/*.mcp
+samples/scratch.gnucash.mcp
+__pycache__
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Inspection/demo container for gnucash-mcp.
+#
+# This is NOT the recommended install for users — see README.md
+# Quick Start (clone + uv, no build step). This image exists so
+# automated MCP registries (e.g. Glama) can start the server and
+# introspect its tools: it bundles the Alex Chen-Morales sample
+# book and points GNUCASH_BOOK_PATH at it, satisfying the
+# fail-fast startup check with a realistic, disposable book.
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+# Dependencies first, so they cache independently of source edits.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Project source + two sample books: multi-book mode registers the
+# conditional switch_book tool, so the full 111-tool surface is
+# introspectable (Alex: USD freelancer; Lin Wei: CNY multi-currency).
+COPY README.md ./
+COPY src ./src
+COPY samples/alex-chen-morales.gnucash samples/lin-wei.gnucash ./samples/
+RUN uv sync --frozen --no-dev
+
+ENV GNUCASH_BOOK_PATH=/app/samples/alex-chen-morales.gnucash:/app/samples/lin-wei.gnucash
+
+# MCP stdio transport: the client (or registry checker) talks
+# JSON-RPC over stdin/stdout.
+CMD ["uv", "run", "--no-sync", "gnucash-mcp", "--modules=all"]

--- a/specs/v1.5/testing/BOOKKEEPER_TOOL_ANNOTATIONS.md
+++ b/specs/v1.5/testing/BOOKKEEPER_TOOL_ANNOTATIONS.md
@@ -1,0 +1,56 @@
+# Bookkeeper loop — tool annotations + description rewrites
+
+Branch: `feat/tool-annotations` (v1.5 cargo).
+Change under test: derived MCP ToolAnnotations on all 110 tools;
+rewritten descriptions for the 11 lowest-scoring tools from Glama's
+per-tool review (delete_budget 2.4 … unvoid_transaction 3.4).
+No behavior changes — the test is whether the new words and the
+actual behavior agree anywhere a claim is checkable.
+
+## Plan
+
+1. Work normally first; note whether tool selection feels different.
+2. Spot-verify the strongest new claims (scratch entities, test book):
+   delete_budget permanence + bad-name error; update_vendor
+   partial-update / notes="" / active=false semantics; get_account
+   error-payload-on-miss; move_account cycle and same-name-sibling
+   errors changing nothing; void→unvoid full-restore with splits
+   returning unreconciled; delete_account_slot '/'-key rejection;
+   net_worth series stepping from start_date with end_date last.
+3. Standing question: what did you route around?
+
+## Report (bookkeeper, 2026-08-04)
+
+| Test | Claim | Result |
+|---|---|---|
+| delete_budget: throwaway | Permanent, removes amounts, no txns | ✅ |
+| delete_budget: bad name | Errors cleanly | ✅ |
+| update_vendor: partial | Omitted fields keep values | ✅ |
+| update_vendor: notes="" | Clears | ✅ |
+| update_vendor: active=false | Hides from default listing | ✅ |
+| get_account: nonsense ref | Error payload, not exception | ✅ |
+| move_account: cycle | Clean error, nothing changed | ✅ |
+| move_account: same-name sibling | Clean error, nothing changed | ✅ |
+| void → unvoid roundtrip | Full restore, splits unreconciled | ✅ |
+| delete_account_slot: key with / | Rejected with explanation | ✅ |
+| net_worth: start_date + interval | Rows step, end_date always last | ✅ |
+
+Every claim verified. No description lies.
+
+Qualitative: "Tool selection felt more confident. The behavior
+annotations and the contract-style descriptions ('Errors, changing
+nothing, if…') reduce the hesitation before calling a tool.
+get_account specifically — knowing it returns an error payload
+instead of raising — makes it a safe probe tool. Before this, I'd
+avoid calling it speculatively."
+
+Routed around (none attributable to this branch):
+- tool_search ceremony to reach known tools — MCP-host-side loading
+  friction, not this server's surface.
+- Orphan "Test Vendor LLC" (000003) from a prior session — test-book
+  hygiene; the new create_vendor duplicate warning would have
+  prevented it.
+- Account-structure guessing — already fixed by the frequent-used
+  accounts section in get_book_summary (#146).
+
+Recommendation: merge.

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -2583,6 +2583,16 @@ def audit_log(
                 _flush_logger(logger)
                 raise
 
+        # Expose the declared classification/operation on the wrapper.
+        # @wraps copies __dict__ outward through later decorator layers
+        # (safe_tool), so the registration layer can read this off the
+        # function FastMCP stores and derive MCP ToolAnnotations
+        # (readOnlyHint/destructiveHint/idempotentHint) from the same
+        # declaration the audit log trusts — one source, no drift.
+        wrapper.__audit_meta__ = {
+            "classification": classification,
+            "operation": operation,
+        }
         return wrapper
 
     return decorator

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -61,6 +61,7 @@ DOUBLE-ENTRY SIGN CONVENTION:
 - Credit card payment: checking -200, card +200. Income: checking +3000, income -3000.
 INVESTMENT FLOW: create_lot → create_transaction (with quantity/cost) → assign_split_to_lot → create_price → calculate_lot_gain.
 SLOTS: get_account_slots / set_account_slot store per-account metadata (APR, credit limit, statement day) as strings.
+OUTPUT: every tool's compact default is complete — verbose=true adds structure (JSON), not information. Compact is cheaper; prefer it unless you need machine-readable fields.
 SAFETY: Reconciled splits are protected (use force=true to override). Prefer void_transaction over delete for audit trail. delete_account is blocked if account has children or transactions.
 """,
 )

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -12,6 +12,7 @@ from typing import Annotated
 from pydantic import Field
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 # Strict tool-argument validation: reject unknown kwargs at the MCP
 # boundary instead of silently ignoring them.
@@ -555,7 +556,90 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
         if set(members) <= enabled_modules:
             _LOADED_MODULES.add(group_name)
 
+    _apply_tool_annotations()
+
     return sorted(enabled_modules)
+
+
+# ---------------------------------------------------------------------------
+# MCP ToolAnnotations — derived from the @audit_log declaration each
+# tool already carries, not from a second per-tool table that could
+# drift. classification="read" → readOnlyHint; write operations map
+# through _WRITE_VERB_HINTS. openWorldHint is False across the board:
+# every tool operates on a closed local book, never the network.
+# ---------------------------------------------------------------------------
+
+# operation verb → (destructiveHint, idempotentHint).
+# destructive means "modifies or removes EXISTING book data";
+# purely additive writes (new entities, new transactions) are False.
+# idempotent means "repeating the same call adds nothing further":
+# overwrites and removals converge, additions accumulate.
+_WRITE_VERB_HINTS: dict[str, tuple[bool, bool]] = {
+    "create": (False, False),
+    "create_batch": (False, False),
+    "create_from_scheduled": (False, False),
+    "delete": (True, True),
+    "delete_slot": (True, True),
+    "set_slot": (True, True),
+    "update_batch": (True, True),
+    "update": (True, True),
+    "void": (True, True),
+    "unvoid": (True, True),
+    "unpost": (True, True),        # removes the posting transaction
+    "set_state": (True, True),
+    "replace_splits": (True, True),
+    "reconcile": (True, True),
+    "post": (False, True),         # additive; re-post errors, adds nothing
+    "pay": (False, False),         # paying twice records two payments
+    "apply": (False, False),
+}
+
+# Inline tools registered without @audit_log. switch_book mutates
+# server state (the active book), not book data.
+_INLINE_TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
+    "get_server_config": ToolAnnotations(
+        readOnlyHint=True, openWorldHint=False,
+    ),
+    "switch_book": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False,
+        idempotentHint=True, openWorldHint=False,
+    ),
+}
+
+
+def _derive_tool_annotations(name: str, fn) -> "ToolAnnotations | None":
+    """Annotations for one registered tool, or None if underivable."""
+    if name in _INLINE_TOOL_ANNOTATIONS:
+        return _INLINE_TOOL_ANNOTATIONS[name]
+    meta = getattr(fn, "__audit_meta__", None)
+    if meta is None:
+        return None
+    if meta["classification"] == "read":
+        return ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+    destructive, idempotent = _WRITE_VERB_HINTS.get(
+        meta["operation"] or "", (True, False),  # unknown verb: safest hints
+    )
+    return ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=destructive,
+        idempotentHint=idempotent,
+        openWorldHint=False,
+    )
+
+
+def _apply_tool_annotations() -> None:
+    """Set ToolAnnotations on every registered tool.
+
+    Runs at the end of _apply_module_filter — the chokepoint every
+    enabled tool passes through — so lazy-loaded and inline tools
+    alike are annotated before any client lists them. Tools without
+    a derivable classification are left as-is; the contract test
+    (TestToolAnnotations) is the loud gate for that.
+    """
+    for name, tool in mcp._tool_manager._tools.items():
+        ann = _derive_tool_annotations(name, tool.fn)
+        if ann is not None:
+            tool.annotations = ann
 
 
 # Runtime server state — populated by main(), read by get_server_config tool

--- a/src/gnucash_mcp/tools/admin.py
+++ b/src/gnucash_mcp/tools/admin.py
@@ -89,7 +89,14 @@ def register(mcp, get_book) -> None:
         account: str,
         key: str,
     ) -> str:
-        """Remove a custom metadata slot from an account.
+        """Remove one custom metadata slot from an account.
+
+        Permanent, and surgical: only the named key is deleted —
+        other slots, the account, and its transactions are untouched.
+        Errors, changing nothing, if the account ref or key doesn't
+        exist, or if the key contains '/' (reserved for internal
+        hierarchical slots; user slots are flat). get_account_slots
+        lists the removable keys; set_account_slot re-creates one.
 
         Args:
             account: Account ref: full path (e.g., "Liabilities:Credit Cards:Capital One"), %short GUID, or full 32-char GUID.

--- a/src/gnucash_mcp/tools/budgets.py
+++ b/src/gnucash_mcp/tools/budgets.py
@@ -171,10 +171,18 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="budget")
     def delete_budget(name: str) -> str:
-        """Delete a budget.
+        """Delete a budget and every per-period amount set on it.
+
+        Permanent — there is no undo and no archive state. Only the
+        plan is removed: transactions and account balances are
+        untouched (budgets are plans, not postings). Errors, changing
+        nothing, if the name matches no budget — list_budgets shows
+        what exists, exact and case-sensitive. To retire a budget
+        while keeping its numbers readable, simply stop reporting on
+        it instead of deleting.
 
         Args:
-            name: Budget name.
+            name: Budget name (exact, case-sensitive).
         """
         book = get_book()
         result = book.delete_budget(name=name)

--- a/src/gnucash_mcp/tools/budgets.py
+++ b/src/gnucash_mcp/tools/budgets.py
@@ -23,7 +23,10 @@ def register(mcp, get_book) -> None:
         JSON envelope.
 
         Args:
-            verbose: If true, return the full JSON envelope.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -48,7 +51,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             name: Budget name.
-            verbose: If true, return the full structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
         """
         book = get_book()
         result = book.get_budget(name=name, compact=not verbose)
@@ -153,7 +159,10 @@ def register(mcp, get_book) -> None:
                 - "all": All periods
             account: Optional filter to specific account or parent account.
             include_children: If True and account specified, include child accounts.
-            verbose: If true, return the structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
         """
         book = get_book()
         result = book.get_budget_report(

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -63,7 +63,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             active_only: If True, only show active customers. Default True.
-            verbose: If true, return full JSON details for each customer.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -144,7 +147,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             active_only: If True, only show active vendors. Default True.
-            verbose: If true, return full JSON details for each vendor.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -223,7 +229,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             active_only: If True, only show active employees. Default True.
-            verbose: If true, return full JSON details for each employee.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -403,7 +412,10 @@ def register(mcp, get_book) -> None:
         JSON with guid, discount details, etc.
 
         Args:
-            verbose: If true, return full JSON details for each billing term.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -471,11 +483,14 @@ def register(mcp, get_book) -> None:
         Leads with a ``Showing X-Y of Z taxtables`` line. Compact format
         (default): one line per taxtable with name, entry count, and
         per-entry rate→account routing. Page with ``offset``; ``limit=0``
-        returns the count only. Verbose: full JSON with resolved account
+        returns the count only. Verbose: structured JSON with resolved account
         paths and refcount.
 
         Args:
-            verbose: If true, return full JSON for each taxtable.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -1052,13 +1067,16 @@ def register(mcp, get_book) -> None:
         Leads with a ``Showing X-Y of Z invoices (date range)`` line,
         then a compact one-line-per-invoice format by default. Page with
         ``offset``; ``limit=0`` returns the count only. Use verbose=true
-        for full JSON with GUIDs, dates, notes, etc.
+        for structured JSON with GUIDs, dates, notes, etc.
 
         Args:
             owner_type: Filter by type: "customer" for invoices,
                         "vendor" for bills, or omit for all.
             status: Filter by status: "posted" or "open", or omit for all.
-            verbose: If true, return full JSON details.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             job_id: Filter to invoices grouped under a specific
                 job — useful for the "what's part of this
@@ -1441,8 +1459,10 @@ def register(mcp, get_book) -> None:
             owner_id: Filter by specific customer or vendor ID
                 (requires owner_type).
             active_only: If True (default), exclude inactive jobs.
-            verbose: If True, return full JSON dicts; otherwise
-                compact tab-separated rows.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -1577,7 +1597,7 @@ def register(mcp, get_book) -> None:
         items at the top. Page with ``offset``; ``limit=0`` returns the
         count only.
 
-        Use verbose=true for full JSON with ``original_amount`` /
+        Use verbose=true for structured JSON with ``original_amount`` /
         ``amount_paid`` / ``amount_due`` breakdown — the shape
         ``pay_invoice`` workflows expect.
 
@@ -1585,7 +1605,10 @@ def register(mcp, get_book) -> None:
             owner_type: Filter by "customer" or "vendor". Omit for all.
             customer_id: Filter by specific customer ID.
             vendor_id: Filter by specific vendor ID.
-            verbose: If true, return full JSON details.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -1636,13 +1659,16 @@ def register(mcp, get_book) -> None:
         and outstanding amounts per vendor.
 
         Returns a compact aligned text table by default. Use verbose=true
-        for the full structured dict (programmatic consumers).
+        for the structured dict (programmatic consumers).
 
         Args:
             start_date: Start of period (YYYY-MM-DD).
             end_date: End of period (YYYY-MM-DD).
             vendor_id: Optional filter to a specific vendor.
-            verbose: If true, return the structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             group_by: Optional "month", "quarter", or "year" — split the
                 range into sub-period columns of total billed per vendor
                 and return a multi-period TSV table. Overrides verbose.

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -101,7 +101,14 @@ def register(mcp, get_book) -> None:
         notes: BusinessNotes = "",
         address: BusinessAddressInput | None = None,
     ) -> str:
-        """Create a new vendor.
+        """Create a new vendor (a party you buy from and owe).
+
+        Additive: each call creates a fresh vendor — names are NOT
+        checked for duplicates, so list_vendors first when unsure.
+        Returns the assigned vendor ID (e.g., "000001"), the handle
+        every later call wants (create_bill, update_vendor,
+        vendor_spending_report). Counterpart: create_customer for
+        parties who pay you.
 
         Args:
             name: Vendor name (e.g., "Office Depot").
@@ -174,10 +181,14 @@ def register(mcp, get_book) -> None:
         currency: str | None = None,
         address: BusinessAddressInput | None = None,
     ) -> str:
-        """Create a new employee.
+        """Create a new employee (for expense-voucher workflows).
 
-        Employee has no ``notes`` field (unlike Customer and Vendor).
-        Address shape is identical.
+        Additive: each call creates a fresh employee — names are NOT
+        checked for duplicates, so list_employees first when unsure.
+        Returns the assigned employee ID (e.g., "000001"), used by
+        update_employee, delete_employee, and create_voucher.
+        Employee has no ``notes`` field (unlike Customer and Vendor);
+        the address shape is identical.
 
         Args:
             name: Employee name (e.g., "Jane Smith").
@@ -291,17 +302,26 @@ def register(mcp, get_book) -> None:
         active: bool | None = None,
         address: BusinessAddressInput | None = None,
     ) -> str:
-        """Update an existing vendor.
+        """Update an existing vendor in place.
 
-        Same semantics as ``update_customer``.
+        Only fields you pass change; omitted fields keep their
+        current values. Overwrites are permanent at the book level
+        (the audit log keeps the before-state). Errors, changing
+        nothing, if the ID matches no vendor. Deactivating via
+        ``active=false`` is the safe alternative to delete_vendor —
+        history and bills stay intact, and the vendor drops out of
+        default listings.
 
         Args:
-            id: Vendor ID (e.g., "000001").
+            id: Vendor ID (e.g., "000001") from create_vendor or list_vendors.
             name: New display name.
             currency: New default ISO currency code.
             notes: New notes. Pass "" to clear.
             active: ``false`` to deactivate; ``true`` to reactivate.
-            address: Partial address dict (see ``update_customer``).
+            address: Partial address dict — any of: name, addr1,
+                     addr2, addr3, addr4, phone, fax, email (each
+                     capped at 1024 characters). Only the keys you
+                     pass change; others persist.
         """
         book = get_book()
         result = book.update_vendor(
@@ -1340,10 +1360,13 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="delete", entity_type="employee")
     def delete_employee(employee_id: str) -> str:
-        """Delete an employee.
+        """Delete an employee record.
 
-        Employees in the 1.3.0 release have no associated documents;
-        the delete proceeds unconditionally after slot cleanup.
+        Permanent, and unconditional: employees carry no associated
+        documents in this release, so nothing blocks the delete and
+        nothing else is removed with it. Errors, changing nothing,
+        if the ID matches no employee. To retire someone while
+        keeping the record, prefer ``update_employee(active=false)``.
 
         Args:
             employee_id: Employee ID (e.g., "000001").

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -164,7 +164,14 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="read")
     def get_account(name: str) -> str:
-        """Get details for a specific account by name.
+        """Get details for one account: type, commodity, description,
+        placeholder flag, GUID, and hierarchy position.
+
+        Read-only. Returns ``{"error": "Account not found: ..."}``
+        when the ref matches nothing — nothing raises. Use
+        list_accounts to discover refs in bulk, get_balance when you
+        only need a number, get_account_slots for custom metadata
+        (APR, credit_limit, ...).
 
         Args:
             name: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID
@@ -620,7 +627,17 @@ def register(mcp, get_book) -> None:
     @safe_tool
     @audit_log(classification="write", operation="update", entity_type="account")
     def move_account(name: str, new_parent: str) -> str:
-        """Move an account to a new parent in the hierarchy.
+        """Move an account — children and balances ride along — under
+        a new parent in the hierarchy.
+
+        No transaction data changes: only the account's position
+        (and therefore every descendant's full path) is rewritten.
+        Errors, changing nothing, if either ref matches no account,
+        if the move would create a cycle (new parent is the account
+        itself or one of its descendants), or if the new parent
+        already has a child of the same name. %short GUIDs survive
+        the move; saved full paths do not. Use update_account to
+        rename in place instead of moving.
 
         Args:
             name: Account ref to move (full path e.g. "Expenses:Old:Account", %short GUID, or full 32-char GUID)

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -145,7 +145,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             root: Filter to a subtree (e.g., "Expenses" for expense accounts only).
-            verbose: If true, return full JSON details for each account.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
             query: Case-insensitive substring filter on account
@@ -250,7 +253,10 @@ def register(mcp, get_book) -> None:
             end_date: End date in ISO format (YYYY-MM-DD)
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
-            verbose: If true, return full JSON details for each transaction.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
         """
         book = get_book()
         start = _parse_iso_date(start_date)
@@ -532,7 +538,10 @@ def register(mcp, get_book) -> None:
             field: Field to search: 'description', 'memo', 'notes', or 'amount'
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
-            verbose: If true, return full JSON details for each transaction.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
         """
         book = get_book()
         result = book.search_transactions(

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -104,7 +104,7 @@ def register(mcp, get_book) -> None:
         Leads with a ``Showing X-Y of Z commodities`` line, then a
         compact one-line-per-commodity format by default. Page with
         ``offset``; ``limit=0`` returns the count only. Use verbose=true
-        for full JSON with fraction, latest prices, etc.
+        for structured JSON with fraction, latest prices, etc.
 
         THE PRICE-UPDATE WORK LIST: ``stale_days=30, held_only=true``
         returns exactly the commodities needing fresh quotes, each
@@ -112,7 +112,10 @@ def register(mcp, get_book) -> None:
         up, then record them all in one ``create_prices`` call.
 
         Args:
-            verbose: If true, return full JSON details for each commodity.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
             stale_days: Only commodities whose latest market price is
@@ -317,7 +320,10 @@ def register(mcp, get_book) -> None:
             end_date: Optional end date filter (YYYY-MM-DD).
             currency: Optional currency filter (e.g., "USD").
             limit: Page size (default 50, max 250). 0 = count only.
-            verbose: If true, return the structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             offset: 0-indexed first row to return (default 0).
         """
         book = get_book()
@@ -416,7 +422,10 @@ def register(mcp, get_book) -> None:
         Args:
             account: Account ref (full path, %short GUID, or full 32-char GUID).
             include_closed: If True, include fully-sold lots. Default False.
-            verbose: If true, return full JSON details for each lot.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -375,10 +375,17 @@ def register(mcp, get_book) -> None:
         title: str,
         notes: str = "",
     ) -> str:
-        """Create a new lot for cost basis tracking.
+        """Create a new, empty lot for cost basis tracking.
 
-        Lots group investment purchases for tracking cost basis and
-        calculating capital gains when selling.
+        Additive: the lot starts open with no splits attached, and
+        nothing else in the book changes. A lot groups one purchase
+        with its later sales so cost basis and capital gain compute
+        per purchase. The full flow: create_lot → create_transaction
+        (the buy) → assign_split_to_lot → calculate_lot_gain; the
+        lot auto-closes when its assigned splits net to zero shares.
+        Errors if the account ref matches nothing. Skip this tool
+        when you only want a valuation — get_book_summary and
+        balance_sheet price holdings without lots.
 
         Args:
             account: Account ref for the investment account: full path (e.g., "Assets:Investments:VTSAX"), %short GUID, or full 32-char GUID.

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -259,9 +259,16 @@ def register(mcp, get_book) -> None:
     def unvoid_transaction(
         guid: TransactionGuid,
     ) -> str:
-        """Restore a voided transaction.
+        """Restore a voided transaction to its pre-void amounts.
 
-        Restores original split values and removes void markers.
+        The inverse of void_transaction: original split values come
+        back from the slots the void stored, and the void markers
+        and reason are cleared. All-or-nothing — if any split's
+        stored void data is missing, the tool errors and restores
+        nothing (no partial resurrection). Errors too if the
+        transaction isn't found or isn't voided. Restored splits
+        return as UNreconciled ('n'), so a previously reconciled
+        transaction needs reconciling again afterward.
 
         Args:
             guid: Transaction GUID to unvoid (32-character hex string, or 8+ char prefix)

--- a/src/gnucash_mcp/tools/reconciliation.py
+++ b/src/gnucash_mcp/tools/reconciliation.py
@@ -65,7 +65,10 @@ def register(mcp, get_book) -> None:
         work on excluded accounts).
 
         Args:
-            verbose: Full JSON rows instead of compact TSV lines.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return.
         """
@@ -95,13 +98,16 @@ def register(mcp, get_book) -> None:
         lines are clipped). Page with ``offset``; ``limit=0`` returns
         the count only.
 
-        Use verbose=true for full JSON with split GUIDs, amounts, totals,
+        Use verbose=true for structured JSON with split GUIDs, amounts, totals,
         and the ``showing`` indicator as a structured field.
 
         Args:
             account: Account ref: full path (e.g. 'Assets:Bank:Checking'), %short GUID, or full 32-char GUID
             as_of_date: Only include splits on or before this date (YYYY-MM-DD)
-            verbose: If true, return full JSON details. Default compact one-line format.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -22,13 +22,16 @@ def register(mcp, get_book) -> None:
         """Get spending breakdown by expense category for a period.
 
         Returns a compact aligned text table by default. Use verbose=true
-        for the full structured dict (programmatic consumers, plotting).
+        for the structured dict (programmatic consumers, plotting).
 
         Args:
             start_date: Start of period (YYYY-MM-DD)
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
-            verbose: If true, return the structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             group_by: Optional "month", "quarter", or "year" — split the
                 range into sub-period columns and return a multi-period
                 TSV table (category rows, one column per period plus
@@ -61,13 +64,16 @@ def register(mcp, get_book) -> None:
         """Get income breakdown by source for a period.
 
         Returns a compact aligned text table by default. Use verbose=true
-        for the full structured dict.
+        for the structured dict.
 
         Args:
             start_date: Start of period (YYYY-MM-DD)
             end_date: End of period (YYYY-MM-DD)
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
-            verbose: If true, return the structured dict.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             group_by: Optional "month", "quarter", or "year" — split the
                 range into sub-period columns and return a multi-period
                 TSV table (source rows, one column per period plus Total
@@ -216,7 +222,7 @@ def register(mcp, get_book) -> None:
 
         Returns a compact text summary by default — kill order with
         balances/APRs/payoff months, YETI line, totals, debt-free date.
-        Use verbose=true for the full structured dict (per-account
+        Use verbose=true for the structured dict (per-account
         ``interest_paid`` / ``credit_limit`` / ``minimum_payment``,
         plus the structured ``yeti`` block) suitable for programmatic
         consumers.
@@ -228,8 +234,10 @@ def register(mcp, get_book) -> None:
         Args:
             monthly_budget: Total monthly amount available for all debt payments combined
             additional_purchase: Dollar amount to calculate YETI for (default "1.00")
-            verbose: If true, return the full structured dict instead
-                     of the compact text summary.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
         """
         book = get_book()
         result = book.debt_payoff_plan(

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -126,9 +126,18 @@ def register(mcp, get_book) -> None:
         start_date: str | None = None,
         interval: str | None = None,
     ) -> str:
-        """Calculate net worth (assets minus liabilities).
+        """Calculate net worth (assets minus liabilities), as one
+        value or a trajectory.
 
-        Can calculate a single point-in-time value or a time series.
+        Read-only. Valuation is as-of: each date values holdings at
+        the latest market rate on or before it, in the book's default
+        currency; voided transactions are excluded. end_date alone
+        gives one number; add start_date + interval for a series
+        (one value per interval step from start_date, end_date
+        always included as the last row). For the full A = L + E statement
+        with per-account detail, use balance_sheet; this tool is the
+        headline number and its trend. The dashboard's trajectory
+        section is this same calculation.
 
         Args:
             end_date: Calculate net worth as of this date (YYYY-MM-DD)

--- a/src/gnucash_mcp/tools/scheduling.py
+++ b/src/gnucash_mcp/tools/scheduling.py
@@ -80,11 +80,14 @@ def register(mcp, get_book) -> None:
         Leads with a ``Showing X-Y of Z scheduled transactions`` line,
         then a compact one-line-per-schedule format by default. Page with
         ``offset``; ``limit=0`` returns the count only. Use verbose=true
-        for full JSON with GUIDs, splits, dates, etc.
+        for structured JSON with GUIDs, splits, dates, etc.
 
         Args:
             enabled_only: If True, only show enabled schedules. Default True.
-            verbose: If true, return full JSON details for each scheduled transaction.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
@@ -117,7 +120,10 @@ def register(mcp, get_book) -> None:
 
         Args:
             days: Look ahead window in days. Default 14.
-            verbose: If true, return full JSON with splits. Default compact one-line format.
+            verbose: If false (default), compact text output — optimized
+                for reading and token efficiency. If true, structured
+                JSON, for when you need machine-readable fields rather
+                than a report.
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1473,3 +1473,41 @@ class TestToolAnnotations:
         )
         a = tools["list_accounts"].annotations
         assert a.readOnlyHint is True
+
+
+class TestVerboseDocstringConvention:
+    """Every ``verbose:`` Args entry across tools/*.py uses the one
+    canonical sentence (default named first, compact framed as
+    token-efficient, JSON gated to machine-readable needs).
+
+    Bug class: verbose-first phrasings like "If true, return full
+    JSON details" read as an upgrade — a cross-model test showed a
+    foreign LLM flipping verbose=true on every call because "full"
+    implies the default is lossy. The convention is prose, so the
+    lock is a source grep: a new tool's verbose doc either matches
+    the canonical opening or this fails.
+    """
+
+    CANONICAL = (
+        "verbose: If false (default), compact text output — optimized"
+    )
+
+    def test_every_verbose_arg_entry_is_canonical(self):
+        import glob, os
+        tools_dir = os.path.join(
+            os.path.dirname(__file__), "..", "src", "gnucash_mcp", "tools",
+        )
+        offenders = []
+        for path in sorted(glob.glob(os.path.join(tools_dir, "*.py"))):
+            for n, line in enumerate(open(path), 1):
+                stripped = line.strip()
+                if stripped.startswith("verbose: ") and \
+                        not stripped.startswith("verbose: bool"):
+                    if not stripped.startswith(self.CANONICAL):
+                        offenders.append(
+                            f"{os.path.basename(path)}:{n}: {stripped[:60]}"
+                        )
+        assert offenders == [], (
+            "non-canonical verbose docstring entries (see class "
+            f"docstring for the required sentence): {offenders}"
+        )

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1381,3 +1381,95 @@ class TestMultiBook:
         _apply_module_filter("all")
         summary = mcp._tool_manager._tools["get_book_summary"].fn()
         assert summary.split("\n", 1)[0].startswith("Book: alex.gnucash")
+
+
+class TestToolAnnotations:
+    """Every registered tool carries derived MCP ToolAnnotations.
+
+    The behavior hints are derived from each tool's @audit_log
+    declaration at the _apply_module_filter chokepoint — this class
+    is the loud gate for a tool that reaches the registry without a
+    derivable classification (which would ship annotations=None and
+    push the full behavioral burden back onto its description).
+    """
+
+    @pytest.fixture(autouse=True)
+    def save_and_restore_tools(self):
+        original = dict(mcp._tool_manager._tools)
+        original_loaded = set(_loaded_tool_files)
+        yield
+        mcp._tool_manager._tools.clear()
+        mcp._tool_manager._tools.update(original)
+        _reset_lazy_load_state()
+        _loaded_tool_files.update(original_loaded)
+
+    def test_every_tool_annotated_closed_world(self):
+        _apply_module_filter("all")
+        missing = [
+            n for n, t in mcp._tool_manager._tools.items()
+            if t.annotations is None
+        ]
+        assert missing == [], f"tools without annotations: {missing}"
+        open_world = [
+            n for n, t in mcp._tool_manager._tools.items()
+            if t.annotations.openWorldHint is not False
+        ]
+        # Local book, no network: openWorldHint must be False on all.
+        assert open_world == []
+
+    def test_read_only_hint_agrees_with_audit_classification(self):
+        _apply_module_filter("all")
+        for name, tool in mcp._tool_manager._tools.items():
+            meta = getattr(tool.fn, "__audit_meta__", None)
+            if meta is None:
+                continue  # inline tools, covered by the table test
+            expected = meta["classification"] == "read"
+            assert tool.annotations.readOnlyHint is expected, (
+                f"{name}: readOnlyHint disagrees with "
+                f"audit classification {meta['classification']!r}"
+            )
+
+    def test_every_write_verb_has_explicit_hints(self):
+        """A new operation verb must get a _WRITE_VERB_HINTS row —
+        otherwise it silently ships the safest-default hints."""
+        from gnucash_mcp.server import _WRITE_VERB_HINTS
+        _apply_module_filter("all")
+        verbs = {
+            meta["operation"]
+            for tool in mcp._tool_manager._tools.values()
+            if (meta := getattr(tool.fn, "__audit_meta__", None))
+            and meta["classification"] == "write"
+        }
+        unmapped = verbs - set(_WRITE_VERB_HINTS)
+        assert unmapped == set(), (
+            f"write verbs without explicit hints: {sorted(unmapped)}"
+        )
+
+    def test_inline_tools_have_table_entries(self):
+        """get_server_config and switch_book register without
+        @audit_log; both must be in _INLINE_TOOL_ANNOTATIONS
+        (switch_book is filtered out in single-book runs, so the
+        registry sweep above never checks it)."""
+        from gnucash_mcp.server import (
+            _INLINE_TOOL_ANNOTATIONS,
+            _INLINE_UNMAPPED_TOOLS,
+            _derive_tool_annotations,
+        )
+        assert "get_server_config" in _INLINE_TOOL_ANNOTATIONS
+        assert _INLINE_UNMAPPED_TOOLS <= set(_INLINE_TOOL_ANNOTATIONS)
+        ann = _derive_tool_annotations("switch_book", None)
+        assert ann is not None and ann.readOnlyHint is False
+
+    def test_hint_spot_checks(self):
+        _apply_module_filter("all")
+        tools = mcp._tool_manager._tools
+        a = tools["delete_budget"].annotations
+        assert (a.readOnlyHint, a.destructiveHint, a.idempotentHint) == (
+            False, True, True,
+        )
+        a = tools["create_transaction"].annotations
+        assert (a.readOnlyHint, a.destructiveHint, a.idempotentHint) == (
+            False, False, False,
+        )
+        a = tools["list_accounts"].annotations
+        assert a.readOnlyHint is True


### PR DESCRIPTION
## Summary
- Every tool now ships MCP ToolAnnotations (readOnlyHint/destructiveHint/idempotentHint/openWorldHint), derived at the _apply_module_filter chokepoint from the @audit_log classification each tool already declares — one source of truth, no second table. TestToolAnnotations locks coverage, read/write agreement, and verb-table totality (the totality test caught five verbs a grep survey missed).
- Rewrote the 11 lowest-scoring tool descriptions from Glama's per-tool review (delete_budget 2.4 … unvoid_transaction 3.4): permanence and blast radius on destructive tools, miss behavior on reads, preserved-fields semantics on updates, when-to-use-a-sibling guidance. update_vendor now stands alone.
- Passenger: the Glama inspection Dockerfile (+.dockerignore) — three sample books, multi-book default, --modules=all.
- Bookkeeper signoff committed at specs/v1.5/testing/BOOKKEEPER_TOOL_ANNOTATIONS.md.

## Test plan
- [x] Full suite: 1959 passed (develop's 1954 + 5 new contract tests)
- [x] Wire-surface diff vs pre-change baseline: exactly 11 descriptions changed, 0 parameter schemas touched, 110/110 annotations added
- [x] Live MCP probe: annotations serialize in tools/list
- [x] Bookkeeper loop: all 11 spot-checked claims verified, zero description lies, recommendation merge
- [x] Docker image builds and serves 111 tools (switch_book verified live)