### PR TITLE
feat(mcpb): one-click Claude Desktop bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
       # --extra dev: pytest lives in [project.optional-dependencies],
       # and uv installs extras only when asked (first CI run failed
       # with "Failed to spawn: pytest" — the local venv had the extra
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
       - uses: actions/setup-node@v7
         with:
           node-version: "24"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+# First CI for gnucash-mcp. Two jobs:
+#
+#   test    — the full pytest suite against the LOCKED dependency set,
+#             on the oldest supported Python (3.10 — the GDATE
+#             date.fromisoformat class of bug only bites there) and a
+#             current one. `uv sync --locked` fails if uv.lock is out
+#             of date with pyproject.toml, which is exactly the
+#             stale-lockfile mistake v1.4.1 shipped with.
+#
+#   bundle  — validates manifest.json and packs the MCPB via the same
+#             script humans run (scripts/build_bundle.sh), then
+#             uploads the .mcpb as a build artifact: every PR gets a
+#             downloadable bundle from the Actions run page.
+#
+# Triggers: every PR, and pushes to the two long-lived branches.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies (locked)
+        run: uv sync --locked --python ${{ matrix.python }}
+      - name: Run test suite
+        run: uv run --python ${{ matrix.python }} pytest -q
+
+  bundle:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Build the MCPB bundle
+        run: bash scripts/build_bundle.sh
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gnucash-mcp-bundle
+          path: dist/*.mcpb
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+      # --extra dev: pytest lives in [project.optional-dependencies],
+      # and uv installs extras only when asked (first CI run failed
+      # with "Failed to spawn: pytest" — the local venv had the extra
+      # from an old sync, the clean runner didn't).
       - name: Install dependencies (locked)
-        run: uv sync --locked --python ${{ matrix.python }}
+        run: uv sync --locked --extra dev --python ${{ matrix.python }}
       - name: Run test suite
-        run: uv run --python ${{ matrix.python }} pytest -q
+        run: uv run --locked --extra dev --python ${{ matrix.python }} pytest -q
 
   bundle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         python: ["3.10", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
       # --extra dev: pytest lives in [project.optional-dependencies],
       # and uv installs extras only when asked (first CI run failed
       # with "Failed to spawn: pytest" — the local venv had the extra
@@ -44,16 +44,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-node@v4
+        uses: astral-sh/setup-uv@v10
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Build the MCPB bundle
         run: bash scripts/build_bundle.sh
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gnucash-mcp-bundle
           path: dist/*.mcpb

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,9 +1,9 @@
 # Bundle contents are manifest.json, src/, pyproject.toml, uv.lock,
-# README.md, CHANGELOG.md, LICENSE, and the Alex demo book — everything
-# else stays out (specs/v1.5/MCPB_SPEC.md). CLAUDE.local.md may hold
-# personal notes and must never ship; samples/ is excluded per-entry
-# (not as a directory) so the negation below can re-include the one
-# demo book the manifest appends to --book.
+# README.md, CHANGELOG.md, LICENSE, and the three demo books —
+# everything else stays out (specs/v1.5/MCPB_SPEC.md). CLAUDE.local.md
+# may hold personal notes and must never ship; samples/ is excluded
+# per-entry (not as a directory) so the negations below can re-include
+# just the demo books GNUCASH_DEMO_DIR serves.
 .git
 .github
 .idea
@@ -26,6 +26,8 @@ test.sh
 docs/
 samples/*
 !samples/alex-chen-morales.gnucash
+!samples/lin-wei.gnucash
+!samples/sabine-brenner.gnucash
 scripts/
 specs/
 tests/

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,8 +1,9 @@
 # Bundle contents are manifest.json, src/, pyproject.toml, uv.lock,
-# README.md, CHANGELOG.md, LICENSE — everything else stays out
-# (specs/v1.5/MCPB_SPEC.md). CLAUDE.local.md may hold personal notes
-# and must never ship; samples/ carries megabytes of demo books plus
-# their .mcp audit/backup state.
+# README.md, CHANGELOG.md, LICENSE, and the Alex demo book — everything
+# else stays out (specs/v1.5/MCPB_SPEC.md). CLAUDE.local.md may hold
+# personal notes and must never ship; samples/ is excluded per-entry
+# (not as a directory) so the negation below can re-include the one
+# demo book the manifest appends to --book.
 .git
 .github
 .idea
@@ -23,7 +24,8 @@ ERROR_TESTING.md
 glama.json
 test.sh
 docs/
-samples/
+samples/*
+!samples/alex-chen-morales.gnucash
 scripts/
 specs/
 tests/

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,33 @@
+# Bundle contents are manifest.json, src/, pyproject.toml, uv.lock,
+# README.md, CHANGELOG.md, LICENSE — everything else stays out
+# (specs/v1.5/MCPB_SPEC.md). CLAUDE.local.md may hold personal notes
+# and must never ship; samples/ carries megabytes of demo books plus
+# their .mcp audit/backup state.
+.git
+.github
+.idea
+.claude
+.venv
+.pytest_cache
+.ruff_cache
+.DS_Store
+.mcp.json
+.dockerignore
+.gitignore
+.git-blame-ignore-revs
+.mcpbignore
+CLAUDE.md
+CLAUDE.local.md
+Dockerfile
+ERROR_TESTING.md
+glama.json
+test.sh
+docs/
+samples/
+scripts/
+specs/
+tests/
+dist/
+__pycache__/
+*.pyc
+*.mcpb

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "GnuCash for Claude",
   "version": "1.4.2",
   "description": "Your GnuCash book in chat: transactions, reports, budgets, reconciliation, invoicing.",
-  "long_description": "Connects Claude to a GnuCash book saved in SQLite format. Enter and categorize transactions (including whole statements in one call), reconcile accounts, run reports (balance sheet, net worth, cash flow, spending), manage budgets and scheduled transactions, and optionally run client invoicing, a full small-business suite, or investment lot tracking. Every write is audit-logged beside the book, and automatic backups are taken before the first write of the day. A demo book (Alex, a freelance developer with clients, investments, and a mortgage) ships in the bundle — say 'switch to the alex book' to explore risk-free; it resets on extension update. First launch needs a network connection while uv downloads Python and dependencies (cached afterward).",
+  "long_description": "Connects Claude to a GnuCash book saved in SQLite format. Enter and categorize transactions (including whole statements in one call), reconcile accounts, run reports (balance sheet, net worth, cash flow, spending), manage budgets and scheduled transactions, and optionally run client invoicing, a full small-business suite, or investment lot tracking. Every write is audit-logged beside the book, and automatic backups are taken before the first write of the day. Three demo books ship in the bundle (toggleable): Alex, a USD freelancer with clients, investments, and a mortgage; Lin Wei, a Chinese multi-currency household; and Sabine, a German EUR book — say 'switch to the alex book' to explore risk-free; they reset on extension update. First launch needs a network connection while uv downloads Python and dependencies (cached afterward).",
   "author": {
     "name": "Stephen",
     "email": "stephen@ninetails.io",
@@ -32,14 +32,15 @@
         "-m",
         "gnucash_mcp",
         "--book",
-        "${user_config.books}",
-        "${__dirname}/samples/alex-chen-morales.gnucash"
+        "${user_config.books}"
       ],
       "env": {
         "GNUCASH_ENABLE_PLANNING": "${user_config.planning}",
         "GNUCASH_ENABLE_INVESTMENTS": "${user_config.investments}",
         "GNUCASH_ENABLE_FREELANCER": "${user_config.freelancer}",
         "GNUCASH_ENABLE_BUSINESS": "${user_config.business}",
+        "GNUCASH_DEMO_BOOKS": "${user_config.demo_books}",
+        "GNUCASH_DEMO_DIR": "${__dirname}/samples",
         "GNUCASH_MCP_ADVANCED": "${user_config.advanced}",
         "GNUCASH_REDACT_PATHS": "1"
       }
@@ -76,6 +77,12 @@
       "default": false,
       "title": "Full business suite",
       "description": "Everything in Client invoicing, plus vendors, bills, and employee expenses"
+    },
+    "demo_books": {
+      "type": "boolean",
+      "default": true,
+      "title": "Include demo books",
+      "description": "Add three explorable sample books alongside yours: Alex (USD freelancer), Lin Wei (Chinese, multi-currency), and Sabine (German, EUR). Say 'switch to the alex book' to explore risk-free."
     },
     "advanced": {
       "type": "string",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,85 @@
+{
+  "manifest_version": "0.4",
+  "name": "gnucash-mcp",
+  "display_name": "GnuCash for Claude",
+  "version": "1.4.2",
+  "description": "Your GnuCash book in chat: transactions, reports, budgets, reconciliation, invoicing.",
+  "long_description": "Connects Claude to a GnuCash book saved in SQLite format. Enter and categorize transactions (including whole statements in one call), reconcile accounts, run reports (balance sheet, net worth, cash flow, spending), manage budgets and scheduled transactions, and optionally run client invoicing, a full small-business suite, or investment lot tracking. Every write is audit-logged beside the book, and automatic backups are taken before the first write of the day. First launch needs a network connection while uv downloads Python and dependencies (cached afterward).",
+  "author": {
+    "name": "Stephen",
+    "email": "stephen@ninetails.io",
+    "url": "https://github.com/ninetails-io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninetails-io/gnucash-mcp"
+  },
+  "homepage": "https://github.com/ninetails-io/gnucash-mcp",
+  "documentation": "https://github.com/ninetails-io/gnucash-mcp#readme",
+  "support": "https://github.com/ninetails-io/gnucash-mcp/issues",
+  "license": "MIT",
+  "keywords": ["gnucash", "accounting", "finance", "bookkeeping", "double-entry", "budgets", "invoicing"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/gnucash_mcp/__main__.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "python",
+        "-m",
+        "gnucash_mcp",
+        "--book",
+        "${user_config.books}"
+      ],
+      "env": {
+        "GNUCASH_ENABLE_PLANNING": "${user_config.planning}",
+        "GNUCASH_ENABLE_INVESTMENTS": "${user_config.investments}",
+        "GNUCASH_ENABLE_FREELANCER": "${user_config.freelancer}",
+        "GNUCASH_ENABLE_BUSINESS": "${user_config.business}",
+        "GNUCASH_REDACT_PATHS": "1"
+      }
+    }
+  },
+  "user_config": {
+    "books": {
+      "type": "file",
+      "multiple": true,
+      "required": true,
+      "title": "Your GnuCash book(s)",
+      "description": "Pick one or more .gnucash files saved in SQLite format. Pick several to switch between them in-chat. (Books in GnuCash's older XML format need a one-time File > Save As with the sqlite3 format first.)"
+    },
+    "planning": {
+      "type": "boolean",
+      "default": true,
+      "title": "Budgets & scheduled transactions",
+      "description": "Set budgets, track pacing, and manage recurring transactions"
+    },
+    "investments": {
+      "type": "boolean",
+      "default": false,
+      "title": "Investment tracking",
+      "description": "Lots, cost basis, capital gains, and price updates"
+    },
+    "freelancer": {
+      "type": "boolean",
+      "default": false,
+      "title": "Client invoicing",
+      "description": "Send invoices to clients and record their payments"
+    },
+    "business": {
+      "type": "boolean",
+      "default": false,
+      "title": "Full business suite",
+      "description": "Everything in Client invoicing, plus vendors, bills, and employee expenses"
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.10"
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,7 @@
         "GNUCASH_ENABLE_INVESTMENTS": "${user_config.investments}",
         "GNUCASH_ENABLE_FREELANCER": "${user_config.freelancer}",
         "GNUCASH_ENABLE_BUSINESS": "${user_config.business}",
+        "GNUCASH_MCP_ADVANCED": "${user_config.advanced}",
         "GNUCASH_REDACT_PATHS": "1"
       }
     }
@@ -75,6 +76,13 @@
       "default": false,
       "title": "Full business suite",
       "description": "Everything in Client invoicing, plus vendors, bills, and employee expenses"
+    },
+    "advanced": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "title": "Advanced options",
+      "description": "Leave empty unless you know you need it. Space-separated GNUCASH_*=value settings, e.g. GNUCASH_MCP_DEBUG=1 GNUCASH_LOG_DIR=\"/path/with spaces\" — run the server with --help (or see the README) for the full list."
     }
   },
   "compatibility": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "GnuCash for Claude",
   "version": "1.4.2",
   "description": "Your GnuCash book in chat: transactions, reports, budgets, reconciliation, invoicing.",
-  "long_description": "Connects Claude to a GnuCash book saved in SQLite format. Enter and categorize transactions (including whole statements in one call), reconcile accounts, run reports (balance sheet, net worth, cash flow, spending), manage budgets and scheduled transactions, and optionally run client invoicing, a full small-business suite, or investment lot tracking. Every write is audit-logged beside the book, and automatic backups are taken before the first write of the day. First launch needs a network connection while uv downloads Python and dependencies (cached afterward).",
+  "long_description": "Connects Claude to a GnuCash book saved in SQLite format. Enter and categorize transactions (including whole statements in one call), reconcile accounts, run reports (balance sheet, net worth, cash flow, spending), manage budgets and scheduled transactions, and optionally run client invoicing, a full small-business suite, or investment lot tracking. Every write is audit-logged beside the book, and automatic backups are taken before the first write of the day. A demo book (Alex, a freelance developer with clients, investments, and a mortgage) ships in the bundle — say 'switch to the alex book' to explore risk-free; it resets on extension update. First launch needs a network connection while uv downloads Python and dependencies (cached afterward).",
   "author": {
     "name": "Stephen",
     "email": "stephen@ninetails.io",
@@ -32,7 +32,8 @@
         "-m",
         "gnucash_mcp",
         "--book",
-        "${user_config.books}"
+        "${user_config.books}",
+        "${__dirname}/samples/alex-chen-morales.gnucash"
       ],
       "env": {
         "GNUCASH_ENABLE_PLANNING": "${user_config.planning}",

--- a/manifest.json
+++ b/manifest.json
@@ -82,14 +82,14 @@
       "type": "boolean",
       "default": true,
       "title": "Include demo books",
-      "description": "Add three explorable sample books alongside yours: Alex (USD freelancer), Lin Wei (Chinese, multi-currency), and Sabine (German, EUR). Say 'switch to the alex book' to explore risk-free."
+      "description": "Adds three sample books to explore — say 'switch to the alex book'."
     },
     "advanced": {
       "type": "string",
       "required": false,
       "default": "",
       "title": "Advanced options",
-      "description": "Leave empty unless you know you need it. Space-separated GNUCASH_*=value settings, e.g. GNUCASH_MCP_DEBUG=1 GNUCASH_LOG_DIR=\"/path/with spaces\" — run the server with --help (or see the README) for the full list."
+      "description": "Leave empty unless you need it. Space-separated GNUCASH_*=value settings — see the README."
     }
   },
   "compatibility": {

--- a/scripts/build_bundle.sh
+++ b/scripts/build_bundle.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the MCPB bundle into dist/ — the ONE packing path, shared by
+# local builds and CI, so the two can't drift. Version comes from
+# pyproject.toml (the contract tests already pin manifest.json to it).
+#
+# Requires: node/npx (for the mcpb CLI). Network on first run only.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VERSION=$(python3 - <<'EOF'
+import re
+print(re.search(r'^version = "([^"]+)"', open("pyproject.toml").read(), re.M).group(1))
+EOF
+)
+
+mkdir -p dist
+npx -y @anthropic-ai/mcpb validate manifest.json
+npx -y @anthropic-ai/mcpb pack . "dist/gnucash-mcp-${VERSION}.mcpb"
+echo "Built dist/gnucash-mcp-${VERSION}.mcpb"

--- a/src/gnucash_mcp/__init__.py
+++ b/src/gnucash_mcp/__init__.py
@@ -1,5 +1,14 @@
 """GnuCash MCP Server - AI assistant interface to GnuCash accounting data."""
 
+# Applied FIRST — before any sibling module imports — so every
+# GNUCASH_* env read anywhere in the package (import-time seeds
+# included) sees the advanced-options overrides. `python -m
+# gnucash_mcp` executes this file before gnucash_mcp.server, so
+# applying inside server.py would be too late for that guarantee.
+from gnucash_mcp._env import _apply_advanced_env
+
+_apply_advanced_env()
+
 from gnucash_mcp.book import GnuCashLockError
 from gnucash_mcp.server import main
 

--- a/src/gnucash_mcp/_env.py
+++ b/src/gnucash_mcp/_env.py
@@ -1,0 +1,122 @@
+"""Environment-interface primitives, importable by every layer.
+
+This module owns two things the rest of the package builds on:
+
+* **The boolean toggle vocabulary** (``_TOGGLE_TRUE`` /
+  ``_TOGGLE_FALSE`` and ``_parse_env_toggle``) — the single parser
+  for every GNUCASH_* boolean env var. The MCPB manifest renders
+  checkboxes as ``"true"``/``"false"``; CLI users type ``1``/``0``;
+  two sites once parsed this independently and a third convention
+  (bare ``== "1"``) made ``GNUCASH_MCP_DEBUG=true`` a silent no-op
+  (PR #153 review).
+
+* **The advanced-options passthrough** (``_apply_advanced_env``) —
+  GNUCASH_MCP_ADVANCED holds shell-style ``GNUCASH_*=value`` pairs
+  applied into the process environment. It is called from the top of
+  ``gnucash_mcp/__init__.py``, BEFORE any sibling module imports, so
+  every env read anywhere in the package — import-time seeds
+  included — sees the overrides. (``python -m gnucash_mcp`` executes
+  ``__init__`` first; applying inside ``server.py`` was too late for
+  that guarantee.)
+
+It deliberately imports nothing from the package so ``server.py``
+and ``logging_config.py`` can both use it without a cycle.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_TOGGLE_TRUE = frozenset({"true", "1", "yes", "on"})
+_TOGGLE_FALSE = frozenset({"false", "0", "no", "off", ""})
+
+
+def _parse_env_toggle(var: str) -> bool | None:
+    """Read a boolean env toggle: None when unset, True/False for the
+    accepted vocabulary, ValueError naming the variable and value on
+    anything else — a typo'd toggle must not silently serve the
+    default it meant to change."""
+    raw = os.environ.get(var)
+    if raw is None:
+        return None
+    norm = raw.strip().lower()
+    if norm in _TOGGLE_TRUE:
+        return True
+    if norm in _TOGGLE_FALSE:
+        return False
+    raise ValueError(
+        f"Invalid {var}={raw!r}: expected true/false "
+        "(also accepted: 1/0, yes/no, on/off)"
+    )
+
+
+# Malformed configuration found at import. Import must stay
+# exception-safe (tests, inspectors, and `mcp dev` import this
+# package without running main()), so problems are recorded here —
+# and echoed to stderr immediately so harnesses that never reach
+# main() still surface them — while main() upgrades them to a fatal
+# exit 2.
+_env_errors: list[str] = []
+
+# Keys the box must refuse: itself (recursion), and the book list —
+# --book (which the MCPB manifest always passes) unconditionally
+# overwrites GNUCASH_BOOK_PATH, so accepting it here would be the one
+# misconfiguration that silently evaporates instead of failing fast.
+_ADVANCED_REJECTED_KEYS = {
+    "GNUCASH_MCP_ADVANCED": "it cannot set itself",
+    "GNUCASH_BOOK_PATH": (
+        "books are configured through the book picker / --book, "
+        "which overrides this variable"
+    ),
+}
+
+
+def _apply_advanced_env() -> None:
+    """Parse GNUCASH_MCP_ADVANCED into environment overrides.
+
+    Shell-style tokens (quoted values may contain spaces) with
+    backslash escaping DISABLED — ``shlex``'s POSIX escapes would
+    silently mangle an unquoted Windows path
+    (``GNUCASH_LOG_DIR=C:\\Temp`` became ``C:Temp``; PR #153 review),
+    and no legitimate value here needs escapes. Keys are restricted
+    to the GNUCASH_* namespace — this is a server-options field, not
+    a general environment editor — and pairs OVERRIDE existing
+    values, since the manifest itself sets GNUCASH_REDACT_PATHS=1
+    and the box must be able to turn that off.
+    """
+    raw = os.environ.get("GNUCASH_MCP_ADVANCED")
+    if not raw or not raw.strip():
+        return
+    import re
+    import shlex
+    lex = shlex.shlex(raw, posix=True)
+    lex.whitespace_split = True
+    lex.escape = ""
+    before = len(_env_errors)
+    try:
+        tokens = list(lex)
+    except ValueError as exc:
+        _env_errors.append(
+            f"Invalid advanced options (GNUCASH_MCP_ADVANCED): {exc}"
+        )
+        print(_env_errors[-1], file=sys.stderr)
+        return
+    for token in tokens:
+        key, sep, value = token.partition("=")
+        if key in _ADVANCED_REJECTED_KEYS:
+            _env_errors.append(
+                f"Invalid advanced option {key}: "
+                f"{_ADVANCED_REJECTED_KEYS[key]}."
+            )
+            continue
+        if not sep or not re.fullmatch(r"GNUCASH_[A-Z0-9_]+", key):
+            _env_errors.append(
+                f"Invalid advanced option {token!r}: expected "
+                "GNUCASH_*=value pairs, e.g. GNUCASH_MCP_DEBUG=1 "
+                'GNUCASH_LOG_DIR="/path/with spaces"'
+            )
+            continue
+        os.environ[key] = value
+    for line in _env_errors[before:]:
+        print(line, file=sys.stderr)

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -16,6 +16,8 @@ from functools import wraps
 from pathlib import Path
 from typing import Callable
 
+from gnucash_mcp._env import _TOGGLE_TRUE
+
 AUDIT_LOGGER_NAME = "gnucash_mcp.audit"
 DEBUG_LOGGER_NAME = "gnucash_mcp.debug"
 
@@ -145,7 +147,9 @@ def redact_paths(text: str) -> str:
     bit. POSIX and Windows absolute paths match; relative paths
     pass through (they don't leak layout).
     """
-    if os.environ.get("GNUCASH_REDACT_PATHS") != "1":
+    # Full toggle vocabulary, not just "1" — the MCPB Advanced box
+    # renders booleans as "true", and =="1" made that a silent no-op.
+    if os.environ.get("GNUCASH_REDACT_PATHS", "").strip().lower() not in _TOGGLE_TRUE:
         return text
 
     import re

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -752,7 +752,20 @@ def _parse_book_paths(value: str | None) -> list[Path]:
             "Invalid GNUCASH_BOOK_PATH: contains only separators, "
             "no paths"
         )
+    return _validate_book_paths(raw)
 
+
+def _validate_book_paths(
+    raw: list[str], *, source: str = "GNUCASH_BOOK_PATH"
+) -> list[Path]:
+    """Resolve and validate a list of book path strings.
+
+    The single chokepoint for inbound book lists — both the
+    GNUCASH_BOOK_PATH env var (via _parse_book_paths) and the --book
+    CLI argument land here, so existence, regular-file, and
+    filename-stem uniqueness rules cannot diverge between the two
+    interfaces. ``source`` names the interface in error messages.
+    """
     paths: list[Path] = []
     errors: list[str] = []
     for p in raw:
@@ -791,9 +804,65 @@ def _parse_book_paths(value: str | None) -> list[Path]:
 
     if errors:
         raise _BookPathError(
-            "Invalid GNUCASH_BOOK_PATH:\n" + "\n".join(errors)
+            f"Invalid {source}:\n" + "\n".join(errors)
         )
     return paths
+
+
+def _apply_book_args(book_args: list[str]) -> None:
+    """Install --book CLI paths as the active book list.
+
+    Args win over GNUCASH_BOOK_PATH. The resolved list is mirrored
+    back into the env var (os.pathsep-joined) because get_book()
+    re-reads the env whenever ``_book`` is reset — without the
+    mirror, a test-style reset would silently fall back to the
+    env's books. Logging is (re-)pointed here too: when the books
+    arrive via CLI only, the import-time logging block never ran
+    (it reads the env, which was unset at import).
+    """
+    global _book_paths, _current_path, _book
+    _book_paths = _validate_book_paths(book_args, source="--book")
+    _current_path = _book_paths[0]
+    _book = None
+    os.environ["GNUCASH_BOOK_PATH"] = os.pathsep.join(
+        str(p) for p in _book_paths
+    )
+    _activate_logging(_current_path)
+
+
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def _book_format_error(path: Path) -> str | None:
+    """Detect a non-SQLite book at startup; return a message a
+    non-developer can act on, or None when the header looks right.
+
+    The #1 predictable mistake in the bundle's file picker is a book
+    saved in GnuCash's XML format (uncompressed ``<?xml`` or the
+    gzip default) — piecash would otherwise fail on it at first tool
+    call with a DatabaseError a non-developer can't decode.
+    Unreadable files return None: the real open surfaces its own
+    error with the existing error_type contract.
+    """
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(len(_SQLITE_MAGIC))
+    except OSError:
+        return None
+    if head.startswith(_SQLITE_MAGIC):
+        return None
+    if head.startswith(b"\x1f\x8b") or head.lstrip().startswith(b"<?xml"):
+        return (
+            f"{path.name} is in GnuCash's XML format. Open it in "
+            "GnuCash and use File > Save As with the sqlite3 format, "
+            "then pick the new file."
+        )
+    return (
+        f"{path.name} does not look like a GnuCash book in SQLite "
+        "format (unrecognized file header). In GnuCash, use "
+        "File > Save As with the sqlite3 format, then pick the "
+        "new file."
+    )
 
 
 def _book_for(path: Path) -> GnuCashBook:
@@ -1153,6 +1222,116 @@ def switch_book(
 # ============== Main ==============
 
 
+class _CliParseError(ValueError):
+    """Unusable command line. The message is the complete user-facing
+    text; main() prints it and exits 2."""
+
+
+def _parse_cli_argv(
+    argv: list[str],
+) -> tuple[list[str], bool, bool, str | None]:
+    """Parse CLI arguments: (book_args, debug, noaudit, modules_value).
+
+    ``--book`` consumes every following token up to the next option
+    (the MCPB manifest expands a multi-file picker to ``--book A B``);
+    it also repeats, and accepts the ``--book=PATH`` form. Unrecognized
+    tokens are fatal: a silently ignored flag means the server runs
+    with the wrong tool surface (``--modules all`` once passed
+    unnoticed and served core-only while looking configured). Same
+    fail-fast principle as the unknown-module-NAME check in
+    _apply_module_filter and ``extra="forbid"`` on tool kwargs.
+    """
+    debug_flag = False
+    noaudit_flag = False
+    modules_value: str | None = None
+    book_args: list[str] = []
+    unknown_args: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--debug":
+            debug_flag = True
+        elif arg == "--noaudit":
+            noaudit_flag = True
+        elif arg.startswith("--modules="):
+            modules_value = arg.split("=", 1)[1]
+        elif arg.startswith("--book="):
+            book_args.append(arg.split("=", 1)[1])
+        elif arg == "--book":
+            j = i + 1
+            while j < len(argv) and not argv[j].startswith("--"):
+                book_args.append(argv[j])
+                j += 1
+            if j == i + 1:
+                raise _CliParseError(
+                    "--book requires at least one path, e.g. "
+                    "--book /path/to/ledger.gnucash"
+                )
+            i = j
+            continue
+        else:
+            unknown_args.append(arg)
+        i += 1
+    if unknown_args:
+        lines = [f"Unrecognized argument(s): {' '.join(unknown_args)}"]
+        if "--modules" in unknown_args:
+            lines.append(
+                'The module list must be attached with "=", '
+                "e.g. --modules=all or --modules=core,reporting."
+            )
+        lines.append(
+            "Accepted options: --modules=MODULES, --book PATH ..., "
+            "--debug, --noaudit, --help"
+        )
+        raise _CliParseError("\n".join(lines))
+    return book_args, debug_flag, noaudit_flag, modules_value
+
+
+# The MCPB bundle's only module interface: each manifest checkbox
+# lands as one of these env vars, rendered "true"/"false" by the
+# host app. Values map to module/group names in TOOL_MODULES /
+# MODULE_GROUPS ("planning" spans two leaf modules).
+_ENV_MODULE_TOGGLES: dict[str, tuple[str, ...]] = {
+    "GNUCASH_ENABLE_PLANNING": ("budgets", "scheduling"),
+    "GNUCASH_ENABLE_INVESTMENTS": ("investor",),
+    "GNUCASH_ENABLE_FREELANCER": ("freelancer",),
+    "GNUCASH_ENABLE_BUSINESS": ("business",),
+}
+_TOGGLE_TRUE = frozenset({"true", "1", "yes", "on"})
+_TOGGLE_FALSE = frozenset({"false", "0", "no", "off", ""})
+
+
+def _modules_from_env_toggles() -> str | None:
+    """Compose a --modules value from the GNUCASH_ENABLE_* booleans.
+
+    Returns None when no toggle variable is present at all, so CLI
+    and GNUCASH_MCP_MODULES users (and the core-only default) are
+    untouched. When any toggle is present, the selection is
+    ``reporting`` plus every enabled toggle's modules — core is
+    force-added downstream by _apply_module_filter, matching the
+    bundle design where core + reporting are always on.
+
+    Raises ValueError on an unparseable value: a typo'd toggle must
+    not silently serve the wrong tool surface.
+    """
+    if not any(v in os.environ for v in _ENV_MODULE_TOGGLES):
+        return None
+    selected: list[str] = ["reporting"]
+    for var, modules in _ENV_MODULE_TOGGLES.items():
+        raw = os.environ.get(var)
+        if raw is None:
+            continue
+        norm = raw.strip().lower()
+        if norm in _TOGGLE_TRUE:
+            selected.extend(modules)
+        elif norm not in _TOGGLE_FALSE:
+            raise ValueError(
+                f"Invalid {var}={raw!r}: expected true/false "
+                "(also accepted: 1/0, yes/no, on/off)"
+            )
+    return ",".join(selected)
+
+
 def _build_help_text() -> str:
     """Render ``--help`` output.
 
@@ -1176,6 +1355,12 @@ def _build_help_text() -> str:
 Usage: gnucash-mcp [OPTIONS]
 
 Options:
+  --book PATH [PATH ...]
+                       GnuCash SQLite book(s) to serve. Overrides
+                       GNUCASH_BOOK_PATH; repeatable, and multiple
+                       paths may follow one flag. Two or more books
+                       add the switch_book tool. Filename stems must
+                       be unique (switch_book matches by name).
   --modules=MODULES    Tool modules to load (comma-separated).
                        Default: core ({core} tools, always-on). Use "all"
                        for every module ({total} tools; configuring
@@ -1237,6 +1422,13 @@ Environment variables:
                              (switch_book matches by name).
   GNUCASH_MCP_MODULES        Tool modules to load — same values as
                              --modules (e.g. "bookkeeper" or "core,reporting")
+  GNUCASH_ENABLE_PLANNING    Boolean module toggles (true/false) — the
+  GNUCASH_ENABLE_INVESTMENTS interface the MCPB bundle's checkboxes use.
+  GNUCASH_ENABLE_FREELANCER  When any is set, modules = core + reporting
+  GNUCASH_ENABLE_BUSINESS    plus each enabled toggle's modules (planning
+                             = budgets + scheduling; investments =
+                             investor; business supersedes freelancer).
+                             --modules / GNUCASH_MCP_MODULES win when set.
   GNUCASH_MCP_DEBUG=1        Enable debug logging
   GNUCASH_MCP_NOAUDIT=1      Disable audit logging
   GNUCASH_LOG_DIR            Relocate .mcp storage (audit, debug, backups).
@@ -1274,59 +1466,60 @@ def main() -> None:
     global _book_paths, _current_path, _logging_debug, _logging_audit
     global _book_class
 
-    # GNUCASH_BOOK_PATH: one path or an os.pathsep-separated list. Fail fast
-    # on any invalid/duplicate entry (unset is tolerated — tools error
-    # at call time, matching the prior behavior). ``book_path`` below
-    # is the CURRENT book, used for logging / health / display.
+    # Parse CLI flags first — --book must win over GNUCASH_BOOK_PATH
+    # below. Fail-fast rationale lives on _parse_cli_argv.
+    try:
+        book_args, debug_flag, noaudit_flag, modules_value = (
+            _parse_cli_argv(sys.argv[1:])
+        )
+    except _CliParseError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from None
+    del sys.argv[1:]
+
+    # Resolve the book list: --book args win; otherwise
+    # GNUCASH_BOOK_PATH (one path or an os.pathsep-separated list).
+    # Fail fast on any invalid/duplicate entry (neither set is
+    # tolerated — tools error at call time, matching the prior
+    # behavior). ``book_path`` below is the CURRENT book, used for
+    # logging / health / display.
     raw_book_path = os.environ.get("GNUCASH_BOOK_PATH")
-    if raw_book_path and raw_book_path.strip():
+    if book_args or (raw_book_path and raw_book_path.strip()):
         try:
-            _book_paths = _parse_book_paths(raw_book_path)
+            if book_args:
+                _apply_book_args(book_args)
+            else:
+                _book_paths = _parse_book_paths(raw_book_path)
+                _current_path = _book_paths[0]
         except _BookPathError as exc:
             print(str(exc), file=sys.stderr)
-            raise SystemExit(2)
-        _current_path = _book_paths[0]
+            raise SystemExit(2) from None
         book_path = str(_current_path)
+
+        # Startup format check: an XML-format book (the #1
+        # predictable file-picker mistake) fails here with a message
+        # a non-developer can act on, instead of a piecash
+        # DatabaseError at first tool call.
+        format_errors = [
+            msg for p in _book_paths
+            if (msg := _book_format_error(p)) is not None
+        ]
+        if format_errors:
+            print("\n".join(format_errors), file=sys.stderr)
+            raise SystemExit(2)
     else:
         book_path = None
 
-    # Parse CLI flags. Unrecognized tokens are fatal: a silently
-    # ignored flag means the server runs with the wrong tool surface
-    # (``--modules all`` once passed unnoticed and served core-only
-    # while looking configured). Same fail-fast principle as the
-    # unknown-module-NAME check in _apply_module_filter and
-    # ``extra="forbid"`` on tool kwargs.
-    debug_flag = False
-    noaudit_flag = False
-    modules_value = None
-    unknown_args: list[str] = []
-    for arg in sys.argv[1:]:
-        if arg == "--debug":
-            debug_flag = True
-        elif arg == "--noaudit":
-            noaudit_flag = True
-        elif arg.startswith("--modules="):
-            modules_value = arg.split("=", 1)[1]
-        else:
-            unknown_args.append(arg)
-    if unknown_args:
-        lines = [f"Unrecognized argument(s): {' '.join(unknown_args)}"]
-        if "--modules" in unknown_args:
-            lines.append(
-                'The module list must be attached with "=", '
-                "e.g. --modules=all or --modules=core,reporting."
-            )
-        lines.append(
-            "Accepted options: --modules=MODULES, --debug, "
-            "--noaudit, --help"
-        )
-        print("\n".join(lines), file=sys.stderr)
-        raise SystemExit(2)
-    del sys.argv[1:]
-
-    # Env var fallback for modules (CLI flag takes precedence)
+    # Module selection precedence: --modules, then GNUCASH_MCP_MODULES,
+    # then the MCPB bundle's GNUCASH_ENABLE_* checkbox toggles.
     if modules_value is None:
         modules_value = os.environ.get("GNUCASH_MCP_MODULES")
+    if modules_value is None:
+        try:
+            modules_value = _modules_from_env_toggles()
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            raise SystemExit(2) from None
 
     # Re-init logging if CLI flags override env vars. Update the
     # effective-mode globals so switch_book repoints with the same

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -962,8 +962,13 @@ def _demo_book_paths() -> list[Path]:
             file=sys.stderr,
         )
         return []
+    # A single ".gnucash" only: opening a demo in GnuCash writes
+    # timestamped backups (x.gnucash.20260823120000.gnucash) beside
+    # it, which match the glob and would balloon the roster with
+    # near-identical books and make switch_book prefixes ambiguous.
     return sorted(
-        p.resolve() for p in d.glob("*.gnucash") if p.is_file()
+        p.resolve() for p in d.glob("*.gnucash")
+        if p.is_file() and p.name.count(".gnucash") == 1
     )
 
 
@@ -990,6 +995,17 @@ def _append_demo_books() -> None:
             print(
                 f"Note: bundled demo book {p.name} skipped — a "
                 "configured book shares its filename.",
+                file=sys.stderr,
+            )
+            continue
+        # Same degrade rule for format: a corrupted or XML demo
+        # (truncated extension update, stray file in the demo dir)
+        # is skipped, never fatal — main()'s fatal format check runs
+        # on USER books only, before demos are appended.
+        if _book_format_error(p) is not None:
+            print(
+                f"Note: bundled demo book {p.name} skipped — not a "
+                "readable SQLite book.",
                 file=sys.stderr,
             )
             continue
@@ -1435,11 +1451,19 @@ def _parse_cli_argv(
         elif arg.startswith("--modules="):
             modules_value = arg.split("=", 1)[1]
         elif arg.startswith("--book="):
-            book_args.append(arg.split("=", 1)[1])
+            value = arg.split("=", 1)[1]
+            if value.strip():
+                book_args.append(value)
         elif arg == "--book":
+            # Empty tokens are consumed but dropped: an MCPB host
+            # expanding an unset multi-file config to --book "" must
+            # fall through to the env var / demo books, not brick
+            # startup. A bare --book with NO following token stays a
+            # loud error — that's a human's CLI typo.
             j = i + 1
             while j < len(argv) and not argv[j].startswith("--"):
-                book_args.append(argv[j])
+                if argv[j].strip():
+                    book_args.append(argv[j])
                 j += 1
             if j == i + 1:
                 raise _CliParseError(
@@ -1705,6 +1729,21 @@ def main() -> None:
             print(str(exc), file=sys.stderr)
             raise SystemExit(2) from None
 
+    # Startup format check on the USER's books: an XML-format book
+    # (the #1 predictable file-picker mistake) fails here with a
+    # message a non-developer can act on, instead of a piecash
+    # DatabaseError at first tool call. Runs BEFORE demos append —
+    # demo books get the soft skip inside _append_demo_books instead,
+    # because a broken demo must degrade, never brick the user's
+    # real books.
+    format_errors = [
+        msg for p in _book_paths
+        if (msg := _book_format_error(p)) is not None
+    ]
+    if format_errors:
+        print("\n".join(format_errors), file=sys.stderr)
+        raise SystemExit(2)
+
     # Bundled demo books (MCPB "Include demo books" checkbox) append
     # AFTER the user's own, so their first pick stays the startup
     # default; with no user books configured, the demos alone serve
@@ -1716,18 +1755,6 @@ def main() -> None:
         raise SystemExit(2) from None
 
     book_path = str(_current_path) if _book_paths else None
-
-    # Startup format check: an XML-format book (the #1 predictable
-    # file-picker mistake) fails here with a message a non-developer
-    # can act on, instead of a piecash DatabaseError at first tool
-    # call.
-    format_errors = [
-        msg for p in _book_paths
-        if (msg := _book_format_error(p)) is not None
-    ]
-    if format_errors:
-        print("\n".join(format_errors), file=sys.stderr)
-        raise SystemExit(2)
 
     # Module selection precedence: --modules, then GNUCASH_MCP_MODULES,
     # then the MCPB bundle's GNUCASH_ENABLE_* checkbox toggles.

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -889,6 +889,88 @@ def _apply_book_args(book_args: list[str]) -> None:
     _activate_logging(_current_path)
 
 
+def _demo_book_paths() -> list[Path]:
+    """Bundled demo books to serve alongside the user's own.
+
+    The MCPB manifest sets GNUCASH_DEMO_DIR to the bundle's samples/
+    directory and maps the "Include demo books" checkbox onto
+    GNUCASH_DEMO_BOOKS. Returns the directory's *.gnucash files in
+    sorted order (Alex first, alphabetically) when the toggle is
+    truthy; [] when the toggle is absent/false or the directory is
+    unset or missing — a broken demo must degrade, never brick the
+    user's real books.
+
+    Raises ValueError on an unparseable toggle value (fail fast,
+    same contract as the GNUCASH_ENABLE_* toggles).
+    """
+    raw = os.environ.get("GNUCASH_DEMO_BOOKS")
+    if raw is None:
+        return []
+    norm = raw.strip().lower()
+    if norm in _TOGGLE_FALSE:
+        return []
+    if norm not in _TOGGLE_TRUE:
+        raise ValueError(
+            f"Invalid GNUCASH_DEMO_BOOKS={raw!r}: expected true/false "
+            "(also accepted: 1/0, yes/no, on/off)"
+        )
+    demo_dir = os.environ.get("GNUCASH_DEMO_DIR")
+    if not demo_dir or not demo_dir.strip():
+        return []
+    d = Path(demo_dir).expanduser()
+    if not d.is_dir():
+        print(
+            f"Note: demo books enabled but {d} is not a directory; "
+            "continuing without them.",
+            file=sys.stderr,
+        )
+        return []
+    return sorted(
+        p.resolve() for p in d.glob("*.gnucash") if p.is_file()
+    )
+
+
+def _append_demo_books() -> None:
+    """Append bundled demo books to the active book list.
+
+    Demos always follow the user's own books, so the user's first
+    pick stays the startup default. A demo whose filename stem
+    collides with a configured book is skipped with a stderr note
+    rather than tripping the stem-uniqueness fail-fast — the demo is
+    an optional extra and must not brick startup over a name. When
+    no user books are configured at all, the demos alone become the
+    book list (pure demo mode) and logging activates on the first.
+    The composed list is mirrored into GNUCASH_BOOK_PATH because
+    get_book() re-reads the env whenever ``_book`` is reset.
+    """
+    global _book_paths, _current_path
+    demos = _demo_book_paths()
+    if not demos:
+        return
+    seen = {p.stem.lower() for p in _book_paths}
+    added: list[Path] = []
+    for p in demos:
+        if p.stem.lower() in seen:
+            print(
+                f"Note: bundled demo book {p.name} skipped — a "
+                "configured book shares its filename.",
+                file=sys.stderr,
+            )
+            continue
+        seen.add(p.stem.lower())
+        added.append(p)
+    if not added:
+        return
+    demo_only = not _book_paths
+    _book_paths = _book_paths + added
+    if demo_only:
+        _current_path = _book_paths[0]
+        _activate_logging(_current_path)
+    os.environ["GNUCASH_BOOK_PATH"] = os.pathsep.join(
+        str(p) for p in _book_paths
+    )
+
+
 _SQLITE_MAGIC = b"SQLite format 3\x00"
 
 
@@ -1490,6 +1572,11 @@ Environment variables:
                              --modules / GNUCASH_MCP_MODULES win when set.
   GNUCASH_MCP_DEBUG=1        Enable debug logging
   GNUCASH_MCP_NOAUDIT=1      Disable audit logging
+  GNUCASH_DEMO_BOOKS         true/false — serve the demo books found in
+                             GNUCASH_DEMO_DIR (*.gnucash, sorted) after
+                             the user's own books. The MCPB bundle's
+                             "Include demo books" checkbox; with no other
+                             books configured, the demos serve alone.
   GNUCASH_MCP_ADVANCED       Shell-style GNUCASH_*=value pairs applied to
                              the environment before any other setting is
                              read (quoted values may contain spaces). The
@@ -1565,21 +1652,30 @@ def main() -> None:
         except _BookPathError as exc:
             print(str(exc), file=sys.stderr)
             raise SystemExit(2) from None
-        book_path = str(_current_path)
 
-        # Startup format check: an XML-format book (the #1
-        # predictable file-picker mistake) fails here with a message
-        # a non-developer can act on, instead of a piecash
-        # DatabaseError at first tool call.
-        format_errors = [
-            msg for p in _book_paths
-            if (msg := _book_format_error(p)) is not None
-        ]
-        if format_errors:
-            print("\n".join(format_errors), file=sys.stderr)
-            raise SystemExit(2)
-    else:
-        book_path = None
+    # Bundled demo books (MCPB "Include demo books" checkbox) append
+    # AFTER the user's own, so their first pick stays the startup
+    # default; with no user books configured, the demos alone serve
+    # (pure demo mode).
+    try:
+        _append_demo_books()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from None
+
+    book_path = str(_current_path) if _book_paths else None
+
+    # Startup format check: an XML-format book (the #1 predictable
+    # file-picker mistake) fails here with a message a non-developer
+    # can act on, instead of a piecash DatabaseError at first tool
+    # call.
+    format_errors = [
+        msg for p in _book_paths
+        if (msg := _book_format_error(p)) is not None
+    ]
+    if format_errors:
+        print("\n".join(format_errors), file=sys.stderr)
+        raise SystemExit(2)
 
     # Module selection precedence: --modules, then GNUCASH_MCP_MODULES,
     # then the MCPB bundle's GNUCASH_ENABLE_* checkbox toggles.

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -32,56 +32,17 @@ ArgModelBase.model_config = {
     "extra": "forbid",
 }
 
-# ── Advanced-options passthrough ────────────────────────────────────
-# GNUCASH_MCP_ADVANCED holds shell-style KEY=VALUE pairs (shlex
-# rules, so quoted values may contain spaces) applied into the
-# process environment before ANY other configuration is read. This
-# is the MCPB bundle's escape hatch: the manifest maps one optional
-# "Advanced options" text field onto this variable, giving bundle
-# users the entire GNUCASH_* env surface (debug, audit, log/backup
-# location, redaction, FX guards, rate limits) without a checkbox
-# per knob. Keys are restricted to the GNUCASH_* namespace — this is
-# a server-options field, not a general environment editor — and the
-# pairs OVERRIDE existing values, since the manifest itself sets
-# GNUCASH_REDACT_PATHS=1 and the box must be able to turn that off.
-# Applied here, before the module-level debug/audit/book seeds below
-# and before sibling modules import; malformed input is recorded and
-# fail-fasted in main() (import must stay side-effect-safe for
-# tests and inspection tooling).
-_advanced_env_errors: list[str] = []
-
-
-def _apply_advanced_env() -> None:
-    """Parse GNUCASH_MCP_ADVANCED into environment overrides."""
-    raw = os.environ.get("GNUCASH_MCP_ADVANCED")
-    if not raw or not raw.strip():
-        return
-    import re
-    import shlex
-    try:
-        tokens = shlex.split(raw)
-    except ValueError as exc:
-        _advanced_env_errors.append(
-            f"Invalid advanced options (GNUCASH_MCP_ADVANCED): {exc}"
-        )
-        return
-    for token in tokens:
-        key, sep, value = token.partition("=")
-        if (
-            not sep
-            or not re.fullmatch(r"GNUCASH_[A-Z0-9_]+", key)
-            or key == "GNUCASH_MCP_ADVANCED"
-        ):
-            _advanced_env_errors.append(
-                f"Invalid advanced option {token!r}: expected "
-                "GNUCASH_*=value pairs, e.g. GNUCASH_MCP_DEBUG=1 "
-                'GNUCASH_LOG_DIR="/path/with spaces"'
-            )
-            continue
-        os.environ[key] = value
-
-
-_apply_advanced_env()
+# The advanced-options passthrough (GNUCASH_MCP_ADVANCED) lives in
+# gnucash_mcp/_env.py and is applied at the top of the package
+# __init__ — before this module or any sibling imports — so the
+# seeds below already see its overrides. main() fail-fasts on any
+# recorded _env_errors; harnesses that bypass main() (mcp dev,
+# pytest) still see them on stderr at import.
+from gnucash_mcp._env import (
+    _apply_advanced_env,
+    _env_errors,
+    _parse_env_toggle,
+)
 
 from gnucash_mcp.book import GnuCashBook, build_book_class, extracted_modules
 from gnucash_mcp.logging_config import audit_log, debug_log, setup_logging
@@ -940,17 +901,8 @@ def _demo_book_paths() -> list[Path]:
     Raises ValueError on an unparseable toggle value (fail fast,
     same contract as the GNUCASH_ENABLE_* toggles).
     """
-    raw = os.environ.get("GNUCASH_DEMO_BOOKS")
-    if raw is None:
+    if not _parse_env_toggle("GNUCASH_DEMO_BOOKS"):
         return []
-    norm = raw.strip().lower()
-    if norm in _TOGGLE_FALSE:
-        return []
-    if norm not in _TOGGLE_TRUE:
-        raise ValueError(
-            f"Invalid GNUCASH_DEMO_BOOKS={raw!r}: expected true/false "
-            "(also accepted: 1/0, yes/no, on/off)"
-        )
     demo_dir = os.environ.get("GNUCASH_DEMO_DIR")
     if not demo_dir or not demo_dir.strip():
         return []
@@ -1283,8 +1235,22 @@ def _switch_book_impl(name: str) -> str:
 # Use GNUCASH_MCP_DEBUG=1 env var to enable debug logging
 # Use GNUCASH_MCP_NOAUDIT=1 env var to disable audit logging
 # Logs are stored alongside the book file: {book_path}.mcp/audit/ and {book_path}.mcp/debug/
-_debug_mode = os.environ.get("GNUCASH_MCP_DEBUG") == "1"
-_audit_mode = os.environ.get("GNUCASH_MCP_NOAUDIT") != "1"
+def _seed_toggle(var: str, *, default: bool) -> bool:
+    """Import-time toggle read. Accepts the full toggle vocabulary
+    (so GNUCASH_MCP_DEBUG=true from the Advanced box works, not just
+    =1). Import must not raise, so a garbage value is recorded in
+    _env_errors — main() fail-fasts on it — and the default applies
+    meanwhile."""
+    try:
+        value = _parse_env_toggle(var)
+    except ValueError as exc:
+        _env_errors.append(str(exc))
+        return default
+    return default if value is None else value
+
+
+_debug_mode = _seed_toggle("GNUCASH_MCP_DEBUG", default=False)
+_audit_mode = not _seed_toggle("GNUCASH_MCP_NOAUDIT", default=False)
 _logging_debug = _debug_mode
 _logging_audit = _audit_mode
 # Initial logging points at the first valid book. Best-effort at
@@ -1500,8 +1466,6 @@ _ENV_MODULE_TOGGLES: dict[str, tuple[str, ...]] = {
     "GNUCASH_ENABLE_FREELANCER": ("freelancer",),
     "GNUCASH_ENABLE_BUSINESS": ("business",),
 }
-_TOGGLE_TRUE = frozenset({"true", "1", "yes", "on"})
-_TOGGLE_FALSE = frozenset({"false", "0", "no", "off", ""})
 
 
 def _modules_from_env_toggles() -> str | None:
@@ -1521,17 +1485,8 @@ def _modules_from_env_toggles() -> str | None:
         return None
     selected: list[str] = ["reporting"]
     for var, modules in _ENV_MODULE_TOGGLES.items():
-        raw = os.environ.get(var)
-        if raw is None:
-            continue
-        norm = raw.strip().lower()
-        if norm in _TOGGLE_TRUE:
+        if _parse_env_toggle(var):
             selected.extend(modules)
-        elif norm not in _TOGGLE_FALSE:
-            raise ValueError(
-                f"Invalid {var}={raw!r}: expected true/false "
-                "(also accepted: 1/0, yes/no, on/off)"
-            )
     return ",".join(selected)
 
 
@@ -1632,8 +1587,8 @@ Environment variables:
                              = budgets + scheduling; investments =
                              investor; business supersedes freelancer).
                              --modules / GNUCASH_MCP_MODULES win when set.
-  GNUCASH_MCP_DEBUG=1        Enable debug logging
-  GNUCASH_MCP_NOAUDIT=1      Disable audit logging
+  GNUCASH_MCP_DEBUG=true     Enable debug logging (true/1/yes/on)
+  GNUCASH_MCP_NOAUDIT=true   Disable audit logging (true/1/yes/on)
   GNUCASH_DEMO_BOOKS         true/false — serve the demo books found in
                              GNUCASH_DEMO_DIR (*.gnucash, sorted) after
                              the user's own books. The MCPB bundle's
@@ -1648,7 +1603,7 @@ Environment variables:
                              Each book gets its own subdirectory:
                              {{GNUCASH_LOG_DIR}}/{{book}}.mcp
                              Default location: {{book_path}}.mcp
-  GNUCASH_REDACT_PATHS=1     Collapse absolute paths to basenames in tool
+  GNUCASH_REDACT_PATHS=true  Collapse absolute paths to basenames in tool
                              responses and error messages (safe to share)
   GNUCASH_FX_GUARD_DAYS      Refuse a cross-currency invoice/bill post or pay
                              when the chosen rate is this many days from the
@@ -1678,11 +1633,12 @@ def main() -> None:
 
     global _logging_debug, _logging_audit, _book_class
 
-    # Advanced-options errors surfaced first: the pairs were applied
-    # (or rejected) at import, but a typo'd option must kill startup
-    # loudly, not silently run with the default it meant to change.
-    if _advanced_env_errors:
-        print("\n".join(_advanced_env_errors), file=sys.stderr)
+    # Env-configuration errors surfaced first: advanced-option pairs
+    # and toggle seeds were applied (or rejected) at import, but a
+    # typo'd option must kill startup loudly, not silently run with
+    # the default it meant to change.
+    if _env_errors:
+        print("\n".join(_env_errors), file=sys.stderr)
         raise SystemExit(2)
 
     # Parse CLI flags first — --book must win over GNUCASH_BOOK_PATH

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -741,6 +741,11 @@ _book_paths: list[Path] = []
 _current_path: Path | None = None
 _book_registry: dict[str, GnuCashBook] = {}
 _book = None
+# The exact GNUCASH_BOOK_PATH string _book_paths was derived from (or
+# mirrored into). get_book() re-parses the env ONLY when the live value
+# differs from this — re-splitting our own mirror would corrupt any
+# validated path containing os.pathsep and re-stat every book.
+_book_paths_source: str | None = None
 
 # Effective logging mode. Seeded from env at import; main() may widen
 # it via the --debug / --noaudit CLI flags. switch_book reads these to
@@ -868,25 +873,57 @@ def _validate_book_paths(
     return paths
 
 
+def _install_book_list(paths: list[Path], *, activate: bool) -> None:
+    """Install ``paths`` as the active book list.
+
+    The single owner of the book-list invariant triple — the
+    ``_book_paths``/``_current_path`` globals, the GNUCASH_BOOK_PATH
+    env mirror, and (when ``activate``) logging activation. Every
+    composition site (--book args, the env var, demo append, and any
+    future source) must route here rather than hand-sync the triple.
+
+    The mirror exists because get_book() re-reads the env whenever
+    ``_book`` is reset; the mirrored string is also cached in
+    ``_book_paths_source`` so get_book() can tell "the value I
+    mirrored" from a genuinely swapped one — re-splitting our own
+    mirror on os.pathsep would shatter a validated path that happens
+    to contain the separator (a ``Budget: 2026.gnucash`` picked in
+    the bundle's file dialog).
+
+    ``_current_path`` survives when it appears in the new list (demo
+    append behind an active book); otherwise it resets to the first
+    entry and the cached ``_book`` instance is dropped.
+
+    Pass ``activate=True`` when this install is the moment logging
+    should (re-)point at the current book: books arriving via CLI
+    (the import-time logging block never saw them), pure demo mode,
+    or CLI logging flags changing the effective modes.
+    """
+    global _book_paths, _current_path, _book, _book_paths_source
+    _book_paths = list(paths)
+    if _current_path not in _book_paths:
+        _current_path = _book_paths[0]
+        _book = None
+    mirrored = os.pathsep.join(str(p) for p in _book_paths)
+    os.environ["GNUCASH_BOOK_PATH"] = mirrored
+    _book_paths_source = mirrored
+    if activate:
+        _activate_logging(_current_path)
+
+
 def _apply_book_args(book_args: list[str]) -> None:
     """Install --book CLI paths as the active book list.
 
-    Args win over GNUCASH_BOOK_PATH. The resolved list is mirrored
-    back into the env var (os.pathsep-joined) because get_book()
-    re-reads the env whenever ``_book`` is reset — without the
-    mirror, a test-style reset would silently fall back to the
-    env's books. Logging is (re-)pointed here too: when the books
-    arrive via CLI only, the import-time logging block never ran
-    (it reads the env, which was unset at import).
+    Args win over GNUCASH_BOOK_PATH. Always activates logging: when
+    the books arrive via CLI, the import-time logging block never ran
+    (it reads the env, which was unset or different at import) — and
+    main() folds CLI logging flags into the effective modes before
+    calling here, so the activation sees the final debug/audit state.
     """
-    global _book_paths, _current_path, _book
-    _book_paths = _validate_book_paths(book_args, source="--book")
-    _current_path = _book_paths[0]
-    _book = None
-    os.environ["GNUCASH_BOOK_PATH"] = os.pathsep.join(
-        str(p) for p in _book_paths
+    _install_book_list(
+        _validate_book_paths(book_args, source="--book"),
+        activate=True,
     )
-    _activate_logging(_current_path)
 
 
 def _demo_book_paths() -> list[Path]:
@@ -940,10 +977,9 @@ def _append_demo_books() -> None:
     an optional extra and must not brick startup over a name. When
     no user books are configured at all, the demos alone become the
     book list (pure demo mode) and logging activates on the first.
-    The composed list is mirrored into GNUCASH_BOOK_PATH because
-    get_book() re-reads the env whenever ``_book`` is reset.
+    List installation (globals, env mirror, activation) is
+    _install_book_list's job.
     """
-    global _book_paths, _current_path
     demos = _demo_book_paths()
     if not demos:
         return
@@ -962,13 +998,7 @@ def _append_demo_books() -> None:
     if not added:
         return
     demo_only = not _book_paths
-    _book_paths = _book_paths + added
-    if demo_only:
-        _current_path = _book_paths[0]
-        _activate_logging(_current_path)
-    os.environ["GNUCASH_BOOK_PATH"] = os.pathsep.join(
-        str(p) for p in _book_paths
-    )
+    _install_book_list(_book_paths + added, activate=demo_only)
 
 
 _SQLITE_MAGIC = b"SQLite format 3\x00"
@@ -1035,11 +1065,17 @@ def get_book():
     forces re-initialization from the environment — the reset point
     tests rely on.
     """
-    global _book, _current_path, _book_paths
+    global _book, _current_path, _book_paths, _book_paths_source
     if _book is None:
         # Re-read the env so a test that swapped GNUCASH_BOOK_PATH and
-        # reset _book picks up the new value.
-        _book_paths = _parse_book_paths(os.environ.get("GNUCASH_BOOK_PATH"))
+        # reset _book picks up the new value — but ONLY when the value
+        # actually differs from the one _book_paths came from.
+        # Re-splitting our own mirror would corrupt a validated path
+        # containing os.pathsep and re-stat every book per reset.
+        env_val = os.environ.get("GNUCASH_BOOK_PATH")
+        if not _book_paths or env_val != _book_paths_source:
+            _book_paths = _parse_book_paths(env_val)
+            _book_paths_source = env_val
         if _current_path not in _book_paths:
             _current_path = _book_paths[0]
         _book = _book_for(_current_path)
@@ -1051,15 +1087,17 @@ def _activate_logging(path: Path) -> None:
 
     Used on book switch so each book's writes land in its own
     .mcp/audit trail. setup_logging clears its handlers on every call,
-    so repeated invocations don't stack handlers.
+    so repeated invocations don't stack handlers — and with both
+    modes off it clears WITHOUT reinstalling, which is why this call
+    is unconditional: a --noaudit startup must tear down handlers the
+    import-time block already installed, not skip past them.
     """
-    if _logging_audit or _logging_debug:
-        setup_logging(
-            book_path=str(path),
-            debug=_logging_debug,
-            audit=_logging_audit,
-            get_book=get_book,
-        )
+    setup_logging(
+        book_path=str(path),
+        debug=_logging_debug,
+        audit=_logging_audit,
+        get_book=get_book,
+    )
 
 
 def _book_orientation(book_instance) -> str:
@@ -1614,8 +1652,7 @@ def main() -> None:
         print(_build_help_text())
         sys.exit(0)
 
-    global _book_paths, _current_path, _logging_debug, _logging_audit
-    global _book_class
+    global _logging_debug, _logging_audit, _book_class
 
     # Advanced-options errors surfaced first: the pairs were applied
     # (or rejected) at import, but a typo'd option must kill startup
@@ -1635,6 +1672,16 @@ def main() -> None:
         raise SystemExit(2) from None
     del sys.argv[1:]
 
+    # Fold CLI logging flags into the effective modes BEFORE any book
+    # installation can activate logging — activation must see the
+    # final debug/audit state. (Activating first and re-initializing
+    # later left --noaudit's teardown unreachable: the old re-init
+    # guard skipped setup_logging when both modes were off, and
+    # setup_logging is the only handler-clearing path.)
+    if debug_flag or noaudit_flag:
+        _logging_debug = debug_flag or _debug_mode
+        _logging_audit = (not noaudit_flag) and _audit_mode
+
     # Resolve the book list: --book args win; otherwise
     # GNUCASH_BOOK_PATH (one path or an os.pathsep-separated list).
     # Fail fast on any invalid/duplicate entry (neither set is
@@ -1647,8 +1694,13 @@ def main() -> None:
             if book_args:
                 _apply_book_args(book_args)
             else:
-                _book_paths = _parse_book_paths(raw_book_path)
-                _current_path = _book_paths[0]
+                # Env-configured books: import-time logging already
+                # points at the first one, so re-activate only when
+                # the CLI flags changed the effective modes.
+                _install_book_list(
+                    _parse_book_paths(raw_book_path),
+                    activate=debug_flag or noaudit_flag,
+                )
         except _BookPathError as exc:
             print(str(exc), file=sys.stderr)
             raise SystemExit(2) from None
@@ -1688,23 +1740,14 @@ def main() -> None:
             print(str(exc), file=sys.stderr)
             raise SystemExit(2) from None
 
-    # Re-init logging if CLI flags override env vars. Update the
-    # effective-mode globals so switch_book repoints with the same
-    # debug/audit settings.
-    if debug_flag or noaudit_flag:
-        audit_enabled = not noaudit_flag
-        _logging_debug = debug_flag or _debug_mode
-        _logging_audit = audit_enabled and _audit_mode
-        if book_path and (_logging_audit or _logging_debug):
-            setup_logging(
-                book_path=book_path,
-                debug=_logging_debug,
-                audit=_logging_audit,
-                get_book=get_book,
-            )
-            if _logging_debug:
-                debug_log(f"Server starting via CLI. Book: {book_path}")
-                debug_log(f"Debug logging enabled, audit={'enabled' if _logging_audit else 'disabled'}")
+    # Logging was activated (or torn down) by the book-list install
+    # above with the flag-merged modes; only the breadcrumbs remain.
+    if book_path and _logging_debug:
+        debug_log(f"Server starting via CLI. Book: {book_path}")
+        debug_log(
+            "Debug logging enabled, audit="
+            f"{'enabled' if _logging_audit else 'disabled'}"
+        )
 
     # Validate and apply module filter (also lazy-loads extracted modules)
     _validate_module_groups()

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -765,7 +765,15 @@ def _validate_book_paths(
     CLI argument land here, so existence, regular-file, and
     filename-stem uniqueness rules cannot diverge between the two
     interfaces. ``source`` names the interface in error messages.
+
+    Empty entries are dropped rather than resolved — an MCPB host
+    expanding an unset multi-file config could hand --book an empty
+    string, and ``Path("").resolve(strict=True)`` would otherwise
+    "find" the working directory.
     """
+    raw = [p for p in (s.strip() for s in raw) if p]
+    if not raw:
+        raise _BookPathError(f"Invalid {source}: no paths given")
     paths: list[Path] = []
     errors: list[str] = []
     for p in raw:

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -32,6 +32,57 @@ ArgModelBase.model_config = {
     "extra": "forbid",
 }
 
+# ── Advanced-options passthrough ────────────────────────────────────
+# GNUCASH_MCP_ADVANCED holds shell-style KEY=VALUE pairs (shlex
+# rules, so quoted values may contain spaces) applied into the
+# process environment before ANY other configuration is read. This
+# is the MCPB bundle's escape hatch: the manifest maps one optional
+# "Advanced options" text field onto this variable, giving bundle
+# users the entire GNUCASH_* env surface (debug, audit, log/backup
+# location, redaction, FX guards, rate limits) without a checkbox
+# per knob. Keys are restricted to the GNUCASH_* namespace — this is
+# a server-options field, not a general environment editor — and the
+# pairs OVERRIDE existing values, since the manifest itself sets
+# GNUCASH_REDACT_PATHS=1 and the box must be able to turn that off.
+# Applied here, before the module-level debug/audit/book seeds below
+# and before sibling modules import; malformed input is recorded and
+# fail-fasted in main() (import must stay side-effect-safe for
+# tests and inspection tooling).
+_advanced_env_errors: list[str] = []
+
+
+def _apply_advanced_env() -> None:
+    """Parse GNUCASH_MCP_ADVANCED into environment overrides."""
+    raw = os.environ.get("GNUCASH_MCP_ADVANCED")
+    if not raw or not raw.strip():
+        return
+    import re
+    import shlex
+    try:
+        tokens = shlex.split(raw)
+    except ValueError as exc:
+        _advanced_env_errors.append(
+            f"Invalid advanced options (GNUCASH_MCP_ADVANCED): {exc}"
+        )
+        return
+    for token in tokens:
+        key, sep, value = token.partition("=")
+        if (
+            not sep
+            or not re.fullmatch(r"GNUCASH_[A-Z0-9_]+", key)
+            or key == "GNUCASH_MCP_ADVANCED"
+        ):
+            _advanced_env_errors.append(
+                f"Invalid advanced option {token!r}: expected "
+                "GNUCASH_*=value pairs, e.g. GNUCASH_MCP_DEBUG=1 "
+                'GNUCASH_LOG_DIR="/path/with spaces"'
+            )
+            continue
+        os.environ[key] = value
+
+
+_apply_advanced_env()
+
 from gnucash_mcp.book import GnuCashBook, build_book_class, extracted_modules
 from gnucash_mcp.logging_config import audit_log, debug_log, setup_logging
 from gnucash_mcp.tools._helpers import _json, safe_tool
@@ -1439,6 +1490,11 @@ Environment variables:
                              --modules / GNUCASH_MCP_MODULES win when set.
   GNUCASH_MCP_DEBUG=1        Enable debug logging
   GNUCASH_MCP_NOAUDIT=1      Disable audit logging
+  GNUCASH_MCP_ADVANCED       Shell-style GNUCASH_*=value pairs applied to
+                             the environment before any other setting is
+                             read (quoted values may contain spaces). The
+                             MCPB bundle's "Advanced options" field maps
+                             here; pairs override already-set variables.
   GNUCASH_LOG_DIR            Relocate .mcp storage (audit, debug, backups).
                              Each book gets its own subdirectory:
                              {{GNUCASH_LOG_DIR}}/{{book}}.mcp
@@ -1473,6 +1529,13 @@ def main() -> None:
 
     global _book_paths, _current_path, _logging_debug, _logging_audit
     global _book_class
+
+    # Advanced-options errors surfaced first: the pairs were applied
+    # (or rejected) at import, but a typo'd option must kill startup
+    # loudly, not silently run with the default it meant to change.
+    if _advanced_env_errors:
+        print("\n".join(_advanced_env_errors), file=sys.stderr)
+        raise SystemExit(2)
 
     # Parse CLI flags first — --book must win over GNUCASH_BOOK_PATH
     # below. Fail-fast rationale lives on _parse_cli_argv.
@@ -1598,7 +1661,10 @@ def main() -> None:
         "book_path": book_path or "not set",
         "book_paths": [p.name for p in _book_paths],
         "current_book": _current_path.name if _current_path else None,
-        "debug": debug_flag,
+        # Effective mode, not just the CLI flag — debug enabled via
+        # GNUCASH_MCP_DEBUG (or the advanced-options box) must not
+        # display as "Debug mode: false".
+        "debug": _logging_debug,
         "default_currency_ok": currency_ok,
     })
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,80 @@
+"""Contract lock: manifest.json ↔ the server it launches.
+
+The MCPB manifest names env vars, CLI args, and a version by string;
+nothing at runtime would notice them drifting from the server's
+actual interface (a renamed toggle would silently strand a checkbox;
+a missed version bump would ship a bundle self-identifying as the
+previous release — the v1.4.1 stale-lockfile class). These tests are
+the drift alarm, and the same suite runs in CI before every pack.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_MANIFEST = _ROOT / "manifest.json"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return json.loads(_MANIFEST.read_text())
+
+
+class TestManifestContract:
+    def test_version_matches_package(self, manifest):
+        from gnucash_mcp import __version__
+        assert manifest["version"] == __version__
+
+    def test_version_matches_pyproject(self, manifest):
+        text = (_ROOT / "pyproject.toml").read_text()
+        match = re.search(r'^version = "([^"]+)"', text, re.M)
+        assert match is not None
+        assert manifest["version"] == match.group(1)
+
+    def test_env_keys_cover_the_server_interface(self, manifest):
+        """Every env var the server's bundle paths read must be set
+        by the manifest — a server-side rename may not leave the
+        manifest feeding a dead variable."""
+        from gnucash_mcp.server import _ENV_MODULE_TOGGLES
+        env = manifest["server"]["mcp_config"]["env"]
+        expected = set(_ENV_MODULE_TOGGLES) | {
+            "GNUCASH_DEMO_BOOKS",
+            "GNUCASH_DEMO_DIR",
+            "GNUCASH_MCP_ADVANCED",
+            "GNUCASH_REDACT_PATHS",
+        }
+        missing = expected - set(env)
+        assert not missing, f"manifest env missing: {sorted(missing)}"
+
+    def test_placeholders_reference_declared_user_config(self, manifest):
+        """${user_config.X} placeholders must name declared fields,
+        and the book picker must actually feed --book."""
+        declared = set(manifest["user_config"])
+        blob = json.dumps(manifest["server"]["mcp_config"])
+        used = set(re.findall(r"\$\{user_config\.([a-z_]+)\}", blob))
+        undeclared = used - declared
+        assert not undeclared, f"placeholders without fields: {undeclared}"
+        unused = declared - used
+        assert not unused, f"fields feeding nothing: {unused}"
+        args = manifest["server"]["mcp_config"]["args"]
+        assert "--book" in args
+        assert args[args.index("--book") + 1] == "${user_config.books}"
+
+    def test_demo_dir_points_inside_the_bundle(self, manifest):
+        env = manifest["server"]["mcp_config"]["env"]
+        assert env["GNUCASH_DEMO_DIR"] == "${__dirname}/samples"
+
+    def test_mcpbignore_negations_name_real_books(self):
+        """Each !samples/... re-inclusion must exist on disk, or the
+        pack silently ships fewer demo books than intended."""
+        negations = [
+            line[1:].strip()
+            for line in (_ROOT / ".mcpbignore").read_text().splitlines()
+            if line.startswith("!")
+        ]
+        assert negations, "expected demo-book negations in .mcpbignore"
+        for rel in negations:
+            assert (_ROOT / rel).is_file(), f"negated but missing: {rel}"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1716,6 +1716,114 @@ class TestEnvModuleToggles:
                 assert name in valid, name
 
 
+class TestDemoBooks:
+    """GNUCASH_DEMO_BOOKS / GNUCASH_DEMO_DIR — the MCPB "Include demo
+    books" checkbox. Demos append after the user's books (their first
+    pick stays the startup default), collide softly instead of
+    tripping the stem fail-fast, and serve alone when no user books
+    are configured."""
+
+    @pytest.fixture(autouse=True)
+    def restore_book_state(self, monkeypatch):
+        import gnucash_mcp.server as srv
+        import gnucash_mcp.logging_config as logcfg
+        monkeypatch.delenv("GNUCASH_DEMO_BOOKS", raising=False)
+        monkeypatch.delenv("GNUCASH_DEMO_DIR", raising=False)
+        saved = (srv._book, list(srv._book_paths), srv._current_path)
+        log_saved = (
+            logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
+        )
+        yield
+        srv._book, srv._book_paths, srv._current_path = saved
+        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
+
+    @pytest.fixture
+    def demo_dir(self, tmp_path, monkeypatch):
+        d = tmp_path / "samples"
+        d.mkdir()
+        _make_min_book(d / "beta-demo.gnucash")
+        _make_min_book(d / "alpha-demo.gnucash")
+        monkeypatch.setenv("GNUCASH_DEMO_DIR", str(d))
+        return d
+
+    def test_toggle_unset_yields_nothing(self, demo_dir):
+        from gnucash_mcp.server import _demo_book_paths
+        assert _demo_book_paths() == []
+
+    def test_toggle_false_yields_nothing(self, demo_dir, monkeypatch):
+        from gnucash_mcp.server import _demo_book_paths
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "false")
+        assert _demo_book_paths() == []
+
+    def test_toggle_true_yields_sorted_books(self, demo_dir, monkeypatch):
+        from gnucash_mcp.server import _demo_book_paths
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        names = [p.name for p in _demo_book_paths()]
+        assert names == ["alpha-demo.gnucash", "beta-demo.gnucash"]
+
+    def test_invalid_toggle_raises(self, demo_dir, monkeypatch):
+        from gnucash_mcp.server import _demo_book_paths
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "ture")
+        with pytest.raises(ValueError, match="GNUCASH_DEMO_BOOKS"):
+            _demo_book_paths()
+
+    def test_missing_dir_degrades_to_nothing(self, tmp_path, monkeypatch, capsys):
+        from gnucash_mcp.server import _demo_book_paths
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        monkeypatch.setenv("GNUCASH_DEMO_DIR", str(tmp_path / "gone"))
+        assert _demo_book_paths() == []
+        assert "continuing without" in capsys.readouterr().err
+
+    def test_demos_append_after_user_books(
+        self, demo_dir, tmp_path, monkeypatch
+    ):
+        import gnucash_mcp.server as srv
+        mine = _make_min_book(tmp_path / "mine.gnucash")
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(mine))
+        srv._book_paths = [mine.resolve()]
+        srv._current_path = mine.resolve()
+        srv._append_demo_books()
+        assert [p.name for p in srv._book_paths] == [
+            "mine.gnucash", "alpha-demo.gnucash", "beta-demo.gnucash",
+        ]
+        # User's pick stays the startup default; env mirror composed.
+        assert srv._current_path == mine.resolve()
+        assert os.environ["GNUCASH_BOOK_PATH"] == os.pathsep.join(
+            str(p) for p in srv._book_paths
+        )
+
+    def test_demo_only_mode_when_no_user_books(self, demo_dir, monkeypatch):
+        import gnucash_mcp.server as srv
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", "placeholder")
+        srv._book_paths = []
+        srv._current_path = None
+        srv._append_demo_books()
+        assert [p.name for p in srv._book_paths] == [
+            "alpha-demo.gnucash", "beta-demo.gnucash",
+        ]
+        assert srv._current_path == srv._book_paths[0]
+
+    def test_stem_collision_skips_demo_softly(
+        self, demo_dir, tmp_path, monkeypatch, capsys
+    ):
+        """A user book named like a demo must not brick startup —
+        the colliding demo is skipped with a note; the rest serve."""
+        import gnucash_mcp.server as srv
+        mine = _make_min_book(tmp_path / "alpha-demo.gnucash")
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(mine))
+        srv._book_paths = [mine.resolve()]
+        srv._current_path = mine.resolve()
+        srv._append_demo_books()
+        assert [p.name for p in srv._book_paths] == [
+            "alpha-demo.gnucash", "beta-demo.gnucash",
+        ]
+        assert srv._book_paths[0] == mine.resolve()
+        assert "skipped" in capsys.readouterr().err
+
+
 class TestAdvancedEnvPassthrough:
     """GNUCASH_MCP_ADVANCED — the MCPB "Advanced options" field.
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1716,6 +1716,90 @@ class TestEnvModuleToggles:
                 assert name in valid, name
 
 
+class TestAdvancedEnvPassthrough:
+    """GNUCASH_MCP_ADVANCED — the MCPB "Advanced options" field.
+
+    Shell-style GNUCASH_*=value pairs applied into the environment at
+    import time, overriding already-set variables (the manifest sets
+    GNUCASH_REDACT_PATHS=1; the box must be able to turn it off).
+    Malformed input is recorded in _advanced_env_errors and
+    fail-fasted by main().
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_env_and_errors(self):
+        import gnucash_mcp.server as srv
+        saved_errors = list(srv._advanced_env_errors)
+        saved_env = {
+            k: v for k, v in os.environ.items() if k.startswith("GNUCASH")
+        }
+        yield
+        srv._advanced_env_errors[:] = saved_errors
+        for k in [k for k in os.environ if k.startswith("GNUCASH")]:
+            if k not in saved_env:
+                del os.environ[k]
+        os.environ.update(saved_env)
+
+    def _run(self, value):
+        import gnucash_mcp.server as srv
+        srv._advanced_env_errors.clear()
+        os.environ["GNUCASH_MCP_ADVANCED"] = value
+        srv._apply_advanced_env()
+        return srv._advanced_env_errors
+
+    def test_pairs_applied_and_override_existing(self):
+        os.environ["GNUCASH_REDACT_PATHS"] = "1"
+        errors = self._run(
+            "GNUCASH_MCP_DEBUG=1 GNUCASH_REDACT_PATHS=0"
+        )
+        assert errors == []
+        assert os.environ["GNUCASH_MCP_DEBUG"] == "1"
+        assert os.environ["GNUCASH_REDACT_PATHS"] == "0"
+
+    def test_quoted_value_keeps_spaces(self):
+        errors = self._run('GNUCASH_LOG_DIR="/Volumes/My Backups"')
+        assert errors == []
+        assert os.environ["GNUCASH_LOG_DIR"] == "/Volumes/My Backups"
+
+    def test_empty_value_is_a_noop(self):
+        import gnucash_mcp.server as srv
+        srv._advanced_env_errors.clear()
+        os.environ["GNUCASH_MCP_ADVANCED"] = "   "
+        srv._apply_advanced_env()
+        assert srv._advanced_env_errors == []
+
+    def test_non_gnucash_key_rejected_valid_pairs_still_apply(self):
+        errors = self._run("PATH=/tmp GNUCASH_FX_GUARD_DAYS=14")
+        assert len(errors) == 1
+        assert "PATH=/tmp" in errors[0]
+        assert os.environ["GNUCASH_FX_GUARD_DAYS"] == "14"
+        assert os.environ["PATH"] != "/tmp"
+
+    def test_bare_token_without_equals_rejected(self):
+        errors = self._run("GNUCASH_MCP_DEBUG")
+        assert len(errors) == 1
+        assert "GNUCASH_MCP_DEBUG" in errors[0]
+
+    def test_self_reference_rejected(self):
+        errors = self._run("GNUCASH_MCP_ADVANCED=recursion")
+        assert len(errors) == 1
+
+    def test_main_fails_fast_on_recorded_errors(
+        self, monkeypatch, capsys
+    ):
+        import sys as _sys
+        import gnucash_mcp.server as srv
+        monkeypatch.setattr(
+            srv, "_advanced_env_errors", ["Invalid advanced option 'x'"]
+        )
+        monkeypatch.setattr(_sys, "argv", ["gnucash-mcp"])
+        monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)
+        with pytest.raises(SystemExit) as excinfo:
+            srv.main()
+        assert excinfo.value.code == 2
+        assert "Invalid advanced option" in capsys.readouterr().err
+
+
 class TestBookFormatSniff:
     """Startup rejects non-SQLite books with a message a
     non-developer can act on (the XML-format file-picker mistake)."""

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1935,19 +1935,19 @@ class TestAdvancedEnvPassthrough:
     Shell-style GNUCASH_*=value pairs applied into the environment at
     import time, overriding already-set variables (the manifest sets
     GNUCASH_REDACT_PATHS=1; the box must be able to turn it off).
-    Malformed input is recorded in _advanced_env_errors and
+    Malformed input is recorded in _env_errors and
     fail-fasted by main().
     """
 
     @pytest.fixture(autouse=True)
     def restore_env_and_errors(self):
         import gnucash_mcp.server as srv
-        saved_errors = list(srv._advanced_env_errors)
+        saved_errors = list(srv._env_errors)
         saved_env = {
             k: v for k, v in os.environ.items() if k.startswith("GNUCASH")
         }
         yield
-        srv._advanced_env_errors[:] = saved_errors
+        srv._env_errors[:] = saved_errors
         for k in [k for k in os.environ if k.startswith("GNUCASH")]:
             if k not in saved_env:
                 del os.environ[k]
@@ -1955,10 +1955,10 @@ class TestAdvancedEnvPassthrough:
 
     def _run(self, value):
         import gnucash_mcp.server as srv
-        srv._advanced_env_errors.clear()
+        srv._env_errors.clear()
         os.environ["GNUCASH_MCP_ADVANCED"] = value
         srv._apply_advanced_env()
-        return srv._advanced_env_errors
+        return srv._env_errors
 
     def test_pairs_applied_and_override_existing(self):
         os.environ["GNUCASH_REDACT_PATHS"] = "1"
@@ -1976,10 +1976,10 @@ class TestAdvancedEnvPassthrough:
 
     def test_empty_value_is_a_noop(self):
         import gnucash_mcp.server as srv
-        srv._advanced_env_errors.clear()
+        srv._env_errors.clear()
         os.environ["GNUCASH_MCP_ADVANCED"] = "   "
         srv._apply_advanced_env()
-        assert srv._advanced_env_errors == []
+        assert srv._env_errors == []
 
     def test_non_gnucash_key_rejected_valid_pairs_still_apply(self):
         errors = self._run("PATH=/tmp GNUCASH_FX_GUARD_DAYS=14")
@@ -1997,13 +1997,49 @@ class TestAdvancedEnvPassthrough:
         errors = self._run("GNUCASH_MCP_ADVANCED=recursion")
         assert len(errors) == 1
 
+    def test_book_path_rejected_with_picker_pointer(self):
+        """GNUCASH_BOOK_PATH would be silently clobbered by the
+        --book mirror — the box must refuse it loudly instead
+        (PR #153 review)."""
+        errors = self._run("GNUCASH_BOOK_PATH=/x.gnucash")
+        assert len(errors) == 1
+        assert "book picker" in errors[0]
+
+    def test_windows_backslash_path_survives(self):
+        r"""POSIX shlex escapes ate unquoted backslashes
+        (C:\Temp -> C:Temp) and applied the mangled value silently;
+        escaping is disabled now (PR #153 review)."""
+        errors = self._run(r"GNUCASH_LOG_DIR=C:\Temp\gnclogs")
+        assert errors == []
+        assert os.environ["GNUCASH_LOG_DIR"] == r"C:\Temp\gnclogs"
+
+    def test_legacy_debug_vocab_accepts_true(self):
+        """GNUCASH_MCP_DEBUG=true (the vocabulary every checkbox in
+        the same dialog uses) must parse as ON via the shared toggle
+        parser, not silently fail an =='1' check."""
+        import gnucash_mcp.server as srv
+        os.environ["GNUCASH_MCP_DEBUG"] = "true"
+        assert srv._seed_toggle("GNUCASH_MCP_DEBUG", default=False) is True
+        os.environ["GNUCASH_MCP_DEBUG"] = "1"
+        assert srv._seed_toggle("GNUCASH_MCP_DEBUG", default=False) is True
+
+    def test_seed_toggle_records_garbage_for_main(self):
+        """A garbage value can't raise at import; it lands in
+        _env_errors for main() to fail-fast on."""
+        import gnucash_mcp.server as srv
+        srv._env_errors.clear()
+        os.environ["GNUCASH_MCP_DEBUG"] = "maybe"
+        assert srv._seed_toggle("GNUCASH_MCP_DEBUG", default=False) is False
+        assert len(srv._env_errors) == 1
+        assert "GNUCASH_MCP_DEBUG" in srv._env_errors[0]
+
     def test_main_fails_fast_on_recorded_errors(
         self, monkeypatch, capsys
     ):
         import sys as _sys
         import gnucash_mcp.server as srv
         monkeypatch.setattr(
-            srv, "_advanced_env_errors", ["Invalid advanced option 'x'"]
+            srv, "_env_errors", ["Invalid advanced option 'x'"]
         )
         monkeypatch.setattr(_sys, "argv", ["gnucash-mcp"])
         monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1555,6 +1555,212 @@ class TestCliArgStrictness:
         assert "GnuCash MCP Server" in capsys.readouterr().out
 
 
+class TestBookCliArg:
+    """--book CLI argument — the MCPB bundle's book interface.
+
+    Multi-value (``--book A B``, the shape a manifest multi-file
+    picker expands to), repeatable, ``--book=PATH``. Args win over
+    GNUCASH_BOOK_PATH, and both interfaces share the
+    _validate_book_paths chokepoint so validation cannot diverge.
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_book_state(self):
+        import gnucash_mcp.server as srv
+        import gnucash_mcp.logging_config as logcfg
+
+        saved = (
+            srv._book, list(srv._book_paths), srv._current_path,
+            dict(srv._book_registry),
+        )
+        log_saved = (
+            logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
+        )
+        yield
+        srv._book, srv._book_paths, srv._current_path = saved[:3]
+        srv._book_registry = saved[3]
+        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
+
+    # ── _parse_cli_argv ────────────────────────────────────────────
+
+    def test_multi_value_form(self):
+        from gnucash_mcp.server import _parse_cli_argv
+        books, debug, noaudit, modules = _parse_cli_argv(
+            ["--book", "/a.gnucash", "/b.gnucash", "--debug"]
+        )
+        assert books == ["/a.gnucash", "/b.gnucash"]
+        assert debug is True
+        assert noaudit is False
+        assert modules is None
+
+    def test_repeat_and_equals_forms(self):
+        from gnucash_mcp.server import _parse_cli_argv
+        books, *_ = _parse_cli_argv(["--book=/a", "--book", "/b"])
+        assert books == ["/a", "/b"]
+
+    def test_book_without_value_fails(self):
+        from gnucash_mcp.server import _CliParseError, _parse_cli_argv
+        with pytest.raises(_CliParseError, match="--book requires"):
+            _parse_cli_argv(["--book", "--debug"])
+
+    def test_unknown_flag_still_fails(self):
+        from gnucash_mcp.server import _CliParseError, _parse_cli_argv
+        with pytest.raises(_CliParseError, match="Unrecognized"):
+            _parse_cli_argv(["--books=/a"])
+
+    # ── _apply_book_args ───────────────────────────────────────────
+
+    def test_apply_overrides_env_and_mirrors_it(self, tmp_path, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        beast = _make_min_book(tmp_path / "beast-man.gnucash")
+        other = _make_min_book(tmp_path / "other.gnucash")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(other))
+        srv._apply_book_args([str(alex), str(beast)])
+        assert srv._book_paths == [alex.resolve(), beast.resolve()]
+        assert srv._current_path == alex.resolve()
+        # Mirrored into the env: get_book() re-reads it on reset.
+        assert os.environ["GNUCASH_BOOK_PATH"] == os.pathsep.join(
+            [str(alex.resolve()), str(beast.resolve())]
+        )
+        assert srv._book is None
+
+    def test_apply_missing_file_names_the_flag(self, tmp_path):
+        import gnucash_mcp.server as srv
+        with pytest.raises(srv._BookPathError, match=r"Invalid --book"):
+            srv._apply_book_args([str(tmp_path / "nope.gnucash")])
+
+    # ── main() integration (failure exits before the module filter,
+    #    so the tool registry is untouched) ─────────────────────────
+
+    def test_main_book_flag_missing_file_fails_fast(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        import sys as _sys
+        from gnucash_mcp.server import main
+        monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)
+        monkeypatch.setattr(
+            _sys, "argv",
+            ["gnucash-mcp", "--book", str(tmp_path / "nope.gnucash")],
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        assert excinfo.value.code == 2
+        assert "Invalid --book" in capsys.readouterr().err
+
+
+class TestEnvModuleToggles:
+    """GNUCASH_ENABLE_* booleans — the MCPB manifest's checkbox
+    interface. Composed only when at least one toggle var is present;
+    --modules / GNUCASH_MCP_MODULES win in main()."""
+
+    @pytest.fixture(autouse=True)
+    def clear_toggles(self, monkeypatch):
+        from gnucash_mcp.server import _ENV_MODULE_TOGGLES
+        for var in _ENV_MODULE_TOGGLES:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_absent_returns_none(self):
+        from gnucash_mcp.server import _modules_from_env_toggles
+        assert _modules_from_env_toggles() is None
+
+    def test_planning_only(self, monkeypatch):
+        from gnucash_mcp.server import _modules_from_env_toggles
+        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "true")
+        assert _modules_from_env_toggles() == "reporting,budgets,scheduling"
+
+    def test_all_false_still_gets_reporting(self, monkeypatch):
+        from gnucash_mcp.server import (
+            _ENV_MODULE_TOGGLES, _modules_from_env_toggles,
+        )
+        for var in _ENV_MODULE_TOGGLES:
+            monkeypatch.setenv(var, "false")
+        assert _modules_from_env_toggles() == "reporting"
+
+    def test_mcpb_style_selection(self, monkeypatch):
+        from gnucash_mcp.server import _modules_from_env_toggles
+        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "false")
+        monkeypatch.setenv("GNUCASH_ENABLE_INVESTMENTS", "true")
+        monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "false")
+        monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "true")
+        assert _modules_from_env_toggles() == "reporting,investor,business"
+
+    def test_invalid_value_fails_fast(self, monkeypatch):
+        from gnucash_mcp.server import _modules_from_env_toggles
+        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "ture")
+        with pytest.raises(ValueError, match="GNUCASH_ENABLE_PLANNING"):
+            _modules_from_env_toggles()
+
+    def test_toggle_targets_exist_in_registry(self):
+        """Contract lock: every toggle target (and the always-on
+        ``reporting``) must be a real module or group name, so a
+        module rename cannot silently strand the bundle's checkboxes
+        on an unknown-module startup error."""
+        from gnucash_mcp.server import _ENV_MODULE_TOGGLES
+        valid = set(TOOL_MODULES) | set(MODULE_GROUPS)
+        assert "reporting" in valid
+        for modules in _ENV_MODULE_TOGGLES.values():
+            for name in modules:
+                assert name in valid, name
+
+
+class TestBookFormatSniff:
+    """Startup rejects non-SQLite books with a message a
+    non-developer can act on (the XML-format file-picker mistake)."""
+
+    @pytest.fixture(autouse=True)
+    def restore_book_state(self):
+        import gnucash_mcp.server as srv
+        saved = (srv._book, list(srv._book_paths), srv._current_path)
+        yield
+        srv._book, srv._book_paths, srv._current_path = saved
+
+    def test_sqlite_book_passes(self, tmp_path):
+        from gnucash_mcp.server import _book_format_error
+        book = _make_min_book(tmp_path / "ok.gnucash")
+        assert _book_format_error(book) is None
+
+    def test_xml_book_gets_save_as_message(self, tmp_path):
+        from gnucash_mcp.server import _book_format_error
+        p = tmp_path / "old.gnucash"
+        p.write_bytes(b'<?xml version="1.0" encoding="utf-8" ?>\n<gnc-v2>')
+        msg = _book_format_error(p)
+        assert msg is not None
+        assert "XML format" in msg
+        assert "Save As" in msg
+        assert "old.gnucash" in msg
+
+    def test_gzipped_xml_book_gets_save_as_message(self, tmp_path):
+        import gzip
+        from gnucash_mcp.server import _book_format_error
+        p = tmp_path / "compressed.gnucash"
+        p.write_bytes(gzip.compress(b'<?xml version="1.0"?><gnc-v2>'))
+        msg = _book_format_error(p)
+        assert msg is not None
+        assert "XML format" in msg
+
+    def test_unrecognized_header_gets_generic_message(self, tmp_path):
+        from gnucash_mcp.server import _book_format_error
+        p = tmp_path / "mystery.gnucash"
+        p.write_bytes(b"\x00\x01 definitely not a book")
+        msg = _book_format_error(p)
+        assert msg is not None
+        assert "does not look like" in msg
+        assert "sqlite3" in msg
+
+    def test_main_xml_book_fails_fast(self, tmp_path, monkeypatch, capsys):
+        import sys as _sys
+        from gnucash_mcp.server import main
+        p = tmp_path / "old.gnucash"
+        p.write_bytes(b'<?xml version="1.0"?>\n<gnc-v2>')
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(p))
+        monkeypatch.setattr(_sys, "argv", ["gnucash-mcp"])
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        assert excinfo.value.code == 2
+        assert "XML format" in capsys.readouterr().err
+
+
 class TestHelpTextCounts:
     """--help tool counts derive from the registry, so they can
     never again drift the way the hardcoded "107 tools" did while

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1618,6 +1618,16 @@ class TestBookCliArg:
         with pytest.raises(_CliParseError, match="--book requires"):
             _parse_cli_argv(["--book", "--debug"])
 
+    def test_book_with_empty_value_falls_through(self):
+        """--book "" (an MCPB host expanding an unset picker) must
+        yield NO books — env/demo fallback — not a startup error."""
+        from gnucash_mcp.server import _parse_cli_argv
+        assert _parse_cli_argv(["--book", ""])[0] == []
+        assert _parse_cli_argv(["--book="])[0] == []
+        assert _parse_cli_argv(["--book", "", "/a.gnucash"])[0] == [
+            "/a.gnucash"
+        ]
+
     def test_unknown_flag_still_fails(self):
         from gnucash_mcp.server import _CliParseError, _parse_cli_argv
         with pytest.raises(_CliParseError, match="Unrecognized"):
@@ -1866,6 +1876,39 @@ class TestDemoBooks:
             "alpha-demo.gnucash", "beta-demo.gnucash",
         ]
         assert srv._current_path == srv._book_paths[0]
+
+    def test_glob_skips_gnucash_backup_files(self, demo_dir, monkeypatch):
+        """Opening a demo in GnuCash writes x.gnucash.TIMESTAMP.gnucash
+        backups beside it; they match *.gnucash and must not serve."""
+        from gnucash_mcp.server import _demo_book_paths
+        (demo_dir / "alpha-demo.gnucash.20260824120000.gnucash").write_bytes(
+            b"SQLite format 3\x00 backup"
+        )
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        names = [p.name for p in _demo_book_paths()]
+        assert names == ["alpha-demo.gnucash", "beta-demo.gnucash"]
+
+    def test_unreadable_demo_skipped_softly(
+        self, demo_dir, tmp_path, monkeypatch, capsys
+    ):
+        """A corrupted/XML demo must be skipped with a note, never
+        fatal — the demo-degrade contract (PR #153 review)."""
+        import gnucash_mcp.server as srv
+        (demo_dir / "aa-broken.gnucash").write_bytes(
+            b'<?xml version="1.0"?><gnc-v2>'
+        )
+        mine = _make_min_book(tmp_path / "mine.gnucash")
+        monkeypatch.setenv("GNUCASH_DEMO_BOOKS", "true")
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(mine))
+        srv._book_paths = [mine.resolve()]
+        srv._current_path = mine.resolve()
+        srv._append_demo_books()
+        assert [p.name for p in srv._book_paths] == [
+            "mine.gnucash", "alpha-demo.gnucash", "beta-demo.gnucash",
+        ]
+        err = capsys.readouterr().err
+        assert "aa-broken.gnucash" in err
+        assert "skipped" in err
 
     def test_stem_collision_skips_demo_softly(
         self, demo_dir, tmp_path, monkeypatch, capsys

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1630,6 +1630,18 @@ class TestBookCliArg:
         with pytest.raises(srv._BookPathError, match=r"Invalid --book"):
             srv._apply_book_args([str(tmp_path / "nope.gnucash")])
 
+    def test_empty_entries_dropped_not_resolved(self, tmp_path):
+        """An MCPB host expanding an unset multi-file config can hand
+        --book an empty string; it must be dropped, never resolved
+        (Path("").resolve(strict=True) "finds" the cwd)."""
+        import gnucash_mcp.server as srv
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        assert srv._validate_book_paths(
+            ["", str(alex), "  "], source="--book"
+        ) == [alex.resolve()]
+        with pytest.raises(srv._BookPathError, match="no paths given"):
+            srv._validate_book_paths(["", "  "], source="--book")
+
     # ── main() integration (failure exits before the module filter,
     #    so the tool registry is untouched) ─────────────────────────
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -919,6 +919,32 @@ def _make_min_book(path: Path) -> Path:
     return path
 
 
+@pytest.fixture
+def book_state_guard():
+    """Snapshot/restore every global the book-list paths touch.
+
+    One superset guard shared by every class that pokes book state —
+    per-class subsets drifted (one saved the registry, one skipped
+    logging_config) and a test touching an unsaved global would leak
+    order-dependent state into whichever class runs next.
+    """
+    import gnucash_mcp.logging_config as logcfg
+    import gnucash_mcp.server as srv
+    saved = (
+        srv._book, list(srv._book_paths), srv._current_path,
+        srv._book_paths_source, dict(srv._book_registry),
+        srv._logging_debug, srv._logging_audit,
+    )
+    log_saved = (
+        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
+    )
+    yield
+    (srv._book, srv._book_paths, srv._current_path,
+     srv._book_paths_source, srv._book_registry,
+     srv._logging_debug, srv._logging_audit) = saved
+    logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
+
+
 class TestMultiBook:
     """Comma-separated GNUCASH_BOOK_PATH, the switch_book tool, and the
     current-book surfacing in get_server_config / get_book_summary."""
@@ -940,6 +966,7 @@ class TestMultiBook:
             "_book": srv._book,
             "_book_paths": list(srv._book_paths),
             "_current_path": srv._current_path,
+            "_book_paths_source": srv._book_paths_source,
             "_book_registry": dict(srv._book_registry),
             "_logging_debug": srv._logging_debug,
             "_logging_audit": srv._logging_audit,
@@ -954,6 +981,7 @@ class TestMultiBook:
         srv._book = saved["_book"]
         srv._book_paths = saved["_book_paths"]
         srv._current_path = saved["_current_path"]
+        srv._book_paths_source = saved["_book_paths_source"]
         srv._book_registry = saved["_book_registry"]
         srv._logging_debug = saved["_logging_debug"]
         srv._logging_audit = saved["_logging_audit"]
@@ -1565,21 +1593,8 @@ class TestBookCliArg:
     """
 
     @pytest.fixture(autouse=True)
-    def restore_book_state(self):
-        import gnucash_mcp.server as srv
-        import gnucash_mcp.logging_config as logcfg
-
-        saved = (
-            srv._book, list(srv._book_paths), srv._current_path,
-            dict(srv._book_registry),
-        )
-        log_saved = (
-            logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
-        )
-        yield
-        srv._book, srv._book_paths, srv._current_path = saved[:3]
-        srv._book_registry = saved[3]
-        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
+    def _state(self, book_state_guard):
+        pass
 
     # ── _parse_cli_argv ────────────────────────────────────────────
 
@@ -1629,6 +1644,62 @@ class TestBookCliArg:
         import gnucash_mcp.server as srv
         with pytest.raises(srv._BookPathError, match=r"Invalid --book"):
             srv._apply_book_args([str(tmp_path / "nope.gnucash")])
+
+    def test_get_book_skips_reparse_of_own_mirror(
+        self, tmp_path, monkeypatch
+    ):
+        """After --book install, a _book=None reset must reuse the
+        validated list instead of re-splitting the mirrored env value
+        — re-parsing would shatter a path containing os.pathsep and
+        re-stat every book (PR #153 review, mirror-corruption bug)."""
+        import gnucash_mcp.server as srv
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)
+        srv._apply_book_args([str(alex)])
+        srv._book = None
+
+        def _boom(value):
+            raise AssertionError("mirror was re-parsed")
+
+        monkeypatch.setattr(srv, "_parse_book_paths", _boom)
+        assert srv.get_book() is not None
+        assert srv._current_path == alex.resolve()
+
+    def test_get_book_reparses_on_genuine_env_swap(
+        self, tmp_path, monkeypatch
+    ):
+        """The test-contract half of the same coin: a genuinely
+        swapped GNUCASH_BOOK_PATH plus a _book reset still re-reads
+        the env."""
+        import gnucash_mcp.server as srv
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        beast = _make_min_book(tmp_path / "beast-man.gnucash")
+        monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)
+        srv._apply_book_args([str(alex)])
+        srv._book = None
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", str(beast))
+        srv.get_book()
+        assert srv._current_path == beast.resolve()
+
+    def test_noaudit_modes_tear_down_logging_on_install(
+        self, tmp_path, monkeypatch
+    ):
+        """With both logging modes off (main's --noaudit merge runs
+        BEFORE book install), installing books must clear/disable the
+        audit logger, not skip activation — setup_logging is the only
+        handler-clearing path (PR #153 review, --noaudit ordering)."""
+        import logging as _logging
+
+        import gnucash_mcp.server as srv
+        from gnucash_mcp.logging_config import AUDIT_LOGGER_NAME
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        monkeypatch.delenv("GNUCASH_BOOK_PATH", raising=False)
+        srv._logging_debug = False
+        srv._logging_audit = False
+        srv._apply_book_args([str(alex)])
+        audit_logger = _logging.getLogger(AUDIT_LOGGER_NAME)
+        assert audit_logger.handlers == []
+        assert audit_logger.level > _logging.CRITICAL
 
     def test_empty_entries_dropped_not_resolved(self, tmp_path):
         """An MCPB host expanding an unset multi-file config can hand
@@ -1724,18 +1795,9 @@ class TestDemoBooks:
     are configured."""
 
     @pytest.fixture(autouse=True)
-    def restore_book_state(self, monkeypatch):
-        import gnucash_mcp.server as srv
-        import gnucash_mcp.logging_config as logcfg
+    def _state(self, book_state_guard, monkeypatch):
         monkeypatch.delenv("GNUCASH_DEMO_BOOKS", raising=False)
         monkeypatch.delenv("GNUCASH_DEMO_DIR", raising=False)
-        saved = (srv._book, list(srv._book_paths), srv._current_path)
-        log_saved = (
-            logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func,
-        )
-        yield
-        srv._book, srv._book_paths, srv._current_path = saved
-        logcfg._book_path_str, logcfg._log_dir, logcfg._get_book_func = log_saved
 
     @pytest.fixture
     def demo_dir(self, tmp_path, monkeypatch):
@@ -1913,11 +1975,8 @@ class TestBookFormatSniff:
     non-developer can act on (the XML-format file-picker mistake)."""
 
     @pytest.fixture(autouse=True)
-    def restore_book_state(self):
-        import gnucash_mcp.server as srv
-        saved = (srv._book, list(srv._book_paths), srv._current_path)
-        yield
-        srv._book, srv._book_paths, srv._current_path = saved
+    def _state(self, book_state_guard):
+        pass
 
     def test_sqlite_book_passes(self, tmp_path):
         from gnucash_mcp.server import _book_format_error


### PR DESCRIPTION
## Summary
- MCPB manifest (`manifest.json`) + pack ignore list for a one-click Claude Desktop bundle: `server.type: uv` runtime, file-picker book selection, and four persona checkboxes (planning, investments, freelancer, business) mapped to `GNUCASH_ENABLE_*` env toggles
- `--book` CLI arg and env module toggles in `server.py`, with friendly errors for XML-format books; checkbox toggles compose to core + reporting + enabled modules
- All three demo books ship in the bundle as a single toggleable trio (`GNUCASH_DEMO_BOOKS`/`GNUCASH_DEMO_DIR`), appended after the user's own books
- Advanced options passthrough: one free-text field maps to `GNUCASH_MCP_ADVANCED`, parsed shell-style into `GNUCASH_*` env overrides applied before any other config is read — the whole env surface without a checkbox per knob
- Config-dialog copy tightened for first-time users

## Test plan
- [x] Full suite: 2006 passed, 0 failed
- [x] Live install of the packed .mcpb in Claude Desktop: server boots, 63 tools, correct module set from checkboxes
- [x] Demo book trio appears alongside the user book; `switch_book` works across all four
- [x] Advanced field verified live: `GNUCASH_MCP_DEBUG=1` flipped `get_server_config` to `Debug mode: true`
- [x] Confirmed Desktop mechanics: extension disable/re-enable does NOT reload config; a full app restart does