### PR TITLE
fix(business): document lifecycle fixes, mcp<2 cap, install guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,17 +152,20 @@ what's in each.
 
 ## Quick Start (5 minutes)
 
-### 1. Download
+### 1. Download and install
 
 ```bash
 git clone https://github.com/ninetails-io/gnucash-mcp.git
+uv tool install -e ./gnucash-mcp
 ```
 
-That's the whole install — there's no build or install step. The
-client launches the server with `uv run` (next step), which syncs
-dependencies from the lockfile automatically on every start. To
-update later, just `git pull` inside the repo; the next launch
-picks up new code *and* new dependencies with nothing else to do.
+The second command gives you a `gnucash-mcp` command (in
+`~/.local/bin`) with its dependencies in a private environment —
+your other Python projects never see them. The `-e` makes it an
+*updatable* install: the command runs whatever code is in your
+clone, so updating is `git pull` plus a server restart. The one
+exception: if an update changes *dependencies*, run
+`uv tool install -e ./gnucash-mcp --reinstall` once.
 
 > If you don't have `uv`, install it with one line:
 > `curl -LsSf https://astral.sh/uv/install.sh | sh`
@@ -185,21 +188,14 @@ Find your Claude Desktop config:
 - **Mac:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add this — replace `/path/to/gnucash-mcp` with the repo you just
-cloned, and `GNUCASH_BOOK_PATH` with your book's path:
+Add this — replace `yourname` in both paths:
 
 ```json
 {
   "mcpServers": {
     "gnucash": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--directory",
-        "/path/to/gnucash-mcp",
-        "gnucash-mcp",
-        "--modules=all"
-      ],
+      "command": "/Users/yourname/.local/bin/gnucash-mcp",
+      "args": ["--modules=all"],
       "env": {
         "GNUCASH_BOOK_PATH": "/Users/yourname/gnucash-mcp-scratch/alex.gnucash"
       }
@@ -208,12 +204,13 @@ cloned, and `GNUCASH_BOOK_PATH` with your book's path:
 }
 ```
 
-`uv run --directory` runs the server straight from the clone,
-resyncing dependencies each launch — so a `git pull` is all it
-takes to update. `--modules=all` loads every tool (111 of them)
-so you can poke at anything. Once you know what you actually use,
-narrow it — see [choosing a module set](#choosing-a-module-set)
-below.
+Use the **full path** to the command: GUI apps launch without
+your shell's PATH, so a bare `gnucash-mcp` may not resolve even
+though it works in your terminal. (`uv tool dir --bin` prints
+the right directory if yours differs.) `--modules=all` loads
+every tool (111 of them) so you can poke at anything. Once you
+know what you actually use, narrow it — see
+[choosing a module set](#choosing-a-module-set) below.
 
 Quit Claude Desktop completely (not just close the window —
 quit) and reopen it. Look for the hammer 🔨 icon next to the
@@ -276,13 +273,20 @@ point at your own SQLite-format book. Restart Claude Desktop.
 ### Other AI clients
 
 This is an [MCP](https://modelcontextprotocol.io/) server, so
-it works with any client that speaks MCP. Notes for non–Claude
-Desktop clients:
+it works with any client that speaks MCP. Everywhere below,
+`gnucash-mcp` means the full path from the install step
+(`/Users/yourname/.local/bin/gnucash-mcp`; `uv tool dir --bin`
+prints yours).
 
-- **Claude Code**: `claude mcp add-json gnucash '{"command":"uv","args":["run","--directory","/path/to/gnucash-mcp","gnucash-mcp","--modules=all"],"env":{"GNUCASH_BOOK_PATH":"/path/to/your/book.gnucash"}}'`
+- **Claude Code**: `claude mcp add-json gnucash '{"command":"/Users/yourname/.local/bin/gnucash-mcp","args":["--modules=all"],"env":{"GNUCASH_BOOK_PATH":"/path/to/your/book.gnucash"}}'`
   Add `--scope user` for all projects, `--scope project` for
   this one only.
-- **Gemini CLI**: `gemini mcp add -e GNUCASH_BOOK_PATH="/path/to/your/book.gnucash" gnucash uv run --directory /path/to/gnucash-mcp gnucash-mcp --modules=all`
+- **ChatGPT (desktop app / Codex)**: Settings → Connectors →
+  Add MCP server. Name it `gnucash-mcp`, type **STDIO**,
+  "Command to launch" = the full `gnucash-mcp` path, one
+  argument `--modules=all`, and an environment variable
+  `GNUCASH_BOOK_PATH` = your book's path.
+- **Gemini CLI**: `gemini mcp add -e GNUCASH_BOOK_PATH="/path/to/your/book.gnucash" gnucash /Users/yourname/.local/bin/gnucash-mcp --modules=all`
   This writes a project `.gemini/settings.json` with the server
   registered; run `/mcp list` inside Gemini to confirm it shows
   `gnucash - Ready`. (Verified on Linux — if GnuCash never offered
@@ -291,15 +295,18 @@ Desktop clients:
   [@hpuri](https://github.com/hpuri)'s testing in
   [#89](https://github.com/ninetails-io/gnucash-mcp/issues/89) —
   thanks.)
-- **Anything else**: set `GNUCASH_BOOK_PATH` and run `uv run
-  --directory /path/to/gnucash-mcp gnucash-mcp`. Any client that
-  can spawn a command and speak MCP over stdio will work.
+- **Anything else**: set `GNUCASH_BOOK_PATH` and run
+  `gnucash-mcp`. No install at all? `uv run --directory
+  /path/to/gnucash-mcp gnucash-mcp` and
+  `python -m gnucash_mcp` (with the repo on the path) both
+  still work. Any client that can spawn a command and speak
+  MCP over stdio will do.
 
 ---
 
 ## Choosing a module set
 
-`--modules=all` is the easy default — every tool, 107 of them.
+`--modules=all` is the easy default — every tool, 111 of them.
 For day-to-day use you'll probably want less. Pick the role that
 matches how you'll talk to the server. Each role is a *group*
 that expands to the underlying tool modules; you can also pick
@@ -658,11 +665,13 @@ uv run ruff check src/ tests/
 uv run black --check src/ tests/
 ```
 
-The `uv run --directory PATH ...` form the Quick Start uses is
-also how you point a client at a specific worktree — swap the
-directory and you're running that checkout, no reinstall. If you
-prefer a `gnucash-mcp` binary on your PATH instead, `uv tool
-install -e ./gnucash-mcp` still works and tracks your source.
+The installed `gnucash-mcp` command tracks your clone live: it
+serves whatever branch the checkout is on, so switching branches
+switches the served code at the next restart — handy for testing,
+worth remembering when you forget you're mid-branch. To run a
+DIFFERENT checkout (a second worktree) without touching the
+install, `uv run --directory PATH gnucash-mcp` still runs any
+directory you point it at.
 
 The server is built on
 [piecash](https://github.com/sdementen/piecash) (Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ authors = [
     { name = "Stephen", email = "stephen@ninetails.io" }
 ]
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    # <2: mcp 2.0.0 moved/removed mcp.server.fastmcp, and the
+    # strict-kwargs patch reaches into 1.x FastMCP internals.
+    "mcp[cli]>=1.0.0,<2",
     "piecash>=1.2.0",
     "python-dateutil>=2.8.0",
 ]

--- a/specs/v1.5/BUSINESS_CONSOLIDATION_SPEC.md
+++ b/specs/v1.5/BUSINESS_CONSOLIDATION_SPEC.md
@@ -1,0 +1,153 @@
+# Business-surface consolidation — v1.5 implementation spec
+
+For the next session picking this up cold. Everything you need is
+in this file, `CODEX_TOOL_GUIDE.md` beside it (the full outside
+audit this spec distills — read its "Consolidation plan" section
+before writing code), and `CODEX_TEST_FINDINGS.md` +
+`testing/CROSS_MODEL_BATTERY_2026_08_05.md` for the bug/battery
+history that motivated all of this.
+
+## Status and authority
+
+- Design source: ChatGPT/Codex contract audit, 2026-08-05, on
+  branch `fix/business-doc-lifecycle` (all 111 tools cataloged,
+  suite verified 1,972 passing at time of audit).
+- Prior ruling: consolidation was litigated pre-v1.3 and HELD AT
+  NO (asymmetry, LLM clarity over count, --modules as the lever).
+  The re-litigation trigger ("if the count grows") has since been
+  met three independent ways: Glama scored Tool Count 2/5, the
+  outside-model battery flagged the document family as
+  non-orthogonal, and the Codex audit produced this design.
+- Stephen has NOT yet ruled GO on implementation. This spec is the
+  shovel-ready plan for when he does. Do not start without his
+  word; do not open a PR before the validation loop (standing
+  rules).
+
+## The decision already argued (don't re-derive)
+
+Consolidate across **party/document TYPE**; keep materially
+different **ACTIONS** as separate tools. Reject the aggressive
+19-tool variant and every `manage_*(action=...)` union: they
+sacrifice truthful per-action ToolAnnotations, which this repo
+ships (derived from @audit_log at the _apply_module_filter
+chokepoint) and scored with. One tool = one safety class, always.
+The target is the audit's "strict annotation fidelity" variant:
+
+**Business surface: 48 → 25 tools** (all-modules ≈ 87 + switch_book).
+
+- Parties (15 → 5): `create_party`, `list_parties`, `get_party`,
+  `update_party`, `delete_party` — `party_type:
+  customer|vendor|employee` required (ID counters collide across
+  types; this repo has the scars: see the apply_credit_note
+  owner-mismatch fix). Employee has no notes field — reject,
+  don't ignore.
+- Documents (18 → 8): `create_document`, `add_document_entry`,
+  `list_documents`, `get_document`, `post_document`,
+  `unpost_document`, `pay_document`, `delete_document` —
+  `document_type: invoice|bill|voucher|credit_note`. Keep
+  `apply_credit_note` separate (9 doc-family tools total) rather
+  than folding a settlement union into pay: the union needs too
+  many nullable fields.
+- Reference data (7 → 4): `list_taxtables`, `get_taxtable` merged
+  into list(id=...) or kept — pick ONE pattern and match jobs;
+  mutations stay separate per safety class. Billterms gain
+  nothing from unions: keep `create_billterm`, `list_billterms`.
+- Jobs (6 → 5): merge `get_job` into `list_jobs(id=...)` (both
+  reads, same annotations); keep create/update/delete/report.
+- Reports (2, renamed 1): `get_outstanding_invoices` →
+  `get_outstanding_documents`; `vendor_spending_report` stays.
+
+Arithmetic check before you trust any count: recount from
+TOOL_MODULES, not from this file. The audit itself shipped one
+count error and corrected it.
+
+## Implementation shape (the audit's steps, amended)
+
+1. NO book-layer rewrite. The book mixin already routes
+   polymorphically (`_find_invoice`, `_effective_owner_type`,
+   `_ENTRY_CONFIG`, shared create path with `extra_slots`).
+   Consolidation is a tool-wrapper routing layer in
+   `tools/business.py`.
+2. `Literal` types for `party_type` / `document_type`; typed
+   `TaxTableEntryInput` nested model replacing `list[dict]`
+   (audit doc-fix #7 — do it here, it changes parameter schemas
+   and belongs in this schema-changing release).
+3. Every mutation returns canonical `type`, `id`, `owner_type`,
+   `status` — no follow-up lookup needed (the correlatable-output
+   doctrine).
+4. New names registered in revised `freelancer` /
+   `business_complete` TOOL_MODULES lists; old names move to an
+   opt-in `business_legacy` module for ONE compatibility cycle.
+   Never expose old and new by default together. Note
+   MODULE_BACKED_BY still maps everything onto tools/business.py.
+5. Annotations derive automatically (audit_log classification →
+   hints) — new wrappers must carry @audit_log like all others;
+   the TestToolAnnotations contract will fail loud if not.
+6. Contract tests to extend: TOOL_MODULES set-equality counts,
+   TestToolFileVsModulesMapping, TestToolAnnotations,
+   TestVerboseDocstringConvention (new list tools must use the
+   canonical verbose sentence), TestShortGuidRoundTripClosure
+   untouched (no new GUID entities). Add: legacy-parity test
+   (every legacy tool's behavior reachable via a new tool),
+   cross-type ID-collision error tests, credit-note identity
+   through post/unpost (exists: TestCodexCrossModelFindings),
+   voucher lifecycle via new names.
+7. Audit-log dispatch: new wrappers keep existing
+   (entity_type, operation) pairs by routing to the same book
+   methods — verify the dispatcher renders new-tool writes
+   identically (the audit log is the human-readable surface).
+
+## Validation gates, in order
+
+1. Full suite green.
+2. Wire-surface capture before/after (scratchpad JSON diff — the
+   pattern used for the annotations branch): new surface counts
+   verified, legacy module verified absent by default.
+3. Bookkeeper (Abe) round on the new names — he is ONE persona
+   (books + testing + specs); test plan into specs/v1.5/testing/.
+4. Cross-model battery COLD against consolidated names (reuse
+   testing/CROSS_MODEL_BATTERY_2026_08_05.md structure; foreign
+   models must select correct tools from names + docstrings with
+   no legacy exposure). This gate is the audit's own step 9 and
+   non-negotiable: the consolidation exists FOR foreign callers.
+5. PR only after all four; Stephen's word before it opens.
+
+## Loose ends folded in or explicitly out
+
+- IN: audit doc-fixes #4 (list_invoices → list_documents naming
+  resolves it; get Stephen's ruling on whether vouchers/credit
+  notes are filterable there), #5 (Args blocks for
+  update_transactions/create_prices), #7 (typed tax entries).
+- Possibly already done on fix/business-doc-lifecycle — VERIFY
+  before redoing: doc-fixes #1-#3 (owner_type Args lines naming
+  employee; post_invoice lead sentence), #6 (create_prices fixed
+  column order in first paragraph). Grep, don't trust.
+- OUT (separate concerns): Codex-presentation instruction
+  duplication (client adapter bug, not server); MCPB packaging;
+  enter_statement; the `cur` column / two-tools question — the
+  audit's consolidation makes that conversation easier but is not
+  it.
+- Docs: README "Choosing a module set" counts and the Glama env
+  schema description mention module tool counts — update both.
+  CHANGELOG entry should lead with WHY (three independent
+  reviewers, one verdict) per house style.
+
+## Known traps for this specific work
+
+- Per-type ID collision is the house bug class (customer 000005
+  vs vendor 000005): every new tool that takes an ID must require
+  or unambiguously infer its type, and every error message must
+  name the type. Test the collision explicitly.
+- piecash slot-sweep landmine: deleting a transaction that
+  carries a GUID-valued slot (gncInvoice) cascades away the
+  referenced invoice's own slots. unpost_invoice restores the
+  credit-note flag by raw SQL — preserve that behavior through
+  any refactor, and consider the same hazard for any new delete
+  path near posted documents.
+- `_gate_owner_type` gates Freelancer/Business module splits on
+  shared tools — the new document tools need the same gating so
+  --modules=freelancer still can't touch vendor documents.
+- Version numbering is Stephen's; GitHub must never mint v1.4.3
+  (Glama owns that number). This work is v1.5.0 by every plan.
+
+tekeli-li. The letters have the rest.

--- a/specs/v1.5/CODEX_TEST_FINDINGS.md
+++ b/specs/v1.5/CODEX_TEST_FINDINGS.md
@@ -1,0 +1,84 @@
+# Cross-model test findings — ChatGPT Codex battery, 2026-08-05
+
+First deliberate foreign-model bookkeeper run: ChatGPT Codex against
+the repo checkout's `samples/alex-chen-morales.gnucash` (local MCP,
+v1.4.2, all modules), ~10 minutes, majority of the 111-tool surface
+exercised. Overall verdict: functional 8/10, payload design 8.5/10,
+"ready to ship." Three workflow-correctness findings, all in the
+business module's credit-note/voucher corner. Targeted at the 1.4.4
+patch release alongside the annotations + CLI-strictness branches.
+
+## F1 — apply_credit_note error message is self-contradictory (CONFIRMED)
+
+Reported: applying `ZZZ-CN-1` to `ZZZ-INV-POST` failed with
+"credit note belongs to `000005` but target belongs to `000005`,
+and they must match."
+
+Mechanism (confirmed by code read, `book/business.py`
+`apply_credit_note`, ~line 6166): the same-owner check correctly
+compares `owner_guid`s, but the error message renders each owner's
+**ID string**. Entity ID sequences are per-type, so customer
+`000005` and vendor `000005` are different entities with identical
+IDs — a true mismatch prints as a contradiction. The tester created
+both a disposable customer and a disposable vendor, which is exactly
+the collision.
+
+Fix shape: include the owner type label (and ideally name) in the
+message: "belongs to vendor '000005' (Acme LLC) but target belongs
+to customer '000005' (…)". Audit sibling messages: the create-side
+applies-to check (~line 4221) compares by **ID string**, not GUID —
+that one may be a REAL comparison bug (cross-type ID collision would
+false-PASS), stricter than the message cosmetics. Grep for other
+`owner.id` comparisons; the check-vs-act class.
+
+## F2 — credit-note identity lost after unpost (REPRO NEEDED)
+
+Reported: `unpost_invoice("ZZZ-CN-1")` succeeded, then
+`get_invoice("ZZZ-CN-1")` returned `type: "invoice"` and
+`delete_credit_note` rejected it; only `delete_invoice` worked.
+
+Code context: credit-note-ness is the GnuCash `credit-note` slot
+(int 1) read via `_get_is_credit_note`. `unpost_invoice` itself
+reads the flag BEFORE deleting lot/txn and returns
+`type: "credit_note"` correctly — but a comment there warns slot
+reads "can flake ('Multiple rows returned with uselist=False')
+while lots/transactions are being deleted in the same session."
+Hypothesis: the unpost path corrupts, duplicates, or cascades away
+the invoice's slot row, so later sessions misread the flag.
+Reproduce on a scratch book: create CN → post → unpost → reopen →
+`_get_is_credit_note`; inspect the slots table directly for the
+CN's obj_guid before/after.
+
+## F3 — voucher posting unreachable via post_invoice (REPRO NEEDED)
+
+Reported: voucher create/add-entry/delete all work, but
+`post_invoice(id="ZZZ-VOUCH-1")` → "Document not found", and no
+voucher-specific post tool exists.
+
+Code context: `post_invoice`'s docstring offers only
+customer/vendor for `owner_type`; the no-filter finder path should
+still match a voucher row by ID. Candidate causes: (a)
+`create_voucher` auto-assigns IDs from `counter_exp_voucher` and
+ignores/replaces the caller's `id` (so "ZZZ-VOUCH-1" was never the
+stored ID); (b) `_find_invoice` excludes owner_type=5 somewhere;
+(c) voucher posting genuinely unsupported → then it's a docs +
+error-message gap at minimum. v1.3 letters imply posting math
+handles the voucher quadrant, so (a) is the leading suspect.
+
+## Payload notes (no action required, recorded for the record)
+
+Cross-model grades: TSV batch entry A ("excellent for batch
+entry"); short GUIDs A- ("materially improves payload size");
+create_prices B+ (strict optional-column ORDER is easy to trip
+over — possible future leniency); get_unreconciled_splits verbose
+on large accounts C+ (pagination correct, still heavy — known).
+
+## Test residue
+
+The run wrote into the working-tree copy of
+`samples/alex-chen-morales.gnucash` (repo checkout). Leftovers:
+posted/paid ZZZ-INV-POST and ZZZ-BILL-1, customer 000005, vendor
+000005, `Expenses:ZZZ MCP TEST 2026-08-05`, voided txn 87585ada.
+Samples are frozen oracles — `git restore` the file rather than
+hand-cleaning (also discards pre-existing drift; the committed
+version is the reference).

--- a/specs/v1.5/CODEX_TOOL_GUIDE.md
+++ b/specs/v1.5/CODEX_TOOL_GUIDE.md
@@ -1,0 +1,585 @@
+# GnuCash MCP Tool Guide and Interface Assessment
+
+Assessment target: `/Users/stephen/Projects/gnucash-mcp`, branch
+`fix/business-doc-lifecycle`, with the server reloaded on 2026-08-05.
+The repository declares version 1.4.2 while this branch also contains
+the v1.5 contract and lifecycle work.
+
+This guide covers all 110 tools in `TOOL_MODULES` plus the conditional
+`switch_book` tool, for 111 tools in a multi-book, all-modules session.
+
+## Executive assessment
+
+Overall LLM interface quality: **8.7/10**.
+
+| Dimension | Score | Assessment |
+|---|---:|---|
+| Accounting correctness and safety | 9.3 | Strong double-entry validation, reconciled-split protection, audit logging, backups, strict unknown-argument rejection, and decimal-string handling. |
+| Input design | 9.0 | Exact account references, typed nested splits, dry runs, correlation keys, and excellent TSV batch entry. Business CRUD is the main source of repetition. |
+| Output design | 8.5 | Compact text and TSV defaults are excellent for an LLM; verbose JSON is explicit and minified. Some mutation envelopes contain TSV encoded inside JSON. |
+| Tool selection and naming | 7.9 | Core names are clear. The business document family is polymorphic but still named around invoices, so the type coverage is not obvious from names alone. |
+| Documentation | 9.1 | Detailed, operational docstrings with examples, failure behavior, and workflow guidance. A few descriptions remain longer than they need to be or lag the full polymorphic contract. |
+| Payload efficiency | 8.0 | Compact responses and short GUIDs are strong. Tool-definition cost is high in an all-modules session, especially where common server instructions are repeated by the client presentation layer. |
+| Modularity | 9.0 | Role and leaf modules let deployments avoid irrelevant tools. `core` remains complete enough to do real bookkeeping and reconciliation. |
+
+The best design decisions are `get_book_summary` as an orientation
+chokepoint, `%short` account GUIDs, decimal strings, compact-by-default
+read tools, batch TSV with caller-owned `ref` values, and
+`reconcile_all=true`. The biggest weakness is not behavior. It is the
+48-tool business surface, where entity type and action are multiplied
+into many near-duplicate names.
+
+## How to use the server
+
+### First calls
+
+1. Call `get_book_summary` first.
+2. In a multi-book session, confirm the current book in the summary or
+   call `get_server_config`; use `switch_book` before resolving any
+   account or entity references.
+3. Use `list_accounts(query=...)` to resolve exact paths or `%short`
+   GUIDs before writing.
+4. Use `search_transactions` before creating entries where duplicates
+   are plausible.
+5. Prefer compact defaults. Set `verbose=true` only when structured
+   JSON fields are needed; it does not add accounting information.
+
+### Reference and sign conventions
+
+- Account inputs accept a full case-sensitive path, a `%` plus 7 or
+  more hexadecimal GUID characters, or a full 32-character GUID.
+- Transaction, split, lot, and scheduled-transaction GUIDs accept a
+  bare prefix of 8 or more hexadecimal characters.
+- Positive values are debits; negative values are credits.
+- Asset and expense debits increase balances. Liability, income, and
+  equity credits increase balances.
+- Amounts and quantities should be decimal strings, not JSON numbers.
+- A transaction's split amounts must sum to zero in its transaction
+  currency. A split into a different commodity also needs `quantity`.
+
+### Output conventions
+
+- Compact list/report output is complete text or TSV and usually begins
+  with a `Showing X-Y of Z` indicator.
+- `verbose=true` changes list/report output to structured JSON.
+- Point reads and mutations generally return minified JSON.
+- `limit=0` is the cheap count-only path on paginated tools.
+- Empty strings and `null` values are stripped from serialized result
+  objects; false booleans and empty collections remain.
+
+### Mutation discipline
+
+- Use `dry_run=true` before large transaction or price batches.
+- Leave duplicate checking enabled. Use `force` only after inspecting
+  the duplicate or safety condition it overrides.
+- Prefer `void_transaction` to deletion when an audit trail matters.
+- Reconciled data is protected. Preserve an unchanged reconciled bank
+  leg when using `replace_splits` to recategorize its other leg.
+- Posted business documents must normally be unwound in dependency
+  order: void/remove payment, unpost document, then delete document.
+
+## Module selection
+
+`core` is always added. Counts below are current source-of-truth counts.
+
+| Selection | Added tools | Intended caller |
+|---|---:|---|
+| `core` | 32 | Ledger, transactions, reconciliation, backups, audit, and balance sheet. |
+| `bookkeeper` | 17 | Reporting, budgets, and recurring transactions. |
+| `investor` | 13 | Commodities, prices, and tax lots. |
+| `freelancer` | 31 | Customer invoicing, jobs, taxes, terms, and credit notes. |
+| `business` | 48 | `freelancer` plus vendors, bills, employees, vouchers, and vendor reporting. |
+| `all` | 110 | Every mapped tool; multi-book configuration can add `switch_book` as tool 111. |
+
+For most personal books, `--modules=bookkeeper` produces 49 tools
+including forced core. A freelancer gets 63 with
+`--modules=freelancer`. A complete small-business deployment gets 80
+with `--modules=business`. These cuts matter because the model must
+select among every surfaced tool.
+
+## Rating rubric
+
+- **10**: immediately selectable, complete contract, efficient payload,
+  strong safety, and no unnecessary lookup.
+- **9**: production-quality with a minor naming, batching, or output
+  limitation.
+- **8**: correct and usable but requires inference, an extra call, or a
+  repetitive schema.
+- **7**: meaningful discoverability, consistency, or lifecycle friction.
+- **6 or lower**: misleading, unsafe, materially incomplete, or costly.
+
+The scores below assess LLM-caller interface quality, not the financial
+importance of the operation.
+
+## Complete tool catalog
+
+### Summary (1 tool, module score 10/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `get_book_summary` | First-call dashboard: book identity, currency, data range, account structure, major balances, warnings, reconciliation state, net-worth trajectory, budget, schedules, and business counts. Compact and unusually high-value. | 10 |
+
+### Accounts (7 tools, module score 9.2/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `list_accounts` | Browse or search the chart. Use `query` instead of paging when resolving a name; `root` scopes a subtree; compact rows expose reusable `%short` GUIDs. | 10 |
+| `get_account` | Fetch type, commodity, description, placeholder state, GUID, and hierarchy for one account. A miss returns an error object rather than raising. | 9 |
+| `get_balance` | Return one account balance on an explicit date; defaults to today and therefore excludes future-dated entries. Echoes the canonical account path. | 10 |
+| `create_account` | Create a typed account under an optional parent, including non-currency commodities, description, notes, and placeholder state. | 9 |
+| `update_account` | Rename or change metadata and compatible account types. Empty notes clear; cross-polarity type changes are blocked. | 9 |
+| `move_account` | Reparent an account with children and balances intact. Cycle and sibling-name conflicts fail without changing the book. | 9 |
+| `delete_account` | Delete only an empty leaf account. Children and transactions are hard blockers. Concise and safe. | 9 |
+
+### Transactions (11 tools, module score 9.5/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `list_transactions` | Browse by account and date. Account-filtered compact output becomes register form with signed account impact; large split sets are summarized honestly. | 10 |
+| `get_transaction` | Fetch the complete transaction and all split GUIDs/details from an 8+ character transaction GUID prefix. | 9 |
+| `create_transaction` | Create one balanced transaction with optional auto-fill, duplicate detection, notes, raw-statement memos, multi-currency quantities, and dry run. | 10 |
+| `create_transactions` | Atomic TSV bulk entry with caller refs, flexible split groups, notes, memos, quantities, actions, per-row currency, auto-fill, duplicate tables, dry run, and abort/skip policy. Best-in-class batch interface. | 10 |
+| `update_transaction` | Update one transaction or broadcast identical fields to many. Supports clearing notes and guarded changes to reconciled entries. | 9 |
+| `update_transactions` | TSV per-row bulk changes to date, description, and notes with abort/skip behavior. Efficient, but its docstring lacks a conventional `Args` block and batch cells cannot clear values. | 9 |
+| `delete_transaction` | Delete one or an atomic list. Reconciled and invoice-posting transactions are protected unless the appropriate workflow or explicit force is used. | 9 |
+| `replace_splits` | Replace the full split set while preserving unchanged reconciled legs and their memos/state. This makes safe recategorization possible without a bespoke tool. | 10 |
+| `search_transactions` | Search description, memo, notes, or amount with pagination and compact output. Amount operators cover exact, range, greater-than, and less-than queries. | 9 |
+| `void_transaction` | Audit-preserving cancellation that zeros split values and requires a reason. Prefer over deletion for booked activity. | 10 |
+| `unvoid_transaction` | Restore pre-void amounts and reset restored splits to unreconciled. Clear contract, though the name does not advertise the reconciliation reset. | 9 |
+
+### Account slots (3 tools, module score 8.5/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `get_account_slots` | Read all custom account metadata or one key, such as APR, credit limit, statement day, or `no_reconcile`. | 9 |
+| `set_account_slot` | Store one string value under an account key. Flexible and compact, but intentionally schema-light because values are untyped. | 8 |
+| `delete_account_slot` | Remove one metadata key; rejects unsafe slash-containing keys and leaves other slots intact. | 9 |
+
+### Audit (1 tool, module score 9/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `get_audit_log` | Read human-oriented mutation history by date with pagination. Strong operational complement to the book, though it is not a general query language over audit fields. | 9 |
+
+### Backup (3 tools, module score 9/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_backup` | Create a labeled on-demand snapshot in addition to automatic pre-write backups. Returns file metadata without exposing unnecessary content. | 9 |
+| `list_backups` | List timestamped backups newest-first with stage and pagination. | 9 |
+| `prune_backups` | Retention cleanup by stage with `dry_run=true` by default. Excellent destructive default; keeping a count rather than a date policy is simple but limited. | 9 |
+
+### Balance sheet (1 tool, module score 9/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `balance_sheet` | Canonical assets, liabilities, and equity report on an optional as-of date, including commodity valuation. Clear single-purpose reporting primitive. | 9 |
+
+### Diagnostics and book selection (2 possible tools, module score 9.5/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `get_server_config` | Verify loaded modules, tool count, active book filename, version, and debug state. Useful when client/server state may be stale. | 9 |
+| `switch_book` | Multi-book-only session switch by unique filename prefix. Returns a loud context reset and invalidates all prior account/GUID/entity references. Transactional logging handoff is well designed. | 10 |
+
+### Reconciliation (4 tools, module score 9.5/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `get_reconciliation_status` | Account-level work queue grouped into behind, never, current, dormant, and explicitly excluded. Better than inferring state from balances. | 10 |
+| `get_unreconciled_splits` | Default compact TSV/text is the right choice. It returns split GUIDs and full-set totals with honest pagination; use `verbose=true` only for JSON fields. | 10 |
+| `set_reconcile_state` | Set one split to new, cleared, or reconciled with a date. Correct low-level escape hatch, but easier to misuse than statement-level reconciliation. | 8 |
+| `reconcile_account` | Reconcile targeted split GUIDs or sweep all through a date, optionally excluding a few GUIDs, while proving the statement balance. `reconcile_all` removes a costly lookup round trip. | 10 |
+
+### Reporting (5 tools, module score 9/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `spending_by_category` | Expense totals for inclusive caller-supplied dates, optional hierarchy depth, JSON mode, or month/quarter/year TSV trends. No hidden calendar snapping. | 9 |
+| `income_by_source` | Income counterpart to category spending, including depth and grouped trend output. | 9 |
+| `net_worth` | One-date value or interval trajectory. When a series is requested, the end date is included even if it is off the regular step. | 9 |
+| `cash_flow` | Inflow/outflow analysis, optional account scope, transfer treatment, and grouped periods. Detailed transfer semantics make a subtle report usable. | 9 |
+| `debt_payoff_plan` | Avalanche schedule with optional hypothetical purchase and structured output. Valuable but domain-specific `YETI multiplier` terminology raises selection/doc cost. | 8 |
+
+### Budgets (6 tools, module score 8.8/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `list_budgets` | Compact paginated inventory or verbose structured list. | 9 |
+| `get_budget` | Read one budget and all period/account amounts; compact default avoids a large nested payload. | 9 |
+| `create_budget` | Create monthly, weekly, or custom-period budgets from a year or start date. Correct but has several mutually dependent date/period inputs. | 8 |
+| `set_budget_amount` | Set an account target for one period or all periods using decimal strings and exact account refs. | 9 |
+| `get_budget_report` | Compare actuals to targets by period/account with optional child rollup. Compact default is efficient. | 9 |
+| `delete_budget` | Permanently remove a budget and all budget amounts without touching transactions; a missing name fails without change. | 9 |
+
+### Scheduling (6 tools, module score 8.7/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_scheduled_transaction` | Create a recurring balanced template with frequency, dates, notes, currency, and enabled state. Strong schema, necessarily detailed. | 9 |
+| `list_scheduled_transactions` | Inventory templates with enabled filter, compact/JSON modes, and pagination. | 9 |
+| `get_upcoming_transactions` | Due-instance work list for a caller-selected day window. | 9 |
+| `create_transaction_from_scheduled` | Materialize one actual transaction from a template on an optional date. Simple, but no dry-run or duplicate-control arguments are surfaced here. | 8 |
+| `update_scheduled_transaction` | Update enabled state, end date, or notes. Narrow update surface means frequency/splits require replacement rather than edit. | 8 |
+| `delete_scheduled_transaction` | Delete a template by GUID. Clear but destructive and without a soft-disable shortcut in the same call; `update... enabled=false` is the safer route. | 8 |
+
+### Portfolio and prices (7 tools, module score 8.9/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `list_commodities` | Inventory currencies/securities or produce the exact stale-held-quote work list with `stale_days` and `held_only`. | 10 |
+| `create_commodity` | Create a security/currency-like commodity with namespace, precision, and optional CUSIP/ISIN. | 9 |
+| `create_price` | Upsert one quote by commodity, currency, date, and source. Decimal-string value and quote-direction example are strong. | 9 |
+| `create_prices` | Atomic TSV bulk quote upsert with refs, dry run, and abort policy. Optional columns must appear in one fixed order, which is stricter than `create_transactions`. | 8 |
+| `get_prices` | Paginated compact history or verbose JSON with date/currency filters. | 9 |
+| `get_latest_price` | Return the newest quote, including date, value, type, and source, or null. | 9 |
+| `delete_price` | Delete by commodity/namespace/date with source disambiguation. Correct but naturally identity-heavy for one deletion. | 8 |
+
+### Tax lots (6 tools, module score 8.5/10)
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_lot` | Create an empty cost-basis lot for an investment account; docstring gives the complete follow-on workflow. | 9 |
+| `list_lots` | Paginated open-lot inventory with optional closed lots and JSON detail. | 9 |
+| `get_lot` | Return assigned splits, quantity, cost basis, and per-share summary. | 9 |
+| `assign_split_to_lot` | Attach an investment split to a lot. Correct, but requires a preceding transaction-detail lookup for the split GUID. | 8 |
+| `calculate_lot_gain` | Actual/latest-price or hypothetical shares-and-price gain calculation. Useful but caller must understand whether it is realized or projected. | 8 |
+| `close_lot` | Manual cleanup for a zero-share lot that did not auto-close. A low-level operation appropriately kept out of core. | 8 |
+
+### Freelancer business tools (31 tools, module score 8.0/10)
+
+#### Customers
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_customer` | Create a customer with currency, notes, and typed address fields. Duplicate-name warnings reduce orphan test records. | 8 |
+| `list_customers` | Compact paginated active-customer list or verbose JSON. | 9 |
+| `get_customer` | Fetch one customer by business ID. Simple, but duplicates the vendor/employee shape. | 8 |
+| `update_customer` | Partial update, clearable notes, activation state, and partial address changes. | 8 |
+| `delete_customer` | Delete only when no invoices depend on the customer; deactivation is the safer historical-record path. | 8 |
+
+#### Documents and settlement
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_invoice` | Create a draft customer invoice, optionally tied to a term or job. No ledger entry exists until posting. | 8 |
+| `add_invoice_entry` | Add a positive quantity/price line to an unposted invoice, with income account, tax table, notes, and action. | 8 |
+| `list_invoices` | Actually queries the shared document table, but the name and description emphasize invoices/bills and under-advertise vouchers and credit notes. | 7 |
+| `get_invoice` | Returns every document type, including vouchers and credit notes, with full entries. The polymorphism is good; the invoice-only name and customer/vendor-only `owner_type` argument text remain misleading. | 7 |
+| `post_invoice` | Posts invoices, bills, vouchers, and credit notes through one implementation with FX staleness protection. The first sentence still names only invoices/bills. | 8 |
+| `unpost_invoice` | Correctly reverses all four document types and preserves type identity. Its `owner_type` argument text still omits `employee`. | 8 |
+| `pay_invoice` | Handles partial payments, bills, vouchers/credit notes where applicable, FX gain/loss, early-payment discounts, memo, and stale-rate forcing. Powerful but a 12-argument, 389-word local docstring is near the practical schema limit. | 8 |
+| `delete_invoice` | Delete an unposted customer invoice, with preferred `id` plus a legacy alias. Safe but contributes to four duplicated document delete tools. | 7 |
+| `get_outstanding_invoices` | Compact receivable/payable work list with owner filters, balances, and pagination. Strong report despite invoice-centric name. | 9 |
+
+#### Taxes, terms, jobs, and credit notes
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_taxtable` | Create a multi-entry tax table with account routing and percentage/value semantics. Detailed and safe, but input entries are loose `list[dict]` rather than a typed nested model. | 8 |
+| `list_taxtables` | Compact paginated inventory or verbose JSON. | 9 |
+| `get_taxtable` | Fetch one table and all entries. | 8 |
+| `update_taxtable` | Rename or replace entries with protection when posted documents depend on the table; `force` makes the exceptional path explicit. | 8 |
+| `delete_taxtable` | Delete only when dependency rules permit. | 8 |
+| `create_billterm` | Create due/discount terms. There is no corresponding get, update, or delete tool, so the lifecycle is visibly incomplete. | 7 |
+| `list_billterms` | Read available terms in compact or JSON form. | 8 |
+| `create_job` | Create a customer/vendor job with name and reference. | 8 |
+| `list_jobs` | Filter by owner and active state with compact/JSON output. | 9 |
+| `get_job` | Fetch one job by ID. | 8 |
+| `update_job` | Partial name/reference/active update. | 8 |
+| `delete_job` | Delete, with optional force behavior around linked documents. Deactivation is normally safer. | 8 |
+| `get_job_report` | Per-job billed, paid, outstanding, and document breakdown. High-value endpoint that avoids client-side joins. | 9 |
+| `create_credit_note` | Create a customer or vendor credit note, optionally tied to a source document, with correct reversed-posting semantics documented. | 9 |
+| `add_credit_note_entry` | Add a positive-price line and let the credit-note flag invert posting. Explicitly prevents a common sign mistake. | 9 |
+| `delete_credit_note` | Delete an unposted credit note with type validation, owner disambiguation, preferred `id`, and legacy alias. | 8 |
+| `apply_credit_note` | Net a posted credit against a same-owner document without cash. Cross-owner errors now identify both owner types, IDs, and names. | 9 |
+
+### Complete-business additions (17 tools, module score 8.0/10)
+
+#### Vendors and employees
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_vendor` | Vendor counterpart to customer creation with currency, notes, address, and duplicate warning. | 8 |
+| `list_vendors` | Compact paginated active-vendor list or verbose JSON. | 9 |
+| `get_vendor` | Fetch one vendor by ID. | 8 |
+| `update_vendor` | Partial update with clearable notes, activation, and partial address semantics. | 8 |
+| `delete_vendor` | Delete only without dependent bills; deactivation preserves history. | 8 |
+| `create_employee` | Create an employee for voucher workflows with currency and address. | 8 |
+| `list_employees` | Compact paginated active-employee list or verbose JSON. | 9 |
+| `get_employee` | Fetch one employee by ID. | 8 |
+| `update_employee` | Partial employee update and activation. Unlike customer/vendor, there is no notes field, reflecting the underlying model but reducing family symmetry. | 8 |
+| `delete_employee` | Delete only when voucher dependencies allow it; deactivation is safer for history. | 8 |
+
+#### Bills, vouchers, and vendor reporting
+
+| Tool | Use and important behavior | Score |
+|---|---|---:|
+| `create_bill` | Vendor counterpart to invoice creation, with term, job, currency, and caller-supplied ID. | 8 |
+| `add_bill_entry` | Add an expense/asset line, optional input-tax table, notes, and action to an unposted bill. | 8 |
+| `delete_bill` | Delete an unposted bill via preferred `id` or legacy `bill_id`. Repeats the document delete schema. | 7 |
+| `create_voucher` | Create an employee expense voucher that later posts and pays through the shared invoice lifecycle tools. | 8 |
+| `add_voucher_entry` | Add an expense/asset line to an unposted voucher. Repeats almost all bill-entry fields. | 8 |
+| `delete_voucher` | Delete an unposted voucher via preferred `id` or legacy alias. | 7 |
+| `vendor_spending_report` | Posted-bill totals by vendor, including billed, paid, outstanding, and optional grouped-period TSV. | 9 |
+
+## Payload assessment
+
+### Input payloads: 9/10
+
+The strongest input path is headered TSV. It lets a caller send many
+transactions or prices without repeating JSON keys, preserves decimal
+text exactly, and returns caller correlation keys. `create_transactions`
+also allows rows with different split counts and composes optional
+fields through the header.
+
+Short account GUIDs are another material win. A token-heavy path such
+as `Assets:Current Assets:Checking Account` can be replaced after one
+lookup by a stable `%xxxxxxx` reference. Batch mutation, list-valued
+transaction update/delete, `reconcile_all`, and `except_guids` all
+remove avoidable round trips.
+
+The main input costs are:
+
+- All-modules selection exposes 111 schemas.
+- The business surface repeats nearly identical party and document
+  fields.
+- `pay_invoice` is necessarily broad and approaches mega-tool size.
+- `create_prices` requires optional columns in fixed order, unlike the
+  more flexible transaction header grammar.
+- Tax-table entries use `list[dict]`, so their inner shape is described
+  in prose rather than enforced and advertised by a nested model.
+
+### Output payloads: 8.5/10
+
+The compact default is the right design. It prevents models from asking
+for verbose JSON reflexively, and the descriptions now say explicitly
+that verbose changes structure rather than information. Honest page
+indicators and full-set totals prevent truncated pages from being read
+as complete reports.
+
+Minified UTF-8 JSON, noise stripping, and TSV trend tables are sensible.
+The main inefficiency is that some batch mutation results are JSON
+envelopes containing escaped TSV strings. That is defensible when two
+tables must be keyed together, but direct text sections would be
+slightly cheaper for an LLM-only consumer.
+
+### Tool-definition payload: 7.5/10 in the current Codex presentation
+
+Measured from the reloaded `mcp__gnucash_mcp_2` tools visible to this
+Codex session:
+
+- 111 descriptions total 336,844 characters and 45,258 whitespace
+  words, including displayed function declarations.
+- A 2,029-character, 275-word server instruction prefix is repeated on
+  every visible tool description by this presentation layer.
+- That repeated prefix alone accounts for 225,219 characters before
+  individual tool descriptions and schemas.
+- `create_transactions` is the largest visible definition at 8,387
+  characters; `pay_invoice` is second at 5,444.
+
+The source correctly defines the common instructions once on `FastMCP`.
+The repetition is therefore at least partly a client/adapter
+presentation effect, not 111 copies in the Python source. It still
+matters to this model's effective tool context. Module cuts and tool
+consolidation reduce the repetition regardless of which layer causes
+it. The server should not delete useful global guidance merely to work
+around one host; it should first check the raw `tools/list` payload and
+the adapter's flattening behavior.
+
+## Consolidation plan
+
+### Recommendation
+
+Consolidate across **document or party type**, while keeping materially
+different **actions** as separate tools. This preserves strong schemas
+and truthful MCP safety annotations.
+
+The current business package is 48 tools, not more than 50 on this
+branch: 31 in `freelancer` and 17 in `business_complete`. A practical
+target is **19 business tools**, reducing an all-modules server from 110
+mapped tools to about 81 without changing the book layer.
+
+### Why not one `action` mega-tool
+
+A single tool such as:
+
+```text
+business_document(action, document_type, id?, owner_id?, account?,
+                  entries?, post_account?, payment_account?, ...)
+```
+
+would cut the count aggressively, but it has serious costs:
+
+- MCP `ToolAnnotations` apply to the whole tool. One callable cannot
+  honestly be read-only for `get`, non-destructive for `create`, and
+  destructive for `delete` at the same time.
+- Most fields become nullable and legal only for certain action/type
+  combinations. JSON Schema exposes a large bag of options while the
+  real contract moves back into prose and runtime errors.
+- The output shape changes radically by action.
+- The description becomes longer than `pay_invoice`, offsetting some
+  schema-count savings.
+- Permission systems and clients cannot distinguish a read from a
+  deletion before invocation.
+- Audit operation derivation becomes more indirect.
+
+A Pydantic discriminated union could express action-specific variants,
+but MCP clients vary in how well models and UIs handle `oneOf` schemas.
+It also does not solve per-action tool annotations.
+
+An action field is appropriate where every action has similar risk and
+shape. It is not a good top-level boundary for create/get/delete in an
+accounting system.
+
+### Proposed 19-tool business surface
+
+#### Parties: 15 tools to 5
+
+| New tool | Replaces | Key schema |
+|---|---|---|
+| `create_party` | `create_customer`, `create_vendor`, `create_employee` | `party_type: customer|vendor|employee`, name, currency, notes, address. Reject notes for employee if unsupported. |
+| `list_parties` | Three list tools | Optional `party_type`; active filter, pagination, verbose. |
+| `get_party` | Three get tools | `party_type`, `id`. Type should be required because ID counters collide. |
+| `update_party` | Three update tools | `party_type`, `id`, shared partial fields. |
+| `delete_party` | Three delete tools | `party_type`, `id`; retain dependency checks and recommend deactivation. |
+
+#### Documents: 18 tools to 8
+
+| New tool | Replaces | Key schema |
+|---|---|---|
+| `create_document` | Four create tools | `document_type: invoice|bill|voucher|credit_note`, `owner_id`, dates, currency, term, job/source link, optional `id`. Derive valid owner type from document type except credit notes. |
+| `add_document_entry` | Four entry tools | `document_type`, `id`, account, description, quantity, price, tax, notes, action. Account-type validation stays in the book layer. |
+| `list_documents` | `list_invoices` | Optional document/owner type, status, job, pagination, verbose. Name finally matches actual shared-table behavior. |
+| `get_document` | `get_invoice` | `id`, optional/required disambiguating document or owner type; always returns explicit `type`. |
+| `post_document` | `post_invoice` | Same posting schema, with a name that truthfully covers all four types. |
+| `unpost_document` | `unpost_invoice` | Same unpost behavior and payment dependency guard. |
+| `settle_document` | `pay_invoice`, `apply_credit_note` | `method: cash|apply_credit`, then a small method-specific payload. If the union is awkward, keep `pay_document` and `apply_credit_note` as two tools, making the target 20 instead of 19. |
+| `delete_document` | Four delete tools | `document_type`, `id`. One preferred ID field; legacy aliases remain only in legacy wrappers. |
+
+This is the most important consolidation. It removes ten tools and the
+misleading invoice-centric generic names while retaining action-specific
+safety annotations.
+
+#### Reference data: 7 tools to 2
+
+| New tool | Replaces | Design note |
+|---|---|---|
+| `manage_billterms` | `create_billterm`, `list_billterms` | `action=create|list` is acceptable because the surface is tiny; add get/update/delete later only if the book layer supports them. |
+| `manage_taxtable` | Five tax-table tools | An action union is defensible but loses read/delete annotations. Prefer `list_taxtables` plus `mutate_taxtable(action=create|update|delete)` if annotations are a priority. |
+
+For strict annotation fidelity, this section becomes four tools rather
+than two.
+
+#### Jobs: 6 tools to 2
+
+| New tool | Replaces | Design note |
+|---|---|---|
+| `manage_job` | Create/list/get/update/delete job | This is the least certain merge. A five-tool polymorphic CRUD family is safer if per-action annotations matter more than count. |
+| `get_job_report` | Existing report | Keep separate because it is a high-value analytical read with a stable shape. |
+
+An annotation-preserving variant can merge `get_job` into
+`list_jobs(id=...)` because both are reads, while keeping create,
+update, delete, and report separate. That produces five job tools.
+
+#### Reports: keep 2
+
+- Rename `get_outstanding_invoices` to `get_outstanding_documents` or
+  `get_receivables_payables`.
+- Keep `vendor_spending_report` unchanged.
+
+### Preferred balance: 24 tools
+
+The technically strongest endpoint is **24 business tools**, not 19:
+
+- 5 party tools
+- 8 document tools
+- 4 reference-data tools split by read versus mutation
+- 4 job CRUD/list tools (`list_jobs` also handles exact-ID lookup) plus
+  `get_job_report` (5 total)
+- 2 reports
+
+This preserves truthful read-only/destructive/idempotent annotations
+while still removing 24 of 48 business tools. The all-modules surface
+falls from 110 to about 86 mapped tools, plus conditional `switch_book`.
+Keeping `get_job` separate would make the package 25 tools and the
+all-modules surface 87.
+
+### Implementation shape
+
+No rewrite of the 7,896-line book business mixin is required. The book
+layer already has shared document primitives (`get_invoice`,
+`post_invoice`, `unpost_invoice`, `pay_invoice`) and type-resolution
+helpers. Consolidation can be a tool-wrapper routing layer.
+
+1. Add strict `Literal` aliases for `PartyType`, `DocumentType`, and
+   settlement method.
+2. Add typed nested models for tax-table entries and any settlement
+   variants. Keep `extra="forbid"` and decimal-string coercion.
+3. Implement private routing helpers in `tools/business.py` that map
+   document/party type to the existing book methods.
+4. Register the new surface in revised `freelancer` and
+   `business_complete` module lists.
+5. Move old names into an opt-in `business_legacy` module for one
+   compatibility cycle. Do not expose old and new names together by
+   default, or the tool-count goal is defeated.
+6. Return canonical `type`, `id`, `owner_type`, and status fields from
+   every document mutation so follow-up calls need no lookup.
+7. Preserve one action per safety class. Derive annotations from the
+   actual wrapper operation as the server does today.
+8. Extend contract tests to assert registry count, no unmapped tools,
+   annotation truth, legacy parity, owner-ID collision errors, credit
+   identity through post/unpost, and voucher lifecycle behavior.
+9. Run the existing cross-model battery cold against the consolidated
+   names before removing legacy exposure.
+
+### Naming and schema rules for the new surface
+
+- Use `document_type`, not `owner_type`, when the caller is choosing an
+  invoice, bill, voucher, or credit note.
+- Use `party_type` for customer/vendor/employee records.
+- Use `id` everywhere after creation. Do not carry four legacy ID field
+  names into the new tools.
+- Require explicit type where independent ID counters can collide.
+- Always return the canonical document type, even when the caller gave
+  enough context to infer it.
+- Keep compact/verbose semantics identical across every list tool.
+- Keep `pay_document` and `apply_credit_note` separate if a clean typed
+  settlement union cannot be expressed without many nullable fields.
+
+## Specific documentation fixes still worth making
+
+1. `get_invoice` says it supports all four document types, but its
+   `owner_type` argument documents only customer/vendor. Add employee
+   and explain credit-note disambiguation.
+2. `unpost_invoice` names all four types in its lead but documents only
+   customer/vendor in `owner_type`. Add employee.
+3. `post_invoice` supports all four types but opens with only customer
+   invoice/vendor bill. Rename it or make the first sentence complete.
+4. `list_invoices` understates the shared table's document coverage.
+   Confirm and document whether vouchers and credit notes should be
+   included and filterable.
+5. `update_transactions` and `create_prices` explain their parameters
+   in prose but omit conventional `Args` sections. The schemas are
+   still usable, but consistency would improve generated descriptions.
+6. `create_prices` should either allow optional header columns in any
+   declared order or state the fixed-order difference from
+   `create_transactions` in its first input paragraph.
+7. Replace `list[dict]` in `create_taxtable` and `update_taxtable` with a
+   typed `TaxTableEntryInput` model so account, amount, and type appear
+   in JSON Schema and reject misspelled keys before backup/audit work.
+
+## Verification basis
+
+This assessment used:
+
+- the live, reloaded 111-tool Codex surface;
+- `TOOL_MODULES`, module filtering, common server instructions, and
+  annotation derivation in `src/gnucash_mcp/server.py`;
+- every wrapper and docstring under `src/gnucash_mcp/tools/`;
+- shared input/serialization helpers in `tools/_helpers.py`;
+- the business book-layer routing and lifecycle methods;
+- contract, business, batch, reconciliation, annotation, and prior
+  cross-model test specifications;
+- the repository's full pytest suite: **1,972 passed** in 127.58 seconds
+  (903 dependency/SQLAlchemy warnings, no failures).

--- a/specs/v1.5/testing/CROSS_MODEL_BATTERY_2026_08_05.md
+++ b/specs/v1.5/testing/CROSS_MODEL_BATTERY_2026_08_05.md
@@ -1,0 +1,65 @@
+# Cross-model test battery — 2026-08-05/06
+
+Server under test: `fix/business-doc-lifecycle` with develop merged
+(annotations, verbose framing, CLI strictness, and the three Codex
+fixes all in place). Tester: an outside-model bookkeeper session
+(non-Claude), given the battery cold. Companion to
+`../CODEX_TEST_FINDINGS.md` — this run verifies those fixes.
+
+## Battery (as issued)
+
+Part 1 (undirected): orient and summarize; groceries for the last
+three months; outstanding invoices and biggest debtor; five most
+recent checking transactions. (Stealth measurement: whether the new
+verbose framing keeps a foreign model on compact output.)
+
+Part 2 (directed, disposable `XM-` objects): (5) get_invoice on an
+unposted credit note reports credit_note; (6) identity survives
+post→unpost, delete_credit_note works; (7) cross-owner
+apply_credit_note error names both owners; (8) voucher posts to A/P
+with no owner_type; (9) wrong-owner_type voucher post error teaches
+the fix; (10) bill post/pay round-trips A/P; (11) batch entry +
+reconcile_all without GUID lookups; (12) void/unvoid balance
+round-trip; (13) full cleanup with dependency unwinding.
+
+Part 3: unclear docstrings; what did you route around; 1-10 input
+and output design ratings.
+
+## Results
+
+**All nine directed tests PASS**, with the new error messages quoted
+back verbatim as evidence (owner-mismatch names both owners with
+kind + name; voucher not-found teaches owner_type='employee').
+
+Verbose framing behavior change confirmed, self-reported: "I used
+compact default outputs wherever possible and only used structured
+JSON where aggregation or exact fields were materially helpful."
+(The pre-fix battery had a foreign model flipping verbose=true on
+every call.)
+
+Ratings: input 9/10, output 8/10. Strength: compact defaults + TSV
+batch interfaces. Weakness: document-family surface is slightly
+non-orthogonal — callers must infer which generic tools cover credit
+notes/vouchers unless every docstring says so.
+
+## Findings → actions (all fixed on this branch)
+
+1. get_invoice docstring now names the full document family
+   (invoices, bills, vouchers, credit notes).
+2. unpost_invoice docstrings (tool + book) now name vouchers and
+   credit notes.
+3. spending_by_category documents inclusive dates / no calendar
+   snapping.
+
+## Observations, no action
+
+- Tester routed around the default book (switched books.gnucash →
+  alex): for outside-model runs, configure GNUCASH_BOOK_PATH with
+  scratch books ONLY — never list the real book where an untrusted
+  session can switch_book into it.
+- Scratch Alex carried ZZZ residue from the earlier Codex battery
+  (expected; the git-restore recommendation in CODEX_TEST_FINDINGS
+  stands for the repo working tree).
+- Checking's 992 unreconciled splits (frozen-sample drift) pushed
+  the tester to isolate reconcile tests in a fresh account — sound
+  instinct, worth keeping in future battery instructions.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -5415,7 +5415,8 @@ class BusinessMixin:
         invoice_id: str,
         owner_type: str | None = None,
     ) -> dict:
-        """Unpost a previously-posted invoice or bill.
+        """Unpost a previously-posted document (invoice, bill,
+        voucher, or credit note).
 
         Reverses ``post_invoice``: deletes the posting transaction
         and lot, clears the posted-state metadata. The document

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1624,6 +1624,10 @@ class BusinessMixin:
         # ``applies_to`` further requires the link to be set —
         # floating credit notes are unusual but valid.
         if BusinessMixin._get_is_credit_note(invoice):
+            # ``type`` must agree with the delete/unpost responses,
+            # which already report credit notes as their own type —
+            # owner_type alone can't see the slot.
+            result["type"] = "credit_note"
             result["is_credit_note"] = True
             if applies_to:
                 result["applies_to"] = applies_to
@@ -4218,7 +4222,12 @@ class BusinessMixin:
                         f"dangling owner reference — can't verify "
                         f"it belongs to {owner_id}."
                     )
-                if source_owner.id != owner_id:
+                # Compare effective type AND id — ids alone are
+                # per-type sequences, so customer 000005 vs vendor
+                # 000005 would false-pass an id-only check.
+                if (self._effective_owner_type(book, source)
+                        != int_owner_type
+                        or source_owner.id != owner_id):
                     raise ValueError(
                         f"Source "
                         f"{self._doc_label_for(int_owner_type).lower()} "
@@ -5146,7 +5155,8 @@ class BusinessMixin:
             post_date: ISO date (YYYY-MM-DD). Defaults to today.
             due_date: Payment due date (YYYY-MM-DD). Optional.
             description: Description for the posting transaction.
-            owner_type: 'customer' or 'vendor' for disambiguation.
+            owner_type: 'customer', 'vendor', or 'employee' (vouchers)
+                for disambiguation.
 
         Returns:
             Dict with invoice details, total, transaction_guid, lot_guid.
@@ -5174,6 +5184,7 @@ class BusinessMixin:
             # owner_type, infer it from the post account's type:
             # RECEIVABLE → customer invoice, PAYABLE → vendor bill
             # (the same predicate the later validation uses).
+            inferred = False
             if ot is None:
                 pa = self._resolve_account(book, post_account)
                 if pa is not None:
@@ -5181,11 +5192,21 @@ class BusinessMixin:
                         ot = 2
                     elif pa.type == "PAYABLE":
                         ot = 4
+                        inferred = True
 
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
+            if not inv and inferred:
+                # PAYABLE inference can't distinguish vendor bills
+                # from employee vouchers — both post to A/P. Retry
+                # the voucher side before declaring not-found (an
+                # EXPLICIT owner_type never falls through here).
+                inv = self._find_invoice(book, invoice_id, owner_type=5)
             if not inv:
                 raise ValueError(
-                    f"Document not found: {invoice_id}"
+                    f"Document not found: {invoice_id}. If the ID "
+                    f"is shared across document types, pass "
+                    f"owner_type ('customer', 'vendor', or "
+                    f"'employee' for vouchers) explicitly."
                 )
 
             # ``_is_invoice_posted`` treats None/"" as not-posted —
@@ -5500,6 +5521,7 @@ class BusinessMixin:
             is_credit_note = self._get_is_credit_note(inv)
             inv_id_snapshot = inv.id
             owner_type_snapshot = inv.owner_type
+            inv_guid_snapshot = inv.guid
 
             # The transaction delete cascades its splits; the lot is
             # empty now that the posted-state pointers are cleared.
@@ -5507,6 +5529,31 @@ class BusinessMixin:
                 book.session.delete(txn)
             if lot is not None:
                 book.session.delete(lot)
+
+            if is_credit_note:
+                # Deleting the posting transaction sweeps the
+                # invoice's OWN slots along with the txn's: the
+                # txn carries a ``gncInvoice`` GUID slot, and
+                # piecash's overlapping slot-hierarchy relationship
+                # treats every slot on the referenced invoice as
+                # that slot's child frame, cascading them away.
+                # Restore the identity flag or this document comes
+                # back from unpost as a plain invoice.
+                from sqlalchemy import text
+                book.flush()
+                book.session.execute(text(
+                    "INSERT INTO slots (obj_guid, name, slot_type, "
+                    "int64_val) VALUES (:g, 'credit-note', 1, 1)"
+                ), {"g": inv_guid_snapshot})
+                restored = book.session.execute(text(
+                    "SELECT COUNT(*) FROM slots WHERE obj_guid = :g "
+                    "AND name = 'credit-note'"
+                ), {"g": inv_guid_snapshot}).scalar()
+                if restored != 1:
+                    raise RuntimeError(
+                        f"credit-note flag restore failed for "
+                        f"{inv_id_snapshot} (rows: {restored})"
+                    )
 
             book.save()
 
@@ -6170,11 +6217,21 @@ class BusinessMixin:
                 target_owner = self._find_invoice_owner_by_guid(
                     book, target.owner_type, target.owner_guid,
                 )
+                # Owner IDs are per-type sequences: customer 000005
+                # and vendor 000005 are different entities with the
+                # same ID string. Without the type words this error
+                # can read "belongs to '000005' but target belongs
+                # to '000005'" — a contradiction.
+                _kind = {2: "customer", 4: "vendor", 5: "employee"}
                 raise ValueError(
                     f"Credit note belongs to "
-                    f"{cn_owner.id if cn_owner else '?'!r} but "
-                    f"target belongs to "
-                    f"{target_owner.id if target_owner else '?'!r}. "
+                    f"{_kind.get(cn.owner_type, 'owner')} "
+                    f"{(cn_owner.id if cn_owner else '?')!r}"
+                    f"{f' ({cn_owner.name})' if cn_owner else ''} "
+                    f"but target belongs to "
+                    f"{_kind.get(target.owner_type, 'owner')} "
+                    f"{(target_owner.id if target_owner else '?')!r}"
+                    f"{f' ({target_owner.name})' if target_owner else ''}. "
                     f"Credit notes can only net against documents "
                     f"from the same customer/vendor."
                 )

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1106,8 +1106,10 @@ def register(mcp, get_book) -> None:
     ) -> str:
         """Get full details for an invoice or bill, including line items.
 
-        Works for both customer invoices and vendor bills. Returns all
-        entries with quantities, prices, and totals.
+        Works for every document in the family: customer invoices,
+        vendor bills, employee vouchers, and credit notes (reported
+        as type='credit_note'). Returns all entries with quantities,
+        prices, and totals.
 
         Args:
             id: Invoice or bill ID (e.g., "000001"). This is the
@@ -1178,7 +1180,8 @@ def register(mcp, get_book) -> None:
         id: str,
         owner_type: str | None = None,
     ) -> str:
-        """Reverse a posted invoice or bill.
+        """Reverse a posted document: invoice, bill, voucher, or
+        credit note (each keeps its type through the round-trip).
 
         Deletes the posting transaction and lot, and clears the
         invoice's posted-state metadata. The invoice returns to

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1116,7 +1116,7 @@ def register(mcp, get_book) -> None:
             post_date: Date in ISO format (YYYY-MM-DD). Defaults to today.
             due_date: Payment due date (YYYY-MM-DD). Optional.
             description: Description for the posting transaction. Optional.
-            owner_type: "customer" or "vendor" for disambiguation when IDs collide.
+            owner_type: "customer", "vendor", or "employee" (vouchers) for disambiguation when IDs collide.
             force: Override the stale-FX-rate guard and post with a
                 7–90 day stale rate. Default False.
         """

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -25,8 +25,10 @@ def register(mcp, get_book) -> None:
         for the structured dict (programmatic consumers, plotting).
 
         Args:
-            start_date: Start of period (YYYY-MM-DD)
-            end_date: End of period (YYYY-MM-DD)
+            start_date: Start of period (YYYY-MM-DD), inclusive. No
+                calendar snapping — for calendar-month figures pass
+                full month boundaries (e.g. 2026-05-01 to 2026-07-31).
+            end_date: End of period (YYYY-MM-DD), inclusive.
             depth: Hierarchy depth for grouping (1 = top-level categories, 2 = subcategories)
             verbose: If false (default), compact text output — optimized
                 for reading and token efficiency. If true, structured

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -4856,7 +4856,8 @@ class TestCreateCreditNote:
         # Round-trip via get_invoice confirms the slot was set.
         full = gb.get_invoice(result["id"], owner_type="customer")
         assert full["is_credit_note"] is True
-        assert full["type"] == "invoice"  # owner-type-driven; flag is separate
+        assert full["type"] == "credit_note"  # slot-driven since the
+        # Codex findings fix: type agrees with delete/unpost responses
 
     def test_vendor_credit_note_basic(self, business_book):
         """Symmetric — vendor side credit note. Response keys
@@ -11154,3 +11155,93 @@ class TestDeleteCreditNoteSlotCleanup:
                 {"g": cn_guid},
             ).scalar()
         assert n_after == 0, "credit-note slot rows orphaned"
+
+
+class TestCodexCrossModelFindings:
+    """Regression locks for the 2026-08-05 ChatGPT Codex battery
+    (specs/v1.5/CODEX_TEST_FINDINGS.md): credit-note identity across
+    the document lifecycle, the self-contradictory owner-mismatch
+    error, and voucher posting via inferred owner_type."""
+
+    def _credit_note(self, gb) -> str:
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(owner_id="000001", owner_type="customer")
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="credit", quantity="1", price="100.00",
+        )
+        return cn["id"]
+
+    def test_get_invoice_type_is_credit_note(self, business_book):
+        """The slot, not owner_type, decides ``type`` — get_invoice
+        must agree with the delete/unpost responses."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._credit_note(gb)
+        assert gb.get_invoice(cn_id)["type"] == "credit_note"
+
+    def test_credit_note_identity_survives_unpost(self, business_book):
+        """Deleting the posting transaction sweeps the invoice's own
+        slots (piecash slot-hierarchy overlap); unpost must restore
+        the credit-note flag so a FRESH session still sees it."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._credit_note(gb)
+        gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        gb.unpost_invoice(invoice_id=cn_id, owner_type="customer")
+        fresh = GnuCashBook(str(business_book))
+        assert fresh.get_invoice(cn_id)["type"] == "credit_note"
+        result = fresh.delete_credit_note(cn_id)
+        assert result["type"] == "credit_note"
+
+    def test_apply_mismatch_error_names_owner_kinds(self, business_book):
+        """Owner IDs are per-type sequences; the mismatch error must
+        name the owner KIND so 'belongs to 000001 but target belongs
+        to 000001' can't read as a contradiction."""
+        gb = GnuCashBook(str(business_book))
+        cn_id = self._credit_note(gb)
+        gb.post_invoice(
+            invoice_id=cn_id,
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        gb.create_customer(name="Beta LLC")  # 000002
+        inv = gb.create_invoice(customer_id="000002")
+        gb.add_invoice_entry(
+            invoice_id=inv["id"], account="Income:Sales",
+            description="w", quantity="1", price="200.00",
+        )
+        gb.post_invoice(
+            invoice_id=inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(ValueError) as excinfo:
+            gb.apply_credit_note(
+                credit_note_id=cn_id,
+                applies_to_invoice_id=inv["id"],
+                owner_type="customer",
+            )
+        msg = str(excinfo.value)
+        assert "customer" in msg
+        assert "'000001'" in msg and "'000002'" in msg
+        assert "Acme Co" in msg  # names disambiguate colliding IDs
+
+    def test_post_voucher_without_owner_type(self, business_book):
+        """PAYABLE inference must reach vouchers: bills and vouchers
+        both post to A/P, so the inferred-vendor miss retries the
+        employee side before declaring not-found."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_employee(name="Jane Smith")
+        v = gb.create_voucher(employee_id="000001")
+        gb.add_voucher_entry(
+            voucher_id=v["id"], account="Expenses:Office Supplies",
+            description="travel", quantity="1", price="50.00",
+        )
+        result = gb.post_invoice(
+            invoice_id=v["id"],
+            post_account="Liabilities:Accounts Payable",
+        )
+        assert result["status"] == "posted"

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0,<2" },
     { name = "piecash", specifier = ">=1.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary
- Fix credit-note identity loss (piecash slot-sweep cascade on GUID-valued slots), unreachable voucher posting, and the self-contradicting owner-mismatch error — the three real bugs from the ChatGPT Codex cross-model test battery, each with regression locks
- Cap the mcp SDK below 2.0 (2.0.0 broke fresh installs)
- Rebuild the install story around `uv tool install -e` with per-client guides (Claude / ChatGPT / Gemini)
- Document-family docstring rewrites, cross-model battery findings, business-consolidation spec + preserved Codex audit under specs/v1.5

## Test plan
- [x] Full suite green on the branch: 1972 passed
- [x] Cross-model bookkeeper ran the Codex battery cold and passed everything (signoff recorded in specs)
- [x] Regression tests lock each of the three business-module fixes