### PR TITLE
feat: enter_statement — one-shot statement entry (v1.4.4 headliner)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Parallel by default (pytest-xdist): the suite is tmp_path-isolated
+# and proved parallel-safe; ~3x wall-clock. Pass -n0 for serial runs
+# (pdb debugging, single-test timing).
+addopts = "-n auto"
 
 [tool.ruff]
 line-length = 100
@@ -68,3 +72,8 @@ ignore = ["E501"]
 [tool.black]
 line-length = 100
 target-version = ["py310", "py311", "py312", "py313"]
+
+[dependency-groups]
+dev = [
+    "pytest-xdist>=3.8.0",
+]

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -83,8 +83,9 @@ complete" from an assumption into a checkable claim.
 A second precondition check compares `opening_balance` against the
 account's current reconciled balance. Mismatch is a WARNING in
 dry-run (prior statement may be unentered — a legitimate state),
-and blocks commit unless `force=true` (reconciling onto a base
-that doesn't tie produces a `y` state that means nothing).
+and blocks commit unless `force_base=true` (reconciling onto a
+base that doesn't tie produces a `y` state that means nothing;
+the twin guard stays on — §11.21).
 
 ## 3. Line grammar
 

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -654,6 +654,20 @@ refuted) drove a structural rework, all test-locked:
     (`post-write verification failed`), the `_verify_write`
     doctrine applied to arithmetic.
 
+23. **Signed amounts reach the SCORER (R3 P5, blocker-class,
+    fixed same day).** Round two put direction in the display
+    only; a +104 refund still HIGH-blocked as the -104 payment's
+    twin, with split_match "exact" on inverted legs. The
+    direction anchor is the signed CATEGORY primary — a balanced
+    transaction always carries both signs, so the funding leg
+    cannot carry the signal. Both the amount signal and the
+    comparison columns now anchor there (proposal side resolved
+    pre-signal via `_proposal_category_primary`); category legs
+    render signed; magnitude comparison survives as the
+    transfer-shaped fallback (no category leg on either side),
+    locked in both directions (refund never blocks; true transfer
+    duplicate still does).
+
 Standing residuals (documented, adjudication-contained,
 non-blocking, per the signoff): (a) a ±$1 nonzero-amt_delta
 candidate can still reach MEDIUM → MATCH on a genuinely-new line

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -1,0 +1,609 @@
+# enter_statement — one-shot statement entry (v1.4.4 headliner)
+
+Status: **implemented on `feat/enter-statement` (2026-08-24) —
+rulings 1–9 shipped, ruling 10 deferred to its own branch per the
+§10 phasing note. Three-agent adversarial review run and fixed on
+the branch; §11 records the implementation's flagged deviations
+for maintainer review.** The body is the buildable design; §9–§10
+record rulings, provenance, and the declined/gated items. Retargeted from v1.5 to v1.4.4 on 2026-08-21:
+the 1.4.x line's theme is bulk operations, and this tool is its
+capstone.
+Origin: parked in the 2026-07-25 session ("entry + reconcile in ONE
+session/save"); revived and ruled after a live Cash App PDF-statement
+probe surfaced the four-step friction firsthand.
+Rulings recorded here: statement as verifiable first-class input;
+every line through the judgment pass, exact matches included;
+dry-run rows carry the matched transaction's full annotation and
+date; commit is one atomic open/save that refuses wholesale on a
+failed balance tie.
+
+---
+
+## 1. Problem
+
+Entering a bank/card statement today is four calls with an
+intelligence step wedged between them:
+
+1. `create_transactions` (`dry_run=true`, no split cells) — the
+   auto-fill matcher "predicts" splits and memos per line and
+   surfaces duplicate candidates.
+2. **The judgment pass** (LLM + user, outside the server): read the
+   original lines against the matched records, adjudicate what's a
+   duplicate, adapt annotations, present a confirmation table.
+3. `create_transactions` (`dry_run=false`) — enter and categorize.
+4. `get_unreconciled_splits` → `reconcile_account` — collect split
+   GUIDs, reconcile against the statement balance.
+
+Steps 1, 3, and 4 are server-mechanical. Step 2 is irreducible —
+it IS the intelligence, and the server should serve it, not absorb
+it. The 3→4 gap is the real defect: entry and reconciliation are
+separate acts, so a crash, a distraction, or a balance surprise
+between them leaves a half-landed month — transactions entered but
+unreconciled, with no record that they came from a statement.
+
+The unlock: when the input is a **complete statement** (opening
+balance, closing balance, every line between), reconciliation stops
+being a separate act. It is simply what "commit" means.
+
+## 2. Shape — dry-run, judgment, commit
+
+`enter_statement` collapses the plumbing to two calls around the
+unchanged judgment pass:
+
+```
+enter_statement(dry_run=true)   → classification + prediction table
+[LLM judgment + user confirmation — unchanged, better served]
+enter_statement(dry_run=false)  → enter + claim + reconcile, atomic
+```
+
+The statement itself is first-class input:
+
+```
+enter_statement(
+    account,             # ref: path, %short, or GUID
+    statement_date,      # ISO — the statement's closing date
+    opening_balance,     # decimal string
+    closing_balance,     # decimal string
+    lines,               # TSV block, batch-grammar dialect (§3)
+    dry_run=True,        # DEFAULT TRUE — rehearsal-first
+)
+```
+
+`dry_run` defaults **true** (like `prune_backups`, unlike
+`create_transactions`): a statement is a document-level operation
+and the rehearsal is the workflow, not an option.
+
+### Self-consistency gate (both modes, before anything else)
+
+`opening_balance + Σ(line amounts) == closing_balance`, or the
+call rejects: the statement contradicts itself and no
+classification is trustworthy. This turns "the statement is
+complete" from an assumption into a checkable claim.
+
+A second precondition check compares `opening_balance` against the
+account's current reconciled balance. Mismatch is a WARNING in
+dry-run (prior statement may be unentered — a legitimate state),
+and blocks commit unless `force=true` (reconciling onto a base
+that doesn't tie produces a `y` state that means nothing).
+
+## 3. Line grammar
+
+The `lines` TSV reuses the batch header-is-the-schema grammar —
+same parser lineage, same column vocabulary (`ref`, `date`,
+`description`, `notes`, `memo`, `qty`, split pairs), plus two
+statement-specific columns:
+
+- `raw` — the verbatim statement line. Lands on the bank-leg split
+  memo (provenance, per the annotation convention). In dry-run
+  pass the LLM typically supplies ONLY `ref, date, raw, amount` —
+  transcription, not interpretation.
+- `match` — commit-mode only (§5): the split GUID this line claims
+  instead of creating a new transaction.
+
+Rows with no split cells flow through the auto-fill matcher
+exactly as in `create_transactions` — that machinery
+(`_collect_create_signals`) is reused, not duplicated.
+
+## 4. Dry-run output — the judgment pass's working table
+
+One correlatable table, joined on `ref`, one row per statement
+line, classified:
+
+- **NEW** — no existing-transaction candidate. Carries the
+  auto-fill prediction (splits, memo) when the matcher found a
+  same-description precedent, marked `auto_filled_from:<guid>`.
+- **MATCH** — an existing UNRECONCILED split on this account with
+  candidate-grade correspondence (amount/date). The row is a
+  **self-contained comparison** (ruling 9): the matched
+  transaction's complete annotation — description, notes,
+  bank-leg memo, post date, short GUID — side by side with the
+  statement line's values, plus computed `date_delta_days` and
+  `amount_delta` (raw values AND deltas; a `-0.05` is unreadable
+  without $47.95 vs $48.00), plus the candidate's category
+  accounts and a `split_match` verdict (`exact`/`partial`/
+  `none`) computed over the NON-statement-account split sets —
+  the statement account is shared by construction and carries no
+  signal; the category legs are the comparison. The caller never
+  joins back to its own input to reconstruct either side.
+  Ruling: exact matches are NOT auto-claimed — every line flows
+  through judgment. The context is deliberate: a July 31 line
+  matching a June 30 transaction whose memo reads "July rent"
+  should let the model suggest "August rent" for the new
+  instance — the server cannot make that inference, so it must
+  ship the evidence that lets the model make it.
+- **OVERLAP** — matches an already-RECONCILED split (prior
+  statement's tail). Default disposition: skip — the line is
+  already landed and tied. Surfaced, never silently dropped.
+- **AMBIGUOUS** — multiple candidates. All candidates listed with
+  the same full-comparison columns as MATCH, sorted by
+  descending risk (strongest correspondence first, stable
+  tie-break on candidate GUID) — the reader's model of the list
+  must not form on the harmless entries. Judgment picks or
+  rejects.
+
+Ruling 8's status vocabulary is native here: the class IS the
+review status. NEW is this tool's honest `would_create`;
+MATCH/AMBIGUOUS are `review_required` by construction; OVERLAP
+is a surfaced skip. No projected-action label can masquerade as
+clearance because no class asserts one.
+
+Plus a projected-tie footer: what the reconciled balance would be
+after commit, against `closing_balance`, with the discrepancy if
+any. The rehearsal is a FULL rehearsal — a dry-run that ties is a
+commit that will tie.
+
+When any MATCH/AMBIGUOUS/OVERLAP rows exist, the envelope also
+carries a `review_token` (ruling 10): a content-derived hash
+binding book identity, the normalized statement (balances +
+lines), the candidate set (GUIDs + comparison data), detector
+version, and the deterministic ordering. Stateless by design —
+nothing is stored server-side; commit recomputes it from current
+book state. An all-NEW dry-run emits no token and commit demands
+none: ceremony proportional to risk.
+
+### Summary header (ruling 6, 2026-08-21)
+
+The response OPENS with a count line; the classification table
+sits between it and the tie footer. The header counts the classes
+and assigns the work:
+
+```
+Dry run: 45 lines — 12 NEW, 30 MATCH, 2 OVERLAP, 1 AMBIGUOUS.
+31 rows need adjudication — rule each MATCH/AMBIGUOUS against
+the table before committing.
+```
+
+**The clearance principle:** the server states what it verified;
+it never phrases an unverified judgment as clearance. Counts are
+facts and may headline. "0 blocking", "safe to commit", and any
+cleared/uncleared dichotomy over MATCH/AMBIGUOUS rows are
+judgments the judgment pass has not made yet — banned vocabulary.
+A satisficing consumer treats a verdict-shaped header as
+permission to skip the rows it summarizes, which un-serves the
+one step this tool exists to serve. The ONLY verdict-shaped line
+in the response is the projected tie, because that is an
+arithmetic fact the server actually checked. When a class is
+genuinely empty, saying so plainly ("no duplicate candidates") is
+a verified fact and allowed.
+
+## 5. Commit semantics — one open, one save, or nothing
+
+The judgment pass produces the commit-mode `lines`: NEW rows now
+carry interpreted `description`/`notes` and confirmed splits
+(adapted by the model, confirmed by the user); MATCH rows carry
+`match=<split guid>`; OVERLAP rows are dropped or kept as `match`
+rows pointing at the reconciled split (idempotent no-op). The
+commit grammar IS the disposition table (ruling 10's principle,
+native here): each line's commit form — claimed, created-despite-
+candidate, or dropped — encodes an explicit adjudication.
+Ambiguous correspondence must be resolved explicitly in the
+commit representation; a dry-run MATCH/AMBIGUOUS `ref` that is
+simply absent from the commit lines (rather than dropped-as-
+OVERLAP or resolved) rejects before any write.
+
+When the dry-run emitted a `review_token`, commit requires it.
+The server re-runs classification against CURRENT book state and
+recomputes the token; mismatch → `review_stale` plus a refreshed
+classification table, **no write** — a candidate that appeared
+between rehearsal and commit is caught, not sailed past. Same
+statement, unchanged book → same token: the rehearsal-commit
+bond is deterministic, not stored, so it survives the two-
+process topology (each server copy computes it identically).
+
+In one book session:
+
+1. Create every NEW row (existing batch validation chokepoints:
+   `_validate_transaction_splits`, duplicate screening, quantum
+   checks).
+2. Claim every MATCH — no new transaction; the referenced split is
+   verified to belong to the statement account and to be
+   unreconciled (voided splits reject, per `_is_voided`).
+3. Reconcile every statement-touched split (created + claimed) at
+   `statement_date` — the same tie-then-mutate discipline as
+   `reconcile_account`: compute the resulting reconciled balance,
+   compare to `closing_balance`, and if it does not tie, **refuse
+   before mutating**. Nothing persists. No half-landed months.
+4. Save. One audit entry of a new `("statement", "ENTER")` type
+   rendering the document event: account, period, N created,
+   M claimed, closing balance, tie status — not N disconnected
+   CREATE lines (dispatch-table entry required, per contract
+   test). Per ruling 10's audit payoff, the entry also renders
+   the per-line adjudications: each claimed line with its
+   candidate GUID, each line created despite a surfaced
+   candidate, each OVERLAP skip, and the `review_token` — the
+   judgment pass's outcome enters the permanent human-readable
+   record instead of evaporating in conversation history.
+
+Book transactions inside the period that are NOT on the statement
+(pending checks, in-flight ACH) are naturally untouched — only
+statement-touched splits reconcile, and the tie still closes
+because the statement's own arithmetic already balanced. This is
+`except_guids` semantics without the parameter.
+
+Commit response: the batch-convention results table (`ref`,
+status ∈ `created`/`claimed`/`skipped_duplicate`, short GUID),
+headed by the document line — account, period, N created,
+M claimed, K skipped — and closed by the VERIFIED tie:
+`Reconciled: <count> splits @ <statement_date>; closing balance
+<currency> <amount> — tied.` The tie line is verdict-shaped and
+allowed: it is the arithmetic fact the commit just enforced
+(clearance principle, §4). Statement-native amounts echo nowhere
+— the caller has them; the response reports outcomes.
+
+A consequence worth naming: `y` acquires a stronger meaning on
+this path. `reconcile_account` ties to a balance someone asserts;
+`enter_statement` ties to a document the server verified was
+internally complete. Reconciled-by-statement means
+tied-to-evidence.
+
+## 6. Relationship to existing tools
+
+- `create_transactions` — unchanged in grammar; remains the tool
+  for non-statement bulk entry (opening balances, migrations,
+  manual batches). `enter_statement` shares its parser and signal
+  machinery via the existing chokepoints; divergence between the
+  two grammars is a bug. The rule extends to output (§9–§10):
+  summary header, comparison columns, and the review/token
+  machinery render through shared helpers, so the two dry-run
+  surfaces evolve together — `create_transactions` inherits the
+  review protocol per ruling 7/10 phasing, it doesn't fork it.
+- `reconcile_account` — unchanged; remains the tool for
+  reconciling already-entered books against an asserted balance.
+- `get_unreconciled_splits` — no longer needed on the statement
+  path (dry-run MATCH rows carry the GUIDs); untouched otherwise.
+- The two-tools question (`create_transaction` vs batch): this
+  tool may render it moot for the dominant workflow, as the
+  2026-07-25 letter predicted. Re-litigate after live use, not
+  before.
+
+## 7. Rulings (all five, 2026-08-11)
+
+1. **Match candidate criteria — the existing DAD scoring, window
+   31 days.** Candidacy reuses `_collect_create_signals`'s
+   description/amount/date confidence scoring (no second matcher),
+   with the window at 31 days rather than the duplicate screen's
+   30. The extra day is load-bearing: a monthly pattern (June 30
+   "July rent" vs a July 31 line) must SURFACE as a candidate so
+   the judgment pass can rule "new instance, adapt the annotation"
+   — the MATCH table is deliberately a superset of true
+   same-event matches, and judgment separates claim from
+   new-with-adapted-memo. Candidate noise is the feature.
+2. **Claimed-split annotation updates — yes.** A MATCH row may
+   carry `notes`/`memo` cells that update the claimed
+   transaction's annotations; landing the raw statement line onto
+   a bank-leg memo it never had is provenance, the point of the
+   exercise. Claiming is therefore a write to an existing
+   transaction — the `("statement", "ENTER")` audit entry must
+   render annotation diffs on claimed rows, not just creations.
+
+3. **Foreign-currency statements — deferred.** v1 requires the
+   statement currency to be the account's commodity in the book's
+   default currency. A USD statement against a CNY book is a
+   follow-up (the batch `cur` machinery exists; the tie check
+   would need to compare in statement currency).
+4. **Amount sign convention — statement-native, transformed by
+   account class.** Line amounts AND the opening/closing balances
+   are transcribed exactly as the statement prints them; the
+   server applies the sign transform for the account's class,
+   resolved by `GNCAccountType` (never name, per the i18n
+   invariant). Asset-class (BANK/CASH/ASSET) statements already
+   agree with the split convention — pass-through. Liability-class
+   (CREDIT/LIABILITY) statements print charges positive and
+   balances as amount-owed — the server negates both, so a printed
+   charge lands as a negative split and a printed "$500 owed"
+   closing balance ties against a book balance of −500. The model
+   transcribes verbatim, zero mental sign-flips: this eliminates
+   the transcription-error class, and the self-consistency gate
+   (§2) checks in statement-native signs before any transform.
+5. **Module placement — core, transactions sub-module.** Same
+   "touches money" argument that moved reconciliation into core
+   in v1.4. Tool registration rides `tools/core.py` beside
+   `create_transactions`; `TOOL_MODULES` entry under the
+   transactions sub-module.
+
+## 8. What this is not
+
+- Not an OFX/CSV/PDF parser — transcription from the document to
+  the TSV is the model's job (it is already good at it; the Cash
+  App probe entered a PDF image set with no parser).
+- Not a replacement for judgment — the confirmation table is a
+  feature, not friction. The tool exists to make the two calls
+  around it trivial and the landing atomic.
+- Not business-document aware — invoices/bills settle via
+  `pay_invoice`; a statement line that pays an invoice is a MATCH
+  against the payment transaction like any other.
+
+## 9. Addendum — dry-run response rulings (2026-08-21)
+
+Provenance: an outside-model reviewer (ChatGPT, connected live to
+the sample books via the Glama sandbox) ran a 45-row
+`create_transactions` dry-run on Alex's book and critiqued the
+response. The report validated the core design — `ref`-as-data
+called "the strongest design choice"; the two-table join; the
+suppress-LOW/label-MEDIUM ruling read exactly as intended (it
+classified coffee-shop MEDIUMs as pattern noise without reaching
+for `force`) — and surfaced improvements, triaged here.
+
+6. **Summary header, homework-framed** — specified in §4. The
+   risk that shaped the framing: the reviewer's own suggested
+   header ("0 blocking … safe to commit with force=false") is a
+   free pass — a satisficing model reads a cleared verdict and
+   skips the candidate rows. In-house evidence that response
+   framing steers foreign-model behavior: the verbose-reframing
+   episode, where an outside model changed its output habits
+   because our descriptions reframed compact as complete. Hence
+   the clearance principle (§4): counts headline, judgments
+   don't, the tie is the only verdict.
+
+7. **`create_transactions` inherits, same branch.** The batch
+   dry-run gains the same three upgrades: a summary header
+   (would-create/rejected counts + a candidate homework line,
+   never a clearance line), a `max_confidence` column in the
+   results table (saves the two-table join for the common
+   decision; the candidate table remains for the real one), and a
+   projected per-account effects footer (the rehearsal-
+   completeness principle this spec's tie footer already
+   embodies, minus the tie — batches assert no closing balance).
+   Rendering goes through a shared helper; §6's rule extends
+   from grammar to output — divergence between the two dry-run
+   surfaces is a bug.
+
+Declined from the same review, with reasons: per-row `validated`
+reason padding and per-row currency echo (blank-means-fine is
+measured byte economy — median tool response is ~121 bytes;
+the envelope can state the effective currency once), native
+structured arrays in place of TSV-in-JSON (`verbose=true` is the
+house answer; the reviewer's own ratings conceded "machine
+usability: excellent"), an in-response signal-code legend (lives
+in the tool description, which the reviewing model itself decoded
+without one), a category-distribution echo (summarizes the
+caller's own input back at it), and commit-recommendation lines
+("safe to commit with force=false" — the clearance principle,
+ruling 6).
+
+## 10. Addendum — duplicate-review protocol rulings (2026-08-24)
+
+Provenance: the same outside-model reviewer, cross-examined by
+the maintainer ("would you have pushed through creating those
+medium dupes?"), retracted its structured-arrays critique
+(conceding the TSV envelope), admitted its "safe to commit"
+shorthand was unsound, and — asked what presentation would have
+prevented the gloss — produced the review-queue proposal ruled
+here after a second round of design exchange. The declined
+native-arrays item in §9 stands retracted by its own author.
+
+Architectural note on the stateful piece: an initial objection
+assumed server-held pending-batch state, which the multi-copy
+topology (two clients, two server processes) genuinely breaks.
+The adopted design instead carries dispositions in the caller's
+commit request and recomputes verification state from current
+book contents — stateless multi-copy operation preserved. State
+lives in the conversation; verification lives in the server.
+
+8. **`review_required` status.** The clearance principle (ruling
+   6) applied per-row: a projected-action label must not
+   masquerade as clearance. `would_create` stays on
+   candidate-free rows — there it is an honest, verified
+   clearance. Any row with ≥1 duplicate candidate reports
+   `review_required` instead; `rejected` + `reason` continues to
+   cover HIGH blocks and validation errors. No parallel
+   compat column — one status, one meaning.
+
+9. **Self-contained candidate comparisons.** The caller never
+   joins the candidate table against its own input mentally.
+   Columns: `ref`, `candidate_guid`, confidence, proposed +
+   existing description, proposed + existing date,
+   `date_delta_days`, proposed + existing amount,
+   `amount_delta`, proposed + existing category accounts,
+   `split_match`, signal code. Raw values AND deltas both — a
+   `-0.05` delta is unreadable without $47.95 vs $48.00, and
+   candidate tables are small; this is the right place to spend
+   width. `split_match` (`exact`/`partial`/`none`) compares the
+   NON-PAYMENT split sets — the batch's payment account is
+   shared by construction and carries no signal; the category
+   legs are the comparison (the review's own Chewy/fuel case:
+   MEDIUM on date+amount, decisively distinct on category).
+   Candidates sort by descending risk (strongest correspondence
+   first), stable tie-break on (`ref`, `candidate_guid`) — the
+   reader's model of the list must not form on the harmless
+   entries.
+
+10. **Disposition acknowledgment protocol (stateless).** Active
+    only when `review_required` rows exist — zero-candidate
+    batches commit exactly as today, no token, no ceremony.
+
+    Flow: dry-run returns a content-derived `review_token`
+    binding book identity, normalized batch contents, candidate
+    GUIDs + comparison data, detector version, and the
+    deterministic candidate ordering. Commit requires the token
+    plus one disposition per (`ref`, `candidate_guid`) pair:
+
+        ref  candidate_guid  decision          reason
+        A06  7ee458e4        distinct          repeat merchant; 28 days apart
+        A31  51bbd002        same_transaction  same merchant/amount; date off by one
+
+    - `distinct` (reason required) — clears that pair.
+    - `same_transaction` (reason required) — the proposed row is
+      NOT created; it lands in results as `skipped_duplicate`
+      with the candidate GUID (the OVERLAP semantics of §4,
+      generalized — a correct adjudication is never punished
+      with a batch rejection).
+    - `uncertain` — blocks commit; the escalation path is
+      `get_transaction` on the candidate, inspect splits,
+      re-dispose.
+    - Any missing disposition — reject before any write.
+
+    Commit reruns detection and recomputes the token from
+    CURRENT book state. Mismatch → `review_stale` + a refreshed
+    review table, no write: a MEDIUM candidate that appeared
+    between rehearsal and commit is caught, which the current
+    design cannot do. The token derives from the signal sweep
+    commit already runs — no new pass (and this ships AFTER the
+    batch signal hoist; the sweep is the known p95 tail).
+
+    Honest limit, on the record: the protocol guarantees CONTACT
+    with the evidence, not quality of judgment — a careless
+    caller can still write `distinct` mechanically. But one
+    disposition per pair, a nonempty reason, candidate-specific
+    identifiers, and a matching token raise the cost of careless
+    approval and make failures inspectable afterward.
+
+    **Audit is the largest payoff:** the commit's audit entry
+    persists the hash, each (`ref`, `candidate_guid`,
+    decision, reason), detector confidence/signals, and whether
+    `force` was used. The adjudication reasoning — today
+    evaporating in conversation history — enters the permanent
+    human-readable record for the first time.
+
+    **Flagged for a bookkeeper ruling before adoption:** the
+    protocol's `force` division (acknowledgment proves
+    adjudication; `force` only authorizes creating despite a
+    HIGH match adjudicated `distinct`) tightens the DIRECT
+    commit path — today `force=true` with no dry-run bypasses
+    HIGH blocks wholesale, and that is a live workflow. Right
+    design, but it changes bookkeeper-validated behavior;
+    per `feedback_bookkeeper_validates_base_cases`, it does not
+    ship on spec alone.
+
+    Implementation phasing is the maintainer's call: rulings
+    8–9 are cheap riders on the §9 dry-run work; ruling 10 is
+    its own branch, sequenced after the signal hoist.
+
+## 11. Implementation notes — flagged deviations (2026-08-24)
+
+Recorded by the implementing session for maintainer review; each
+is deliberate and test-locked, none silent. Reverse any of them by
+ruling.
+
+1. **Ruling 1's "no second matcher," amended by its own rent
+   case.** Statement candidacy is an account-scoped scan, not a
+   `_collect_create_signals` pass: the collector's ≥2-signal
+   admission rule would NOT surface the June-30-rent-vs-July-31
+   line (amount signal only), which ruling 1 requires to surface.
+   The scan admits the amount signal alone — sound in the narrow
+   universe of one account's splits. The A/D thresholds themselves
+   are shared module constants (`_MATCH_AMOUNT_TOLERANCE`,
+   `_MATCH_DATE_TIGHT_DAYS`) read by both matchers, so the signal
+   semantics cannot drift; only the admission rule differs, on
+   purpose.
+2. **OVERLAP means the same event, exactly.** Classification and
+   the commit guard define overlap as amount-exact (to the
+   commodity quantum) AND date within the tight window. Amount-fuzz
+   overlap misclassified the genuine next-month line as already
+   landed (adversarial-review finding). Fuzzy reconciled
+   candidates still ship as evidence rows under NEW — that is the
+   annotation-adaptation case working as designed.
+3. **`force` also bypasses the closing tie, recorded not silent.**
+   Forcing past an opening gap G mathematically guarantees a
+   closing discrepancy of G, so opening-force without tie-force
+   would be a dead parameter. A forced untied landing reports and
+   audits `DISCREPANCY … landed under force`. Unforced commits
+   refuse wholesale per §5.
+4. **The commit guard is stricter than §5's letter.** A bare
+   create whose EXACT twin (amount + tight date) exists unclaimed
+   — unreconciled or reconciled — rejects unless forced: it is the
+   one double-entry the tie cannot catch. This tightens the
+   direct-commit path ahead of ruling 10's protocol; the same
+   bookkeeper-ruling flag applies.
+5. **Claim memo updates ride `raw`.** The statement grammar has no
+   per-line memo cell; a claim's bank-leg memo becomes the
+   verbatim `raw` line (§3's provenance convention). `notes` cells
+   update the claimed transaction's notes as ruled.
+6. **Zero-line statements reject** ("statement has no lines"), with
+   `reconcile_account` as the pointed workaround. A no-activity
+   statement is a real monthly occurrence — needs a ruling if the
+   workaround isn't acceptable.
+7. **Claim exactness is unconditional.** A match cell naming any
+   split — reconciled included — whose amount differs from the
+   line rejects at the row (wrong-GUID paste protection); the
+   reconciled no-op path applies only after the amounts agree.
+
+### Maiden-voyage amendments (2026-08-24, bookkeeper findings)
+
+8. **Invisible line separators reject by name.** The maiden
+   flight's one open bug: `str.splitlines` shatters a row on
+   U+2028/U+2029/NEL/VT/FF hiding inside a cell, and the resulting
+   mid-group error truthfully blames the row while unable to name
+   the invisible byte (four deterministic failures, a night of
+   bisection, every retyped reduction passing). All TSV parsers
+   now split on real newlines only and reject the exotic
+   separators loudly, naming the character and row.
+9. **Claim rows end at their last fixed column.** Stray cells
+   beyond it get a claim-specific error instead of falling into
+   the group chunker's mid-group miscount.
+10. **MATCH/AMBIGUOUS gate on MEDIUM+ correspondence.** LOW
+    (single-signal) candidates still surface — ruling 1's
+    superset — but no longer drive the class: a line whose best
+    candidates are amount-only lookalikes is NEW with evidence
+    attached, not AMBIGUOUS (the invented-ATM case: three weak
+    lookalikes must not adopt a genuinely new line).
+
+### Test-plan-round amendments (2026-08-24 late, bookkeeper)
+
+11. **Recurring signature never drives the class (T6).** desc +
+    amount at ≥21 days' remove (`_RECURRENCE_MIN_DAYS`) is the
+    monthly-pattern signature — last month's HOA, not this line's
+    twin. Such candidates ship as evidence under NEW. Short
+    clearing drift (≤~3 weeks) with desc+amount still MATCHes —
+    the maiden flight's date-drift claims depend on it.
+12. **Commit rejections coach inline (T5b).** The row's error —
+    including the "claim it with match=…, or force" next move —
+    rides the results note column; the rejection envelope has no
+    separate warnings table to get stranded away from.
+13. **LOW display ruled best-evidence-only** (bookkeeper's ruling
+    at the implementer's request). Lines with ≥1 MEDIUM/HIGH
+    candidate suppress their LOW amount-coincidences with a
+    breadcrumb in the cands column ("1 (+18 LOW suppressed)") and
+    a `show_all=true` escape hatch; LOW-only lines keep their
+    evidence (the rent case is load-bearing). Candidate ordering
+    refined: risk desc, then |amt_delta|, |date_delta| asc, then
+    the stable (ref, guid) tie-break. Supersedes the interim
+    "cap ~5" note.
+14. **Batch candidates carry `state` (T7).** The shared comparison
+    table's state column fills on the batch surface with the
+    candidate transaction's most-anchored split state (y > c > n)
+    — a reconciled candidate is entered AND tied, which is
+    decisive for the duplicate call.
+
+### Signoff round (2026-08-24, Abe VI — certified for Statement
+### Week)
+
+15. **Twin guard precedes counter-split validation** (the signoff's
+    one carried item, fixed same day): commit processes claims
+    first, then runs the twin guard BEFORE auto-fill/counter-split
+    validation on create rows — a bare raw line whose exact twin
+    exists gets the claim coaching, not an auto-fill complaint.
+16. **Verified-empty phrasing counts claimable candidates**: when
+    evidence rows exist but nothing is MEDIUM+, the homework line
+    reads "No claimable (MEDIUM+) candidates — the listed rows are
+    evidence only" rather than contradicting the visible table.
+
+Standing residuals (documented, adjudication-contained,
+non-blocking, per the signoff): (a) a ±$1 nonzero-amt_delta
+candidate can still reach MEDIUM → MATCH on a genuinely-new line
+(wire-fee shape) — the delta column exposes it instantly; a
+possible refinement caps amt_delta≠0 at LOW. (b) identical-amount
+14-day payroll sits below `_RECURRENCE_MIN_DAYS`; cadence
+inference (3+ priors at ~Nd spacing ⇒ delta≈N is the pattern's
+own signature) is the v-next fix, wanting the same
+per-description history as the batch signal hoist.

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -153,7 +153,8 @@ any. The rehearsal is a FULL rehearsal — a dry-run that ties is a
 commit that will tie.
 
 When any MATCH/AMBIGUOUS/OVERLAP rows exist, the envelope also
-carries a `review_token` (ruling 10): a content-derived hash
+carries a `review_token` (ruling 10 — DEFERRED, not on the
+implementation branch; see the §10 phasing note): a content-derived hash
 binding book identity, the normalized statement (balances +
 lines), the candidate set (GUIDs + comparison data), detector
 version, and the deterministic ordering. Stateless by design —
@@ -201,7 +202,8 @@ commit representation; a dry-run MATCH/AMBIGUOUS `ref` that is
 simply absent from the commit lines (rather than dropped-as-
 OVERLAP or resolved) rejects before any write.
 
-When the dry-run emitted a `review_token`, commit requires it.
+When the dry-run emitted a `review_token` (ruling 10 —
+deferred, phase 2), commit requires it.
 The server re-runs classification against CURRENT book state and
 recomputes the token; mismatch → `review_stale` plus a refreshed
 classification table, **no write** — a candidate that appeared
@@ -597,6 +599,48 @@ ruling.
     evidence rows exist but nothing is MEDIUM+, the homework line
     reads "No claimable (MEDIUM+) candidates — the listed rows are
     evidence only" rather than contradicting the visible table.
+
+### Round-two adversarial review (2026-08-24, five-agent panel)
+
+A second review of the post-review delta (nine verified HIGHs, none
+refuted) drove a structural rework, all test-locked:
+
+17. **The disposition chokepoint.** Rehearsal and commit now run
+    ONE phase-A resolver (`_statement_dispositions`: claims first,
+    twin guard, then prep — force-aware in both modes). The
+    dry-run's notes carry the guard's coaching verbatim, the
+    projection derives from resolved dispositions (not the
+    evidence class), and the tie footer counts the rows the exact
+    payload would refuse. The five verified rehearsal/commit
+    divergences (reconciled twin behind a fuzzy MATCH, OVERLAP
+    rows carrying claims, force never reaching the rehearsal,
+    false refusal notes, guard/prep ordering) die by construction.
+18. **Output escape chokepoint** (`_tsv_cell` + `_cats_str`
+    escaping): book free text can no longer shatter response TSVs
+    — the output mirror of §11.8, which itself now covers all
+    ten `str.splitlines` boundaries and the prices parser, with
+    row numbers computed post-normalization.
+19. **Comparison-table honesty:** cross-frame detection keys on
+    candidate-vs-PROPOSAL currency (cur names the candidate's
+    currency exactly when frames differ; deltas blank only then);
+    amounts are SIGNED on both surfaces; withheld deltas sort at
+    the head of their tier; the effects footer excludes
+    review_required rows; batch state ranking preserves `f`.
+20. **Force is recorded** unconditionally: the commit summary and
+    the audit header both say FORCED on any forced landing, tie
+    held or not. Counter-splits naming the statement account
+    reject (the tie is an identity over inputs and cannot see the
+    account move by more than the line). Reconciled no-op splits
+    are one-per-row like claims, and both are exempt from the
+    guard.
+
+**Open ruling for the maintainer (round-two HIGH, not
+implemented):** `force` remains ONE flag over three safeties
+(opening base, closing tie, twin guard), and the opening gate's
+refusal text coaches it in exactly the partial-re-entry scenario
+where the guard matters most. The reviewer's proposed fix —
+splitting it (`force_base` vs `force_duplicates`) — is an API
+change awaiting a ruling.
 
 Standing residuals (documented, adjudication-contained,
 non-blocking, per the signoff): (a) a ±$1 nonzero-amt_delta

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -634,13 +634,24 @@ refuted) drove a structural rework, all test-locked:
     are one-per-row like claims, and both are exempt from the
     guard.
 
-**Open ruling for the maintainer (round-two HIGH, not
-implemented):** `force` remains ONE flag over three safeties
-(opening base, closing tie, twin guard), and the opening gate's
-refusal text coaches it in exactly the partial-re-entry scenario
-where the guard matters most. The reviewer's proposed fix —
-splitting it (`force_base` vs `force_duplicates`) — is an API
-change awaiting a ruling.
+21. **`force` split (RULED 2026-08-24, implemented same day).**
+    `force_base` clears the opening precondition (its consequent
+    tie failure records as a discrepancy) and `force_duplicates`
+    disables the twin guard — independently. The trap the single
+    flag set — the opening gate coaching a force that silently
+    disabled duplicate detection in exactly the partial-re-entry
+    scenario — is closed and locked in both directions
+    (force_base keeps the guard on; force_duplicates keeps the
+    base gate on). Clean break, no compat alias: the LLM-facing
+    API adapts.
+22. **Round-two MEDIUMs**, same pass: the evidence-only homework
+    line no longer names a confidence tier its own table can
+    contradict; the effects footer carries a commodity column and
+    remains review_required-exclusive; and the closing tie is now
+    a POST-WRITE VERIFICATION — the reconciled balance is read
+    back from the saved splits and a mismatch raises
+    (`post-write verification failed`), the `_verify_write`
+    doctrine applied to arithmetic.
 
 Standing residuals (documented, adjudication-contained,
 non-blocking, per the signoff): (a) a ±$1 nonzero-amt_delta

--- a/specs/v1.5/README.md
+++ b/specs/v1.5/README.md
@@ -94,6 +94,23 @@ The rest of this section remains unscheduled.
   `cur`, never a same-release deletion — deprecation notice first,
   removal a release later.
 
+- **`enter_statement` — one-shot statement entry** — a complete
+  statement (opening/closing balances + lines) enters, claims
+  matches, and reconciles in one atomic open/save; dry-run is a
+  full rehearsal including the balance tie. Collapses the current
+  four-step workflow around the one irreducible step (the LLM/user
+  judgment pass), which its classification table is designed to
+  serve. Design complete — five questions ruled 2026-08-11; two
+  dry-run response rulings (summary header + the clearance
+  principle, `create_transactions` inheritance) added 2026-08-21;
+  three duplicate-review rulings (`review_required` status,
+  self-contained candidate comparisons, stateless disposition
+  acknowledgment protocol) added 2026-08-24 — the last gated on a
+  bookkeeper ruling for its `force` tightening and sequenced
+  after the batch signal hoist.
+  **Retargeted to v1.4.4** as the bulk-ops line's headliner; it
+  leaves this list when the 1.4.4 release ships it.
+  _Spec: [ENTER_STATEMENT_SPEC.md](ENTER_STATEMENT_SPEC.md)._
 - **Custom period alignment (`periods` parameter)** — the three
   breakdown reports (`spending_by_category`, `income_by_source`,
   `cash_flow`) accept an explicit list of caller-supplied boundary

--- a/specs/v1.5/testing/BOOKKEEPER_REPROBE_ENTER_STATEMENT_R3.md
+++ b/specs/v1.5/testing/BOOKKEEPER_REPROBE_ENTER_STATEMENT_R3.md
@@ -1,0 +1,98 @@
+# Bookkeeper Re-Probe — enter_statement round 3 (post-adversarial)
+
+Status: **LOOP CLOSED 2026-08-26 — all probes PASS (P5 re-probe
+verified at `19f4a7f`); certification closed whole; Statement
+Week: GO. Signed: Abe VI.** The hang investigated mid-round was
+amended to a Claude Desktop dispatch-layer wedge (a second,
+unrelated MCP server hung identically); the gnucash server is
+exonerated — it answered every dispatched call in <500ms.
+Defense-in-depth roadmap banked from the round: startup PID +
+spawn-time logging, a doctor instance self-count, the SAWarning
+startup filter, and a commit hash in get_server_config (running
+interpreter ≠ HEAD was the round's deployment-gap lesson).
+
+Branch: `feat/enter-statement` at `a10b3a0` (PR #154). Bounce the
+server first. Your signoff stands for the workflow; this pass
+re-verifies the surfaces that CHANGED under it after a five-agent
+adversarial review (nine verified HIGHs, all fixed). Re-read the
+`enter_statement` docstring after the bounce — the parameter list
+changed.
+
+## ⚠ Breaking change for your procedures file
+
+**`force=true` no longer exists.** It split into two independent
+flags (maintainer ruling — the single flag let an untied-base
+landing silently disable duplicate detection in exactly the
+partial-re-entry scenario the guard exists for):
+
+- `force_base=true` — land onto an untied opening base. The tie
+  discrepancy is recorded; **twin detection stays ON**.
+- `force_duplicates=true` — create past exact twins you have
+  adjudicated as distinct. The base gate stays on.
+
+Update any Statement Week procedure that says `force`.
+
+## Probes
+
+1. **Force independence (the ruling's point).** Re-run your T5-a
+   shape with `force_base=true` on a statement that re-prints an
+   already-reconciled line as a bare create. Expected: REJECTED,
+   the note coaching the match-row no-op — NOT a triple entry.
+   Then a clean-base statement with a deliberately duplicate
+   create under `force_duplicates=true`: lands, and both the
+   summary ("LANDED UNDER FORCE (duplicates)") and the audit
+   header ("(FORCED: duplicates)") say so.
+2. **The rehearsal is now the landing.** Dry-run a payload with an
+   exact unreconciled twin left unclaimed: the line's NOTE should
+   carry the commit rejection's coaching VERBATIM ("claim it with
+   match=…, or force_duplicates=true"), and the tie footer should
+   count it ("N row(s) this payload would refuse at commit").
+   Then commit the same payload and confirm the note text matches
+   word for word — dry-run and commit now run one shared
+   disposition resolver; any wording divergence is a bug.
+3. **Claims announce themselves.** A dry-run row carrying a
+   `match` cell should read class MATCH with note "will claim
+   <guid>" — no refusal language on a row that resolves.
+4. **Forced rehearsal.** Dry-run with `force_duplicates=true`:
+   guard notes vanish and the projection models the forced
+   landing (what commit will actually do), not the unforced one.
+5. **[FIXED post-R3 — 30s re-probe]** Your P5: the refund shape.
+   Re-run the +104-refund-vs-−104-payment probe: expected
+   review_required (MEDIUM, desc+date), signals WITHOUT 'A',
+   signed amt columns showing the 208 gap, split_match
+   "partial". A true transfer duplicate (no category leg) still
+   HIGH-blocks on magnitude — probe that too if quick.
+5b. **Candidates table upgrades** (both surfaces): batch
+   `duplicates` rows now carry `state` (y/c/f/n), SIGNED amounts
+   (a deposit is no longer a payment's twin at delta 0), and
+   `cur` names the candidate's currency exactly when its frame
+   differs from your proposal's (with `amt_delta` blank there).
+   Statement candidates sort nearest-correspondence-first within
+   each confidence tier. Multi-line notes/memos from OFX imports
+   render as `\n` escapes in ONE row — flag any shattered or
+   phantom rows immediately.
+6. **Effects footer**: now `account / delta / commodity`, and
+   review_required rows are excluded (their deltas are homework,
+   not projection). Homework line for evidence-only tables reads
+   "No rows need adjudication — the listed candidates are
+   evidence only."
+7. **Your ensemble-bug class, extended.** The invisible-character
+   rejection now covers all ten line-separator exotics and the
+   prices TSV too. If your generator can be coaxed into emitting
+   one, confirm the error names the character and the correct
+   row. Also: the `amt1` lazy header spelling now parses, and a
+   typo'd fixed column errors by name.
+
+## What did you route around?
+
+Standing section — anything you worked around instead of
+reporting is an unfiled bug report, including anything about the
+two-flag force feeling wrong in live use.
+
+## Known residuals (unchanged, documented in spec §11)
+
+±$1 non-zero-delta MEDIUMs on genuinely-new lines (deltas expose
+them); 14-day identical-amount payroll below the recurrence
+threshold (cadence inference is the v-next); claim rows show
+blank cat_new/split_match (their proposal side is genuinely
+unknown).

--- a/specs/v1.5/testing/BOOKKEEPER_TEST_PLAN_ENTER_STATEMENT.md
+++ b/specs/v1.5/testing/BOOKKEEPER_TEST_PLAN_ENTER_STATEMENT.md
@@ -1,0 +1,91 @@
+# Bookkeeper Test Plan — enter_statement (v1.4.4 headliner)
+
+Branch: `feat/enter-statement` (ten commits on top of develop).
+Bounce the server on this branch before testing. Read the
+`enter_statement` docstring fresh after the bounce — it is the
+workflow spec and part of what's under validation. The server
+orientation also gained a STATEMENT ENTRY section; note whether it
+changed what you reached for without being told (adoption test).
+
+## What this is
+
+The four-step statement dance — `create_transactions` dry-run →
+judgment → `create_transactions` → `get_unreconciled_splits` +
+`reconcile_account` — collapses to two calls around your judgment:
+
+1. `enter_statement(account, statement_date, opening_balance,
+   closing_balance, lines, dry_run=true)` — transcribe the
+   statement EXACTLY as printed (credit cards too: charges
+   positive, balances as amount-owed; the server flips signs from
+   the account's type). Get back per-line classification: NEW /
+   MATCH / OVERLAP / AMBIGUOUS, with self-contained comparison
+   rows for every candidate.
+2. Rule each MATCH/AMBIGUOUS row; adapt annotations; confirm.
+3. Same call, `dry_run=false` — NEW rows now carry your
+   interpreted description/notes and counter-splits (or auto-fill),
+   MATCH rows carry `match=<candidate_guid>` claims. One atomic
+   save: enter + claim + reconcile against the closing balance, or
+   nothing at all.
+
+The statement account's own leg is SYNTHESIZED — never a column.
+`raw` (the verbatim statement line) lands on that leg's memo.
+
+## Test sequence
+
+1. **The headline workflow, on a real statement.** Pick a month on
+   your test book with a real (or realistic) bank statement.
+   Dry-run with only `ref, date, raw, amount` columns — pure
+   transcription. Confirm: the summary counts read correctly, the
+   candidates table lets you rule each MATCH **without re-reading
+   your own input** (both sides + deltas are in the row), and the
+   projected tie footer matches your own arithmetic.
+2. **Commit and verify.** Add `match` cells from the candidates
+   table, interpreted descriptions/notes, counter-splits (or leave
+   splitless rows to auto-fill). Commit. Then check with your
+   normal tools: `get_reconciliation_status` (everything through
+   the statement date reconciled), `get_balance`, and the audit
+   log — one ENTER STATEMENT entry rendering creates, claims with
+   memo/notes diffs, and the tie line.
+3. **A credit-card statement, transcribed native.** Charges
+   positive, closing balance as printed ("$412.88 owed"). Zero
+   mental sign-flips is the promise — flag ANY place you caught
+   yourself negating something.
+4. **The self-check gate.** Deliberately drop a line from an
+   otherwise-correct transcription. The call must reject naming
+   the arithmetic (opening + lines ≠ closing) before any
+   classification.
+5. **The double-entry guard.** Commit a statement, then re-commit
+   the same payload. It should refuse on the untied opening base.
+   Then try a single line whose twin is already reconciled, as a
+   bare create — it should refuse and point you at the match-row
+   no-op form.
+6. **The monthly pattern.** A line ~1 month after a same-amount
+   recurring transaction (rent shape). It should classify NEW with
+   the prior instance listed as evidence (state `y` or `n`), NOT
+   OVERLAP — and the note/annotation columns should give you what
+   you need to adapt the memo ("July rent" → "August rent").
+7. **Batch inheritance.** Run a `create_transactions` dry-run with
+   some duplicate bait. New surfaces: `summary` header,
+   `review_required` status on candidate-bearing rows,
+   `max_confidence` column, self-contained `duplicates`
+   comparison rows (`split_match` should read exact/partial/none
+   sensibly), `effects` footer. Does `review_required` change how
+   you treat those rows vs the old `would_create`?
+
+## What did you route around?
+
+Standing section. Anything you worked around instead of reporting —
+a column you wished existed, a classification you second-guessed, a
+response you had to re-read, an error message that didn't name the
+fix — is an unfiled bug report. Name it even if you solved it.
+
+## Known edges (flagged, not hidden)
+
+- Foreign-currency statements reject with a pointer to the old
+  workflow (deferred, spec ruling 3).
+- Zero-line statements reject; `reconcile_account` covers the
+  no-activity month (needs a ruling if that's not acceptable).
+- `force=true` means "land it anyway": untied opening base, tie
+  discrepancy (recorded in response + audit), and exact-twin
+  creates. Try it once on purpose; confirm the audit entry says
+  what happened.

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -597,16 +597,26 @@ def _candidate_risk(row: dict) -> int:
 
 def _candidate_comparison_tsv(rows: list[dict]) -> str:
     """Render candidate-comparison dicts as the shared TSV, sorted
-    by descending risk with a stable (ref, candidate_guid)
-    tie-break — the reader's model of the list must not form on
-    the harmless entries. Empty input renders "" (dropped by
-    _strip_noise)."""
+    by descending risk, then |amt_delta| and |date_delta| ascending
+    (nearest correspondence first within a tier — bookkeeper
+    ruling), then the stable (ref, candidate_guid) tie-break — the
+    reader's model of the list must not form on the harmless
+    entries. Empty input renders "" (dropped by _strip_noise)."""
     if not rows:
         return ""
+
+    def _abs_or_inf(value) -> Decimal:
+        try:
+            return abs(Decimal(str(value)))
+        except InvalidOperation:
+            return Decimal("Infinity")
+
     ordered = sorted(
         rows,
         key=lambda r: (
             -_candidate_risk(r),
+            _abs_or_inf(r.get("amt_delta", "")),
+            _abs_or_inf(r.get("date_delta_days", "")),
             str(r.get("ref", "")), str(r.get("candidate_guid", "")),
         ),
     )

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -529,6 +529,71 @@ def _parse_statement_tsv(tsv: str) -> list[dict]:
     return out
 
 
+# Ruling 9 (statement spec §10): candidate rows are SELF-CONTAINED
+# comparisons — proposed + existing values AND deltas, category
+# legs, a split_match verdict. The caller never joins back to its
+# own input to reconstruct either side. One column set for both
+# rehearsal surfaces (batch duplicates, statement candidates);
+# cells a surface can't fill render blank.
+_CANDIDATE_COMPARISON_COLUMNS = (
+    "ref", "candidate_guid", "confidence", "state",
+    "date_new", "date_old", "date_delta_days",
+    "amt_new", "amt_old", "amt_delta", "cur",
+    "desc_new", "desc_old", "notes_old", "memo_old",
+    "cat_new", "cat_old", "split_match", "signals",
+)
+
+
+def _candidate_risk(row: dict) -> int:
+    """Correspondence strength = lit signal count."""
+    return sum(1 for ch in str(row.get("signals", "")) if ch != "-")
+
+
+def _candidate_comparison_tsv(rows: list[dict]) -> str:
+    """Render candidate-comparison dicts as the shared TSV, sorted
+    by descending risk with a stable (ref, candidate_guid)
+    tie-break — the reader's model of the list must not form on
+    the harmless entries. Empty input renders "" (dropped by
+    _strip_noise)."""
+    if not rows:
+        return ""
+    ordered = sorted(
+        rows,
+        key=lambda r: (
+            -_candidate_risk(r),
+            str(r.get("ref", "")), str(r.get("candidate_guid", "")),
+        ),
+    )
+    lines = ["\t".join(_CANDIDATE_COMPARISON_COLUMNS)]
+    for r in ordered:
+        lines.append(
+            "\t".join(
+                str(r.get(c, "")) for c in
+                _CANDIDATE_COMPARISON_COLUMNS
+            )
+        )
+    return "\n".join(lines)
+
+
+def _split_match_verdict(
+    cat_new: list[tuple[str, str]] | None,
+    cat_old: list[tuple[str, str]],
+) -> str:
+    """``exact`` / ``partial`` / ``none`` over the category
+    (non-payment) split sets — the payment account is shared by
+    construction and carries no signal. exact = same accounts and
+    amounts; partial = any account overlap; none = disjoint.
+    Unknown proposal side renders blank."""
+    if cat_new is None:
+        return ""
+    new_set, old_set = set(cat_new), set(cat_old)
+    if new_set == old_set:
+        return "exact"
+    if {a for a, _ in new_set} & {a for a, _ in old_set}:
+        return "partial"
+    return "none"
+
+
 def _dry_run_summary(
     total: int, noun: str, counts: list[tuple[str, int]],
     homework: str = "",

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -586,7 +586,19 @@ def _split_match_verdict(
     Unknown proposal side renders blank."""
     if cat_new is None:
         return ""
-    new_set, old_set = set(cat_new), set(cat_old)
+
+    def norm(cats):
+        # Amounts compare as numbers — "800.00" IS "800"; the raw
+        # strings come from different layers with different scales.
+        out = set()
+        for a, v in cats:
+            try:
+                out.add((a, Decimal(v)))
+            except InvalidOperation:
+                out.add((a, v))
+        return out
+
+    new_set, old_set = norm(cat_new), norm(cat_old)
     if new_set == old_set:
         return "exact"
     if {a for a, _ in new_set} & {a for a, _ in old_set}:

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -376,6 +376,159 @@ def _batch_row_splits(rest: list[str], group: tuple[str, ...]) -> list[dict]:
     return splits
 
 
+# Statement-dialect fixed columns (``enter_statement``). The batch
+# grammar's fixed prefix is positional (ref, date, description,
+# [notes], [cur]); a statement header instead declares an
+# ANY-ORDER set of per-line columns after ``ref, date``. ``cur``
+# is deliberately absent — foreign-currency statements are a
+# deferred follow-up (spec ruling 3), so the token stays unknown
+# and rejects loudly rather than parsing and half-working.
+_STATEMENT_FIXED_TOKENS = {
+    "description": "description", "desc": "description",
+    "notes": "notes",
+    "raw": "raw",
+    "match": "match",
+    "amount": "amount", "amt": "amount",
+}
+
+
+def _statement_tsv_layout(header_line: str) -> dict:
+    """Column layout of an ``enter_statement`` lines TSV.
+
+    Same header-is-the-schema contract as ``_batch_tsv_layout``, with
+    the statement dialect's fixed columns: ``ref, date`` first, then
+    any order of ``description``/``desc``, ``notes``, ``raw``,
+    ``match``, ``amount`` (required — the self-consistency gate sums
+    it), then optional split-group columns for the COUNTER-side of
+    created rows (``amt, acct, memo, qty, act`` — the statement
+    account's own leg is synthesized by the server, never a column).
+
+    ``amount``/``amt`` is claimed by the fixed section at most once;
+    a second amount-ish token starts the split groups, so the
+    canonical spelling — fixed ``amount``, group ``amt1`` — and the
+    lazy one both parse. Every token is validated; unknown or typo'd
+    names reject on the format, same as batch.
+
+    Returns ``{"fixed_idx": {name: column}, "fixed": int,
+    "group": tuple[str, ...]}``.
+    """
+    raw_tokens = [t.strip().lower() for t in header_line.split("\t")]
+    while raw_tokens and not raw_tokens[-1]:
+        raw_tokens.pop()
+    tokens = [t.rstrip("0123456789") for t in raw_tokens]
+
+    if len(tokens) < 3 or tokens[0] != "ref" or tokens[1] != "date":
+        raise ValueError(
+            "statement header must start with ref, date — got "
+            f"{', '.join(raw_tokens[:2]) or '(empty header)'}"
+        )
+
+    fixed_idx: dict[str, int] = {}
+    start = 2
+    while start < len(tokens):
+        name = _STATEMENT_FIXED_TOKENS.get(tokens[start])
+        if name is None or name in fixed_idx:
+            break
+        fixed_idx[name] = start
+        start += 1
+
+    if "amount" not in fixed_idx:
+        raise ValueError(
+            "statement header needs an amount column — every line "
+            "carries the amount the statement prints"
+        )
+    if "description" not in fixed_idx and "raw" not in fixed_idx:
+        raise ValueError(
+            "statement header needs a description or raw column — "
+            "something has to identify each line"
+        )
+
+    canonical: list[str] = []
+    for raw, token in zip(raw_tokens[start:], tokens[start:]):
+        name = _BATCH_SPLIT_TOKENS.get(token)
+        if name is None:
+            raise ValueError(
+                f"unrecognized column {raw!r} in statement header — "
+                f"columns are ref, date, then "
+                f"description/notes/raw/match/amount in any order, "
+                f"then amt, acct, memo, qty counter-split groups "
+                f"(the statement account's own leg is synthesized — "
+                f"never a column)"
+            )
+        canonical.append(name)
+
+    layout = {"fixed_idx": fixed_idx, "fixed": start}
+    if not canonical:
+        return layout | {"group": _BATCH_LEGACY_GROUP}
+    group: list[str] = []
+    for name in canonical:
+        if name in group:
+            break
+        group.append(name)
+    if "amount" not in group or "account" not in group:
+        raise ValueError(
+            "counter-split columns must include both an amount and "
+            "an account column (or declare none at all)"
+        )
+    return layout | {"group": tuple(group)}
+
+
+def _parse_statement_tsv(tsv: str) -> list[dict]:
+    """Parse an ``enter_statement`` lines TSV into row dicts.
+
+    Row shape: ``{ref, date (ISO string — the caller converts),
+    amount (string), description?, notes?, raw?, match?, splits}``.
+    Optional fixed cells appear only when non-empty. ``date`` and
+    ``amount`` cells are REQUIRED per row — a statement line without
+    either isn't a transcription, and defaulting a date (as batch
+    does) would silently corrupt the date signal every
+    classification leans on.
+
+    Split cells beyond the fixed columns chunk through
+    ``_batch_row_splits`` — the same group mechanics as batch, so
+    the two grammars can't drift.
+    """
+    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        raise ValueError(
+            "statement lines TSV needs a header row and at least one "
+            "data row"
+        )
+    layout = _statement_tsv_layout(lines[0])
+    fixed_idx = layout["fixed_idx"]
+    fixed = layout["fixed"]
+    out: list[dict] = []
+    for i, ln in enumerate(lines[1:], start=1):
+        fields = ln.split("\t")
+        while fields and not fields[-1].strip():
+            fields.pop()
+        ref = fields[0].strip() if fields else ""
+        if not ref:
+            raise ValueError(f"row {i}: empty ref (each row needs a key)")
+        if len(fields) < 2 or not fields[1].strip():
+            raise ValueError(f"row {i} (ref {ref!r}): missing date")
+        row: dict = {"ref": ref, "date": fields[1].strip()}
+        for name, idx in fixed_idx.items():
+            if len(fields) > idx and fields[idx].strip():
+                row[name] = fields[idx].strip()
+        if "amount" not in row:
+            raise ValueError(
+                f"row {i} (ref {ref!r}): missing amount — transcribe "
+                f"the amount exactly as the statement prints it"
+            )
+        if len(fields) <= fixed:
+            row["splits"] = []
+        else:
+            try:
+                row["splits"] = _batch_row_splits(
+                    fields[fixed:], layout["group"]
+                )
+            except ValueError as e:
+                raise ValueError(f"row {i} (ref {ref!r}): {e}")
+        out.append(row)
+    return out
+
+
 # ── Numeric formatting ─────────────────────────────────────────────
 
 

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -529,6 +529,27 @@ def _parse_statement_tsv(tsv: str) -> list[dict]:
     return out
 
 
+def _dry_run_summary(
+    total: int, noun: str, counts: list[tuple[str, int]],
+    homework: str = "",
+) -> str:
+    """Shared dry-run summary header for the two rehearsal surfaces
+    (``enter_statement`` and ``create_transactions`` dry-runs) —
+    divergence between them is a bug, same as the grammars.
+
+    The clearance principle (statement spec §4): counts are facts
+    and may headline; "safe to commit" / "0 blocking" style verdicts
+    over rows the judgment pass hasn't ruled are banned vocabulary.
+    ``homework`` assigns the work ("K rows need adjudication…") or
+    states a verified empty ("no duplicate candidates") — never a
+    clearance."""
+    parts = ", ".join(f"{n} {label}" for label, n in counts)
+    out = f"Dry run: {total} {noun} — {parts}."
+    if homework:
+        out += f"\n{homework}"
+    return out
+
+
 # ── Numeric formatting ─────────────────────────────────────────────
 
 

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -376,6 +376,42 @@ def _batch_row_splits(rest: list[str], group: tuple[str, ...]) -> list[dict]:
     return splits
 
 
+# Characters str.splitlines() treats as line breaks but no TSV cell
+# legitimately contains: Unicode LINE/PARAGRAPH SEPARATOR, NEL,
+# vertical tab, form feed. Models and copy/paste occasionally emit
+# them invisibly; splitting on one SHATTERS a row mid-cell, and the
+# resulting structural error truthfully blames the row while being
+# unable to name the invisible byte — a bookkeeper lost a night's
+# bisection to exactly that. Reject them loudly by name instead.
+_EXOTIC_SEPARATORS = {
+    "\u2028": "U+2028 LINE SEPARATOR",
+    "\u2029": "U+2029 PARAGRAPH SEPARATOR",
+    "\x85": "U+0085 NEXT LINE",
+    "\x0b": "U+000B VERTICAL TAB",
+    "\x0c": "U+000C FORM FEED",
+}
+
+
+def _tsv_lines(tsv: str, what: str) -> list[str]:
+    """Split a TSV block on REAL newlines only, rejecting the
+    invisible separator characters ``str.splitlines`` would have
+    silently split on. Shared by every TSV parser — one splitting
+    discipline, one diagnosis."""
+    for ch, name in _EXOTIC_SEPARATORS.items():
+        if ch in tsv:
+            before = tsv[: tsv.index(ch)]
+            row = before.count("\n")  # 0 = header line
+            where = f"row {row}" if row else "the header"
+            raise ValueError(
+                f"invisible {name} character inside {what} at "
+                f"{where} — a copy/paste or generation artifact "
+                f"that would silently shatter the row; re-emit it "
+                f"with plain newlines and tabs"
+            )
+    text = tsv.replace("\r\n", "\n").replace("\r", "\n")
+    return [ln for ln in text.split("\n") if ln.strip()]
+
+
 # Statement-dialect fixed columns (``enter_statement``). The batch
 # grammar's fixed prefix is positional (ref, date, description,
 # [notes], [cur]); a statement header instead declares an
@@ -488,7 +524,7 @@ def _parse_statement_tsv(tsv: str) -> list[dict]:
     ``_batch_row_splits`` — the same group mechanics as batch, so
     the two grammars can't drift.
     """
-    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    lines = _tsv_lines(tsv, "the statement lines TSV")
     if len(lines) < 2:
         raise ValueError(
             "statement lines TSV needs a header row and at least one "
@@ -518,6 +554,16 @@ def _parse_statement_tsv(tsv: str) -> list[dict]:
             )
         if len(fields) <= fixed:
             row["splits"] = []
+        elif row.get("match"):
+            # A claim row takes no split cells — say so BEFORE the
+            # group chunker turns the stray cells into a confusing
+            # mid-group miscount (bookkeeper finding, maiden
+            # flight).
+            raise ValueError(
+                f"row {i} (ref {ref!r}): a claim row (match cell "
+                f"set) takes no split cells — end the row at its "
+                f"last fixed column"
+            )
         else:
             try:
                 row["splits"] = _batch_row_splits(
@@ -895,7 +941,7 @@ def _parse_update_tsv(tsv: str) -> list[dict]:
     this parser and wants text). Shared with the audit formatter so
     the display parse can't drift from the tool parse.
     """
-    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    lines = _tsv_lines(tsv, "the updates TSV")
     if len(lines) < 2:
         raise ValueError(
             "updates TSV needs a header row and at least one data row"

--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -389,6 +389,15 @@ _EXOTIC_SEPARATORS = {
     "\x85": "U+0085 NEXT LINE",
     "\x0b": "U+000B VERTICAL TAB",
     "\x0c": "U+000C FORM FEED",
+    # The other three str.splitlines boundaries — without them the
+    # shatter class was only HALF-fixed: the byte flowed silently
+    # into a cell and died later as a bare ConversionSyntax naming
+    # no character (review finding). splitlines breaks on exactly
+    # ten characters; \n and \r are the real newlines, these are
+    # the other eight.
+    "\x1c": "U+001C FILE SEPARATOR",
+    "\x1d": "U+001D GROUP SEPARATOR",
+    "\x1e": "U+001E RECORD SEPARATOR",
 }
 
 
@@ -397,10 +406,15 @@ def _tsv_lines(tsv: str, what: str) -> list[str]:
     invisible separator characters ``str.splitlines`` would have
     silently split on. Shared by every TSV parser — one splitting
     discipline, one diagnosis."""
+    # Normalize BEFORE locating, or a bare-\r file reports every
+    # exotic as "the header" (review finding); and number the same
+    # blank-filtered rows the parse loops number, so this
+    # diagnosis and every other row error agree about a line.
+    text = tsv.replace("\r\n", "\n").replace("\r", "\n")
     for ch, name in _EXOTIC_SEPARATORS.items():
-        if ch in tsv:
-            before = tsv[: tsv.index(ch)]
-            row = before.count("\n")  # 0 = header line
+        if ch in text:
+            prior = text[: text.index(ch)].split("\n")[:-1]
+            row = sum(1 for ln in prior if ln.strip())
             where = f"row {row}" if row else "the header"
             raise ValueError(
                 f"invisible {name} character inside {what} at "
@@ -408,7 +422,6 @@ def _tsv_lines(tsv: str, what: str) -> list[str]:
                 f"that would silently shatter the row; re-emit it "
                 f"with plain newlines and tabs"
             )
-    text = tsv.replace("\r\n", "\n").replace("\r", "\n")
     return [ln for ln in text.split("\n") if ln.strip()]
 
 
@@ -462,23 +475,21 @@ def _statement_tsv_layout(header_line: str) -> dict:
     fixed_idx: dict[str, int] = {}
     start = 2
     while start < len(tokens):
-        name = _STATEMENT_FIXED_TOKENS.get(tokens[start])
+        # Match on the RAW token: a digit-suffixed spelling (amt1)
+        # is always a split-group column, never the per-line fixed
+        # amount — the docstring's "lazy spelling" promise depends
+        # on this (review finding: the digit-stripped token was
+        # getting swallowed as fixed, inverting the group order).
+        name = _STATEMENT_FIXED_TOKENS.get(raw_tokens[start])
         if name is None or name in fixed_idx:
             break
         fixed_idx[name] = start
         start += 1
 
-    if "amount" not in fixed_idx:
-        raise ValueError(
-            "statement header needs an amount column — every line "
-            "carries the amount the statement prints"
-        )
-    if "description" not in fixed_idx and "raw" not in fixed_idx:
-        raise ValueError(
-            "statement header needs a description or raw column — "
-            "something has to identify each line"
-        )
-
+    # Validate the remaining tokens BEFORE the presence checks: a
+    # typo'd fixed column ("descrption") must error by NAME, not as
+    # a bogus "missing amount" about a column visibly present
+    # (review finding).
     canonical: list[str] = []
     for raw, token in zip(raw_tokens[start:], tokens[start:]):
         name = _BATCH_SPLIT_TOKENS.get(token)
@@ -492,6 +503,17 @@ def _statement_tsv_layout(header_line: str) -> dict:
                 f"never a column)"
             )
         canonical.append(name)
+
+    if "amount" not in fixed_idx:
+        raise ValueError(
+            "statement header needs an amount column — every line "
+            "carries the amount the statement prints"
+        )
+    if "description" not in fixed_idx and "raw" not in fixed_idx:
+        raise ValueError(
+            "statement header needs a description or raw column — "
+            "something has to identify each line"
+        )
 
     layout = {"fixed_idx": fixed_idx, "fixed": start}
     if not canonical:
@@ -590,6 +612,33 @@ _CANDIDATE_COMPARISON_COLUMNS = (
 )
 
 
+def _tsv_cell(value) -> str:
+    """Escape one response-TSV cell — the OUTPUT mirror of
+    ``_tsv_lines``. Book-sourced free text (notes, memos,
+    descriptions, account names) is routinely multi-line in
+    OFX-imported books; written raw into a TSV it shatters the row
+    into phantom rows exactly like the input-side bug this branch
+    already fixed (review finding: a two-line note became a
+    candidate row for a ref that didn't exist). Structural
+    characters render as visible escapes; the invisible separator
+    exotics render as spaces. ``None`` renders empty — never the
+    string "None"."""
+    if value is None:
+        return ""
+    s = str(value)
+    if not s:
+        return ""
+    s = (
+        s.replace("\\", "\\\\")
+        .replace("\t", "\\t")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+    for ch in _EXOTIC_SEPARATORS:
+        s = s.replace(ch, " ")
+    return s
+
+
 def _candidate_risk(row: dict) -> int:
     """Correspondence strength = lit signal count."""
     return sum(1 for ch in str(row.get("signals", "")) if ch != "-")
@@ -605,18 +654,25 @@ def _candidate_comparison_tsv(rows: list[dict]) -> str:
     if not rows:
         return ""
 
-    def _abs_or_inf(value) -> Decimal:
+    def _abs_or_zero(value) -> Decimal:
+        # Blank deltas are WITHHELD comparisons (cross-currency),
+        # not distant ones — sorting them last would demote exactly
+        # the rows that need manual eyes (review finding). They
+        # sort at the head of their risk tier instead. NaN would
+        # escape the constructor guard and blow up inside sorted();
+        # it lands with the blanks.
         try:
-            return abs(Decimal(str(value)))
+            d = abs(Decimal(str(value)))
         except InvalidOperation:
-            return Decimal("Infinity")
+            return Decimal(0)
+        return Decimal(0) if d.is_nan() else d
 
     ordered = sorted(
         rows,
         key=lambda r: (
             -_candidate_risk(r),
-            _abs_or_inf(r.get("amt_delta", "")),
-            _abs_or_inf(r.get("date_delta_days", "")),
+            _abs_or_zero(r.get("amt_delta", "")),
+            _abs_or_zero(r.get("date_delta_days", "")),
             str(r.get("ref", "")), str(r.get("candidate_guid", "")),
         ),
     )
@@ -624,7 +680,7 @@ def _candidate_comparison_tsv(rows: list[dict]) -> str:
     for r in ordered:
         lines.append(
             "\t".join(
-                str(r.get(c, "")) for c in
+                _tsv_cell(r.get(c)) for c in
                 _CANDIDATE_COMPARISON_COLUMNS
             )
         )

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -62,6 +62,20 @@ def _slot_value_str(value) -> str:
     return str(value)
 
 
+def _commodity_quantum(commodity) -> Decimal:
+    """Smallest representable unit of a commodity, as a Decimal quantum.
+
+    Derived from ``commodity.fraction`` (piecash stores 100 for USD,
+    1 for JPY, 1000 for BHD, 10000 for shares). A hardcoded
+    ``Decimal("0.01")`` would silently corrupt non-2-decimal
+    currencies — half-yen amounts on JPY, lost mils on BHD/KWD.
+    """
+    fraction = getattr(commodity, "fraction", 100)
+    if fraction <= 1:
+        return Decimal(1)
+    return Decimal(1) / Decimal(fraction)
+
+
 def _is_voided(split) -> bool:
     """True iff ``split`` carries GnuCash's voided marker.
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -21,6 +21,7 @@ from decimal import Decimal
 import piecash
 
 from gnucash_mcp.book._base import (
+    _commodity_quantum,
     _slot_value_str,
     _to_decimal,
     _unique_prefix,
@@ -38,20 +39,6 @@ from gnucash_mcp._format import (
 
 
 debug_logger = logging.getLogger("gnucash_mcp.debug")
-
-
-def _commodity_quantum(commodity) -> Decimal:
-    """Smallest representable unit of a commodity, as a Decimal quantum.
-
-    Derived from ``commodity.fraction`` (piecash stores 100 for USD,
-    1 for JPY, 1000 for BHD, 10000 for shares). A hardcoded
-    ``Decimal("0.01")`` would silently corrupt non-2-decimal
-    currencies — half-yen amounts on JPY, lost mils on BHD/KWD.
-    """
-    fraction = getattr(commodity, "fraction", 100)
-    if fraction <= 1:
-        return Decimal(1)
-    return Decimal(1) / Decimal(fraction)
 
 
 def _safe_invoice_date(inv, attr: str):

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -117,6 +117,19 @@ class _SummaryData:
     expense_total: int = 0
 
 
+# Shared correspondence thresholds — the ONE definition both
+# matchers (the duplicate screen in _collect_create_signals and the
+# statement candidate scan in enter_statement) read, so the A/D
+# signal semantics can't drift between the two surfaces. The
+# ADMISSION rules deliberately differ (documented at each site):
+# the book-wide duplicate screen demands >=2 signals; the
+# account-scoped statement scan admits the amount signal alone,
+# because its narrow universe makes an amount match meaningful —
+# and the spec's own monthly-rent case carries only that signal.
+_MATCH_AMOUNT_TOLERANCE = Decimal("1.00")
+_MATCH_DATE_TIGHT_DAYS = 2
+
+
 def _post_date_as_date(transaction) -> date | None:
     """Transaction post_date normalized to a bare date — piecash
     stores it with a neutral-time datetime component."""
@@ -2881,13 +2894,17 @@ class CoreMixin:
                     or txn.currency.mnemonic == trans_currency
                 )
                 amount_match = same_frame and (
-                    abs(proposed_primary - primary_amount) <= Decimal("1.00")
+                    abs(proposed_primary - primary_amount)
+                    <= _MATCH_AMOUNT_TOLERANCE
                 )
 
                 # Signal 3: date within ±2 days of trans_date (tighter
                 # than the window filter — window is for "worth
                 # considering at all").
-                date_match = abs((txn.post_date - trans_date).days) <= 2
+                date_match = (
+                    abs((txn.post_date - trans_date).days)
+                    <= _MATCH_DATE_TIGHT_DAYS
+                )
 
                 signals = sum([desc_match, amount_match, date_match])
                 if signals >= 2:
@@ -3997,9 +4014,13 @@ class CoreMixin:
                     if abs((pd - ln["date"]).days) > 31:
                         continue
                     amount_match = (
-                        abs(s.quantity - target) <= Decimal("1.00")
+                        abs(s.quantity - target)
+                        <= _MATCH_AMOUNT_TOLERANCE
                     )
-                    date_match = abs((pd - ln["date"]).days) <= 2
+                    date_match = (
+                        abs((pd - ln["date"]).days)
+                        <= _MATCH_DATE_TIGHT_DAYS
+                    )
                     tdesc = (
                         s.transaction.description or ""
                     ).lower().strip()

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -21,7 +21,12 @@ from decimal import Decimal, InvalidOperation
 import piecash
 
 from gnucash_mcp.logging_config import DEBUG_LOGGER_NAME
-from gnucash_mcp._format import _dry_run_summary, _paginate
+from gnucash_mcp._format import (
+    _candidate_comparison_tsv,
+    _dry_run_summary,
+    _paginate,
+    _split_match_verdict,
+)
 
 _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
 
@@ -2892,11 +2897,26 @@ class CoreMixin:
                         + ("A" if amount_match else "-")
                         + ("D" if date_match else "-")
                     )
+                    # Category (non-funding) legs, for the ruling-9
+                    # self-contained comparison; all legs when
+                    # filtering leaves nothing (transfers), same
+                    # fallback as _extract_account_pattern.
+                    cat_legs = [
+                        (s.account.fullname, str(abs(s.value)))
+                        for s in txn.splits
+                        if s.account.type
+                        not in CoreMixin._FUNDING_ACCOUNT_TYPES
+                    ] or [
+                        (s.account.fullname, str(abs(s.value)))
+                        for s in txn.splits
+                    ]
                     duplicates.append({
                         "confidence": confidence,
                         "guid": txn_prefixes[txn.guid],
                         "date": txn.post_date.isoformat(),
                         "description": txn.description,
+                        "notes": txn.notes or "",
+                        "categories": cat_legs,
                         "amount": str(primary_amount),
                         # Labeling non-default candidates lets the
                         # caller interpret a cross-currency MEDIUM
@@ -3512,8 +3532,29 @@ class CoreMixin:
                     trans_currency=p["currency"].mnemonic,
                 )
                 dups = signals.duplicates
-                for d in dups:
-                    dup_rows.append((p["ref"], d))
+                if dups:
+                    # Proposal-side context for the ruling-9
+                    # comparison rows — computed once per row.
+                    p_cats = [
+                        (v["account"].fullname, str(abs(v["value"])))
+                        for v in p["validated"]
+                        if v["account"].type
+                        not in self._FUNDING_ACCOUNT_TYPES
+                    ] or [
+                        (v["account"].fullname, str(abs(v["value"])))
+                        for v in p["validated"]
+                    ]
+                    proposal = {
+                        "desc": p["description"],
+                        "date": p["trans_date"],
+                        "amount": (
+                            max(p["proposed_amounts"])
+                            if p["proposed_amounts"] else Decimal("0")
+                        ),
+                        "cats": p_cats,
+                    }
+                    for d in dups:
+                        dup_rows.append((p["ref"], d, proposal))
                 # Duplicates arrive HIGH-first, so [0] is the max —
                 # the results-table shortcut that saves the
                 # two-table join for the common decision.
@@ -3555,9 +3596,19 @@ class CoreMixin:
 
             # --- Phase 3: build all accepted rows, one save ---
             if dry_run:
+                # Ruling 8: a projected-action label must not
+                # masquerade as clearance. would_create stays only
+                # on candidate-free rows (there it is an honest,
+                # verified clearance); any row with >=1 candidate
+                # reports review_required. HIGH blocks stay
+                # rejected + reason.
                 for p, dup_count, max_conf in accepted:
                     by_ref[p["ref"]] = {
-                        "ref": p["ref"], "status": "would_create",
+                        "ref": p["ref"],
+                        "status": (
+                            "review_required" if dup_count
+                            else "would_create"
+                        ),
                         "dup_count": dup_count,
                         "max_confidence": max_conf,
                         **_fill_marker(p),
@@ -3570,12 +3621,22 @@ class CoreMixin:
                 # per-account effects footer — the rehearsal-
                 # completeness principle, minus the tie (batches
                 # assert no closing balance).
-                n_would = len(accepted)
-                n_rejected = len(transactions) - n_would
+                n_review = sum(
+                    1 for r in by_ref.values()
+                    if r["status"] == "review_required"
+                )
+                n_would = len(accepted) - n_review
+                n_rejected = len(transactions) - len(accepted)
                 with_cands = sum(
                     1 for r in by_ref.values() if r.get("dup_count")
                 )
-                if with_cands:
+                if n_review:
+                    homework = (
+                        f"{n_review} rows are review_required — "
+                        f"rule each against the duplicates table "
+                        f"before committing."
+                    )
+                elif with_cands:
                     homework = (
                         f"{with_cands} rows have duplicate "
                         f"candidates — review the duplicates table "
@@ -3586,6 +3647,7 @@ class CoreMixin:
                 summary = _dry_run_summary(
                     len(transactions), "rows",
                     [("would create", n_would),
+                     ("review_required", n_review),
                      ("rejected", n_rejected)],
                     homework,
                 )
@@ -3695,22 +3757,49 @@ class CoreMixin:
         return "\n".join(lines)
 
     @staticmethod
+    def _cats_str(cats: list[tuple[str, str]]) -> str:
+        """Render category legs as ``account=amount`` pipe-joined."""
+        return "|".join(f"{a}={v}" for a, v in sorted(cats))
+
+    @staticmethod
     def _batch_duplicates_to_tsv(dup_rows: list) -> str:
-        """DUPLICATES table: single-entry's column order with ``ref``
-        prepended as the FK. Empty string when no row has a match."""
-        if not dup_rows:
-            return ""
-        lines = [
-            "ref\tconfidence\tguid\tdate\tamount\tcur\t"
-            "description\tsignals"
-        ]
-        for ref, d in dup_rows:
-            lines.append(
-                f"{ref}\t{d['confidence']}\t{d['guid']}\t{d['date']}\t"
-                f"{d['amount']}\t{d.get('currency', '')}\t"
-                f"{d['description']}\t{d['signals']}"
-            )
-        return "\n".join(lines)
+        """DUPLICATES table in the shared ruling-9 comparison shape:
+        proposed + existing values AND deltas, category legs,
+        split_match — the caller never joins back to its own input.
+        Empty string when no row has a match. ``amt_delta`` renders
+        blank on cross-currency candidates (the ``cur`` column
+        labels them): 188 HKD − 188 CNY is not a number."""
+        rows = []
+        for ref, d, prop in dup_rows:
+            date_old = date.fromisoformat(d["date"])
+            cross_frame = bool(d.get("currency"))
+            rows.append({
+                "ref": ref,
+                "candidate_guid": d["guid"],
+                "confidence": d["confidence"],
+                "date_new": prop["date"].isoformat(),
+                "date_old": d["date"],
+                "date_delta_days": (date_old - prop["date"]).days,
+                "amt_new": str(prop["amount"]),
+                "amt_old": d["amount"],
+                "amt_delta": (
+                    "" if cross_frame
+                    else str(_to_decimal(d["amount"]) - prop["amount"])
+                ),
+                "cur": d.get("currency", ""),
+                "desc_new": prop["desc"],
+                "desc_old": d["description"],
+                "notes_old": d.get("notes", ""),
+                "cat_new": CoreMixin._cats_str(prop["cats"]),
+                "cat_old": CoreMixin._cats_str(
+                    d.get("categories", [])
+                ),
+                "split_match": _split_match_verdict(
+                    prop["cats"], d.get("categories", []),
+                ),
+                "signals": d["signals"],
+            })
+        return _candidate_comparison_tsv(rows)
 
     # ── Statement entry ────────────────────────────────────────────
 
@@ -4091,7 +4180,7 @@ class CoreMixin:
         default_currency = self._require_default_currency(book)
         counts = {"NEW": 0, "MATCH": 0, "OVERLAP": 0, "AMBIGUOUS": 0}
         line_rows: list[tuple] = []
-        cand_rows: list[tuple] = []
+        cand_rows: list[dict] = []
         projected = reconciled_balance.quantize(quantum)
 
         seen_claims: set[str] = set()
@@ -4140,6 +4229,7 @@ class CoreMixin:
             # Full rehearsal: run exactly what commit would run on
             # this row — a dry-run that ties is a commit that will
             # tie, and a row commit would reject must say so now.
+            proposal_cats = None
             try:
                 if ln.get("match"):
                     s, kind = self._statement_resolve_claim(
@@ -4160,6 +4250,11 @@ class CoreMixin:
                         book, account, ln, _book_amount(ln),
                         default_currency,
                     )
+                    proposal_cats = [
+                        (v["account"].fullname, str(abs(v["value"])))
+                        for v in validated
+                        if v["account"].guid != account.guid
+                    ]
                     if cls == "NEW" and not ln.get("splits"):
                         counter_names = ", ".join(
                             v["account"].fullname
@@ -4182,13 +4277,45 @@ class CoreMixin:
             for c in listed:
                 s = c["split"]
                 txn = s.transaction
-                cand_rows.append((
-                    ln["ref"], split_prefixes[s.guid],
-                    s.reconcile_state,
-                    txn.post_date.isoformat(), str(s.quantity),
-                    txn.description or "", txn.notes or "",
-                    s.memo or "", c["signals"],
-                ))
+                cat_old = [
+                    (s2.account.fullname, str(abs(s2.value)))
+                    for s2 in txn.splits
+                    if s2.account.guid != account.guid
+                ]
+                risk = sum(1 for ch in c["signals"] if ch != "-")
+                cand_rows.append({
+                    "ref": ln["ref"],
+                    "candidate_guid": split_prefixes[s.guid],
+                    "confidence": {
+                        3: "HIGH", 2: "MEDIUM", 1: "LOW",
+                    }.get(risk, ""),
+                    "state": s.reconcile_state,
+                    "date_new": ln["date"].isoformat(),
+                    "date_old": txn.post_date.isoformat(),
+                    "date_delta_days": (
+                        txn.post_date - ln["date"]
+                    ).days,
+                    "amt_new": str(_book_amount(ln)),
+                    "amt_old": str(s.quantity),
+                    "amt_delta": str(
+                        s.quantity - _book_amount(ln)
+                    ),
+                    "desc_new": (
+                        ln.get("description") or ln.get("raw") or ""
+                    ),
+                    "desc_old": txn.description or "",
+                    "notes_old": txn.notes or "",
+                    "memo_old": s.memo or "",
+                    "cat_new": (
+                        self._cats_str(proposal_cats)
+                        if proposal_cats is not None else ""
+                    ),
+                    "cat_old": self._cats_str(cat_old),
+                    "split_match": _split_match_verdict(
+                        proposal_cats, cat_old,
+                    ),
+                    "signals": c["signals"],
+                })
             line_rows.append((ln["ref"], cls, len(listed), note))
 
         # Summary header via the shared rehearsal renderer — counts
@@ -4238,20 +4365,11 @@ class CoreMixin:
         lines_tsv = ["ref\tclass\tcands\tnote"]
         for r in line_rows:
             lines_tsv.append(f"{r[0]}\t{r[1]}\t{r[2]}\t{r[3]}")
-        cands_tsv = ""
-        if cand_rows:
-            out = [
-                "ref\tsplit_guid\tstate\tdate\tamount\t"
-                "description\tnotes\tmemo\tsignals"
-            ]
-            for r in cand_rows:
-                out.append("\t".join(str(x) for x in r))
-            cands_tsv = "\n".join(out)
 
         return {
             "summary": header,
             "lines": "\n".join(lines_tsv),
-            "candidates": cands_tsv,
+            "candidates": _candidate_comparison_tsv(cand_rows),
             "warnings": self._batch_warnings_to_tsv(warn_rows),
             "tie": tie,
         }
@@ -4366,10 +4484,14 @@ class CoreMixin:
             new_reconciled += _book_amount(ln)
         new_reconciled = new_reconciled.quantize(quantum)
         closing_book = (sign * closing).quantize(quantum)
+        n_touched = len(prepared) + len(claims)
+        cur = account.commodity.mnemonic
         if new_reconciled == closing_book:
             tie = (
-                f"reconciled balance {new_reconciled} ties to the "
-                f"statement closing ({closing} as printed)"
+                f"Reconciled: {n_touched} splits @ "
+                f"{statement_date.isoformat()}; closing balance "
+                f"{cur} {new_reconciled} ({closing} as printed) — "
+                f"tied."
             )
         elif force:
             tie = (
@@ -4463,19 +4585,18 @@ class CoreMixin:
             )
         for ln, s in skipped:
             by_ref[ln["ref"]] = (
-                f"{ln['ref']}\tskipped_overlap\t"
+                f"{ln['ref']}\tskipped_duplicate\t"
                 f"{split_prefixes[s.guid]}\talready reconciled"
             )
         for ln in lines:
             rows.append(by_ref[ln["ref"]])
 
-        n_touched = len(built) + len(claims)
         return {
             "summary": (
-                f"Statement entered: {len(built)} created, "
-                f"{len(claims)} claimed, {len(skipped)} skipped "
-                f"(already reconciled); {n_touched} splits "
-                f"reconciled at {statement_date.isoformat()}."
+                f"Statement entered on {account.fullname} through "
+                f"{statement_date.isoformat()}: {len(built)} "
+                f"created, {len(claims)} claimed, {len(skipped)} "
+                f"skipped (already reconciled)."
             ),
             "results": "\n".join(rows),
             "new_reconciled_balance": str(new_reconciled),

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2721,6 +2721,28 @@ class CoreMixin:
         )
         return categorization if categorization else all_names
 
+    def _proposal_category_primary(
+        self, book, splits: list[dict],
+    ) -> Decimal | None:
+        """Signed max-abs value among the proposal's category
+        (non-funding) legs — the direction anchor for the duplicate
+        amount signal (R3 P5). None when any ref fails to resolve
+        or no category leg exists (transfers) — the signal then
+        falls back to magnitude comparison."""
+        legs = []
+        for sp in splits:
+            acct = self._resolve_account(book, sp["account"])
+            if acct is None:
+                return None
+            if acct.type not in self._FUNDING_ACCOUNT_TYPES:
+                try:
+                    legs.append(_to_decimal(sp["amount"]))
+                except (InvalidOperation, ValueError):
+                    return None
+        if not legs:
+            return None
+        return max(legs, key=abs)
+
     def _collect_create_signals(
         self,
         book: piecash.Book,
@@ -2728,6 +2750,7 @@ class CoreMixin:
         trans_date: date,
         proposed_amounts: list[Decimal],
         *,
+        proposed_category_primary: Decimal | None = None,
         want_auto_fill: bool,
         want_stability: bool,
         want_duplicates: bool,
@@ -2798,7 +2821,15 @@ class CoreMixin:
 
         # Proposed primary = headline amount (max abs split value)
         # for the duplicate amount-signal; zero when the caller
-        # passed [] (that branch never runs then).
+        # passed [] (that branch never runs then). When BOTH sides
+        # have a category anchor (proposed_category_primary + the
+        # candidate's), the signal compares SIGNED category
+        # primaries instead — a +104 refund is not a -104
+        # payment's twin, and the direction lives in the category
+        # legs because a balanced transaction always carries both
+        # signs (bookkeeper R3 P5, blocker-class). Magnitude
+        # comparison remains the fallback for transfer-shaped
+        # rows with no category leg.
         proposed_primary = max(proposed_amounts) if proposed_amounts else Decimal("0")
 
         # Local accumulators — each bucket is independent. We finalize
@@ -2892,6 +2923,15 @@ class CoreMixin:
                 # kills the noise without losing real duplicates
                 # (paycheck-vs-paycheck still matches on gross).
                 primary_amount = max(abs(s.value) for s in txn.splits)
+                cand_cat_values = [
+                    s.value for s in txn.splits
+                    if s.account.type
+                    not in CoreMixin._FUNDING_ACCOUNT_TYPES
+                ]
+                cand_cat_primary = (
+                    max(cand_cat_values, key=abs)
+                    if cand_cat_values else None
+                )
                 # Amounts only compare within the same currency
                 # frame: 188 HKD and 188 CNY are not the same money,
                 # and the cross-frame version of a true duplicate
@@ -2905,10 +2945,23 @@ class CoreMixin:
                     trans_currency is None
                     or txn.currency.mnemonic == trans_currency
                 )
-                amount_match = same_frame and (
-                    abs(proposed_primary - primary_amount)
-                    <= _MATCH_AMOUNT_TOLERANCE
-                )
+                if (
+                    same_frame
+                    and proposed_category_primary is not None
+                    and cand_cat_primary is not None
+                ):
+                    amount_match = (
+                        abs(
+                            proposed_category_primary
+                            - cand_cat_primary
+                        )
+                        <= _MATCH_AMOUNT_TOLERANCE
+                    )
+                else:
+                    amount_match = same_frame and (
+                        abs(proposed_primary - primary_amount)
+                        <= _MATCH_AMOUNT_TOLERANCE
+                    )
 
                 # Signal 3: date within ±2 days of trans_date (tighter
                 # than the window filter — window is for "worth
@@ -2930,13 +2983,16 @@ class CoreMixin:
                     # self-contained comparison; all legs when
                     # filtering leaves nothing (transfers), same
                     # fallback as _extract_account_pattern.
+                    # SIGNED legs: a refund's inverted categories
+                    # must not read exact against the purchase's
+                    # (R3 P5).
                     cat_legs = [
-                        (s.account.fullname, str(abs(s.value)))
+                        (s.account.fullname, str(s.value))
                         for s in txn.splits
                         if s.account.type
                         not in CoreMixin._FUNDING_ACCOUNT_TYPES
                     ] or [
-                        (s.account.fullname, str(abs(s.value)))
+                        (s.account.fullname, str(s.value))
                         for s in txn.splits
                     ]
                     # Most-anchored split state: a reconciled
@@ -2950,8 +3006,12 @@ class CoreMixin:
                         else "c" if "c" in states
                         else "f" if "f" in states else "n"
                     )
-                    primary_signed = max(
-                        (s.value for s in txn.splits), key=abs,
+                    primary_signed = (
+                        cand_cat_primary
+                        if cand_cat_primary is not None
+                        else max(
+                            (s.value for s in txn.splits), key=abs,
+                        )
                     )
                     duplicates.append({
                         "confidence": confidence,
@@ -3294,6 +3354,9 @@ class CoreMixin:
                 description,
                 trans_date,
                 proposed_amounts,
+                proposed_category_primary=(
+                    self._proposal_category_primary(book, splits)
+                ),
                 want_auto_fill=False,
                 want_stability=False,
                 want_duplicates=check_duplicates,
@@ -3579,9 +3642,19 @@ class CoreMixin:
             # --- Phase 2: duplicate screen (against existing book) ---
             accepted = []
             for p in prepared:
+                p_cat_values = [
+                    v["value"] for v in p["validated"]
+                    if v["account"].type
+                    not in self._FUNDING_ACCOUNT_TYPES
+                ]
+                p_cat_primary = (
+                    max(p_cat_values, key=abs)
+                    if p_cat_values else None
+                )
                 signals = self._collect_create_signals(
                     book, p["description"], p["trans_date"],
                     p["proposed_amounts"],
+                    proposed_category_primary=p_cat_primary,
                     want_auto_fill=False, want_stability=False,
                     want_duplicates=True, want_recent=False,
                     trans_currency=p["currency"].mnemonic,
@@ -3591,12 +3664,12 @@ class CoreMixin:
                     # Proposal-side context for the ruling-9
                     # comparison rows — computed once per row.
                     p_cats = [
-                        (v["account"].fullname, str(abs(v["value"])))
+                        (v["account"].fullname, str(v["value"]))
                         for v in p["validated"]
                         if v["account"].type
                         not in self._FUNDING_ACCOUNT_TYPES
                     ] or [
-                        (v["account"].fullname, str(abs(v["value"])))
+                        (v["account"].fullname, str(v["value"]))
                         for v in p["validated"]
                     ]
                     proposal = {
@@ -3608,7 +3681,9 @@ class CoreMixin:
                         # deposit and a -50 payment never render
                         # as a perfect twin (review finding).
                         "amount": (
-                            max(
+                            p_cat_primary
+                            if p_cat_primary is not None
+                            else max(
                                 (v["value"] for v in p["validated"]),
                                 key=abs,
                             )
@@ -4397,7 +4472,7 @@ class CoreMixin:
             elif d["kind"] == "create":
                 validated = d["validated"]
                 proposal_cats = [
-                    (v["account"].fullname, str(abs(v["value"])))
+                    (v["account"].fullname, str(v["value"]))
                     for v in validated
                     if v["account"].guid != account.guid
                 ]
@@ -4450,7 +4525,7 @@ class CoreMixin:
                 s = c["split"]
                 txn = s.transaction
                 cat_old = [
-                    (s2.account.fullname, str(abs(s2.value)))
+                    (s2.account.fullname, str(s2.value))
                     for s2 in txn.splits
                     if s2.account.guid != account.guid
                 ]

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -21,7 +21,7 @@ from decimal import Decimal, InvalidOperation
 import piecash
 
 from gnucash_mcp.logging_config import DEBUG_LOGGER_NAME
-from gnucash_mcp._format import _paginate
+from gnucash_mcp._format import _dry_run_summary, _paginate
 
 _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
 
@@ -3514,19 +3514,25 @@ class CoreMixin:
                 dups = signals.duplicates
                 for d in dups:
                     dup_rows.append((p["ref"], d))
+                # Duplicates arrive HIGH-first, so [0] is the max —
+                # the results-table shortcut that saves the
+                # two-table join for the common decision.
+                max_conf = dups[0]["confidence"] if dups else ""
                 if signals.has_high_duplicate and not force:
                     by_ref[p["ref"]] = {
                         "ref": p["ref"], "status": "rejected",
-                        "reason": "duplicate_detected", "dup_count": len(dups),
+                        "reason": "duplicate_detected",
+                        "dup_count": len(dups),
+                        "max_confidence": max_conf,
                     }
                 else:
-                    accepted.append((p, len(dups)))
+                    accepted.append((p, len(dups), max_conf))
 
             # Cross-commodity implied-rate sanity per accepted row
             # (non-blocking) — surfaced as a side table keyed by ref,
             # so a decimal slip in a bulk import is caught too.
             warn_rows: list = []
-            for p, _dc in accepted:
+            for p, _dc, _mc in accepted:
                 for w in p["auto_fill_warnings"]:
                     warn_rows.append((p["ref"], w["message"]))
                 for w in self._fx_sanity_warnings(
@@ -3549,18 +3555,62 @@ class CoreMixin:
 
             # --- Phase 3: build all accepted rows, one save ---
             if dry_run:
-                for p, dup_count in accepted:
+                for p, dup_count, max_conf in accepted:
                     by_ref[p["ref"]] = {
                         "ref": p["ref"], "status": "would_create",
                         "dup_count": dup_count,
+                        "max_confidence": max_conf,
                         **_fill_marker(p),
                     }
-                return self._batch_envelope(
+                envelope = self._batch_envelope(
                     transactions, by_ref, dup_rows, warn_rows,
                 )
+                # Ruling 7 upgrades: shared rehearsal header (counts
+                # + homework, never a clearance) and the projected
+                # per-account effects footer — the rehearsal-
+                # completeness principle, minus the tie (batches
+                # assert no closing balance).
+                n_would = len(accepted)
+                n_rejected = len(transactions) - n_would
+                with_cands = sum(
+                    1 for r in by_ref.values() if r.get("dup_count")
+                )
+                if with_cands:
+                    homework = (
+                        f"{with_cands} rows have duplicate "
+                        f"candidates — review the duplicates table "
+                        f"before committing."
+                    )
+                else:
+                    homework = "No duplicate candidates."
+                summary = _dry_run_summary(
+                    len(transactions), "rows",
+                    [("would create", n_would),
+                     ("rejected", n_rejected)],
+                    homework,
+                )
+                effects: dict[str, Decimal] = {}
+                for p, _dc, _mc in accepted:
+                    for v in p["validated"]:
+                        key = v["account"].fullname
+                        effects[key] = (
+                            effects.get(key, Decimal("0"))
+                            + v["quantity"]
+                        )
+                effects_tsv = ""
+                if effects:
+                    out = ["account\tdelta"]
+                    for name in sorted(effects):
+                        out.append(f"{name}\t{effects[name]}")
+                    effects_tsv = "\n".join(out)
+                return {
+                    "summary": summary,
+                    **envelope,
+                    "effects": effects_tsv,
+                }
 
             built = []
-            for p, dup_count in accepted:
+            for p, dup_count, _max_conf in accepted:
                 piecash_splits = [
                     piecash.Split(
                         account=v["account"], value=v["value"],
@@ -3576,7 +3626,7 @@ class CoreMixin:
                     post_date=p["trans_date"],
                     splits=piecash_splits,
                 )
-                built.append((p, txn_obj, dup_count))
+                built.append((p, txn_obj, dup_count, _max_conf))
 
             # Single flush for the whole batch — per the "don't flush
             # mid-build" rule, every Transaction is fully constructed
@@ -3584,11 +3634,12 @@ class CoreMixin:
             book.save()
 
             all_guids = [t.guid for t in book.transactions]
-            for p, txn_obj, dup_count in built:
+            for p, txn_obj, dup_count, max_conf in built:
                 by_ref[p["ref"]] = {
                     "ref": p["ref"], "status": "created",
                     "txn_guid": _unique_prefix(txn_obj.guid, all_guids),
                     "dup_count": dup_count,
+                    "max_confidence": max_conf,
                     **_fill_marker(p),
                 }
 
@@ -3624,15 +3675,22 @@ class CoreMixin:
     @staticmethod
     def _batch_results_to_tsv(rows: list[dict]) -> str:
         """RESULTS table: header + one row per input transaction.
-        Blank cells for fields a given status doesn't carry; ``dup_count``
-        of 0 renders as "0", absent renders blank."""
-        header = "ref\tstatus\ttxn_guid\tdup_count\treason"
+        Blank cells for fields a given status doesn't carry;
+        ``dup_count`` of 0 renders as "0", absent renders blank.
+        ``max_confidence`` (HIGH/MEDIUM/blank) is the row's top
+        duplicate candidate — the shortcut that saves the two-table
+        join for the common keep/drop decision; the duplicates
+        table remains for the real one."""
+        header = (
+            "ref\tstatus\ttxn_guid\tdup_count\tmax_confidence\treason"
+        )
         lines = [header]
         for r in rows:
             dup = r["dup_count"] if "dup_count" in r else ""
             lines.append(
                 f"{r['ref']}\t{r['status']}\t{r.get('txn_guid', '')}\t"
-                f"{dup}\t{r.get('reason', '')}"
+                f"{dup}\t{r.get('max_confidence', '')}\t"
+                f"{r.get('reason', '')}"
             )
         return "\n".join(lines)
 
@@ -4044,23 +4102,25 @@ class CoreMixin:
                 ))
             line_rows.append((ln["ref"], cls, len(listed), note))
 
-        # Summary header — counts are facts and may headline;
-        # clearance verdicts over unadjudicated rows may not (the
-        # clearance principle, spec §4).
+        # Summary header via the shared rehearsal renderer — counts
+        # are facts and may headline; clearance verdicts over
+        # unadjudicated rows may not (the clearance principle,
+        # spec §4).
         n_judge = counts["MATCH"] + counts["AMBIGUOUS"]
-        header = (
-            f"Dry run: {len(lines)} lines — {counts['NEW']} NEW, "
-            f"{counts['MATCH']} MATCH, {counts['OVERLAP']} OVERLAP, "
-            f"{counts['AMBIGUOUS']} AMBIGUOUS."
-        )
         if n_judge:
-            header += (
-                f"\n{n_judge} rows need adjudication — rule each "
+            homework = (
+                f"{n_judge} rows need adjudication — rule each "
                 f"MATCH/AMBIGUOUS against the candidates table "
                 f"before committing."
             )
         else:
-            header += "\nNo existing-split candidates on any line."
+            homework = "No existing-split candidates on any line."
+        header = _dry_run_summary(
+            len(lines), "lines",
+            [(c, counts[c]) for c in
+             ("NEW", "MATCH", "OVERLAP", "AMBIGUOUS")],
+            homework,
+        )
 
         closing_book = (sign * closing).quantize(quantum)
         projected = projected.quantize(quantum)

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -29,6 +29,7 @@ from gnucash_mcp.book._base import (
     _slot_bool,
     _account_to_compact_line,
     _account_to_dict,
+    _commodity_quantum,
     _guid_prefix_map,
     _is_market_price,
     _is_unreconciled,
@@ -3652,6 +3653,698 @@ class CoreMixin:
                 f"{d['description']}\t{d['signals']}"
             )
         return "\n".join(lines)
+
+    # ── Statement entry ────────────────────────────────────────────
+
+    # Statement-native sign transform, keyed by GNCAccountType (never
+    # by name — i18n invariant). Asset-class statements print amounts
+    # in the split convention already; liability-class statements
+    # print charges positive and balances as amount-owed, so both
+    # negate. The model transcribes verbatim; the server flips.
+    _STATEMENT_SIGNS = {
+        "BANK": 1, "CASH": 1, "ASSET": 1,
+        "CREDIT": -1, "LIABILITY": -1,
+    }
+
+    def enter_statement(
+        self,
+        account_name: str,
+        statement_date: date,
+        opening_balance: str,
+        closing_balance: str,
+        lines: list[dict],
+        dry_run: bool = True,
+        force: bool = False,
+    ) -> dict:
+        """One-shot statement entry: enter, claim, and reconcile a
+        complete bank/card statement in one atomic open/save.
+
+        Spec: specs/v1.5/ENTER_STATEMENT_SPEC.md. Each line dict is
+        ``{ref, date (date), amount (statement-native string),
+        description?, notes?, raw?, match?, splits}``.
+
+        ``dry_run=True`` (the default) classifies every line —
+        NEW / MATCH / OVERLAP / AMBIGUOUS — against the account's
+        existing splits and projects the balance tie; nothing is
+        written. ``dry_run=False`` creates NEW rows, claims ``match``
+        rows, reconciles every statement-touched split at
+        ``statement_date``, and saves once — or refuses wholesale.
+
+        ``force=True`` means "I know the base doesn't tie — land the
+        statement anyway": it clears the opening-balance precondition
+        AND downgrades a failed closing tie from refusal to a
+        recorded discrepancy. Without it, both refuse.
+        """
+        refs = [ln["ref"] for ln in lines]
+        if len(set(refs)) != len(refs):
+            raise ValueError(
+                "duplicate ref in statement — each line needs a "
+                "unique ref"
+            )
+        opening = _to_decimal(opening_balance)
+        closing = _to_decimal(closing_balance)
+
+        with self.open(readonly=dry_run) as book:
+            default_currency = self._require_default_currency(book)
+            account = self._resolve_account(book, account_name)
+            if not account:
+                raise self._account_not_found_error(book, account_name)
+            sign = self._STATEMENT_SIGNS.get(account.type)
+            if sign is None:
+                raise ValueError(
+                    f"enter_statement needs a balance-carrying "
+                    f"statement account (BANK, CASH, ASSET, CREDIT, "
+                    f"or LIABILITY); '{account.fullname}' is "
+                    f"{account.type}"
+                )
+            if account.commodity != default_currency:
+                raise ValueError(
+                    f"'{account.fullname}' is denominated in "
+                    f"{account.commodity.mnemonic}, not the book "
+                    f"default {default_currency.mnemonic} — "
+                    f"foreign-currency statements are a planned "
+                    f"follow-up; enter this one via "
+                    f"create_transactions + reconcile_account"
+                )
+            quantum = _commodity_quantum(account.commodity)
+
+            amounts: dict[str, Decimal] = {}
+            for ln in lines:
+                try:
+                    amounts[ln["ref"]] = _to_decimal(ln["amount"])
+                except (InvalidOperation, ValueError):
+                    raise ValueError(
+                        f"line {ln['ref']}: amount "
+                        f"{ln['amount']!r} is not a decimal"
+                    )
+
+            # Self-consistency gate — statement-native signs, before
+            # any transform: the statement must not contradict itself.
+            line_sum = sum(amounts.values(), Decimal("0"))
+            if (opening + line_sum).quantize(quantum) != \
+                    closing.quantize(quantum):
+                raise ValueError(
+                    f"statement does not self-check: opening "
+                    f"{opening} + line sum {line_sum} = "
+                    f"{opening + line_sum}, but closing is {closing} "
+                    f"(difference "
+                    f"{closing - (opening + line_sum)}). A missed or "
+                    f"doubled line, or a sign slip — re-check the "
+                    f"transcription before trusting any "
+                    f"classification."
+                )
+
+            # Opening precondition: the base the statement lands on.
+            reconciled_balance = Decimal("0")
+            for s in account.splits:
+                if s.reconcile_state == "y":
+                    reconciled_balance += s.quantity
+            opening_book = (sign * opening).quantize(quantum)
+            opening_gap = (
+                reconciled_balance.quantize(quantum) - opening_book
+            )
+            warn_rows: list[tuple[str, str]] = []
+            if opening_gap != 0:
+                gap_msg = (
+                    f"account's reconciled balance "
+                    f"{reconciled_balance} does not tie to the "
+                    f"statement's opening balance ({opening} as "
+                    f"printed → {opening_book} in book convention); "
+                    f"difference {opening_gap}. A prior statement "
+                    f"may be unentered."
+                )
+                if dry_run:
+                    warn_rows.append(("*", gap_msg))
+                elif not force:
+                    raise ValueError(
+                        gap_msg + " Commit refuses on an untied "
+                        "base — enter the prior statement first, or "
+                        "pass force=true to land this one anyway "
+                        "(the resulting reconciled state is only as "
+                        "good as the base)."
+                    )
+
+            split_prefixes = self._split_prefix_map(book)
+
+            # Candidate universe: this account's splits within the
+            # match window of any line. Ruling 1: window 31 days —
+            # one day wider than the duplicate screen, so a monthly
+            # pattern (June 30 "July rent" vs a July 31 line)
+            # SURFACES for judgment. Candidate noise is the feature.
+            window = timedelta(days=31)
+            lo = min(ln["date"] for ln in lines) - window
+            hi = max(ln["date"] for ln in lines) + window
+            acct_splits = []
+            for s in account.splits:
+                pd = s.transaction.post_date
+                if pd is None or _is_voided(s):
+                    continue
+                if lo <= pd <= hi:
+                    acct_splits.append(s)
+
+            def _book_amount(ln) -> Decimal:
+                return (sign * amounts[ln["ref"]]).quantize(quantum)
+
+            def _candidates_for(ln) -> list[dict]:
+                """DAD-style scoring against the account's own
+                splits. A candidate needs the amount signal alone
+                (the universe is narrow enough that an amount match
+                is meaningful — and the rent case has ONLY that), or
+                desc+date without amount (the fix-the-book-typo
+                case)."""
+                target = _book_amount(ln)
+                probe = (
+                    ln.get("description") or ln.get("raw") or ""
+                ).lower().strip()
+                cands = []
+                for s in acct_splits:
+                    pd = s.transaction.post_date
+                    if abs((pd - ln["date"]).days) > 31:
+                        continue
+                    amount_match = (
+                        abs(s.quantity - target) <= Decimal("1.00")
+                    )
+                    date_match = abs((pd - ln["date"]).days) <= 2
+                    tdesc = (
+                        s.transaction.description or ""
+                    ).lower().strip()
+                    desc_match = (
+                        bool(probe) and bool(tdesc)
+                        and (probe in tdesc or tdesc in probe)
+                    )
+                    if not (
+                        amount_match or (desc_match and date_match)
+                    ):
+                        continue
+                    cands.append({
+                        "split": s,
+                        "signals": (
+                            ("D" if desc_match else "-")
+                            + ("A" if amount_match else "-")
+                            + ("D" if date_match else "-")
+                        ),
+                    })
+                return cands
+
+            if dry_run:
+                return self._statement_dry_run(
+                    book, account, lines, amounts, sign, quantum,
+                    _book_amount, _candidates_for, split_prefixes,
+                    reconciled_balance, closing, warn_rows,
+                )
+            return self._statement_commit(
+                book, account, lines, amounts, sign, quantum,
+                statement_date, _book_amount, _candidates_for,
+                split_prefixes, reconciled_balance, closing, force,
+                default_currency,
+            )
+
+    def _statement_prep_create(
+        self, book, account, ln, book_amount, default_currency,
+    ) -> tuple[list[dict], dict | None]:
+        """Validate one would-be-created statement line into resolved
+        splits (bank leg synthesized first, counter legs from the
+        row or a 2-split auto-fill precedent). Returns
+        ``(validated, auto_fill_source | None)``; raises ValueError
+        with the row-level problem."""
+        if not (ln.get("description") or ln.get("raw")):
+            raise ValueError(
+                "a created line needs a description (or at least "
+                "a raw cell to fall back on)"
+            )
+        bank: dict = {
+            "account": account.fullname, "amount": str(book_amount),
+        }
+        if ln.get("raw"):
+            bank["memo"] = ln["raw"]
+
+        counters = ln.get("splits") or []
+        src = None
+        if not counters:
+            probe = ln.get("description") or ln.get("raw") or ""
+            sig = self._collect_create_signals(
+                book, probe, ln["date"], [],
+                want_auto_fill=True, want_stability=False,
+                want_duplicates=False, want_recent=False,
+            )
+            if sig.auto_fill is None:
+                raise ValueError(
+                    "no matching transaction to auto-fill from — "
+                    "supply explicit counter-splits"
+                )
+            filled, src = sig.auto_fill
+            if len(filled) != 2:
+                raise ValueError(
+                    f"auto-fill precedent {src['guid']} has "
+                    f"{len(filled)} splits — statement auto-fill "
+                    f"only adapts 2-split precedents to the line "
+                    f"amount; supply explicit counter-splits"
+                )
+            counter = next(
+                (
+                    f for f in filled
+                    if f["account"] != account.fullname
+                ),
+                None,
+            )
+            if counter is None or "quantity" in counter:
+                raise ValueError(
+                    f"auto-fill precedent {src['guid']} doesn't "
+                    f"adapt cleanly (same-account or "
+                    f"cross-commodity leg) — supply explicit "
+                    f"counter-splits"
+                )
+            counters = [{
+                "account": counter["account"],
+                "amount": str(-book_amount),
+                **(
+                    {"memo": counter["memo"]}
+                    if counter.get("memo") else {}
+                ),
+            }]
+
+        validated = self._validate_transaction_splits(
+            book, [bank] + counters, default_currency,
+        )
+        for v in validated:
+            if v["account"].placeholder:
+                raise self._placeholder_error(v["account"])
+        return validated, src
+
+    def _statement_resolve_claim(
+        self, book, account, ln, book_amount, quantum,
+    ):
+        """Resolve and vet one ``match`` cell. Returns
+        ``(split, "claim" | "overlap")`` — overlap means the split
+        is already reconciled and the row is an idempotent no-op.
+        Raises ValueError on any claim that would lie."""
+        if ln.get("splits"):
+            raise ValueError(
+                "a match row claims an existing split — it cannot "
+                "also carry counter-splits"
+            )
+        s = self._find_split(book, ln["match"])
+        if s is None:
+            raise ValueError(f"match split not found: {ln['match']}")
+        if s.account.guid != account.guid:
+            raise ValueError(
+                f"match split {ln['match']} is on "
+                f"'{s.account.fullname}', not the statement account"
+            )
+        if _is_voided(s):
+            raise ValueError(
+                f"match split {ln['match']} is voided — voided "
+                f"splits cannot be claimed; unvoid_transaction "
+                f"first"
+            )
+        if s.reconcile_state == "y":
+            return s, "overlap"
+        if s.quantity.quantize(quantum) != book_amount:
+            raise ValueError(
+                f"match split {ln['match']} has amount "
+                f"{s.quantity}, but the line says {ln['amount']} "
+                f"as printed ({book_amount} in book convention) — "
+                f"fix the book entry first (update_transaction), "
+                f"then claim it"
+            )
+        return s, "claim"
+
+    def _statement_dry_run(
+        self, book, account, lines, amounts, sign, quantum,
+        _book_amount, _candidates_for, split_prefixes,
+        reconciled_balance, closing, warn_rows,
+    ) -> dict:
+        """The rehearsal: classify every line, validate everything a
+        commit would validate, and project the balance tie."""
+        default_currency = self._require_default_currency(book)
+        counts = {"NEW": 0, "MATCH": 0, "OVERLAP": 0, "AMBIGUOUS": 0}
+        line_rows: list[tuple] = []
+        cand_rows: list[tuple] = []
+        projected = reconciled_balance.quantize(quantum)
+
+        for ln in lines:
+            cands = _candidates_for(ln)
+            unrec = [
+                c for c in cands if _is_unreconciled(c["split"])
+            ]
+            rec = [
+                c for c in cands
+                if c["split"].reconcile_state == "y"
+            ]
+            note = ""
+            if unrec:
+                cls = "MATCH" if len(unrec) == 1 else "AMBIGUOUS"
+                listed = unrec + rec
+            elif rec:
+                cls = "OVERLAP"
+                listed = rec
+                note = (
+                    "already reconciled — commit skips this line "
+                    "(drop it, or keep it as a match row: no-op)"
+                )
+            else:
+                cls = "NEW"
+                listed = []
+                if not ln.get("splits") and not ln.get("match"):
+                    note = self._statement_predict(
+                        book, account, ln, _book_amount(ln),
+                    )
+
+            # Full rehearsal: anything commit would validate,
+            # validate now — a dry-run that ties is a commit that
+            # will tie.
+            try:
+                if ln.get("match"):
+                    _, kind = self._statement_resolve_claim(
+                        book, account, ln, _book_amount(ln), quantum,
+                    )
+                    if kind == "overlap":
+                        cls = "OVERLAP"
+                        note = "match names a reconciled split — no-op"
+                elif ln.get("splits"):
+                    self._statement_prep_create(
+                        book, account, ln, _book_amount(ln),
+                        default_currency,
+                    )
+            except ValueError as e:
+                warn_rows.append((ln["ref"], str(e)))
+
+            counts[cls] += 1
+            if cls != "OVERLAP":
+                projected += _book_amount(ln)
+            for c in listed:
+                s = c["split"]
+                txn = s.transaction
+                cand_rows.append((
+                    ln["ref"], split_prefixes[s.guid],
+                    s.reconcile_state,
+                    txn.post_date.isoformat(), str(s.quantity),
+                    txn.description or "", txn.notes or "",
+                    s.memo or "", c["signals"],
+                ))
+            line_rows.append((ln["ref"], cls, len(listed), note))
+
+        # Summary header — counts are facts and may headline;
+        # clearance verdicts over unadjudicated rows may not (the
+        # clearance principle, spec §4).
+        n_judge = counts["MATCH"] + counts["AMBIGUOUS"]
+        header = (
+            f"Dry run: {len(lines)} lines — {counts['NEW']} NEW, "
+            f"{counts['MATCH']} MATCH, {counts['OVERLAP']} OVERLAP, "
+            f"{counts['AMBIGUOUS']} AMBIGUOUS."
+        )
+        if n_judge:
+            header += (
+                f"\n{n_judge} rows need adjudication — rule each "
+                f"MATCH/AMBIGUOUS against the candidates table "
+                f"before committing."
+            )
+        else:
+            header += "\nNo existing-split candidates on any line."
+
+        closing_book = (sign * closing).quantize(quantum)
+        projected = projected.quantize(quantum)
+        if projected == closing_book:
+            tie = (
+                f"Projected reconciled balance after commit: "
+                f"{projected} — ties to the statement closing "
+                f"({closing} as printed)."
+            )
+        else:
+            tie = (
+                f"Projected reconciled balance after commit: "
+                f"{projected} vs statement closing {closing_book} "
+                f"({closing} as printed) — DISCREPANCY "
+                f"{closing_book - projected}."
+            )
+
+        lines_tsv = ["ref\tclass\tcands\tnote"]
+        for r in line_rows:
+            lines_tsv.append(f"{r[0]}\t{r[1]}\t{r[2]}\t{r[3]}")
+        cands_tsv = ""
+        if cand_rows:
+            out = [
+                "ref\tsplit_guid\tstate\tdate\tamount\t"
+                "description\tnotes\tmemo\tsignals"
+            ]
+            for r in cand_rows:
+                out.append("\t".join(str(x) for x in r))
+            cands_tsv = "\n".join(out)
+
+        return {
+            "summary": header,
+            "lines": "\n".join(lines_tsv),
+            "candidates": cands_tsv,
+            "warnings": self._batch_warnings_to_tsv(warn_rows),
+            "tie": tie,
+        }
+
+    def _statement_predict(
+        self, book, account, ln, book_amount,
+    ) -> str:
+        """Auto-fill prediction note for a splitless NEW line — the
+        evidence the judgment pass adapts, never something the
+        dry-run enters."""
+        probe = ln.get("description") or ln.get("raw") or ""
+        if not probe.strip():
+            return ""
+        sig = self._collect_create_signals(
+            book, probe, ln["date"], [],
+            want_auto_fill=True, want_stability=False,
+            want_duplicates=False, want_recent=False,
+        )
+        if sig.auto_fill is None:
+            return "no auto-fill precedent — supply counter-splits"
+        filled, src = sig.auto_fill
+        if len(filled) != 2:
+            return (
+                f"precedent {src['guid']} has {len(filled)} "
+                f"splits — supply explicit counter-splits"
+            )
+        counter = next(
+            (f for f in filled if f["account"] != account.fullname),
+            None,
+        )
+        if counter is None or "quantity" in counter:
+            return (
+                f"precedent {src['guid']} doesn't adapt cleanly — "
+                f"supply explicit counter-splits"
+            )
+        return (
+            f"would create {book_amount} → {counter['account']} "
+            f"(auto_filled_from:{src['guid']})"
+        )
+
+    def _statement_commit(
+        self, book, account, lines, amounts, sign, quantum,
+        statement_date, _book_amount, _candidates_for,
+        split_prefixes, reconciled_balance, closing, force,
+        default_currency,
+    ) -> dict:
+        """The landing: validate every row, check the tie, then — and
+        only then — mutate and save once."""
+        prepared: list[tuple] = []   # (ln, validated, src)
+        claims: list[tuple] = []     # (ln, split)
+        skipped: list[tuple] = []    # (ln, split)  overlap no-ops
+        errors: list[tuple[str, str]] = []
+        claimed_guids: set[str] = set()
+
+        for ln in lines:
+            try:
+                if ln.get("match"):
+                    s, kind = self._statement_resolve_claim(
+                        book, account, ln, _book_amount(ln), quantum,
+                    )
+                    if kind == "overlap":
+                        skipped.append((ln, s))
+                    else:
+                        if s.guid in claimed_guids:
+                            raise ValueError(
+                                "split already claimed by another "
+                                "row in this statement"
+                            )
+                        claimed_guids.add(s.guid)
+                        claims.append((ln, s))
+                else:
+                    validated, src = self._statement_prep_create(
+                        book, account, ln, _book_amount(ln),
+                        default_currency,
+                    )
+                    prepared.append((ln, validated, src))
+            except ValueError as e:
+                errors.append((ln["ref"], str(e)))
+
+        # Statement-duplicate guard: a created line that exactly
+        # matches an unreconciled, unclaimed split on this account
+        # would double-enter — and the tie would still hold, because
+        # only the new split reconciles. Judgment overrides with
+        # force (it saw the MATCH table and ruled NEW).
+        if not force:
+            for ln, _validated, _src in prepared:
+                target = _book_amount(ln)
+                for c in _candidates_for(ln):
+                    s = c["split"]
+                    if s.guid in claimed_guids:
+                        continue
+                    if not _is_unreconciled(s):
+                        continue
+                    pd = s.transaction.post_date
+                    if abs((pd - ln["date"]).days) > 2:
+                        continue
+                    if s.quantity.quantize(quantum) == target:
+                        errors.append((
+                            ln["ref"],
+                            f"unreconciled split "
+                            f"{split_prefixes[s.guid]} on this "
+                            f"account matches this line exactly "
+                            f"(amount + date) and no row claims it "
+                            f"— claim it with "
+                            f"match={split_prefixes[s.guid]}, or "
+                            f"force=true to create anyway",
+                        ))
+                        break
+
+        if errors:
+            errored = {ref for ref, _ in errors}
+            rows = []
+            for ln in lines:
+                status = (
+                    "rejected" if ln["ref"] in errored
+                    else "statement_aborted"
+                )
+                rows.append(f"{ln['ref']}\t{status}\t\t")
+            return {
+                "summary": (
+                    f"Statement REJECTED — {len(errors)} row "
+                    f"error(s); nothing was written."
+                ),
+                "results": "ref\tstatus\tguid\tnote\n"
+                + "\n".join(rows),
+                "warnings": self._batch_warnings_to_tsv(errors),
+            }
+
+        # The tie, BEFORE any mutation. Claim amounts equal line
+        # amounts by the exactness rule, so both dispositions
+        # contribute the transformed line amount.
+        new_reconciled = reconciled_balance
+        for ln, _s in claims:
+            new_reconciled += _book_amount(ln)
+        for ln, _v, _src in prepared:
+            new_reconciled += _book_amount(ln)
+        new_reconciled = new_reconciled.quantize(quantum)
+        closing_book = (sign * closing).quantize(quantum)
+        if new_reconciled == closing_book:
+            tie = (
+                f"reconciled balance {new_reconciled} ties to the "
+                f"statement closing ({closing} as printed)"
+            )
+        elif force:
+            tie = (
+                f"DISCREPANCY {closing_book - new_reconciled}: "
+                f"reconciled balance {new_reconciled} vs statement "
+                f"closing {closing_book} ({closing} as printed) — "
+                f"landed under force"
+            )
+        else:
+            raise ValueError(
+                f"balance tie failed: the reconciled balance would "
+                f"be {new_reconciled}, but the statement closes at "
+                f"{closing_book} ({closing} as printed); difference "
+                f"{closing_book - new_reconciled}. Nothing was "
+                f"written."
+            )
+
+        # Audit before-state: the claimed splits' prior annotations
+        # and states, for the ENTER formatter's diffs.
+        self._stage_audit_before({
+            "account": account.fullname,
+            "claims": [
+                {
+                    "guid": s.guid,
+                    "state": s.reconcile_state,
+                    "memo": s.memo or "",
+                    "notes": s.transaction.notes or "",
+                    "description": s.transaction.description or "",
+                    "date": s.transaction.post_date.isoformat(),
+                }
+                for _ln, s in claims
+            ],
+        })
+
+        # Mutate: claims first (annotations + state), then builds.
+        rec_dt = datetime.combine(
+            statement_date, datetime.min.time()
+        )
+        for ln, s in claims:
+            if ln.get("raw"):
+                s.memo = ln["raw"]
+            if ln.get("notes"):
+                s.transaction.notes = ln["notes"]
+            s.reconcile_state = "y"
+            s.reconcile_date = rec_dt
+
+        built = []
+        for ln, validated, src in prepared:
+            piecash_splits = [
+                piecash.Split(
+                    account=v["account"], value=v["value"],
+                    quantity=v["quantity"], memo=v["memo"] or "",
+                    action=v["action"] or "",
+                )
+                for v in validated
+            ]
+            txn_obj = piecash.Transaction(
+                currency=default_currency,
+                description=(
+                    ln.get("description") or ln.get("raw") or ""
+                ),
+                notes=ln.get("notes") or None,
+                post_date=ln["date"],
+                splits=piecash_splits,
+            )
+            # The bank leg is validated[0] by construction; it is
+            # part of the statement, so it lands reconciled.
+            piecash_splits[0].reconcile_state = "y"
+            piecash_splits[0].reconcile_date = rec_dt
+            built.append((ln, txn_obj, src))
+
+        book.save()
+
+        all_guids = [t.guid for t in book.transactions]
+        rows = ["ref\tstatus\tguid\tnote"]
+        by_ref: dict[str, str] = {}
+        for ln, txn_obj, src in built:
+            note = (
+                f"auto_filled_from:{src['guid']}" if src else ""
+            )
+            by_ref[ln["ref"]] = (
+                f"{ln['ref']}\tcreated\t"
+                f"{_unique_prefix(txn_obj.guid, all_guids)}\t{note}"
+            )
+        for ln, s in claims:
+            by_ref[ln["ref"]] = (
+                f"{ln['ref']}\tclaimed\t{split_prefixes[s.guid]}\t"
+            )
+        for ln, s in skipped:
+            by_ref[ln["ref"]] = (
+                f"{ln['ref']}\tskipped_overlap\t"
+                f"{split_prefixes[s.guid]}\talready reconciled"
+            )
+        for ln in lines:
+            rows.append(by_ref[ln["ref"]])
+
+        n_touched = len(built) + len(claims)
+        return {
+            "summary": (
+                f"Statement entered: {len(built)} created, "
+                f"{len(claims)} claimed, {len(skipped)} skipped "
+                f"(already reconciled); {n_touched} splits "
+                f"reconciled at {statement_date.isoformat()}."
+            ),
+            "results": "\n".join(rows),
+            "new_reconciled_balance": str(new_reconciled),
+            "tie": tie,
+        }
 
     def search_transactions(
         self,

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3714,7 +3714,7 @@ class CoreMixin:
                      ("rejected", n_rejected)],
                     homework,
                 )
-                effects: dict[str, Decimal] = {}
+                effects: dict[str, list] = {}
                 for p, _dc, _mc in accepted:
                     if _dc:
                         # review_required rows are homework, not a
@@ -3724,16 +3724,23 @@ class CoreMixin:
                         continue
                     for v in p["validated"]:
                         key = v["account"].fullname
-                        effects[key] = (
-                            effects.get(key, Decimal("0"))
-                            + v["quantity"]
+                        entry = effects.setdefault(
+                            key,
+                            [Decimal("0"),
+                             v["account"].commodity.mnemonic],
                         )
+                        entry[0] += v["quantity"]
                 effects_tsv = ""
                 if effects:
-                    out = ["account\tdelta"]
+                    # Deltas are in each account's OWN commodity —
+                    # the commodity column keeps a mixed batch
+                    # legible under one heading.
+                    out = ["account\tdelta\tcommodity"]
                     for name in sorted(effects):
+                        delta, mnemonic = effects[name]
                         out.append(
-                            f"{_tsv_cell(name)}\t{effects[name]}"
+                            f"{_tsv_cell(name)}\t{delta}\t"
+                            f"{mnemonic}"
                         )
                     effects_tsv = "\n".join(out)
                 return {
@@ -3910,7 +3917,8 @@ class CoreMixin:
         closing_balance: str,
         lines: list[dict],
         dry_run: bool = True,
-        force: bool = False,
+        force_base: bool = False,
+        force_duplicates: bool = False,
         show_all: bool = False,
     ) -> dict:
         """One-shot statement entry: enter, claim, and reconcile a
@@ -3927,10 +3935,15 @@ class CoreMixin:
         rows, reconciles every statement-touched split at
         ``statement_date``, and saves once — or refuses wholesale.
 
-        ``force=True`` means "I know the base doesn't tie — land the
-        statement anyway": it clears the opening-balance precondition
-        AND downgrades a failed closing tie from refusal to a
-        recorded discrepancy. Without it, both refuse.
+        The two force flags are INDEPENDENT safeties (maintainer
+        ruling after the round-two review found one flag coaching
+        itself into the exact scenario its other half guards):
+        ``force_base=True`` clears the opening-balance precondition
+        and downgrades the consequent closing-tie failure to a
+        recorded discrepancy; ``force_duplicates=True`` disables
+        the exact-twin guard on create rows. Forcing the base
+        never silently disables duplicate detection, and vice
+        versa.
         """
         if not lines:
             raise ValueError(
@@ -4040,13 +4053,14 @@ class CoreMixin:
                 )
                 if dry_run:
                     warn_rows.append(("*", gap_msg))
-                elif not force:
+                elif not force_base:
                     raise ValueError(
                         gap_msg + " Commit refuses on an untied "
-                        "base — enter the prior statement first, or "
-                        "pass force=true to land this one anyway "
-                        "(the resulting reconciled state is only as "
-                        "good as the base)."
+                        "base — enter the prior statement first, "
+                        "or pass force_base=true to land this one "
+                        "anyway (the resulting reconciled state is "
+                        "only as good as the base; duplicate "
+                        "detection stays on)."
                     )
 
             split_prefixes = self._split_prefix_map(book)
@@ -4138,13 +4152,13 @@ class CoreMixin:
                     book, account, lines, amounts, sign, quantum,
                     _book_amount, _candidates_for, split_prefixes,
                     reconciled_balance, closing, warn_rows,
-                    show_all, force,
+                    show_all, force_duplicates,
                 )
             return self._statement_commit(
                 book, account, lines, amounts, sign, quantum,
                 statement_date, _book_amount, _candidates_for,
-                split_prefixes, reconciled_balance, closing, force,
-                default_currency,
+                split_prefixes, reconciled_balance, closing,
+                force_base, force_duplicates, default_currency,
             )
 
     def _statement_prep_create(
@@ -4290,7 +4304,8 @@ class CoreMixin:
     def _statement_dry_run(
         self, book, account, lines, amounts, sign, quantum,
         _book_amount, _candidates_for, split_prefixes,
-        reconciled_balance, closing, warn_rows, show_all, force,
+        reconciled_balance, closing, warn_rows, show_all,
+        force_duplicates,
     ) -> dict:
         """The rehearsal: run the SAME disposition resolution commit
         runs (the chokepoint), classify every line as evidence, and
@@ -4301,7 +4316,8 @@ class CoreMixin:
         default_currency = self._require_default_currency(book)
         phase_a = self._statement_dispositions(
             book, account, lines, _book_amount, _candidates_for,
-            quantum, default_currency, force, split_prefixes,
+            quantum, default_currency, force_duplicates,
+            split_prefixes,
         )
         by_ref = phase_a["by_ref"]
         for ref, msg in phase_a["errors"]:
@@ -4486,13 +4502,16 @@ class CoreMixin:
                 f"before committing."
             )
         elif cand_rows:
-            # Verified-empty phrasing must not contradict visible
-            # evidence rows (bookkeeper signoff, copy quibble): the
-            # claim is about CLAIMABLE candidates, and the listed
-            # rows are context, not work.
+            # Verified-empty phrasing must not contradict the
+            # visible table (bookkeeper copy quibble + round-two
+            # R6: a recurring candidate labels MEDIUM in the
+            # confidence column, so "no MEDIUM+ candidates" argued
+            # with its own table). State what is true: no row
+            # needs adjudication; the listed rows are evidence.
             homework = (
-                "No claimable (MEDIUM+) candidates — the listed "
-                "rows are evidence only."
+                "No rows need adjudication — the listed candidates "
+                "are evidence only (recurring patterns or "
+                "already-reconciled)."
             )
         else:
             homework = "No existing-split candidates on any line."
@@ -4547,7 +4566,7 @@ class CoreMixin:
 
     def _statement_dispositions(
         self, book, account, lines, _book_amount, _candidates_for,
-        quantum, default_currency, force, split_prefixes,
+        quantum, default_currency, force_duplicates, split_prefixes,
     ) -> dict:
         """Phase A — THE disposition chokepoint both modes run.
 
@@ -4557,9 +4576,9 @@ class CoreMixin:
         impossible by construction. Claims resolve first (the
         guard's exemption set), then each create row runs the twin
         guard BEFORE counter-split/auto-fill prep (bookkeeper
-        signoff, carried item). ``force`` disables the guard here —
-        for BOTH modes, so a forced rehearsal rehearses the forced
-        landing.
+        signoff, carried item). ``force_duplicates`` disables the
+        guard here — for BOTH modes, so a forced rehearsal
+        rehearses the forced landing.
 
         Returns ``{"by_ref": {ref: {"kind": claim|overlap|create|
         guard|error, ...}}, "claims": [(ln, split)], "skipped":
@@ -4633,20 +4652,21 @@ class CoreMixin:
                         f"matches this line exactly (amount + "
                         f"date) and no row claims it — claim it "
                         f"with match={split_prefixes[s.guid]}, or "
-                        f"force=true to create anyway"
+                        f"force_duplicates=true to create "
+                        f"anyway"
                     ), False
                 return (
                     f"reconciled split {split_prefixes[s.guid]} "
                     f"matches this line exactly — it looks landed "
                     f"by a prior statement; keep the line as a "
                     f"match row (match={split_prefixes[s.guid]}, "
-                    f"a no-op skip), or force=true to create "
-                    f"anyway"
+                    f"a no-op skip), or force_duplicates=true "
+                    f"to create anyway"
                 ), True
             return None
 
         for ln in create_rows:
-            if not force:
+            if not force_duplicates:
                 hit = _twin_guard(ln)
                 if hit is not None:
                     msg, twin_reconciled = hit
@@ -4678,14 +4698,15 @@ class CoreMixin:
     def _statement_commit(
         self, book, account, lines, amounts, sign, quantum,
         statement_date, _book_amount, _candidates_for,
-        split_prefixes, reconciled_balance, closing, force,
-        default_currency,
+        split_prefixes, reconciled_balance, closing, force_base,
+        force_duplicates, default_currency,
     ) -> dict:
         """The landing: resolve dispositions (the shared chokepoint),
         check the tie, then — and only then — mutate and save once."""
         phase_a = self._statement_dispositions(
             book, account, lines, _book_amount, _candidates_for,
-            quantum, default_currency, force, split_prefixes,
+            quantum, default_currency, force_duplicates,
+            split_prefixes,
         )
         prepared = phase_a["prepared"]
         claims = phase_a["claims"]
@@ -4740,12 +4761,16 @@ class CoreMixin:
                 f"{cur} {new_reconciled} ({closing} as printed) — "
                 f"tied."
             )
-        elif force:
+        elif force_base:
+            # Only a forced base can produce a discrepancy — the
+            # self-check and opening gates make the unforced tie
+            # an identity, and forced duplicates still contribute
+            # their own line amounts.
             tie = (
                 f"DISCREPANCY {closing_book - new_reconciled}: "
                 f"reconciled balance {new_reconciled} vs statement "
                 f"closing {closing_book} ({closing} as printed) — "
-                f"landed under force"
+                f"landed under force_base"
             )
         else:
             raise ValueError(
@@ -4815,6 +4840,24 @@ class CoreMixin:
 
         book.save()
 
+        # Post-write verification (round-two finding: the pre-save
+        # tie is an arithmetic identity over the operator's own
+        # inputs). Read the reconciled balance BACK from the saved
+        # splits; a mismatch means the write did not land as
+        # computed and must surface loudly, never as a clean
+        # summary. Same doctrine as _verify_write for raw SQL.
+        readback = Decimal("0")
+        for s in account.splits:
+            if s.reconcile_state == "y":
+                readback += s.quantity
+        if readback.quantize(quantum) != new_reconciled:
+            raise ValueError(
+                f"post-write verification failed: the account's "
+                f"reconciled balance reads {readback}, expected "
+                f"{new_reconciled}. The statement WAS saved — "
+                f"inspect the account before retrying."
+            )
+
         all_guids = [t.guid for t in book.transactions]
         rows = ["ref\tstatus\tguid\tnote"]
         by_ref: dict[str, str] = {}
@@ -4845,8 +4888,15 @@ class CoreMixin:
                 f"created, {len(claims)} claimed, {len(skipped)} "
                 f"skipped (already reconciled)."
                 + (
-                    " LANDED UNDER FORCE — base and twin guards "
-                    "were bypassed." if force else ""
+                    " LANDED UNDER FORCE ("
+                    + ", ".join(
+                        n for n, on in (
+                            ("base", force_base),
+                            ("duplicates", force_duplicates),
+                        ) if on
+                    )
+                    + ") — the named guard(s) were bypassed."
+                    if (force_base or force_duplicates) else ""
                 )
             ),
             "results": "\n".join(rows),

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -4422,6 +4422,15 @@ class CoreMixin:
                 f"MATCH/AMBIGUOUS against the candidates table "
                 f"before committing."
             )
+        elif cand_rows:
+            # Verified-empty phrasing must not contradict visible
+            # evidence rows (bookkeeper signoff, copy quibble): the
+            # claim is about CLAIMABLE candidates, and the listed
+            # rows are context, not work.
+            homework = (
+                "No claimable (MEDIUM+) candidates — the listed "
+                "rows are evidence only."
+            )
         else:
             homework = "No existing-split candidates on any line."
         header = _dry_run_summary(
@@ -4481,72 +4490,81 @@ class CoreMixin:
         errors: list[tuple[str, str]] = []
         claimed_guids: set[str] = set()
 
+        # Pass 1 — claims only, so the guard below can exempt every
+        # split a row in THIS statement claims.
+        create_rows = []
         for ln in lines:
+            if not ln.get("match"):
+                create_rows.append(ln)
+                continue
             try:
-                if ln.get("match"):
-                    s, kind = self._statement_resolve_claim(
-                        book, account, ln, _book_amount(ln), quantum,
-                    )
-                    if kind == "overlap":
-                        skipped.append((ln, s))
-                    else:
-                        if s.guid in claimed_guids:
-                            raise ValueError(
-                                "split already claimed by another "
-                                "row in this statement"
-                            )
-                        claimed_guids.add(s.guid)
-                        claims.append((ln, s))
+                s, kind = self._statement_resolve_claim(
+                    book, account, ln, _book_amount(ln), quantum,
+                )
+                if kind == "overlap":
+                    skipped.append((ln, s))
                 else:
-                    validated, src = self._statement_prep_create(
-                        book, account, ln, _book_amount(ln),
-                        default_currency,
-                    )
-                    prepared.append((ln, validated, src))
+                    if s.guid in claimed_guids:
+                        raise ValueError(
+                            "split already claimed by another "
+                            "row in this statement"
+                        )
+                    claimed_guids.add(s.guid)
+                    claims.append((ln, s))
             except ValueError as e:
                 errors.append((ln["ref"], str(e)))
 
-        # Statement-duplicate guard: a created line that exactly
-        # matches an unclaimed split on this account would
-        # double-enter. Unreconciled twin: the tie would still hold
-        # (only the new split reconciles) — silent. Reconciled
-        # twin: this line already landed via a prior statement —
-        # the tie catches it unforced, but under force it would
-        # double-enter with both copies reconciled. Judgment
-        # overrides with force (it saw the MATCH table and ruled
-        # NEW).
-        if not force:
-            for ln, _validated, _src in prepared:
-                for c in _candidates_for(ln):
-                    s = c["split"]
-                    if s.guid in claimed_guids:
-                        continue
-                    if not c["exact"]:
-                        continue
-                    if _is_unreconciled(s):
-                        errors.append((
-                            ln["ref"],
-                            f"unreconciled split "
-                            f"{split_prefixes[s.guid]} on this "
-                            f"account matches this line exactly "
-                            f"(amount + date) and no row claims it "
-                            f"— claim it with "
-                            f"match={split_prefixes[s.guid]}, or "
-                            f"force=true to create anyway",
-                        ))
-                    else:
-                        errors.append((
-                            ln["ref"],
-                            f"reconciled split "
-                            f"{split_prefixes[s.guid]} matches "
-                            f"this line exactly — it looks landed "
-                            f"by a prior statement; keep the line "
-                            f"as a match row "
-                            f"(match={split_prefixes[s.guid]}, a "
-                            f"no-op skip), or force=true to "
-                            f"create anyway",
-                        ))
-                    break
+        def _twin_guard_error(ln) -> str | None:
+            """Statement-duplicate guard: a created line that
+            exactly matches an unclaimed split on this account
+            would double-enter. Unreconciled twin: the tie would
+            still hold (only the new split reconciles) — silent.
+            Reconciled twin: already landed via a prior statement
+            — the tie catches it unforced, but under force both
+            copies would sit reconciled. Judgment overrides with
+            force (it saw the MATCH table and ruled NEW)."""
+            for c in _candidates_for(ln):
+                s = c["split"]
+                if s.guid in claimed_guids or not c["exact"]:
+                    continue
+                if _is_unreconciled(s):
+                    return (
+                        f"unreconciled split "
+                        f"{split_prefixes[s.guid]} on this account "
+                        f"matches this line exactly (amount + "
+                        f"date) and no row claims it — claim it "
+                        f"with match={split_prefixes[s.guid]}, or "
+                        f"force=true to create anyway"
+                    )
+                return (
+                    f"reconciled split {split_prefixes[s.guid]} "
+                    f"matches this line exactly — it looks landed "
+                    f"by a prior statement; keep the line as a "
+                    f"match row (match={split_prefixes[s.guid]}, "
+                    f"a no-op skip), or force=true to create "
+                    f"anyway"
+                )
+            return None
+
+        # Pass 2 — create rows: the twin guard runs BEFORE
+        # counter-split/auto-fill validation, so a bare raw line
+        # whose twin exists gets the claim coaching, not an
+        # auto-fill complaint about a row that shouldn't be
+        # created at all (bookkeeper signoff, carried item).
+        for ln in create_rows:
+            if not force:
+                guard_msg = _twin_guard_error(ln)
+                if guard_msg is not None:
+                    errors.append((ln["ref"], guard_msg))
+                    continue
+            try:
+                validated, src = self._statement_prep_create(
+                    book, account, ln, _book_amount(ln),
+                    default_currency,
+                )
+                prepared.append((ln, validated, src))
+            except ValueError as e:
+                errors.append((ln["ref"], str(e)))
 
         if errors:
             # The row's error rides the note column INLINE — the

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -4214,11 +4214,21 @@ class CoreMixin:
                 c for c in cands
                 if c["split"].reconcile_state == "y"
             ]
+            # MATCH/AMBIGUOUS demand adjudication, so the class is
+            # gated on MEDIUM+ correspondence (>=2 signals). An
+            # amount-only LOW still SURFACES as a candidate row —
+            # ruling 1's superset — but classifies NEW: three weak
+            # lookalikes must not adopt a genuinely new line
+            # (bookkeeper finding, maiden flight).
+            strong = [
+                c for c in unrec
+                if sum(1 for ch in c["signals"] if ch != "-") >= 2
+            ]
             note = ""
-            if unrec:
-                cls = "MATCH" if len(unrec) == 1 else "AMBIGUOUS"
+            if strong:
+                cls = "MATCH" if len(strong) == 1 else "AMBIGUOUS"
                 listed = unrec + rec
-                if any(c["exact"] for c in unrec):
+                if any(c["exact"] for c in strong):
                     note = (
                         "exact twin — commit refuses a bare create "
                         "here (claim it, or force)"
@@ -4240,12 +4250,12 @@ class CoreMixin:
                 )
             else:
                 cls = "NEW"
-                # Reconciled fuzzy candidates stay listed: the
-                # spec's own annotation-adaptation case (June 30
-                # "July rent" vs a July 31 line) needs the prior
-                # instance's annotation shipped as evidence even
-                # when it is already reconciled.
-                listed = rec
+                # Weak (LOW) and reconciled fuzzy candidates stay
+                # listed: the spec's annotation-adaptation case
+                # (June 30 "July rent" vs a July 31 line) needs the
+                # prior instance's annotation shipped as evidence
+                # even when it doesn't drive the class.
+                listed = unrec + rec
 
             # Full rehearsal: run exactly what commit would run on
             # this row — a dry-run that ties is a commit that will

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3753,6 +3753,12 @@ class CoreMixin:
         AND downgrades a failed closing tie from refusal to a
         recorded discrepancy. Without it, both refuse.
         """
+        if not lines:
+            raise ValueError(
+                "statement has no lines — for a no-activity "
+                "statement, reconcile_account covers the balance "
+                "tie on its own"
+            )
         refs = [ln["ref"] for ln in lines]
         if len(set(refs)) != len(refs):
             raise ValueError(
@@ -3789,11 +3795,33 @@ class CoreMixin:
             amounts: dict[str, Decimal] = {}
             for ln in lines:
                 try:
-                    amounts[ln["ref"]] = _to_decimal(ln["amount"])
+                    amt = _to_decimal(ln["amount"])
                 except (InvalidOperation, ValueError):
                     raise ValueError(
                         f"line {ln['ref']}: amount "
                         f"{ln['amount']!r} is not a decimal"
+                    )
+                # Sub-quantum precision is a transcription error,
+                # not a rounding job — and rounding here would let
+                # the self-check gate and the tie compute different
+                # sums for the same statement.
+                if amt != amt.quantize(quantum):
+                    raise ValueError(
+                        f"line {ln['ref']}: amount {ln['amount']} "
+                        f"carries finer precision than "
+                        f"{account.commodity.mnemonic} — re-check "
+                        f"the transcription"
+                    )
+                amounts[ln["ref"]] = amt
+            for label, bal in (
+                ("opening_balance", opening),
+                ("closing_balance", closing),
+            ):
+                if bal != bal.quantize(quantum):
+                    raise ValueError(
+                        f"{label} {bal} carries finer precision "
+                        f"than {account.commodity.mnemonic} — "
+                        f"re-check the transcription"
                     )
 
             # Self-consistency gate — statement-native signs, before
@@ -3901,6 +3929,15 @@ class CoreMixin:
                             + ("A" if amount_match else "-")
                             + ("D" if date_match else "-")
                         ),
+                        # Exact = the same event, not the monthly
+                        # pattern: amount to the quantum AND date
+                        # within the tight window. Drives the
+                        # OVERLAP class and the commit guard.
+                        "exact": (
+                            date_match
+                            and s.quantity.quantize(quantum)
+                            == target
+                        ),
                     })
                 return cands
 
@@ -3958,18 +3995,31 @@ class CoreMixin:
                     f"only adapts 2-split precedents to the line "
                     f"amount; supply explicit counter-splits"
                 )
-            counter = next(
-                (
-                    f for f in filled
-                    if f["account"] != account.fullname
-                ),
-                None,
-            )
-            if counter is None or "quantity" in counter:
+            # The precedent must have a leg ON the statement account
+            # — that's what makes "the other leg is the counter"
+            # well-defined. A description match paid from a
+            # DIFFERENT account would otherwise pick an arbitrary
+            # leg (split iteration order) and could fabricate an
+            # inter-bank transfer instead of the expense (review
+            # finding).
+            on_account = [
+                f for f in filled
+                if f["account"] == account.fullname
+            ]
+            if len(on_account) != 1:
                 raise ValueError(
                     f"auto-fill precedent {src['guid']} doesn't "
-                    f"adapt cleanly (same-account or "
-                    f"cross-commodity leg) — supply explicit "
+                    f"touch this statement account — supply "
+                    f"explicit counter-splits"
+                )
+            counter = next(
+                f for f in filled
+                if f["account"] != account.fullname
+            )
+            if "quantity" in counter:
+                raise ValueError(
+                    f"auto-fill precedent {src['guid']} has a "
+                    f"cross-commodity leg — supply explicit "
                     f"counter-splits"
                 )
             counters = [{
@@ -4015,16 +4065,20 @@ class CoreMixin:
                 f"splits cannot be claimed; unvoid_transaction "
                 f"first"
             )
-        if s.reconcile_state == "y":
-            return s, "overlap"
+        # Exactness has no reconciled-split exemption: a wrong-GUID
+        # paste naming a reconciled split of a different amount must
+        # diagnose at the row, not silently no-op and surface as a
+        # generic tie discrepancy (review finding).
         if s.quantity.quantize(quantum) != book_amount:
             raise ValueError(
                 f"match split {ln['match']} has amount "
                 f"{s.quantity}, but the line says {ln['amount']} "
                 f"as printed ({book_amount} in book convention) — "
-                f"fix the book entry first (update_transaction), "
-                f"then claim it"
+                f"wrong split, or fix the book entry first "
+                f"(update_transaction), then claim it"
             )
+        if s.reconcile_state == "y":
+            return s, "overlap"
         return s, "claim"
 
     def _statement_dry_run(
@@ -4040,6 +4094,7 @@ class CoreMixin:
         cand_rows: list[tuple] = []
         projected = reconciled_balance.quantize(quantum)
 
+        seen_claims: set[str] = set()
         for ln in lines:
             cands = _candidates_for(ln)
             unrec = [
@@ -4053,37 +4108,71 @@ class CoreMixin:
             if unrec:
                 cls = "MATCH" if len(unrec) == 1 else "AMBIGUOUS"
                 listed = unrec + rec
-            elif rec:
+                if any(c["exact"] for c in unrec):
+                    note = (
+                        "exact twin — commit refuses a bare create "
+                        "here (claim it, or force)"
+                    )
+            elif any(c["exact"] for c in rec):
+                # OVERLAP means THE SAME EVENT already landed and
+                # tied — exact amount, tight date. A fuzzy
+                # reconciled candidate (last month's rent, 31 days
+                # out) is evidence for a NEW line, not an overlap
+                # (review finding: the old amount-fuzz class
+                # skipped genuine lines from the projection).
                 cls = "OVERLAP"
                 listed = rec
                 note = (
-                    "already reconciled — commit skips this line "
-                    "(drop it, or keep it as a match row: no-op)"
+                    "already reconciled (exact twin) — keep this "
+                    "line as a match row naming the twin (no-op); "
+                    "commit refuses a bare create here without "
+                    "force"
                 )
             else:
                 cls = "NEW"
-                listed = []
-                if not ln.get("splits") and not ln.get("match"):
-                    note = self._statement_predict(
-                        book, account, ln, _book_amount(ln),
-                    )
+                # Reconciled fuzzy candidates stay listed: the
+                # spec's own annotation-adaptation case (June 30
+                # "July rent" vs a July 31 line) needs the prior
+                # instance's annotation shipped as evidence even
+                # when it is already reconciled.
+                listed = rec
 
-            # Full rehearsal: anything commit would validate,
-            # validate now — a dry-run that ties is a commit that
-            # will tie.
+            # Full rehearsal: run exactly what commit would run on
+            # this row — a dry-run that ties is a commit that will
+            # tie, and a row commit would reject must say so now.
             try:
                 if ln.get("match"):
-                    _, kind = self._statement_resolve_claim(
+                    s, kind = self._statement_resolve_claim(
                         book, account, ln, _book_amount(ln), quantum,
                     )
                     if kind == "overlap":
                         cls = "OVERLAP"
                         note = "match names a reconciled split — no-op"
-                elif ln.get("splits"):
-                    self._statement_prep_create(
+                    elif s.guid in seen_claims:
+                        raise ValueError(
+                            "split already claimed by another row "
+                            "in this statement"
+                        )
+                    else:
+                        seen_claims.add(s.guid)
+                elif cls != "OVERLAP":
+                    validated, src = self._statement_prep_create(
                         book, account, ln, _book_amount(ln),
                         default_currency,
                     )
+                    if cls == "NEW" and not ln.get("splits"):
+                        counter_names = ", ".join(
+                            v["account"].fullname
+                            for v in validated[1:]
+                        )
+                        note = (
+                            f"would create {_book_amount(ln)} → "
+                            f"{counter_names}"
+                        )
+                        if src:
+                            note += (
+                                f" (auto_filled_from:{src['guid']})"
+                            )
             except ValueError as e:
                 warn_rows.append((ln["ref"], str(e)))
 
@@ -4137,6 +4226,14 @@ class CoreMixin:
                 f"({closing} as printed) — DISCREPANCY "
                 f"{closing_book - projected}."
             )
+        if warn_rows:
+            # The projection assumes every warned row still lands;
+            # a commit repeating those rows refuses instead. Facts,
+            # not clearance.
+            tie += (
+                f" {len(warn_rows)} warning(s) outstanding — a "
+                f"commit that repeats them will refuse."
+            )
 
         lines_tsv = ["ref\tclass\tcands\tnote"]
         for r in line_rows:
@@ -4158,42 +4255,6 @@ class CoreMixin:
             "warnings": self._batch_warnings_to_tsv(warn_rows),
             "tie": tie,
         }
-
-    def _statement_predict(
-        self, book, account, ln, book_amount,
-    ) -> str:
-        """Auto-fill prediction note for a splitless NEW line — the
-        evidence the judgment pass adapts, never something the
-        dry-run enters."""
-        probe = ln.get("description") or ln.get("raw") or ""
-        if not probe.strip():
-            return ""
-        sig = self._collect_create_signals(
-            book, probe, ln["date"], [],
-            want_auto_fill=True, want_stability=False,
-            want_duplicates=False, want_recent=False,
-        )
-        if sig.auto_fill is None:
-            return "no auto-fill precedent — supply counter-splits"
-        filled, src = sig.auto_fill
-        if len(filled) != 2:
-            return (
-                f"precedent {src['guid']} has {len(filled)} "
-                f"splits — supply explicit counter-splits"
-            )
-        counter = next(
-            (f for f in filled if f["account"] != account.fullname),
-            None,
-        )
-        if counter is None or "quantity" in counter:
-            return (
-                f"precedent {src['guid']} doesn't adapt cleanly — "
-                f"supply explicit counter-splits"
-            )
-        return (
-            f"would create {book_amount} → {counter['account']} "
-            f"(auto_filled_from:{src['guid']})"
-        )
 
     def _statement_commit(
         self, book, account, lines, amounts, sign, quantum,
@@ -4235,23 +4296,23 @@ class CoreMixin:
                 errors.append((ln["ref"], str(e)))
 
         # Statement-duplicate guard: a created line that exactly
-        # matches an unreconciled, unclaimed split on this account
-        # would double-enter — and the tie would still hold, because
-        # only the new split reconciles. Judgment overrides with
-        # force (it saw the MATCH table and ruled NEW).
+        # matches an unclaimed split on this account would
+        # double-enter. Unreconciled twin: the tie would still hold
+        # (only the new split reconciles) — silent. Reconciled
+        # twin: this line already landed via a prior statement —
+        # the tie catches it unforced, but under force it would
+        # double-enter with both copies reconciled. Judgment
+        # overrides with force (it saw the MATCH table and ruled
+        # NEW).
         if not force:
             for ln, _validated, _src in prepared:
-                target = _book_amount(ln)
                 for c in _candidates_for(ln):
                     s = c["split"]
                     if s.guid in claimed_guids:
                         continue
-                    if not _is_unreconciled(s):
+                    if not c["exact"]:
                         continue
-                    pd = s.transaction.post_date
-                    if abs((pd - ln["date"]).days) > 2:
-                        continue
-                    if s.quantity.quantize(quantum) == target:
+                    if _is_unreconciled(s):
                         errors.append((
                             ln["ref"],
                             f"unreconciled split "
@@ -4262,7 +4323,19 @@ class CoreMixin:
                             f"match={split_prefixes[s.guid]}, or "
                             f"force=true to create anyway",
                         ))
-                        break
+                    else:
+                        errors.append((
+                            ln["ref"],
+                            f"reconciled split "
+                            f"{split_prefixes[s.guid]} matches "
+                            f"this line exactly — it looks landed "
+                            f"by a prior statement; keep the line "
+                            f"as a match row "
+                            f"(match={split_prefixes[s.guid]}, a "
+                            f"no-op skip), or force=true to "
+                            f"create anyway",
+                        ))
+                    break
 
         if errors:
             errored = {ref for ref, _ in errors}
@@ -4325,7 +4398,10 @@ class CoreMixin:
                     "memo": s.memo or "",
                     "notes": s.transaction.notes or "",
                     "description": s.transaction.description or "",
-                    "date": s.transaction.post_date.isoformat(),
+                    "date": (
+                        s.transaction.post_date.isoformat()
+                        if s.transaction.post_date else ""
+                    ),
                 }
                 for _ln, s in claims
             ],

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -26,6 +26,7 @@ from gnucash_mcp._format import (
     _dry_run_summary,
     _paginate,
     _split_match_verdict,
+    _tsv_cell,
 )
 
 _debug_logger = logging.getLogger(DEBUG_LOGGER_NAME)
@@ -2946,17 +2947,32 @@ class CoreMixin:
                     states = {s.reconcile_state for s in txn.splits}
                     txn_state = (
                         "y" if "y" in states
-                        else "c" if "c" in states else "n"
+                        else "c" if "c" in states
+                        else "f" if "f" in states else "n"
+                    )
+                    primary_signed = max(
+                        (s.value for s in txn.splits), key=abs,
                     )
                     duplicates.append({
                         "confidence": confidence,
                         "guid": txn_prefixes[txn.guid],
                         "state": txn_state,
+                        # The frame predicate the amount signal
+                        # actually used — comparability is
+                        # candidate-vs-PROPOSAL currency, not
+                        # candidate-vs-book-default (review
+                        # finding: 100 EUR vs 100 USD rendered as
+                        # a perfect twin). currency_code is always
+                        # present so the cur label can name the
+                        # frame either way.
+                        "same_frame": same_frame,
+                        "currency_code": txn.currency.mnemonic,
                         "date": txn.post_date.isoformat(),
                         "description": txn.description,
                         "notes": txn.notes or "",
                         "categories": cat_legs,
                         "amount": str(primary_amount),
+                        "primary_signed": str(primary_signed),
                         # Labeling non-default candidates lets the
                         # caller interpret a cross-currency MEDIUM
                         # (desc+date) without a follow-up read —
@@ -3586,9 +3602,17 @@ class CoreMixin:
                     proposal = {
                         "desc": p["description"],
                         "date": p["trans_date"],
+                        # SIGNED primary (max-abs split's value) —
+                        # the comparison table reads sign as
+                        # direction on both surfaces, so a +50
+                        # deposit and a -50 payment never render
+                        # as a perfect twin (review finding).
                         "amount": (
-                            max(p["proposed_amounts"])
-                            if p["proposed_amounts"] else Decimal("0")
+                            max(
+                                (v["value"] for v in p["validated"]),
+                                key=abs,
+                            )
+                            if p["validated"] else Decimal("0")
                         ),
                         "cats": p_cats,
                     }
@@ -3685,13 +3709,19 @@ class CoreMixin:
                     homework = "No duplicate candidates."
                 summary = _dry_run_summary(
                     len(transactions), "rows",
-                    [("would create", n_would),
+                    [("would_create", n_would),
                      ("review_required", n_review),
                      ("rejected", n_rejected)],
                     homework,
                 )
                 effects: dict[str, Decimal] = {}
                 for p, _dc, _mc in accepted:
+                    if _dc:
+                        # review_required rows are homework, not a
+                        # settled projection — including them would
+                        # let the footer masquerade as clearance
+                        # (review finding; worst under force).
+                        continue
                     for v in p["validated"]:
                         key = v["account"].fullname
                         effects[key] = (
@@ -3702,7 +3732,9 @@ class CoreMixin:
                 if effects:
                     out = ["account\tdelta"]
                     for name in sorted(effects):
-                        out.append(f"{name}\t{effects[name]}")
+                        out.append(
+                            f"{_tsv_cell(name)}\t{effects[name]}"
+                        )
                     effects_tsv = "\n".join(out)
                 return {
                     "summary": summary,
@@ -3770,7 +3802,7 @@ class CoreMixin:
             return ""
         lines = ["ref\tmessage"]
         for ref, message in warn_rows:
-            lines.append(f"{ref}\t{message}")
+            lines.append(f"{_tsv_cell(ref)}\t{_tsv_cell(message)}")
         return "\n".join(lines)
 
     @staticmethod
@@ -3797,8 +3829,17 @@ class CoreMixin:
 
     @staticmethod
     def _cats_str(cats: list[tuple[str, str]]) -> str:
-        """Render category legs as ``account=amount`` pipe-joined."""
-        return "|".join(f"{a}={v}" for a, v in sorted(cats))
+        """Render category legs as ``account=amount`` pipe-joined.
+        The mini-grammar's own separators are escaped inside
+        account names so an account containing ``|`` or ``=``
+        can't corrupt the cell or flip split_match's reading."""
+        def esc(a: str) -> str:
+            return (
+                a.replace("\\", "\\\\")
+                .replace("=", "\\=")
+                .replace("|", "\\|")
+            )
+        return "|".join(f"{esc(a)}={v}" for a, v in sorted(cats))
 
     @staticmethod
     def _batch_duplicates_to_tsv(dup_rows: list) -> str:
@@ -3811,7 +3852,7 @@ class CoreMixin:
         rows = []
         for ref, d, prop in dup_rows:
             date_old = date.fromisoformat(d["date"])
-            cross_frame = bool(d.get("currency"))
+            cross_frame = not d.get("same_frame", True)
             rows.append({
                 "ref": ref,
                 "candidate_guid": d["guid"],
@@ -3821,12 +3862,20 @@ class CoreMixin:
                 "date_old": d["date"],
                 "date_delta_days": (date_old - prop["date"]).days,
                 "amt_new": str(prop["amount"]),
-                "amt_old": d["amount"],
+                "amt_old": d.get("primary_signed", d["amount"]),
                 "amt_delta": (
                     "" if cross_frame
-                    else str(_to_decimal(d["amount"]) - prop["amount"])
+                    else str(
+                        _to_decimal(
+                            d.get("primary_signed", d["amount"])
+                        )
+                        - prop["amount"]
+                    )
                 ),
-                "cur": d.get("currency", ""),
+                "cur": (
+                    d.get("currency_code", "") if cross_frame
+                    else ""
+                ),
                 "desc_new": prop["desc"],
                 "desc_old": d["description"],
                 "notes_old": d.get("notes", ""),
@@ -4089,7 +4138,7 @@ class CoreMixin:
                     book, account, lines, amounts, sign, quantum,
                     _book_amount, _candidates_for, split_prefixes,
                     reconciled_balance, closing, warn_rows,
-                    show_all,
+                    show_all, force,
                 )
             return self._statement_commit(
                 book, account, lines, amounts, sign, quantum,
@@ -4181,6 +4230,19 @@ class CoreMixin:
         for v in validated:
             if v["account"].placeholder:
                 raise self._placeholder_error(v["account"])
+        # The statement account's leg is SYNTHESIZED from the line
+        # amount; a counter-split resolving back to it would move
+        # the account by more than the printed line while the tie
+        # — an identity over the inputs — still reports success,
+        # and the stray unreconciled split breaks NEXT month's
+        # opening gate (review finding).
+        for v in validated[1:]:
+            if v["account"].guid == account.guid:
+                raise ValueError(
+                    f"counter-splits must not name the statement "
+                    f"account ('{account.fullname}') — its leg is "
+                    f"synthesized from the line amount"
+                )
         return validated, src
 
     def _statement_resolve_claim(
@@ -4228,17 +4290,29 @@ class CoreMixin:
     def _statement_dry_run(
         self, book, account, lines, amounts, sign, quantum,
         _book_amount, _candidates_for, split_prefixes,
-        reconciled_balance, closing, warn_rows, show_all,
+        reconciled_balance, closing, warn_rows, show_all, force,
     ) -> dict:
-        """The rehearsal: classify every line, validate everything a
-        commit would validate, and project the balance tie."""
+        """The rehearsal: run the SAME disposition resolution commit
+        runs (the chokepoint), classify every line as evidence, and
+        project the balance tie from the resolved dispositions —
+        never from the classification (the adversarial round's
+        root-cause finding: an approximated projection diverged
+        from the landing in both directions)."""
         default_currency = self._require_default_currency(book)
+        phase_a = self._statement_dispositions(
+            book, account, lines, _book_amount, _candidates_for,
+            quantum, default_currency, force, split_prefixes,
+        )
+        by_ref = phase_a["by_ref"]
+        for ref, msg in phase_a["errors"]:
+            warn_rows.append((ref, msg))
+        n_refuse = len(phase_a["errors"]) + len(phase_a["guards"])
+
         counts = {"NEW": 0, "MATCH": 0, "OVERLAP": 0, "AMBIGUOUS": 0}
         line_rows: list[tuple] = []
         cand_rows: list[dict] = []
         projected = reconciled_balance.quantize(quantum)
 
-        seen_claims: set[str] = set()
         for ln in lines:
             cands = _candidates_for(ln)
             unrec = [
@@ -4261,87 +4335,76 @@ class CoreMixin:
                 if sum(1 for ch in c["signals"] if ch != "-") >= 2
                 and not c["recurring"]
             ]
-            note = ""
             if strong:
                 cls = "MATCH" if len(strong) == 1 else "AMBIGUOUS"
                 listed = unrec + rec
-                if any(c["exact"] for c in strong):
-                    note = (
-                        "exact twin — commit refuses a bare create "
-                        "here (claim it, or force)"
-                    )
             elif any(c["exact"] for c in rec):
                 # OVERLAP means THE SAME EVENT already landed and
-                # tied — exact amount, tight date. A fuzzy
-                # reconciled candidate (last month's rent, 31 days
-                # out) is evidence for a NEW line, not an overlap
-                # (review finding: the old amount-fuzz class
-                # skipped genuine lines from the projection).
+                # tied — exact amount, tight date; fuzzier
+                # reconciled candidates are evidence for a NEW
+                # line, not an overlap.
                 cls = "OVERLAP"
                 listed = rec
-                note = (
-                    "already reconciled (exact twin) — keep this "
-                    "line as a match row naming the twin (no-op); "
-                    "commit refuses a bare create here without "
-                    "force"
-                )
             else:
                 cls = "NEW"
                 # Weak (LOW) and reconciled fuzzy candidates stay
                 # listed: the spec's annotation-adaptation case
-                # (June 30 "July rent" vs a July 31 line) needs the
-                # prior instance's annotation shipped as evidence
-                # even when it doesn't drive the class.
+                # needs the prior instance's annotation shipped as
+                # evidence even when it doesn't drive the class.
                 listed = unrec + rec
 
-            # Full rehearsal: run exactly what commit would run on
-            # this row — a dry-run that ties is a commit that will
-            # tie, and a row commit would reject must say so now.
+            # Note, class overrides, and projection all come from
+            # the RESOLVED DISPOSITION — what commit will actually
+            # do with this row — not from the evidence class.
+            d = by_ref[ln["ref"]]
+            note = ""
             proposal_cats = None
-            try:
-                if ln.get("match"):
-                    s, kind = self._statement_resolve_claim(
-                        book, account, ln, _book_amount(ln), quantum,
+            if d["kind"] == "claim":
+                cls = "MATCH"
+                note = (
+                    f"will claim "
+                    f"{split_prefixes[d['split'].guid]}"
+                )
+                projected += _book_amount(ln)
+            elif d["kind"] == "overlap":
+                cls = "OVERLAP"
+                note = "match names a reconciled split — no-op"
+            elif d["kind"] == "guard":
+                # The guard's coaching verbatim — the same text the
+                # commit rejection would carry.
+                note = d["message"]
+                if not d["twin_reconciled"]:
+                    # Resolution (claim, or forced create) lands
+                    # the amount either way; a reconciled twin
+                    # resolves to a no-op.
+                    projected += _book_amount(ln)
+            elif d["kind"] == "create":
+                validated = d["validated"]
+                proposal_cats = [
+                    (v["account"].fullname, str(abs(v["value"])))
+                    for v in validated
+                    if v["account"].guid != account.guid
+                ]
+                if cls == "NEW" and not ln.get("splits"):
+                    counter_names = ", ".join(
+                        v["account"].fullname
+                        for v in validated[1:]
                     )
-                    if kind == "overlap":
-                        cls = "OVERLAP"
-                        note = "match names a reconciled split — no-op"
-                    elif s.guid in seen_claims:
-                        raise ValueError(
-                            "split already claimed by another row "
-                            "in this statement"
-                        )
-                    else:
-                        seen_claims.add(s.guid)
-                elif cls != "OVERLAP":
-                    validated, src = self._statement_prep_create(
-                        book, account, ln, _book_amount(ln),
-                        default_currency,
+                    note = (
+                        f"would create {_book_amount(ln)} → "
+                        f"{counter_names}"
                     )
-                    proposal_cats = [
-                        (v["account"].fullname, str(abs(v["value"])))
-                        for v in validated
-                        if v["account"].guid != account.guid
-                    ]
-                    if cls == "NEW" and not ln.get("splits"):
-                        counter_names = ", ".join(
-                            v["account"].fullname
-                            for v in validated[1:]
+                    if d["src"]:
+                        note += (
+                            f" (auto_filled_from:"
+                            f"{d['src']['guid']})"
                         )
-                        note = (
-                            f"would create {_book_amount(ln)} → "
-                            f"{counter_names}"
-                        )
-                        if src:
-                            note += (
-                                f" (auto_filled_from:{src['guid']})"
-                            )
-            except ValueError as e:
-                warn_rows.append((ln["ref"], str(e)))
+                projected += _book_amount(ln)
+            else:  # error — assume the operator fixes the row and
+                # it lands; the caveat counts it either way.
+                projected += _book_amount(ln)
 
             counts[cls] += 1
-            if cls != "OVERLAP":
-                projected += _book_amount(ln)
 
             # Best-evidence-only display (bookkeeper ruling,
             # 2026-08-24): a line with MEDIUM/HIGH candidates
@@ -4455,18 +4518,24 @@ class CoreMixin:
                 f"({closing} as printed) — DISCREPANCY "
                 f"{closing_book - projected}."
             )
-        if warn_rows:
-            # The projection assumes every warned row still lands;
-            # a commit repeating those rows refuses instead. Facts,
-            # not clearance.
+        if n_refuse:
+            # Counts the rows the SAME payload would refuse at
+            # commit — resolved dispositions, not a warning-count
+            # proxy (the old proxy was wrong in both directions:
+            # guard hits raised no warning, and under force the
+            # opening-gap warning implied a refusal that wouldn't
+            # happen). Facts, not clearance.
             tie += (
-                f" {len(warn_rows)} warning(s) outstanding — a "
-                f"commit that repeats them will refuse."
+                f" {n_refuse} row(s) this payload would refuse at "
+                f"commit — resolve the notes/warnings first."
             )
 
         lines_tsv = ["ref\tclass\tcands\tnote"]
         for r in line_rows:
-            lines_tsv.append(f"{r[0]}\t{r[1]}\t{r[2]}\t{r[3]}")
+            lines_tsv.append(
+                f"{_tsv_cell(r[0])}\t{r[1]}\t{r[2]}\t"
+                f"{_tsv_cell(r[3])}"
+            )
 
         return {
             "summary": header,
@@ -4476,22 +4545,37 @@ class CoreMixin:
             "tie": tie,
         }
 
-    def _statement_commit(
-        self, book, account, lines, amounts, sign, quantum,
-        statement_date, _book_amount, _candidates_for,
-        split_prefixes, reconciled_balance, closing, force,
-        default_currency,
+    def _statement_dispositions(
+        self, book, account, lines, _book_amount, _candidates_for,
+        quantum, default_currency, force, split_prefixes,
     ) -> dict:
-        """The landing: validate every row, check the tie, then — and
-        only then — mutate and save once."""
-        prepared: list[tuple] = []   # (ln, validated, src)
-        claims: list[tuple] = []     # (ln, split)
-        skipped: list[tuple] = []    # (ln, split)  overlap no-ops
-        errors: list[tuple[str, str]] = []
-        claimed_guids: set[str] = set()
+        """Phase A — THE disposition chokepoint both modes run.
 
-        # Pass 1 — claims only, so the guard below can exempt every
-        # split a row in THIS statement claims.
+        The adversarial round found the rehearsal approximating this
+        procedure and drifting from it in five distinct ways; the
+        fix is structural: one resolver, two consumers, divergence
+        impossible by construction. Claims resolve first (the
+        guard's exemption set), then each create row runs the twin
+        guard BEFORE counter-split/auto-fill prep (bookkeeper
+        signoff, carried item). ``force`` disables the guard here —
+        for BOTH modes, so a forced rehearsal rehearses the forced
+        landing.
+
+        Returns ``{"by_ref": {ref: {"kind": claim|overlap|create|
+        guard|error, ...}}, "claims": [(ln, split)], "skipped":
+        [(ln, split)], "prepared": [(ln, validated, src)],
+        "errors": [(ref, msg)], "guards": [(ref, msg,
+        twin_reconciled)]}``. Pure read — no mutation on any path.
+        """
+        by_ref: dict[str, dict] = {}
+        prepared: list[tuple] = []
+        claims: list[tuple] = []
+        skipped: list[tuple] = []
+        errors: list[tuple[str, str]] = []
+        guards: list[tuple[str, str, bool]] = []
+        claimed_guids: set[str] = set()
+        overlap_guids: set[str] = set()
+
         create_rows = []
         for ln in lines:
             if not ln.get("match"):
@@ -4501,31 +4585,46 @@ class CoreMixin:
                 s, kind = self._statement_resolve_claim(
                     book, account, ln, _book_amount(ln), quantum,
                 )
+                if s.guid in claimed_guids or (
+                    kind == "overlap" and s.guid in overlap_guids
+                ):
+                    # One split, one row — reconciled no-ops
+                    # included: two lines both no-opping one split
+                    # would report two handled lines for one
+                    # (review finding).
+                    raise ValueError(
+                        "split already used by another row in "
+                        "this statement"
+                    )
                 if kind == "overlap":
+                    overlap_guids.add(s.guid)
                     skipped.append((ln, s))
+                    by_ref[ln["ref"]] = {"kind": "overlap", "split": s}
                 else:
-                    if s.guid in claimed_guids:
-                        raise ValueError(
-                            "split already claimed by another "
-                            "row in this statement"
-                        )
                     claimed_guids.add(s.guid)
                     claims.append((ln, s))
+                    by_ref[ln["ref"]] = {"kind": "claim", "split": s}
             except ValueError as e:
                 errors.append((ln["ref"], str(e)))
+                by_ref[ln["ref"]] = {"kind": "error", "message": str(e)}
 
-        def _twin_guard_error(ln) -> str | None:
+        def _twin_guard(ln) -> tuple[str, bool] | None:
             """Statement-duplicate guard: a created line that
             exactly matches an unclaimed split on this account
             would double-enter. Unreconciled twin: the tie would
             still hold (only the new split reconciles) — silent.
-            Reconciled twin: already landed via a prior statement
-            — the tie catches it unforced, but under force both
-            copies would sit reconciled. Judgment overrides with
-            force (it saw the MATCH table and ruled NEW)."""
+            Reconciled twin: already landed via a prior statement.
+            Splits claimed OR no-op'd by other rows in this
+            statement are exempt — their lines are accounted for,
+            so an exact-matching create is a genuine second
+            charge."""
             for c in _candidates_for(ln):
                 s = c["split"]
-                if s.guid in claimed_guids or not c["exact"]:
+                if (
+                    s.guid in claimed_guids
+                    or s.guid in overlap_guids
+                    or not c["exact"]
+                ):
                     continue
                 if _is_unreconciled(s):
                     return (
@@ -4535,7 +4634,7 @@ class CoreMixin:
                         f"date) and no row claims it — claim it "
                         f"with match={split_prefixes[s.guid]}, or "
                         f"force=true to create anyway"
-                    )
+                    ), False
                 return (
                     f"reconciled split {split_prefixes[s.guid]} "
                     f"matches this line exactly — it looks landed "
@@ -4543,19 +4642,19 @@ class CoreMixin:
                     f"match row (match={split_prefixes[s.guid]}, "
                     f"a no-op skip), or force=true to create "
                     f"anyway"
-                )
+                ), True
             return None
 
-        # Pass 2 — create rows: the twin guard runs BEFORE
-        # counter-split/auto-fill validation, so a bare raw line
-        # whose twin exists gets the claim coaching, not an
-        # auto-fill complaint about a row that shouldn't be
-        # created at all (bookkeeper signoff, carried item).
         for ln in create_rows:
             if not force:
-                guard_msg = _twin_guard_error(ln)
-                if guard_msg is not None:
-                    errors.append((ln["ref"], guard_msg))
+                hit = _twin_guard(ln)
+                if hit is not None:
+                    msg, twin_reconciled = hit
+                    guards.append((ln["ref"], msg, twin_reconciled))
+                    by_ref[ln["ref"]] = {
+                        "kind": "guard", "message": msg,
+                        "twin_reconciled": twin_reconciled,
+                    }
                     continue
             try:
                 validated, src = self._statement_prep_create(
@@ -4563,8 +4662,38 @@ class CoreMixin:
                     default_currency,
                 )
                 prepared.append((ln, validated, src))
+                by_ref[ln["ref"]] = {
+                    "kind": "create", "validated": validated,
+                    "src": src,
+                }
             except ValueError as e:
                 errors.append((ln["ref"], str(e)))
+                by_ref[ln["ref"]] = {"kind": "error", "message": str(e)}
+
+        return {
+            "by_ref": by_ref, "claims": claims, "skipped": skipped,
+            "prepared": prepared, "errors": errors, "guards": guards,
+        }
+
+    def _statement_commit(
+        self, book, account, lines, amounts, sign, quantum,
+        statement_date, _book_amount, _candidates_for,
+        split_prefixes, reconciled_balance, closing, force,
+        default_currency,
+    ) -> dict:
+        """The landing: resolve dispositions (the shared chokepoint),
+        check the tie, then — and only then — mutate and save once."""
+        phase_a = self._statement_dispositions(
+            book, account, lines, _book_amount, _candidates_for,
+            quantum, default_currency, force, split_prefixes,
+        )
+        prepared = phase_a["prepared"]
+        claims = phase_a["claims"]
+        skipped = phase_a["skipped"]
+        # Guard hits are row errors at commit time.
+        errors = phase_a["errors"] + [
+            (ref, msg) for ref, msg, _rec in phase_a["guards"]
+        ]
 
         if errors:
             # The row's error rides the note column INLINE — the
@@ -4579,7 +4708,10 @@ class CoreMixin:
             for ln in lines:
                 msg = error_by_ref.get(ln["ref"], "")
                 status = "rejected" if msg else "statement_aborted"
-                rows.append(f"{ln['ref']}\t{status}\t\t{msg}")
+                rows.append(
+                    f"{_tsv_cell(ln['ref'])}\t{status}\t\t"
+                    f"{_tsv_cell(msg)}"
+                )
             return {
                 "summary": (
                     f"Statement REJECTED — {len(error_by_ref)} row "
@@ -4712,6 +4844,10 @@ class CoreMixin:
                 f"{statement_date.isoformat()}: {len(built)} "
                 f"created, {len(claims)} claimed, {len(skipped)} "
                 f"skipped (already reconciled)."
+                + (
+                    " LANDED UNDER FORCE — base and twin guards "
+                    "were bypassed." if force else ""
+                )
             ),
             "results": "\n".join(rows),
             "new_reconciled_balance": str(new_reconciled),

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -129,6 +129,17 @@ class _SummaryData:
 _MATCH_AMOUNT_TOLERANCE = Decimal("1.00")
 _MATCH_DATE_TIGHT_DAYS = 2
 
+# Statement classification: desc + amount matching at roughly a
+# month's remove is the RECURRING-PAYMENT signature (last month's
+# rent), not same-event correspondence — such candidates ship as
+# evidence but never drive MATCH/AMBIGUOUS (bookkeeper T6, the
+# third specimen of the near-match family). Three weeks: beyond
+# realistic clearing drift, comfortably inside monthly cadence.
+# Biweekly patterns (14d paychecks) stay below it deliberately —
+# a slow check clearing two weeks late is still a plausible match,
+# and judgment rules those with the evidence in hand.
+_RECURRENCE_MIN_DAYS = 21
+
 
 def _post_date_as_date(transaction) -> date | None:
     """Transaction post_date normalized to a bare date — piecash
@@ -2927,9 +2938,20 @@ class CoreMixin:
                         (s.account.fullname, str(abs(s.value)))
                         for s in txn.splits
                     ]
+                    # Most-anchored split state: a reconciled
+                    # candidate is definitely entered AND tied —
+                    # decisive for the duplicate call (bookkeeper
+                    # T7: the shared table's state column must not
+                    # sit empty on the batch surface).
+                    states = {s.reconcile_state for s in txn.splits}
+                    txn_state = (
+                        "y" if "y" in states
+                        else "c" if "c" in states else "n"
+                    )
                     duplicates.append({
                         "confidence": confidence,
                         "guid": txn_prefixes[txn.guid],
+                        "state": txn_state,
                         "date": txn.post_date.isoformat(),
                         "description": txn.description,
                         "notes": txn.notes or "",
@@ -3794,6 +3816,7 @@ class CoreMixin:
                 "ref": ref,
                 "candidate_guid": d["guid"],
                 "confidence": d["confidence"],
+                "state": d.get("state", ""),
                 "date_new": prop["date"].isoformat(),
                 "date_old": d["date"],
                 "date_delta_days": (date_old - prop["date"]).days,
@@ -3839,6 +3862,7 @@ class CoreMixin:
         lines: list[dict],
         dry_run: bool = True,
         force: bool = False,
+        show_all: bool = False,
     ) -> dict:
         """One-shot statement entry: enter, claim, and reconcile a
         complete bank/card statement in one atomic open/save.
@@ -4048,6 +4072,15 @@ class CoreMixin:
                             and s.quantity.quantize(quantum)
                             == target
                         ),
+                        # Recurring signature: same name, same
+                        # amount, a month away — evidence for the
+                        # annotation-adaptation case, never a
+                        # class driver.
+                        "recurring": (
+                            desc_match and amount_match
+                            and abs((pd - ln["date"]).days)
+                            >= _RECURRENCE_MIN_DAYS
+                        ),
                     })
                 return cands
 
@@ -4056,6 +4089,7 @@ class CoreMixin:
                     book, account, lines, amounts, sign, quantum,
                     _book_amount, _candidates_for, split_prefixes,
                     reconciled_balance, closing, warn_rows,
+                    show_all,
                 )
             return self._statement_commit(
                 book, account, lines, amounts, sign, quantum,
@@ -4194,7 +4228,7 @@ class CoreMixin:
     def _statement_dry_run(
         self, book, account, lines, amounts, sign, quantum,
         _book_amount, _candidates_for, split_prefixes,
-        reconciled_balance, closing, warn_rows,
+        reconciled_balance, closing, warn_rows, show_all,
     ) -> dict:
         """The rehearsal: classify every line, validate everything a
         commit would validate, and project the balance tie."""
@@ -4215,14 +4249,17 @@ class CoreMixin:
                 if c["split"].reconcile_state == "y"
             ]
             # MATCH/AMBIGUOUS demand adjudication, so the class is
-            # gated on MEDIUM+ correspondence (>=2 signals). An
-            # amount-only LOW still SURFACES as a candidate row —
-            # ruling 1's superset — but classifies NEW: three weak
-            # lookalikes must not adopt a genuinely new line
-            # (bookkeeper finding, maiden flight).
+            # gated on MEDIUM+ correspondence (>=2 signals) that
+            # is NOT the recurring-payment signature. Weak and
+            # recurring candidates still SURFACE as evidence —
+            # ruling 1's superset — but classify NEW: three weak
+            # lookalikes must not adopt a genuinely new line, and
+            # last month's rent is a precedent, not a twin
+            # (bookkeeper findings, maiden flight + T6).
             strong = [
                 c for c in unrec
                 if sum(1 for ch in c["signals"] if ch != "-") >= 2
+                and not c["recurring"]
             ]
             note = ""
             if strong:
@@ -4305,7 +4342,32 @@ class CoreMixin:
             counts[cls] += 1
             if cls != "OVERLAP":
                 projected += _book_amount(ln)
-            for c in listed:
+
+            # Best-evidence-only display (bookkeeper ruling,
+            # 2026-08-24): a line with MEDIUM/HIGH candidates
+            # suppresses its LOW amount-coincidences — redundant
+            # next to the real evidence, and dense-recurrence
+            # cards make the token weight real (19 LOWs on one
+            # $4.99 line). A line whose ONLY evidence is LOW keeps
+            # it: ruling 1's rent case is load-bearing. The
+            # suppression leaves a breadcrumb in the cands column;
+            # show_all=true is the escape hatch.
+            kept = listed
+            n_suppressed = 0
+            if not show_all:
+                strong_listed = [
+                    c for c in listed
+                    if sum(1 for ch in c["signals"] if ch != "-")
+                    >= 2
+                ]
+                if strong_listed and len(strong_listed) < len(listed):
+                    n_suppressed = len(listed) - len(strong_listed)
+                    kept = strong_listed
+            cands_cell = str(len(kept))
+            if n_suppressed:
+                cands_cell += f" (+{n_suppressed} LOW suppressed)"
+
+            for c in kept:
                 s = c["split"]
                 txn = s.transaction
                 cat_old = [
@@ -4347,7 +4409,7 @@ class CoreMixin:
                     ),
                     "signals": c["signals"],
                 })
-            line_rows.append((ln["ref"], cls, len(listed), note))
+            line_rows.append((ln["ref"], cls, cands_cell, note))
 
         # Summary header via the shared rehearsal renderer — counts
         # are facts and may headline; clearance verdicts over
@@ -4487,22 +4549,26 @@ class CoreMixin:
                     break
 
         if errors:
-            errored = {ref for ref, _ in errors}
+            # The row's error rides the note column INLINE — the
+            # results table is the primary read, and a rejection
+            # whose coaching ("claim it with match=…, or force")
+            # lives elsewhere strands the operator at exactly the
+            # moment they need the next move (bookkeeper T5b).
+            error_by_ref = {}
+            for ref, msg in errors:
+                error_by_ref.setdefault(ref, msg)
             rows = []
             for ln in lines:
-                status = (
-                    "rejected" if ln["ref"] in errored
-                    else "statement_aborted"
-                )
-                rows.append(f"{ln['ref']}\t{status}\t\t")
+                msg = error_by_ref.get(ln["ref"], "")
+                status = "rejected" if msg else "statement_aborted"
+                rows.append(f"{ln['ref']}\t{status}\t\t{msg}")
             return {
                 "summary": (
-                    f"Statement REJECTED — {len(errors)} row "
+                    f"Statement REJECTED — {len(error_by_ref)} row "
                     f"error(s); nothing was written."
                 ),
                 "results": "ref\tstatus\tguid\tnote\n"
                 + "\n".join(rows),
-                "warnings": self._batch_warnings_to_tsv(errors),
             }
 
         # The tie, BEFORE any mutation. Claim amounts equal line

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -14,6 +14,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from gnucash_mcp.book._base import (
+    _commodity_quantum,
     _guid_prefix_map,
     _is_unreconciled,
     _is_voided,
@@ -448,10 +449,7 @@ class ReconciliationMixin:
             # smallest fraction before comparing — otherwise
             # "1234.567" against a 2-decimal book is a perpetual
             # 0.007 mismatch even when the books agree at the cent.
-            fraction = getattr(account.commodity, "fraction", 100)
-            quantum = (
-                Decimal(1) / Decimal(fraction) if fraction > 1 else Decimal(1)
-            )
+            quantum = _commodity_quantum(account.commodity)
             expected_q = expected_balance.quantize(quantum)
             new_balance = (
                 reconciled_balance + reconciling_total

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -2074,12 +2074,17 @@ def _fmt_statement_enter(entry: dict) -> list[str]:
     dry = params.get("dry_run", True)
 
     verb = "ENTER STATEMENT (dry run)" if dry else "ENTER STATEMENT"
-    if params.get("force") and not dry:
+    forced = [
+        n for n, k in (("base", "force_base"),
+                       ("duplicates", "force_duplicates"))
+        if params.get(k)
+    ]
+    if forced and not dry:
         # A forced landing bypassed the base and twin guards — the
         # permanent record says so even when the tie held (review:
         # a forced commit's audit entry was byte-identical to a
         # clean one).
-        verb += " (FORCED)"
+        verb += f" (FORCED: {', '.join(forced)})"
     lines = [
         f"{time_part}  {verb}  {account}  {stmt_date}  "
         f"opening {opening} → closing {closing}"

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -720,7 +720,7 @@ def _fmt_transaction_update_batch(entry: dict) -> list[str]:
         old = next(
             (
                 b for g, b in befores.items()
-                if g.startswith(key) or key.startswith(g[:8])
+                if g.startswith(key)
             ),
             {},
         )
@@ -2125,7 +2125,7 @@ def _fmt_statement_enter(entry: dict) -> list[str]:
             old = next(
                 (
                     b for g, b in befores.items()
-                    if g.startswith(guid) or guid.startswith(g[:8])
+                    if g.startswith(guid)
                 ),
                 {},
             )
@@ -2345,7 +2345,7 @@ def _escape_audit_value(text: str) -> str:
 # still neutralizes \r, stray C0 controls, and bidi overrides that
 # could survive inside a cell.
 _AUDIT_TSV_KEYS = frozenset({"transactions", "updates", "results",
-                             "prices"})
+                             "prices", "lines"})
 
 _AUDIT_UNSAFE_TSV_RE = re.compile(
     "[\\\\\\x00-\\x08\\x0b-\\x1f\\x7f"  # C0 minus \t \n, + DEL

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -2148,7 +2148,7 @@ def _fmt_statement_enter(entry: dict) -> list[str]:
                     f"{old.get('notes', '') or '(empty)'} → "
                     f"{new_notes}"
                 )
-        elif status == "skipped_overlap":
+        elif status == "skipped_duplicate":
             lines.append(
                 f"{_INDENT}SKIP  split:{guid}  already reconciled"
             )

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -2074,6 +2074,12 @@ def _fmt_statement_enter(entry: dict) -> list[str]:
     dry = params.get("dry_run", True)
 
     verb = "ENTER STATEMENT (dry run)" if dry else "ENTER STATEMENT"
+    if params.get("force") and not dry:
+        # A forced landing bypassed the base and twin guards — the
+        # permanent record says so even when the tie held (review:
+        # a forced commit's audit entry was byte-identical to a
+        # clean one).
+        verb += " (FORCED)"
     lines = [
         f"{time_part}  {verb}  {account}  {stmt_date}  "
         f"opening {opening} → closing {closing}"

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -2055,6 +2055,106 @@ def _fmt_scheduled_transaction_delete(entry: dict) -> list[str]:
     return lines
 
 
+def _fmt_statement_enter(entry: dict) -> list[str]:
+    """``enter_statement`` audits as ONE document event — the
+    statement landing (or rehearsing) as a whole, not N disconnected
+    CREATE lines. Created rows render with their interpreted
+    description; claimed rows render their annotation diffs from the
+    staged before-state (a claim is a write to an existing
+    transaction)."""
+    time_part = _extract_time(entry)
+    params = entry.get("params") or {}
+    after = entry.get("after_state") or {}
+    before = entry.get("before_state") or {}
+
+    account = params.get("account", "")
+    stmt_date = params.get("statement_date", "")
+    opening = params.get("opening_balance", "")
+    closing = params.get("closing_balance", "")
+    dry = params.get("dry_run", True)
+
+    verb = "ENTER STATEMENT (dry run)" if dry else "ENTER STATEMENT"
+    lines = [
+        f"{time_part}  {verb}  {account}  {stmt_date}  "
+        f"opening {opening} → closing {closing}"
+    ]
+    summary = (after.get("summary") or "").replace("\n", " ")
+    if summary:
+        lines.append(f"{_INDENT}{summary}")
+    tie = after.get("tie") or ""
+    if tie and not dry:
+        lines.append(f"{_INDENT}{tie}")
+    if dry:
+        return lines
+
+    # Re-parse the submitted lines through the SAME parser the tool
+    # used (no display drift); tolerate malformed input — the write
+    # path already rejected it.
+    from gnucash_mcp._format import _parse_statement_tsv
+
+    try:
+        submitted = {
+            r["ref"]: r
+            for r in _parse_statement_tsv(params.get("lines") or "")
+        }
+    except ValueError:
+        submitted = {}
+    results = _parse_audit_tsv_rows(after.get("results") or "")
+    befores = {c.get("guid", ""): c for c in before.get("claims") or []}
+
+    for r in results:
+        ref = r.get("ref", "")
+        src = submitted.get(ref, {})
+        status = r.get("status", "")
+        guid = r.get("guid", "")
+        if status == "created":
+            desc = src.get("description") or src.get("raw") or ""
+            lines.append(
+                f'{_INDENT}CREATE  guid:{guid}  "{desc}" '
+                f'({src.get("date", "")}, {src.get("amount", "")})'
+            )
+            if src.get("notes"):
+                lines.append(f"{_INDENT_SPLITS}notes: {src['notes']}")
+            note = r.get("note", "")
+            if note.startswith("auto_filled_from:"):
+                lines.append(
+                    f"{_INDENT_SPLITS}auto-filled from "
+                    f"guid:{note.split(':', 1)[1]}"
+                )
+        elif status == "claimed":
+            old = next(
+                (
+                    b for g, b in befores.items()
+                    if g.startswith(guid) or guid.startswith(g[:8])
+                ),
+                {},
+            )
+            desc = old.get("description", "")
+            lines.append(
+                f'{_INDENT}CLAIM  split:{guid}  "{desc}" '
+                f'({old.get("date", "")})  '
+                f'state: {old.get("state", "")} → y'
+            )
+            new_memo = src.get("raw", "")
+            if new_memo and new_memo != old.get("memo", ""):
+                lines.append(
+                    f"{_INDENT_SPLITS}memo: "
+                    f"{old.get('memo', '') or '(empty)'} → {new_memo}"
+                )
+            new_notes = src.get("notes", "")
+            if new_notes and new_notes != old.get("notes", ""):
+                lines.append(
+                    f"{_INDENT_SPLITS}notes: "
+                    f"{old.get('notes', '') or '(empty)'} → "
+                    f"{new_notes}"
+                )
+        elif status == "skipped_overlap":
+            lines.append(
+                f"{_INDENT}SKIP  split:{guid}  already reconciled"
+            )
+    return lines
+
+
 # ── Dispatch table ────────────────────────────────────────────────
 #
 # Key shape: (entity_type, operation). Both in their canonical forms —
@@ -2077,6 +2177,7 @@ _AUDIT_HANDLERS: dict[str, Callable[[dict], list[str]]] = {
     ("account", "MOVE"): _fmt_account_move,
     ("account", "DELETE"): _fmt_account_delete,
     ("split", "RECONCILE"): _fmt_split_reconcile,
+    ("statement", "ENTER"): _fmt_statement_enter,
     ("split", "SET_STATE"): _fmt_split_set_state,
     ("account_slot", "SET_SLOT"): _fmt_account_slot_set,
     ("account_slot", "DELETE_SLOT"): _fmt_account_slot_delete,

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -162,6 +162,7 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_transaction",
         "create_transaction",
         "create_transactions",
+        "enter_statement",
         "update_transaction",
         "update_transactions",
         "delete_transaction",
@@ -616,6 +617,11 @@ _WRITE_VERB_HINTS: dict[str, tuple[bool, bool]] = {
     "set_state": (True, True),
     "replace_splits": (True, True),
     "reconcile": (True, True),
+    # Statement entry adds transactions but also claims and
+    # reconciles EXISTING splits (annotations + state) — destructive.
+    # Repeating the same commit refuses on the opening precondition
+    # (the base moved), adding nothing further.
+    "enter": (True, True),
     "post": (False, True),         # additive; re-post errors, adds nothing
     "pay": (False, False),         # paying twice records two payments
     "apply": (False, False),

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -60,6 +60,9 @@ ORIENTATION:
 - Use list_accounts to get exact paths and short GUIDs before writing.
 - Use search_transactions before creating to avoid duplicates.
 - Every transaction has splits that MUST sum to zero.
+STATEMENT ENTRY (the headline workflow):
+- For a COMPLETE bank/card statement, use enter_statement — not create_transactions + reconcile_account. Dry-run (default) classifies every line against the book and projects the balance tie; commit enters, claims, and reconciles atomically against the closing balance.
+- Transcribe amounts and balances EXACTLY as the statement prints them (credit cards included) — the server applies the sign convention. Your judgment pass between dry-run and commit is the one step the server cannot do.
 ACCOUNT REFERENCES:
 - Tools accept full paths ("Expenses:Groceries"), short GUIDs ("%xxxxxxx" form), or full 32-char GUIDs.
 - list_accounts emits short GUIDs at line start: "%xxxxxxx\\tAssets:Savings [BANK]" (x's are a placeholder — copy real GUIDs from list_accounts output). Reuse them — ~80% smaller than paths.

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -13,6 +13,7 @@ from gnucash_mcp._format import (
     _batch_tsv_layout,
     _parse_statement_tsv,
     _parse_update_tsv,
+    _tsv_lines,
 )
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
@@ -40,7 +41,7 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
     missing header, too-few columns, or a split count that doesn't
     match the declared shape.
     """
-    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    lines = _tsv_lines(tsv, "the transactions TSV")
     if len(lines) < 2:
         raise ValueError(
             "transactions TSV needs a header row and at least one data row"
@@ -597,9 +598,10 @@ def register(mcp, get_book) -> None:
         - ``match`` = the split GUID this line claims instead of
           creating (from the dry-run candidates table). Claim rows
           may also carry ``raw`` (updates the claimed split's memo)
-          and ``notes`` (updates the transaction's notes). The
-          claimed amount must equal the line amount exactly — fix
-          the book first if they disagree.
+          and ``notes`` (updates the transaction's notes), and END
+          at their last fixed column — they take no split cells.
+          The claimed amount must equal the line amount exactly —
+          fix the book first if they disagree.
         - A commit row with no counter-splits auto-fills from the
           most recent same-description 2-split transaction, adapted
           to the line amount (marked ``auto_filled_from:<guid>``).

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -11,6 +11,7 @@ from datetime import date
 from gnucash_mcp._format import (
     _batch_row_splits,
     _batch_tsv_layout,
+    _parse_statement_tsv,
     _parse_update_tsv,
 )
 from gnucash_mcp.logging_config import audit_log
@@ -511,6 +512,126 @@ def register(mcp, get_book) -> None:
         parsed = _parse_transactions_tsv(transactions)
         result = book.create_transactions(
             parsed, force=force, dry_run=dry_run, on_error=on_error,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    @safe_tool
+    @audit_log(
+        classification="write", operation="enter",
+        entity_type="statement",
+    )
+    def enter_statement(
+        account: str,
+        statement_date: str,
+        opening_balance: str,
+        closing_balance: str,
+        lines: str,
+        dry_run: bool = True,
+        force: bool = False,
+    ) -> str:
+        """Enter a COMPLETE bank/card statement in one atomic call:
+        create the new lines, claim the ones already in the book,
+        and reconcile everything against the closing balance — all
+        in one save, or nothing at all.
+
+        THE WORKFLOW (two calls around your judgment):
+
+        1. ``dry_run=true`` (the DEFAULT) — transcribe the statement
+           and get back a classification of every line: NEW (not in
+           the book), MATCH (an existing unreconciled split
+           corresponds), OVERLAP (already reconciled), AMBIGUOUS
+           (several candidates). MATCH/AMBIGUOUS rows come with the
+           candidate's full annotation (date, amount, description,
+           notes, memo, short GUID) so you can adjudicate each one.
+        2. Rule every MATCH/AMBIGUOUS row yourself, adapt
+           annotations, confirm with the user.
+        3. ``dry_run=false`` — NEW rows now carry interpreted
+           description/notes and counter-splits; MATCH rows carry
+           ``match=<split guid>`` claims. The server enters, claims,
+           reconciles every statement-touched split at
+           ``statement_date``, and saves once.
+
+        TRANSCRIBE, DON'T INTERPRET (dry-run): amounts and balances
+        go in EXACTLY as the statement prints them — for credit
+        cards too (charges positive, balance as amount owed). The
+        server applies the sign convention from the account's type;
+        you never flip a sign. The gate
+        ``opening + sum(lines) == closing`` must hold or the call
+        rejects: transcribe every line.
+
+        INPUT — ``lines`` is a TSV block. Header: ``ref, date``
+        first, then any order of ``description``, ``notes``,
+        ``raw``, ``match``, ``amount`` (required), then optional
+        ``amt, acct, memo, qty`` counter-split groups (batch
+        grammar). The statement account's own leg is SYNTHESIZED —
+        never a column. Dry-run typically needs only::
+
+            ref<TAB>date<TAB>raw<TAB>amount
+            1<TAB>2026-07-03<TAB>POS DEBIT WHOLEFDS #123<TAB>-87.12
+
+        - ``raw`` = the verbatim statement line; it lands on the
+          bank leg's memo (provenance). ``description``/``notes``
+          are your interpretation (commit).
+        - ``match`` = the split GUID this line claims instead of
+          creating (from the dry-run candidates table). Claim rows
+          may also carry ``raw`` (updates the claimed split's memo)
+          and ``notes`` (updates the transaction's notes). The
+          claimed amount must equal the line amount exactly — fix
+          the book first if they disagree.
+        - A commit row with no counter-splits auto-fills from the
+          most recent same-description 2-split transaction, adapted
+          to the line amount (marked ``auto_filled_from:<guid>``).
+
+        SAFETY: the account's reconciled balance must tie to
+        ``opening_balance`` (a prior unentered statement blocks
+        commit), every created-vs-existing exact overlap must be
+        explicitly claimed or forced, and the projected closing tie
+        is verified BEFORE anything is written. ``force=true``
+        means "land it anyway" for the base/tie checks; it never
+        bypasses the statement's own self-check.
+
+        OUTPUT (dry-run): ``summary`` (class counts), ``lines``
+        (ref, class, cands, note), ``candidates`` (per-candidate
+        annotation, FK ref), ``warnings``, and ``tie`` — the
+        projected reconciled balance vs the closing. The tie is the
+        only verdict; MATCH/AMBIGUOUS rows are yours to rule.
+        OUTPUT (commit): ``results`` (ref, status
+        created|claimed|skipped_overlap, guid), the new reconciled
+        balance, and the tie.
+
+        Args:
+            account: Statement account ref (path, %short, or GUID).
+                BANK/CASH/ASSET/CREDIT/LIABILITY only.
+            statement_date: The statement's closing date
+                (YYYY-MM-DD); every touched split reconciles at it.
+            opening_balance: Opening balance, exactly as printed.
+            closing_balance: Closing balance, exactly as printed.
+            lines: The TSV block described above.
+            dry_run: DEFAULT TRUE — the rehearsal is the workflow.
+            force: Land despite an untied opening base / closing
+                discrepancy, and create past exact unclaimed
+                overlaps.
+        """
+        book = get_book()
+        stmt_date = _parse_iso_date(statement_date)
+        if stmt_date is None:
+            raise ValueError(
+                f"statement_date {statement_date!r} is not a valid "
+                f"YYYY-MM-DD date"
+            )
+        parsed = _parse_statement_tsv(lines)
+        for row in parsed:
+            d = _parse_iso_date(row["date"])
+            if d is None:
+                raise ValueError(
+                    f"line {row['ref']}: date {row['date']!r} is "
+                    f"not a valid YYYY-MM-DD date"
+                )
+            row["date"] = d
+        result = book.enter_statement(
+            account, stmt_date, opening_balance, closing_balance,
+            parsed, dry_run=dry_run, force=force,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -494,13 +494,20 @@ def register(mcp, get_book) -> None:
 
         OUTPUT — a JSON envelope of two TSV tables joined by ``ref``:
         - ``results`` (always): ``ref, status, txn_guid, dup_count,
-          reason``. status is ``created`` | ``rejected`` |
-          ``would_create`` (dry_run); reason is a code like
-          ``duplicate_detected`` or the validation message.
+          max_confidence, reason``. status is ``created`` |
+          ``rejected`` | ``would_create`` (dry_run); reason is a
+          code like ``duplicate_detected`` or the validation
+          message. ``max_confidence`` (HIGH/MEDIUM/blank) is the
+          row's top duplicate candidate — enough for the common
+          keep/drop call without the join.
         - ``duplicates`` (only when matches exist): ``ref, confidence,
           guid, date, amount, description, signals`` — the columns
           ``create_transaction`` emits, keyed back to the offending
           ``ref``. Σ(dup_count) equals the duplicates row count.
+        - Dry runs additionally lead with ``summary`` (would-create/
+          rejected counts + which rows have candidates to review)
+          and close with ``effects`` — the projected per-account
+          balance deltas of the would-create rows.
 
         Args:
             transactions: The TSV block described above.

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -554,7 +554,8 @@ def register(mcp, get_book) -> None:
         closing_balance: str,
         lines: str,
         dry_run: bool = True,
-        force: bool = False,
+        force_base: bool = False,
+        force_duplicates: bool = False,
         show_all: bool = False,
     ) -> str:
         """Enter a COMPLETE bank/card statement in one atomic call:
@@ -620,9 +621,14 @@ def register(mcp, get_book) -> None:
         ``opening_balance`` (a prior unentered statement blocks
         commit), every created-vs-existing exact overlap must be
         explicitly claimed or forced, and the projected closing tie
-        is verified BEFORE anything is written. ``force=true``
-        means "land it anyway" for the base/tie checks; it never
-        bypasses the statement's own self-check.
+        is verified BEFORE anything is written. The two force
+        flags are INDEPENDENT: ``force_base=true`` lands onto an
+        untied opening base (the consequent tie discrepancy is
+        recorded, and duplicate detection STAYS ON);
+        ``force_duplicates=true`` creates past exact twins you
+        have adjudicated as distinct. Neither bypasses the
+        statement's own self-check. After the save, the reconciled
+        balance is read back and verified against the tie.
 
         OUTPUT (dry-run): ``summary`` (class counts), ``lines``
         (ref, class, cands, note — the note is the resolved
@@ -659,9 +665,10 @@ def register(mcp, get_book) -> None:
             closing_balance: Closing balance, exactly as printed.
             lines: The TSV block described above.
             dry_run: DEFAULT TRUE — the rehearsal is the workflow.
-            force: Land despite an untied opening base / closing
-                discrepancy, and create past exact unclaimed
-                overlaps.
+            force_base: Land onto an untied opening base; the tie
+                discrepancy is recorded, twin detection stays on.
+            force_duplicates: Create past exact unclaimed twins
+                (you adjudicated them as distinct charges).
             show_all: Dry-run only. Lines with MEDIUM/HIGH
                 candidates suppress their LOW amount-coincidences
                 (the cands column notes "+N LOW suppressed");
@@ -685,7 +692,8 @@ def register(mcp, get_book) -> None:
             row["date"] = d
         result = book.enter_statement(
             account, stmt_date, opening_balance, closing_balance,
-            parsed, dry_run=dry_run, force=force, show_all=show_all,
+            parsed, dry_run=dry_run, force_base=force_base,
+            force_duplicates=force_duplicates, show_all=show_all,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -515,9 +515,13 @@ def register(mcp, get_book) -> None:
           ``account=amount|...``; ``split_match``
           (exact/partial/none) compares them — MEDIUM on
           date+amount but ``none`` on category is usually a
-          distinct purchase. ``amt_delta`` is blank on
-          cross-currency candidates (see ``cur``). Never re-read
-          your own input — both sides are in the row.
+          distinct purchase. Amounts are SIGNED (direction
+          matters: a deposit is not a payment's twin).
+          ``amt_delta`` is blank on cross-currency candidates
+          (``cur`` names the candidate's currency exactly when
+          the frames differ); ``memo_old`` and ``state`` blanks
+          mean this surface can't fill them. Never re-read your
+          own input — both sides are in the row.
           Σ(dup_count) equals the duplicates row count.
         - Dry runs additionally lead with ``summary`` (would-create/
           review-required/rejected counts + the homework line)
@@ -606,6 +610,11 @@ def register(mcp, get_book) -> None:
         - A commit row with no counter-splits auto-fills from the
           most recent same-description 2-split transaction, adapted
           to the line amount (marked ``auto_filled_from:<guid>``).
+          The precedent must have exactly one leg on the statement
+          account and no cross-commodity leg — anything else
+          rejects with "supply explicit counter-splits". Explicit
+          counter-splits must not name the statement account (its
+          leg is synthesized).
 
         SAFETY: the account's reconciled balance must tie to
         ``opening_balance`` (a prior unentered statement blocks
@@ -616,19 +625,30 @@ def register(mcp, get_book) -> None:
         bypasses the statement's own self-check.
 
         OUTPUT (dry-run): ``summary`` (class counts), ``lines``
-        (ref, class, cands, note), ``candidates`` — SELF-CONTAINED
-        comparison rows sorted strongest-correspondence first
-        (``ref, candidate_guid, confidence, state, date_new/old +
-        delta, amt_new/old + delta, desc_new/old, notes_old,
-        memo_old, cat_new/old, split_match, signals``; ``_new`` =
-        the statement line in book convention, ``_old`` = the
-        existing split — never re-read your own input), plus
-        ``warnings`` and ``tie`` — the projected reconciled balance
-        vs the closing. The tie is the only verdict;
+        (ref, class, cands, note — the note is the resolved
+        disposition: the guard's refusal coaching verbatim, the
+        auto-fill prediction, or "will claim …"), ``candidates`` —
+        SELF-CONTAINED comparison rows sorted
+        strongest-correspondence first (``ref, candidate_guid,
+        confidence, state, date_new/old + delta, amt_new/old +
+        delta, cur, desc_new/old, notes_old, memo_old, cat_new/old,
+        split_match, signals``; ``_new`` = the statement line in
+        book convention, ``_old`` = the existing split — never
+        re-read your own input; ``cur`` is structurally blank on
+        this surface), plus ``warnings`` (only when present;
+        ``candidates`` likewise) and ``tie`` — the projected
+        reconciled balance vs the closing, with a count of rows
+        this exact payload would refuse at commit. The dry-run
+        rehearses the SAME disposition procedure commit runs —
+        force included. The tie is the only verdict;
         MATCH/AMBIGUOUS rows are yours to rule.
-        OUTPUT (commit): ``results`` (ref, status
-        created|claimed|skipped_duplicate, guid), the new reconciled
-        balance, and the tie.
+        OUTPUT (commit): ``results`` (``ref, status, guid, note``;
+        status is created | claimed | skipped_duplicate, or on a
+        refused statement rejected | statement_aborted — the note
+        column carries the row's coaching and
+        ``auto_filled_from:<guid>`` markers), plus, on success
+        only, the new reconciled balance and the tie (a refusal
+        returns just ``summary`` + ``results``).
 
         Args:
             account: Statement account ref (path, %short, or GUID).

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -551,6 +551,7 @@ def register(mcp, get_book) -> None:
         lines: str,
         dry_run: bool = True,
         force: bool = False,
+        show_all: bool = False,
     ) -> str:
         """Enter a COMPLETE bank/card statement in one atomic call:
         create the new lines, claim the ones already in the book,
@@ -641,6 +642,10 @@ def register(mcp, get_book) -> None:
             force: Land despite an untied opening base / closing
                 discrepancy, and create past exact unclaimed
                 overlaps.
+            show_all: Dry-run only. Lines with MEDIUM/HIGH
+                candidates suppress their LOW amount-coincidences
+                (the cands column notes "+N LOW suppressed");
+                show_all=true lists everything.
         """
         book = get_book()
         stmt_date = _parse_iso_date(statement_date)
@@ -660,7 +665,7 @@ def register(mcp, get_book) -> None:
             row["date"] = d
         result = book.enter_statement(
             account, stmt_date, opening_balance, closing_balance,
-            parsed, dry_run=dry_run, force=force,
+            parsed, dry_run=dry_run, force=force, show_all=show_all,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -495,19 +495,33 @@ def register(mcp, get_book) -> None:
         OUTPUT — a JSON envelope of two TSV tables joined by ``ref``:
         - ``results`` (always): ``ref, status, txn_guid, dup_count,
           max_confidence, reason``. status is ``created`` |
-          ``rejected`` | ``would_create`` (dry_run); reason is a
-          code like ``duplicate_detected`` or the validation
-          message. ``max_confidence`` (HIGH/MEDIUM/blank) is the
-          row's top duplicate candidate — enough for the common
-          keep/drop call without the join.
-        - ``duplicates`` (only when matches exist): ``ref, confidence,
-          guid, date, amount, description, signals`` — the columns
-          ``create_transaction`` emits, keyed back to the offending
-          ``ref``. Σ(dup_count) equals the duplicates row count.
+          ``rejected`` | ``would_create`` (dry_run, candidate-free
+          rows only) | ``review_required`` (dry_run rows with >=1
+          duplicate candidate — rule each against the duplicates
+          table before committing); reason is a code like
+          ``duplicate_detected`` or the validation message.
+          ``max_confidence`` (HIGH/MEDIUM/blank) is the row's top
+          duplicate candidate — enough for the common keep/drop
+          call without the join.
+        - ``duplicates`` (only when matches exist): SELF-CONTAINED
+          comparison rows, sorted strongest-correspondence first —
+          ``ref, candidate_guid, confidence, state, date_new,
+          date_old, date_delta_days, amt_new, amt_old, amt_delta,
+          cur, desc_new, desc_old, notes_old, memo_old, cat_new,
+          cat_old, split_match, signals``. ``_new`` = your proposed
+          row, ``_old`` = the existing transaction; ``cat_*`` are
+          the category (non-payment) legs as
+          ``account=amount|...``; ``split_match``
+          (exact/partial/none) compares them — MEDIUM on
+          date+amount but ``none`` on category is usually a
+          distinct purchase. ``amt_delta`` is blank on
+          cross-currency candidates (see ``cur``). Never re-read
+          your own input — both sides are in the row.
+          Σ(dup_count) equals the duplicates row count.
         - Dry runs additionally lead with ``summary`` (would-create/
-          rejected counts + which rows have candidates to review)
+          review-required/rejected counts + the homework line)
           and close with ``effects`` — the projected per-account
-          balance deltas of the would-create rows.
+          balance deltas of the rows that would land.
 
         Args:
             transactions: The TSV block described above.
@@ -599,12 +613,18 @@ def register(mcp, get_book) -> None:
         bypasses the statement's own self-check.
 
         OUTPUT (dry-run): ``summary`` (class counts), ``lines``
-        (ref, class, cands, note), ``candidates`` (per-candidate
-        annotation, FK ref), ``warnings``, and ``tie`` — the
-        projected reconciled balance vs the closing. The tie is the
-        only verdict; MATCH/AMBIGUOUS rows are yours to rule.
+        (ref, class, cands, note), ``candidates`` — SELF-CONTAINED
+        comparison rows sorted strongest-correspondence first
+        (``ref, candidate_guid, confidence, state, date_new/old +
+        delta, amt_new/old + delta, desc_new/old, notes_old,
+        memo_old, cat_new/old, split_match, signals``; ``_new`` =
+        the statement line in book convention, ``_old`` = the
+        existing split — never re-read your own input), plus
+        ``warnings`` and ``tie`` — the projected reconciled balance
+        vs the closing. The tie is the only verdict;
+        MATCH/AMBIGUOUS rows are yours to rule.
         OUTPUT (commit): ``results`` (ref, status
-        created|claimed|skipped_overlap, guid), the new reconciled
+        created|claimed|skipped_duplicate, guid), the new reconciled
         balance, and the tie.
 
         Args:

--- a/src/gnucash_mcp/tools/investments.py
+++ b/src/gnucash_mcp/tools/investments.py
@@ -22,7 +22,7 @@ def _parse_prices_tsv(tsv: str) -> list[dict]:
     cells take defaults. Dates parse here — the book layer works in
     ``datetime.date``.
     """
-    lines = [ln for ln in tsv.splitlines() if ln.strip()]
+    lines = _tsv_lines(tsv, "the prices TSV")
     if len(lines) < 2:
         raise ValueError(
             "prices TSV needs a header row and at least one data row"
@@ -77,6 +77,7 @@ def _parse_prices_tsv(tsv: str) -> list[dict]:
         out.append(entry)
     return out
 
+from gnucash_mcp._format import _tsv_lines
 from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     LotGuid,

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -576,7 +576,8 @@ class TestBatchDryRunUpgrades:
             dry_run=True,
         )
         assert "Dry run: 2 rows — " in env["summary"]
-        assert "1 would create, 1 rejected" in env["summary"]
+        assert "1 would create, 0 review_required, 1 rejected" in \
+            env["summary"]
         assert "duplicate candidates" in env["summary"]
         # The clearance principle: no verdict vocabulary.
         assert "safe" not in env["summary"].lower()
@@ -633,6 +634,61 @@ class TestBatchDryRunUpgrades:
         env = gc.create_transactions([_txn(1, "A", "10.00")])
         assert "summary" not in env
         assert "effects" not in env
+
+    def test_review_required_status(self, test_book):
+        """Ruling 8: a non-blocking (MEDIUM) candidate turns
+        would_create into review_required — a projected-action
+        label must not masquerade as clearance."""
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        # Same description + date, amount off by > $1: desc+date
+        # MEDIUM, non-blocking.
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1700", d=date(2026, 5, 21))],
+            dry_run=True,
+        )
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "review_required"
+        assert rows[0]["max_confidence"] == "MEDIUM"
+        assert "1 rows are review_required" in env["summary"]
+
+    def test_duplicates_table_is_self_contained(self, test_book):
+        """Ruling 9: the candidate row carries proposed + existing
+        values, deltas, category legs, and a split_match verdict —
+        no join back to the caller's input."""
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1700", d=date(2026, 5, 21))],
+            dry_run=True,
+        )
+        lines = env["duplicates"].splitlines()
+        row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
+        assert row["desc_new"] == "Rent"
+        assert row["desc_old"] == "Rent"
+        assert row["date_delta_days"] == "-1"
+        assert row["amt_new"] == "1700"
+        assert row["amt_old"] == "1800"
+        assert row["amt_delta"] == "100"
+        assert row["cat_new"] == "Expenses:Groceries=1700"
+        assert row["cat_old"] == "Expenses:Groceries=1800"
+        assert row["split_match"] == "partial"
+
+    def test_split_match_none_on_distinct_categories(
+        self, test_book
+    ):
+        """The Chewy/fuel case: MEDIUM on date+amount, decisively
+        distinct on category."""
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1799.50", d=date(2026, 5, 21),
+                  acct_to="Income:Salary")],
+            dry_run=True,
+        )
+        lines = env["duplicates"].splitlines()
+        row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
+        assert row["split_match"] == "none"
 
 
 class TestBatchCurColumn:

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -678,6 +678,29 @@ class TestBatchDryRunUpgrades:
         # state of the candidate transaction.
         assert row["state"] == "n"
 
+    def test_reconciled_candidate_shows_state_y(self, test_book):
+        """The bookkeeper's fourth verification probe: a reconciled
+        duplicate candidate reads y — entered AND tied, decisive."""
+        import piecash as pc
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        b = pc.open_book(str(test_book), readonly=False,
+                         do_backup=False)
+        for txn in b.transactions:
+            if txn.description == "Rent":
+                for s in txn.splits:
+                    if s.account.name == "Checking":
+                        s.reconcile_state = "y"
+        b.save()
+        b.close()
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1800", d=date(2026, 5, 20))],
+            dry_run=True,
+        )
+        lines = env["duplicates"].splitlines()
+        row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
+        assert row["state"] == "y"
+
     def test_split_match_none_on_distinct_categories(
         self, test_book
     ):

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -561,6 +561,80 @@ class TestBatchCreate:
             gc.create_transactions([_txn(1, "x", "1")], on_error="bad")
 
 
+class TestBatchDryRunUpgrades:
+    """Ruling 7 (statement spec §9): the batch dry-run inherits the
+    rehearsal surface — summary header (counts + homework, never a
+    clearance), max_confidence results column, per-account effects
+    footer."""
+
+    def test_summary_counts_and_homework(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1800", d=date(2026, 5, 20)),
+             _txn(2, "Fresh Thing", "10.00")],
+            dry_run=True,
+        )
+        assert "Dry run: 2 rows — " in env["summary"]
+        assert "1 would create, 1 rejected" in env["summary"]
+        assert "duplicate candidates" in env["summary"]
+        # The clearance principle: no verdict vocabulary.
+        assert "safe" not in env["summary"].lower()
+        assert "blocking" not in env["summary"].lower()
+
+    def test_summary_verified_empty(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions(
+            [_txn(1, "Fresh Thing", "10.00")], dry_run=True,
+        )
+        assert "No duplicate candidates." in env["summary"]
+
+    def test_max_confidence_column(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1800", d=date(2026, 5, 20)),
+             _txn(2, "Fresh Thing", "10.00")],
+            dry_run=True,
+        )
+        rows = {r["ref"]: r for r in _parse(env["results"])}
+        assert rows["1"]["max_confidence"] == "HIGH"
+        assert rows["2"]["max_confidence"] == ""
+
+    def test_max_confidence_on_commit_rows_too(self, test_book):
+        """One results shape across modes — the column isn't
+        dry-run-only."""
+        gc = GnuCashBook(str(test_book))
+        _seed_rent(gc)
+        env = gc.create_transactions(
+            [_txn(1, "Rent", "1800", d=date(2026, 5, 20))],
+            force=True,
+        )
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "created"
+        assert rows[0]["max_confidence"] == "HIGH"
+
+    def test_effects_footer(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions(
+            [_txn(1, "A", "10.00"), _txn(2, "B", "5.50")],
+            dry_run=True,
+        )
+        effects = {
+            f[0]: f[1] for f in
+            (ln.split("\t") for ln in
+             env["effects"].splitlines()[1:])
+        }
+        assert effects["Assets:Checking"] == "-15.50"
+        assert effects["Expenses:Groceries"] == "15.50"
+
+    def test_commit_has_no_summary_or_effects(self, test_book):
+        gc = GnuCashBook(str(test_book))
+        env = gc.create_transactions([_txn(1, "A", "10.00")])
+        assert "summary" not in env
+        assert "effects" not in env
+
+
 class TestBatchCurColumn:
     """The ``cur`` column sets a ROW's transaction currency.
 

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -667,9 +667,11 @@ class TestBatchDryRunUpgrades:
         assert row["desc_new"] == "Rent"
         assert row["desc_old"] == "Rent"
         assert row["date_delta_days"] == "-1"
-        assert row["amt_new"] == "-1700"
-        assert row["amt_old"] == "-1800"
-        assert row["amt_delta"] == "-100"
+        # Amounts anchor to the SIGNED CATEGORY primary (R3 P5):
+        # the expense leg, +1700 vs +1800.
+        assert row["amt_new"] == "1700"
+        assert row["amt_old"] == "1800"
+        assert row["amt_delta"] == "100"
         assert row["cat_new"] == "Expenses:Groceries=1700"
         assert row["cat_old"] == "Expenses:Groceries=1800"
         assert row["split_match"] == "partial"
@@ -706,6 +708,82 @@ class TestBatchDryRunUpgrades:
         row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
         assert row["cur"] == "EUR"
         assert row["amt_delta"] == ""
+
+    def test_refund_is_not_the_payments_twin(self, test_book):
+        """R3 P5 (blocker-class): signed amounts must live in the
+        SCORER, not just the display. A +104 refund was HIGH-
+        blocked as a duplicate of the -104 payment, with
+        split_match 'exact' on inverted legs. The direction anchor
+        is the signed CATEGORY primary — a balanced transaction
+        always carries both signs, so the funding leg can't carry
+        the signal."""
+        gc = GnuCashBook(str(test_book))
+        gc.create_transaction(
+            description="Amazon",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-104.00"},
+                {"account": "Expenses:Groceries",
+                 "amount": "104.00"},
+            ],
+            trans_date=date(2026, 5, 20),
+        )
+        env = gc.create_transactions(
+            [{
+                "ref": "1", "date": date(2026, 5, 21),
+                "description": "Amazon Refund",
+                "splits": [
+                    {"account": "Assets:Checking",
+                     "amount": "104.00"},
+                    {"account": "Expenses:Groceries",
+                     "amount": "-104.00"},
+                ],
+            }],
+            dry_run=True,
+        )
+        rows = _parse(env["results"])
+        # Surfaced for review (desc+date), never HIGH-blocked.
+        assert rows[0]["status"] == "review_required"
+        assert rows[0]["max_confidence"] == "MEDIUM"
+        lines = env["duplicates"].splitlines()
+        row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
+        assert "A" not in row["signals"]
+        assert Decimal(row["amt_new"]) == Decimal("-104")
+        assert Decimal(row["amt_old"]) == Decimal("104")
+        assert Decimal(row["amt_delta"]) == Decimal("208")
+        assert row["split_match"] == "partial"
+
+    def test_transfer_duplicates_still_match_on_magnitude(
+        self, test_book
+    ):
+        """The fallback: transfer-shaped rows (no category leg)
+        keep magnitude comparison, so a true transfer duplicate
+        still blocks."""
+        gc = GnuCashBook(str(test_book))
+        gc.create_transaction(
+            description="Card Payment",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-500.00"},
+                {"account": "Equity:Opening Balance",
+                 "amount": "500.00"},
+            ],
+            trans_date=date(2026, 5, 20),
+        )
+        env = gc.create_transactions(
+            [{
+                "ref": "1", "date": date(2026, 5, 20),
+                "description": "Card Payment",
+                "splits": [
+                    {"account": "Assets:Checking",
+                     "amount": "-500.00"},
+                    {"account": "Equity:Opening Balance",
+                     "amount": "500.00"},
+                ],
+            }],
+            dry_run=True,
+        )
+        rows = _parse(env["results"])
+        assert rows[0]["status"] == "rejected"
+        assert rows[0]["max_confidence"] == "HIGH"
 
     def test_reconciled_candidate_shows_state_y(self, test_book):
         """The bookkeeper's fourth verification probe: a reconciled

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -576,7 +576,7 @@ class TestBatchDryRunUpgrades:
             dry_run=True,
         )
         assert "Dry run: 2 rows — " in env["summary"]
-        assert "1 would create, 0 review_required, 1 rejected" in \
+        assert "1 would_create, 0 review_required, 1 rejected" in \
             env["summary"]
         assert "duplicate candidates" in env["summary"]
         # The clearance principle: no verdict vocabulary.
@@ -667,9 +667,9 @@ class TestBatchDryRunUpgrades:
         assert row["desc_new"] == "Rent"
         assert row["desc_old"] == "Rent"
         assert row["date_delta_days"] == "-1"
-        assert row["amt_new"] == "1700"
-        assert row["amt_old"] == "1800"
-        assert row["amt_delta"] == "100"
+        assert row["amt_new"] == "-1700"
+        assert row["amt_old"] == "-1800"
+        assert row["amt_delta"] == "-100"
         assert row["cat_new"] == "Expenses:Groceries=1700"
         assert row["cat_old"] == "Expenses:Groceries=1800"
         assert row["split_match"] == "partial"
@@ -677,6 +677,35 @@ class TestBatchDryRunUpgrades:
         # populated on the batch surface too — most-anchored split
         # state of the candidate transaction.
         assert row["state"] == "n"
+
+    def test_cross_frame_blanks_delta_and_names_currency(
+        self, multi_currency_book
+    ):
+        """Round-two renderer finding: comparability is
+        candidate-vs-PROPOSAL currency. A default-currency proposal
+        against an EUR candidate must blank amt_delta and name EUR
+        in cur — 100 EUR vs 100 USD is not a twin."""
+        gc = GnuCashBook(str(multi_currency_book))
+        gc.create_transaction(
+            description="Consulting Invoice",
+            currency="EUR",
+            splits=[
+                {"account": "Assets:Euro Savings",
+                 "amount": "-100.00"},
+                {"account": "Expenses:Groceries",
+                 "amount": "100.00", "quantity": "108.00"},
+            ],
+            trans_date=date(2026, 5, 21),
+            check_duplicates=False,
+        )
+        env = gc.create_transactions(
+            [_txn(1, "Consulting Invoice", "100.00")],
+            dry_run=True,
+        )
+        lines = env["duplicates"].splitlines()
+        row = dict(zip(lines[0].split("\t"), lines[1].split("\t")))
+        assert row["cur"] == "EUR"
+        assert row["amt_delta"] == ""
 
     def test_reconciled_candidate_shows_state_y(self, test_book):
         """The bookkeeper's fourth verification probe: a reconciled

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -673,6 +673,10 @@ class TestBatchDryRunUpgrades:
         assert row["cat_new"] == "Expenses:Groceries=1700"
         assert row["cat_old"] == "Expenses:Groceries=1800"
         assert row["split_match"] == "partial"
+        # T7 (statement round): the shared table's state column is
+        # populated on the batch surface too — most-anchored split
+        # state of the candidate transaction.
+        assert row["state"] == "n"
 
     def test_split_match_none_on_distinct_categories(
         self, test_book

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,22 +84,23 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_group_resolves_to_32_tools(self):
-        """The ``core`` group expands to 32 tools across its nine
-        sub-modules (summary 1 + accounts 7 + transactions 11 + slots
+        """The ``core`` group expands to 33 tools across its nine
+        sub-modules (summary 1 + accounts 7 + transactions 12 + slots
         3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
         reconciliation 4). Reconciliation joined core in v1.3.1
         per the bookkeeper-driven principle that any configuration
         which handles money must include reconciliation.
         """
-        assert len(_core_tool_names()) == 32
+        assert len(_core_tool_names()) == 33
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 110 —
+        """Total tools across all sub-modules should be 111 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
-        1 get_job_report + 5 taxtable CRUD tools added in v1.3."""
+        1 get_job_report + 5 taxtable CRUD tools added in v1.3 +
+        1 enter_statement added in v1.4.4."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 110
+        assert total == 111
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -263,9 +264,9 @@ class TestApplyModuleFilter:
         return set(mcp._tool_manager._tools.keys())
 
     def test_all_keeps_everything(self):
-        """--modules=all should keep all 108 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables + 1 batch prices)."""
+        """--modules=all should keep all 111 tools (88 + 3 vouchers + 4 credit notes + 5 job CRUD + 1 job report + 5 taxtables + 1 batch prices)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 110
+        assert len(self._tool_names()) == 111
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -297,12 +298,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 110
+        assert len(self._tool_names()) == 111
 
     def test_all_in_list_keeps_everything(self):
-        """'all' mixed with other modules should keep all 108 tools."""
+        """'all' mixed with other modules should keep all 111 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 110
+        assert len(self._tool_names()) == 111
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.
@@ -1122,17 +1123,17 @@ class TestMultiBook:
         alex, _ = two_books
         srv._book_paths = [alex.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 110
+        assert len(mcp._tool_manager._tools) == 111
 
     def test_tool_count_multi_book(self, two_books):
-        """The lone runtime delta from single-book: switch_book (109).
+        """The lone runtime delta from single-book: switch_book (112).
         Each filter call relies on switch_book being registered at
         import; the production flow filters once at startup."""
         import gnucash_mcp.server as srv
         alex, beast = two_books
         srv._book_paths = [alex.resolve(), beast.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 111
+        assert len(mcp._tool_manager._tools) == 112
 
     # ── switch_book matching ───────────────────────────────────────
 

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -353,6 +353,13 @@ class TestStatementDryRun:
         assert cand["amt_old"] == "-800"
         assert cand["amt_delta"] == "0.00"
         assert cand["cat_old"] == "Expenses:Rent=800"
+        # Line 1 carries raw only and has no auto-fill precedent,
+        # so its proposal side is unknown — split_match blank.
+        assert cand["split_match"] == ""
+        # Line 3 auto-fills, so its comparison is complete — and
+        # Decimal-normalized: "5.50" vs "5.5" is the SAME leg.
+        cand3 = _cands(_dry(gc))["3"][0]
+        assert cand3["split_match"] == "exact"
 
     def test_amount_only_candidate_surfaces(self, statement_book):
         """Ruling 1's rent case: a line 31 days from a same-amount

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -972,6 +972,46 @@ class TestPlanRoundFindings:
         row = res["lines"].splitlines()[1].split("\t")
         assert row[2] == "1"
 
+    def test_twin_guard_precedes_countersplit_validation(
+        self, statement_book
+    ):
+        """Signoff carried item: a bare raw line (the stranger's
+        natural shape) whose exact twin exists gets the claim
+        coaching — NOT an auto-fill complaint about a row that
+        shouldn't be created at all."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            # raw-only: no description, no splits, no auto-fill
+            # precedent ("ACH RENT" matches no book description).
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT")],
+            dry_run=False,
+        )
+        rejected = res["results"].splitlines()[1]
+        assert "claim it with match=" in rejected
+        assert "auto-fill" not in rejected
+
+    def test_evidence_only_homework_phrasing(self, statement_book):
+        """Signoff copy quibble: the verified-empty line must not
+        contradict visible evidence rows — it counts claimable
+        candidates, and says what the listed rows are."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 8, 1), "-800.00",
+                   description="July Rent",
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert _classes(res)["1"] == "NEW"
+        assert len(_cands(res)["1"]) == 1
+        assert "evidence only" in res["summary"]
+        assert "No existing-split candidates" not in res["summary"]
+
     def test_commit_rejection_coaching_is_inline(
         self, statement_book
     ):

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -162,8 +162,8 @@ def _commit(gc, statement_book, **kw):
     """Run the standard dry-run → claim → commit flow."""
     res = _dry(gc)
     cands = _cands(res)
-    rent_guid = cands["1"][0]["split_guid"]
-    coffee_guid = cands["3"][0]["split_guid"]
+    rent_guid = cands["1"][0]["candidate_guid"]
+    coffee_guid = cands["3"][0]["candidate_guid"]
     return gc.enter_statement(
         "Assets:Checking", date(2026, 7, 31), _OPEN, _CLOSE,
         _checking_lines(rent_guid, coffee_guid),
@@ -331,19 +331,28 @@ class TestStatementDryRun:
         assert "2 rows need adjudication" in res["summary"]
 
     def test_match_carries_full_annotation(self, statement_book):
-        """Ruling: the MATCH row ships the evidence — description,
-        notes, memo, post date, short GUID — so the judgment pass
-        can adapt annotations the server can't infer."""
+        """Rulings 2 + 9: the MATCH row is a self-contained
+        comparison — the candidate's complete annotation AND the
+        proposed side with deltas, so the judgment pass never joins
+        back to its own input."""
         gc = GnuCashBook(str(statement_book))
         cand = _cands(_dry(gc))["1"][0]
-        assert cand["description"] == "July Rent"
-        assert cand["notes"] == "rent note"
-        assert cand["date"] == "2026-07-01"
+        assert cand["desc_old"] == "July Rent"
+        assert cand["notes_old"] == "rent note"
+        assert cand["date_old"] == "2026-07-01"
         assert cand["state"] == "n"
         # The probe is the raw cell ("ACH RENT PAYMENT"), which does
         # NOT desc-match "July Rent" — amount + date carry it.
         assert cand["signals"] == "-AD"
-        assert len(cand["split_guid"]) >= 8
+        assert len(cand["candidate_guid"]) >= 8
+        # Proposed side + computed deltas (ruling 9).
+        assert cand["desc_new"] == "ACH RENT PAYMENT"
+        assert cand["date_new"] == "2026-07-01"
+        assert cand["date_delta_days"] == "0"
+        assert cand["amt_new"] == "-800.00"
+        assert cand["amt_old"] == "-800"
+        assert cand["amt_delta"] == "0.00"
+        assert cand["cat_old"] == "Expenses:Rent=800"
 
     def test_amount_only_candidate_surfaces(self, statement_book):
         """Ruling 1's rent case: a line 31 days from a same-amount
@@ -357,8 +366,10 @@ class TestStatementDryRun:
             dry_run=True,
         )
         cand = _cands(res)["1"][0]
-        assert cand["description"] == "July Rent"
+        assert cand["desc_old"] == "July Rent"
         assert cand["signals"] == "-A-"
+        assert cand["confidence"] == "LOW"
+        assert cand["date_delta_days"] == "-31"
 
     def test_prediction_note_for_new(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -405,8 +416,10 @@ class TestStatementCommit:
         gc = GnuCashBook(str(statement_book))
         res = _commit(gc, statement_book)
         assert "2 created, 2 claimed, 0 skipped" in res["summary"]
+        assert "Assets:Checking through 2026-07-31" in res["summary"]
         assert res["new_reconciled_balance"] == "2107.38"
-        assert "ties" in res["tie"]
+        assert "Reconciled: 4 splits @ 2026-07-31" in res["tie"]
+        assert "tied." in res["tie"]
         statuses = {
             f[0]: f[1] for f in
             (ln.split("\t") for ln in
@@ -454,7 +467,7 @@ class TestStatementCommit:
     def test_claim_amount_mismatch_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
         cands = _cands(_dry(gc))
-        rent_guid = cands["1"][0]["split_guid"]
+        rent_guid = cands["1"][0]["candidate_guid"]
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
             "1000.00", "200.50",
@@ -467,7 +480,7 @@ class TestStatementCommit:
 
     def test_match_row_with_splits_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
-        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        rent_guid = _cands(_dry(gc))["1"][0]["candidate_guid"]
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
             "1000.00", "200.00",
@@ -481,7 +494,7 @@ class TestStatementCommit:
 
     def test_double_claim_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
-        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        rent_guid = _cands(_dry(gc))["1"][0]["candidate_guid"]
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
             "1000.00", "-600.00",
@@ -578,7 +591,7 @@ class TestStatementCommit:
                    raw="ACH RENT", match=guid)],
             dry_run=False, force=True,
         )
-        assert "skipped_overlap" in res["results"]
+        assert "skipped_duplicate" in res["results"]
         assert "1 skipped" in res["summary"]
 
     def test_multi_split_precedent_rejects_autofill(
@@ -753,7 +766,7 @@ class TestStatementReviewFindings:
 
     def test_dry_run_detects_double_claim(self, statement_book):
         gc = GnuCashBook(str(statement_book))
-        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        rent_guid = _cands(_dry(gc))["1"][0]["candidate_guid"]
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
             "1000.00", "-600.00",
@@ -797,7 +810,8 @@ class TestStatementSignTransform:
         )
         assert "1 created" in res["summary"]
         assert res["new_reconciled_balance"] == "-42.00"
-        assert "ties" in res["tie"]
+        assert "USD -42.00" in res["tie"]
+        assert "tied." in res["tie"]
         assert gc.get_balance("Visa") == Decimal("-42")
 
     def test_payment_line_on_card(self, statement_book):
@@ -833,7 +847,7 @@ class TestStatementRoundTrip:
         """The dry-run candidates table's split_guid short form is
         valid match input — output hands look like input hands."""
         gc = GnuCashBook(str(statement_book))
-        guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        guid = _cands(_dry(gc))["1"][0]["candidate_guid"]
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
             "1000.00", "200.00",

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -1,0 +1,754 @@
+"""Behavior tests for one-shot statement entry (enter_statement).
+
+Spec: specs/v1.5/ENTER_STATEMENT_SPEC.md. Grammar tests exercise the
+statement TSV dialect; the rest exercise the book method directly
+(the tool wrapper + audit formatter get their own classes at the
+bottom, same division as batch entry).
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import piecash
+import pytest
+
+from gnucash_mcp._format import (
+    _parse_statement_tsv,
+    _statement_tsv_layout,
+)
+from gnucash_mcp.book import GnuCashBook
+
+
+# ── Fixture ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def statement_book(tmp_path):
+    """A book shaped for statement scenarios: a reconciled opening
+    anchor (+1000 checking), one unreconciled rent txn (MATCH bait),
+    one auto-fill precedent (Whole Foods), identical twin coffees
+    (AMBIGUOUS bait), and a credit card. Returns the path."""
+    book_path = tmp_path / "stmt.gnucash"
+    b = piecash.create_book(
+        str(book_path), currency="USD", overwrite=True
+    )
+    usd = b.default_currency
+    root = b.root_account
+    assets = piecash.Account(
+        name="Assets", type="ASSET", commodity=usd, parent=root,
+        placeholder=True,
+    )
+    checking = piecash.Account(
+        name="Checking", type="BANK", commodity=usd, parent=assets
+    )
+    piecash.Account(
+        name="Visa", type="CREDIT", commodity=usd, parent=root
+    )
+    exp = piecash.Account(
+        name="Expenses", type="EXPENSE", commodity=usd, parent=root,
+        placeholder=True,
+    )
+    groceries = piecash.Account(
+        name="Groceries", type="EXPENSE", commodity=usd, parent=exp
+    )
+    rent = piecash.Account(
+        name="Rent", type="EXPENSE", commodity=usd, parent=exp
+    )
+    income = piecash.Account(
+        name="Income", type="INCOME", commodity=usd, parent=root
+    )
+
+    def txn(dt, desc, legs, notes=None):
+        return piecash.Transaction(
+            currency=usd, description=desc, post_date=dt,
+            notes=notes,
+            splits=[
+                piecash.Split(
+                    account=a, value=Decimal(v), memo=m or ""
+                )
+                for a, v, m in legs
+            ],
+        )
+
+    anchor = txn(
+        date(2026, 6, 1), "Opening",
+        [(checking, "1000", None), (income, "-1000", None)],
+    )
+    txn(
+        date(2026, 7, 1), "July Rent",
+        [(checking, "-800", None), (rent, "800", "july rent")],
+        notes="rent note",
+    )
+    txn(
+        date(2026, 6, 20), "Whole Foods",
+        [(checking, "-60.00", None), (groceries, "60.00", "wk")],
+    )
+    txn(
+        date(2026, 7, 10), "Blue Bottle",
+        [(checking, "-5.50", None), (groceries, "5.50", None)],
+    )
+    txn(
+        date(2026, 7, 10), "Blue Bottle",
+        [(checking, "-5.50", None), (groceries, "5.50", None)],
+    )
+    b.save()
+    for s in anchor.splits:
+        if s.account == checking:
+            s.reconcile_state = "y"
+    b.save()
+    b.close()
+    return book_path
+
+
+def _line(ref, d, amount, **kw):
+    row = {"ref": str(ref), "date": d, "amount": amount,
+           "splits": kw.pop("splits", [])}
+    row.update(kw)
+    return row
+
+
+# The checking statement every commit-path test lands: rent claimed,
+# groceries auto-filled, one coffee claimed, paycheck explicit.
+_OPEN, _CLOSE = "1000.00", "2107.38"
+
+
+def _checking_lines(rent_guid=None, coffee_guid=None):
+    return [
+        _line("1", date(2026, 7, 1), "-800.00",
+              raw="ACH RENT PAYMENT", match=rent_guid),
+        _line("2", date(2026, 7, 3), "-87.12",
+              description="Whole Foods", raw="POS WHOLEFDS 123",
+              notes="groceries"),
+        _line("3", date(2026, 7, 10), "-5.50",
+              description="Blue Bottle", raw="BLUE BOTTLE OAK",
+              match=coffee_guid),
+        _line("4", date(2026, 7, 15), "2000.00",
+              description="Paycheck", raw="DIRECT DEP ACME",
+              splits=[{"account": "Income", "amount": "-2000.00"}]),
+    ]
+
+
+def _dry(gc, lines=None, **kw):
+    return gc.enter_statement(
+        "Assets:Checking", date(2026, 7, 31), _OPEN, _CLOSE,
+        lines if lines is not None else _checking_lines(),
+        dry_run=True, **kw,
+    )
+
+
+def _cands(res) -> dict[str, list[dict]]:
+    """candidates TSV → {ref: [row dicts]}."""
+    out: dict[str, list[dict]] = {}
+    lines = res["candidates"].splitlines()
+    if not lines:
+        return out
+    header = lines[0].split("\t")
+    for ln in lines[1:]:
+        row = dict(zip(header, ln.split("\t")))
+        out.setdefault(row["ref"], []).append(row)
+    return out
+
+
+def _classes(res) -> dict[str, str]:
+    """lines TSV → {ref: class}."""
+    out = {}
+    for ln in res["lines"].splitlines()[1:]:
+        f = ln.split("\t")
+        out[f[0]] = f[1]
+    return out
+
+
+def _commit(gc, statement_book, **kw):
+    """Run the standard dry-run → claim → commit flow."""
+    res = _dry(gc)
+    cands = _cands(res)
+    rent_guid = cands["1"][0]["split_guid"]
+    coffee_guid = cands["3"][0]["split_guid"]
+    return gc.enter_statement(
+        "Assets:Checking", date(2026, 7, 31), _OPEN, _CLOSE,
+        _checking_lines(rent_guid, coffee_guid),
+        dry_run=False, **kw,
+    )
+
+
+# ── Grammar ────────────────────────────────────────────────────────
+
+
+class TestStatementGrammar:
+    def test_minimal_dry_run_header(self):
+        rows = _parse_statement_tsv(
+            "ref\tdate\traw\tamount\n"
+            "1\t2026-07-03\tPOS WHOLEFDS\t-87.12"
+        )
+        assert rows == [{
+            "ref": "1", "date": "2026-07-03",
+            "raw": "POS WHOLEFDS", "amount": "-87.12", "splits": [],
+        }]
+
+    def test_full_header_any_order(self):
+        rows = _parse_statement_tsv(
+            "ref\tdate\tdescription\tnotes\traw\tmatch\tamount\t"
+            "amt\tacct\tmemo\n"
+            "1\t2026-07-03\tWhole Foods\tgroceries\tPOS 123\t\t"
+            "-87.12\t87.12\tExpenses:Groceries\tweekly"
+        )
+        assert rows[0]["description"] == "Whole Foods"
+        assert rows[0]["splits"] == [{
+            "amount": "87.12", "account": "Expenses:Groceries",
+            "memo": "weekly",
+        }]
+
+    def test_fixed_amount_then_group_amt(self):
+        """The fixed section claims amount once; the second
+        amount-ish token starts the split groups."""
+        layout = _statement_tsv_layout(
+            "ref\tdate\traw\tamount\tamt\tacct"
+        )
+        assert layout["fixed_idx"]["amount"] == 3
+        assert layout["group"] == ("amount", "account")
+
+    def test_missing_amount_column_rejects(self):
+        with pytest.raises(ValueError, match="amount column"):
+            _parse_statement_tsv("ref\tdate\traw\n1\t2026-07-03\tX")
+
+    def test_missing_identity_column_rejects(self):
+        with pytest.raises(ValueError, match="description or raw"):
+            _parse_statement_tsv("ref\tdate\tamount\n1\t2026-07-01\t5")
+
+    def test_cur_stays_unknown(self):
+        """Foreign-currency statements are deferred — the token must
+        reject loudly, not half-parse."""
+        with pytest.raises(ValueError, match="'cur'"):
+            _parse_statement_tsv(
+                "ref\tdate\traw\tamount\tcur\n1\t2026-07-01\tX\t5\tUSD"
+            )
+
+    def test_missing_date_cell_rejects(self):
+        with pytest.raises(ValueError, match="missing date"):
+            _parse_statement_tsv(
+                "ref\tdate\traw\tamount\n1\t\tX\t5"
+            )
+
+    def test_missing_amount_cell_rejects(self):
+        with pytest.raises(ValueError, match="missing amount"):
+            _parse_statement_tsv(
+                "ref\tdate\traw\tamount\n1\t2026-07-01\tX\t"
+            )
+
+    def test_empty_ref_rejects(self):
+        with pytest.raises(ValueError, match="empty ref"):
+            _parse_statement_tsv(
+                "ref\tdate\traw\tamount\n\t2026-07-01\tX\t5"
+            )
+
+
+# ── Gates and preconditions ────────────────────────────────────────
+
+
+class TestStatementGates:
+    def test_self_check_gate(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="does not self-check"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "1000.00", "999.00",
+                [_line("1", date(2026, 7, 3), "-87.12", raw="X")],
+            )
+
+    def test_duplicate_refs_reject(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="duplicate ref"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "1000.00", "990.00",
+                [_line("1", date(2026, 7, 3), "-5.00", raw="X"),
+                 _line("1", date(2026, 7, 4), "-5.00", raw="Y")],
+            )
+
+    def test_non_statement_account_rejects(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="balance-carrying"):
+            gc.enter_statement(
+                "Expenses:Groceries", date(2026, 7, 31),
+                "0.00", "5.00",
+                [_line("1", date(2026, 7, 3), "5.00", raw="X")],
+            )
+
+    def test_foreign_commodity_account_rejects(self, tmp_path):
+        book_path = tmp_path / "fx.gnucash"
+        b = piecash.create_book(
+            str(book_path), currency="USD", overwrite=True
+        )
+        eur = piecash.factories.create_currency_from_ISO("EUR")
+        piecash.Account(
+            name="EUR Savings", type="BANK", commodity=eur,
+            parent=b.root_account,
+        )
+        b.save()
+        b.close()
+        gc = GnuCashBook(str(book_path))
+        with pytest.raises(ValueError, match="denominated in EUR"):
+            gc.enter_statement(
+                "EUR Savings", date(2026, 7, 31), "0.00", "5.00",
+                [_line("1", date(2026, 7, 3), "5.00", raw="X")],
+            )
+
+    def test_opening_gap_warns_in_dry_run(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "900.00", "2007.38", _checking_lines(), dry_run=True,
+        )
+        assert "does not tie to the statement's opening" in \
+            res["warnings"]
+
+    def test_opening_gap_blocks_commit(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="untied base"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "900.00", "2007.38",
+                [_line("4", date(2026, 7, 15), "1107.38",
+                       description="Paycheck",
+                       splits=[{"account": "Income",
+                                "amount": "-1107.38"}])],
+                dry_run=False,
+            )
+
+
+# ── Dry-run classification ─────────────────────────────────────────
+
+
+class TestStatementDryRun:
+    def test_classification(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        res = _dry(gc)
+        assert _classes(res) == {
+            "1": "MATCH", "2": "NEW", "3": "AMBIGUOUS", "4": "NEW",
+        }
+        assert "2 NEW, 1 MATCH, 0 OVERLAP, 1 AMBIGUOUS" in \
+            res["summary"]
+        assert "2 rows need adjudication" in res["summary"]
+
+    def test_match_carries_full_annotation(self, statement_book):
+        """Ruling: the MATCH row ships the evidence — description,
+        notes, memo, post date, short GUID — so the judgment pass
+        can adapt annotations the server can't infer."""
+        gc = GnuCashBook(str(statement_book))
+        cand = _cands(_dry(gc))["1"][0]
+        assert cand["description"] == "July Rent"
+        assert cand["notes"] == "rent note"
+        assert cand["date"] == "2026-07-01"
+        assert cand["state"] == "n"
+        # The probe is the raw cell ("ACH RENT PAYMENT"), which does
+        # NOT desc-match "July Rent" — amount + date carry it.
+        assert cand["signals"] == "-AD"
+        assert len(cand["split_guid"]) >= 8
+
+    def test_amount_only_candidate_surfaces(self, statement_book):
+        """Ruling 1's rent case: a line 31 days from a same-amount
+        split must surface even with no desc/date signal."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 8, 1), "-800.00",
+                   raw="ACH RENT AUG")],
+            dry_run=True,
+        )
+        cand = _cands(res)["1"][0]
+        assert cand["description"] == "July Rent"
+        assert cand["signals"] == "-A-"
+
+    def test_prediction_note_for_new(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        res = _dry(gc)
+        note = {
+            f[0]: f[3] for f in
+            (ln.split("\t") for ln in res["lines"].splitlines()[1:])
+        }["2"]
+        assert "would create -87.12 → Expenses:Groceries" in note
+        assert "auto_filled_from:" in note
+
+    def test_tie_footer_ties(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        assert "ties to the statement closing" in _dry(gc)["tie"]
+
+    def test_dry_run_writes_nothing(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        before = gc.get_balance("Assets:Checking")
+        _dry(gc)
+        assert gc.get_balance("Assets:Checking") == before
+
+    def test_dry_run_validates_explicit_splits(self, statement_book):
+        """Full rehearsal: a bad counter account surfaces in the
+        dry-run warnings, not at commit time."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "995.00",
+            [_line("1", date(2026, 7, 3), "-5.00", raw="X",
+                   description="Typo",
+                   splits=[{"account": "Expenses:Nope",
+                            "amount": "5.00"}])],
+            dry_run=True,
+        )
+        assert "1\t" in res["warnings"]
+        assert "Nope" in res["warnings"]
+
+
+# ── Commit ─────────────────────────────────────────────────────────
+
+
+class TestStatementCommit:
+    def test_full_landing(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        res = _commit(gc, statement_book)
+        assert "2 created, 2 claimed, 0 skipped" in res["summary"]
+        assert res["new_reconciled_balance"] == "2107.38"
+        assert "ties" in res["tie"]
+        statuses = {
+            f[0]: f[1] for f in
+            (ln.split("\t") for ln in
+             res["results"].splitlines()[1:])
+        }
+        assert statuses == {
+            "1": "claimed", "2": "created", "3": "claimed",
+            "4": "created",
+        }
+
+    def test_landing_reconciles_and_annotates(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        _commit(gc, statement_book)
+        with gc.open() as book:
+            checking = [
+                a for a in book.accounts if a.name == "Checking"
+            ][0]
+            rent_split = next(
+                s for s in checking.splits
+                if s.transaction.description == "July Rent"
+            )
+            # Claimed: reconciled, raw landed on the memo, notes
+            # updated... rent line carried raw but no notes.
+            assert rent_split.reconcile_state == "y"
+            assert rent_split.memo == "ACH RENT PAYMENT"
+            wf = next(
+                s for s in checking.splits
+                if s.transaction.description == "Whole Foods"
+                and s.transaction.post_date == date(2026, 7, 3)
+            )
+            # Created: bank leg reconciled, raw as memo, notes set,
+            # auto-filled counter on Groceries at the LINE amount.
+            assert wf.reconcile_state == "y"
+            assert wf.memo == "POS WHOLEFDS 123"
+            assert wf.transaction.notes == "groceries"
+            counter = next(
+                s for s in wf.transaction.splits if s is not wf
+            )
+            assert counter.account.fullname == "Expenses:Groceries"
+            assert counter.value == Decimal("87.12")
+            # Counter legs do NOT reconcile — only the statement
+            # account's own legs are on the statement.
+            assert counter.reconcile_state != "y"
+
+    def test_claim_amount_mismatch_rejects(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        cands = _cands(_dry(gc))
+        rent_guid = cands["1"][0]["split_guid"]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.50",
+            [_line("1", date(2026, 7, 1), "-799.50",
+                   raw="ACH RENT", match=rent_guid)],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "fix the book entry first" in res["warnings"]
+
+    def test_match_row_with_splits_rejects(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT", match=rent_guid,
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=False,
+        )
+        assert "cannot also carry counter-splits" in res["warnings"]
+
+    def test_double_claim_rejects(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "-600.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT", match=rent_guid),
+             _line("2", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT AGAIN", match=rent_guid)],
+            dry_run=False,
+        )
+        assert "already claimed by another row" in res["warnings"]
+
+    def test_duplicate_guard(self, statement_book):
+        """A created line exactly matching an unclaimed unreconciled
+        split rejects — the tie would hold while the book
+        double-entered. force overrides (judgment ruled NEW)."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   description="July Rent", raw="ACH RENT")],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "claim it with match=" in res["warnings"]
+
+    def test_tie_failure_refuses_wholesale(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        # Consistent statement (gate passes) whose base makes the
+        # tie impossible: force past the opening gap WITHOUT force
+        # on the tie is impossible — so instead: consistent lines,
+        # correct opening, but an OVERLAP-free skip that breaks the
+        # tie is unreachable by construction. The reachable case:
+        # forced landing onto an untied base records a discrepancy.
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "900.00", "1000.00",
+            [_line("1", date(2026, 7, 20), "100.00",
+                   description="Deposit",
+                   splits=[{"account": "Income",
+                            "amount": "-100.00"}])],
+            dry_run=False, force=True,
+        )
+        assert "DISCREPANCY" in res["tie"]
+        assert "under force" in res["tie"]
+
+    def test_atomicity_on_row_error(self, statement_book):
+        """One bad row → nothing written, good rows report
+        statement_aborted."""
+        gc = GnuCashBook(str(statement_book))
+        before = gc.get_balance("Assets:Checking")
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "1095.00",
+            [_line("1", date(2026, 7, 20), "100.00",
+                   description="Deposit",
+                   splits=[{"account": "Income",
+                            "amount": "-100.00"}]),
+             _line("2", date(2026, 7, 21), "-5.00",
+                   description="Bad",
+                   splits=[{"account": "Expenses:Nope",
+                            "amount": "5.00"}])],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        statuses = {
+            f[0]: f[1] for f in
+            (ln.split("\t") for ln in
+             res["results"].splitlines()[1:])
+        }
+        assert statuses == {
+            "1": "statement_aborted", "2": "rejected",
+        }
+        assert gc.get_balance("Assets:Checking") == before
+
+    def test_overlap_claim_is_noop(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        _commit(gc, statement_book)
+        # Re-land one already-reconciled line as a match row on the
+        # NEXT statement: skipped, tie unaffected.
+        with gc.open() as book:
+            checking = [
+                a for a in book.accounts if a.name == "Checking"
+            ][0]
+            rent_split = next(
+                s for s in checking.splits
+                if s.transaction.description == "July Rent"
+            )
+            guid = rent_split.guid
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "2907.38", "2107.38",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT", match=guid)],
+            dry_run=False, force=True,
+        )
+        assert "skipped_overlap" in res["results"]
+        assert "1 skipped" in res["summary"]
+
+    def test_multi_split_precedent_rejects_autofill(
+        self, statement_book
+    ):
+        gc = GnuCashBook(str(statement_book))
+        # Give "Payday" a 3-split precedent.
+        gc.create_transaction(
+            description="Payday",
+            splits=[
+                {"account": "Assets:Checking", "amount": "900.00"},
+                {"account": "Income", "amount": "-1000.00"},
+                {"account": "Expenses:Groceries",
+                 "amount": "100.00"},
+            ],
+            trans_date=date(2026, 6, 5),
+            check_duplicates=False,
+        )
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "1900.00",
+            [_line("1", date(2026, 7, 20), "900.00",
+                   description="Payday")],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "supply explicit counter-splits" in res["warnings"]
+
+
+# ── Sign transform (credit card) ───────────────────────────────────
+
+
+class TestStatementSignTransform:
+    def test_credit_card_statement_native(self, statement_book):
+        """Charges print positive, balances print as amount owed;
+        the server negates both. Zero mental sign-flips."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Visa", date(2026, 7, 31), "0.00", "42.00",
+            [_line("1", date(2026, 7, 20), "42.00",
+                   description="Trader Joes", raw="TRADER JOES 88",
+                   splits=[{"account": "Expenses:Groceries",
+                            "amount": "42.00"}])],
+            dry_run=False,
+        )
+        assert "1 created" in res["summary"]
+        assert res["new_reconciled_balance"] == "-42.00"
+        assert "ties" in res["tie"]
+        assert gc.get_balance("Visa") == Decimal("-42")
+
+    def test_payment_line_on_card(self, statement_book):
+        """A payment prints negative on a card statement and lands
+        positive in the book."""
+        gc = GnuCashBook(str(statement_book))
+        gc.enter_statement(
+            "Visa", date(2026, 7, 31), "0.00", "42.00",
+            [_line("1", date(2026, 7, 20), "42.00",
+                   description="Trader Joes",
+                   splits=[{"account": "Expenses:Groceries",
+                            "amount": "42.00"}])],
+            dry_run=False,
+        )
+        res = gc.enter_statement(
+            "Visa", date(2026, 8, 31), "42.00", "2.00",
+            [_line("1", date(2026, 8, 10), "-40.00",
+                   description="Payment Thank You",
+                   splits=[{"account": "Assets:Checking",
+                            "amount": "-40.00"}])],
+            dry_run=False,
+        )
+        assert "1 created" in res["summary"]
+        assert res["new_reconciled_balance"] == "-2.00"
+        assert gc.get_balance("Visa") == Decimal("-2")
+
+
+# ── Round-trip closure ─────────────────────────────────────────────
+
+
+class TestStatementRoundTrip:
+    def test_candidate_guid_claims(self, statement_book):
+        """The dry-run candidates table's split_guid short form is
+        valid match input — output hands look like input hands."""
+        gc = GnuCashBook(str(statement_book))
+        guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT", match=guid)],
+            dry_run=False,
+        )
+        assert "claimed" in res["results"]
+
+
+# ── Audit formatter ────────────────────────────────────────────────
+
+
+class TestStatementAuditFormatter:
+    def _entry(self, dry):
+        lines_tsv = (
+            "ref\tdate\tdescription\tnotes\traw\tmatch\tamount\n"
+            "1\t2026-07-01\tJuly Rent\t\tACH RENT\tddc40a70\t-800.00\n"
+            "2\t2026-07-03\tWhole Foods\tgroceries\tPOS 123\t\t-87.12"
+        )
+        return {
+            "timestamp": "2026-08-24T10:00:00-07:00",
+            "params": {
+                "account": "Assets:Checking",
+                "statement_date": "2026-07-31",
+                "opening_balance": "1000.00",
+                "closing_balance": "112.88",
+                "lines": lines_tsv,
+                "dry_run": dry,
+            },
+            "before_state": {
+                "account": "Assets:Checking",
+                "claims": [{
+                    "guid": "ddc40a70" + "0" * 24,
+                    "state": "n", "memo": "", "notes": "rent note",
+                    "description": "July Rent",
+                    "date": "2026-07-01",
+                }],
+            },
+            "after_state": {
+                "summary": "Statement entered: 1 created, 1 "
+                           "claimed, 0 skipped (already "
+                           "reconciled); 2 splits reconciled at "
+                           "2026-07-31.",
+                "results": "ref\tstatus\tguid\tnote\n"
+                           "1\tclaimed\tddc40a70\t\n"
+                           "2\tcreated\tabcd1234\t"
+                           "auto_filled_from:ad888455",
+                "tie": "reconciled balance 112.88 ties to the "
+                       "statement closing (112.88 as printed)",
+            },
+        }
+
+    def test_commit_render(self):
+        from gnucash_mcp.logging_config import _fmt_statement_enter
+        out = "\n".join(_fmt_statement_enter(self._entry(False)))
+        assert "ENTER STATEMENT  Assets:Checking  2026-07-31" in out
+        assert "opening 1000.00 → closing 112.88" in out
+        assert 'CLAIM  split:ddc40a70  "July Rent"' in out
+        assert "state: n → y" in out
+        assert "memo: (empty) → ACH RENT" in out
+        assert 'CREATE  guid:abcd1234  "Whole Foods"' in out
+        assert "auto-filled from guid:ad888455" in out
+        assert "ties to the statement closing" in out
+
+    def test_dry_run_render_is_one_summary(self):
+        from gnucash_mcp.logging_config import _fmt_statement_enter
+        entry = self._entry(True)
+        entry["after_state"] = {
+            "summary": "Dry run: 2 lines — 1 NEW, 1 MATCH, 0 "
+                       "OVERLAP, 0 AMBIGUOUS.",
+        }
+        out = _fmt_statement_enter(entry)
+        assert len(out) == 2
+        assert "(dry run)" in out[0]
+
+
+# ── Tool wrapper ───────────────────────────────────────────────────
+
+
+class TestStatementToolParse:
+    def test_bad_line_date_is_not_defaulted(self):
+        """The grammar keeps the date cell as a string; the tool
+        wrapper rejects invalid ones. Batch defaults a bad date to
+        today — a statement transcription must never."""
+        rows = _parse_statement_tsv(
+            "ref\tdate\traw\tamount\n1\tnot-a-date\tX\t5"
+        )
+        assert rows[0]["date"] == "not-a-date"

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -608,6 +608,177 @@ class TestStatementCommit:
         assert "supply explicit counter-splits" in res["warnings"]
 
 
+class TestStatementReviewFindings:
+    """Regression locks for the adversarial-review findings on the
+    first implementation — each of these demonstrated a live defect
+    before its fix."""
+
+    def _reconcile_rent(self, statement_book):
+        """Mark the July rent split reconciled, returning its guid."""
+        import piecash as pc
+        b = pc.open_book(str(statement_book), readonly=False,
+                         do_backup=False)
+        guid = None
+        for txn in b.transactions:
+            if txn.description == "July Rent":
+                for s in txn.splits:
+                    if s.account.name == "Checking":
+                        s.reconcile_state = "y"
+                        guid = s.guid
+        b.save()
+        b.close()
+        return guid
+
+    def test_monthly_pattern_vs_reconciled_prior_is_NEW(
+        self, statement_book
+    ):
+        """The August rent line, 31 days after the RECONCILED July
+        rent of the same amount, is a genuine NEW line: it must
+        count in the projection (old code classed it OVERLAP,
+        skipped it, and reported a false discrepancy)."""
+        gc = GnuCashBook(str(statement_book))
+        self._reconcile_rent(statement_book)
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "200.00", "-600.00",
+            [_line("1", date(2026, 8, 1), "-800.00",
+                   raw="ACH RENT AUG",
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert _classes(res)["1"] == "NEW"
+        # The reconciled July candidate still ships as adaptation
+        # evidence.
+        assert _cands(res)["1"][0]["state"] == "y"
+        assert "ties" in res["tie"]
+
+    def test_reconciled_exact_twin_is_OVERLAP_and_guarded(
+        self, statement_book
+    ):
+        """A line whose exact twin (amount + tight date) is already
+        reconciled: dry-run classes OVERLAP; a bare-create commit
+        refuses (old code silently double-entered under force)."""
+        gc = GnuCashBook(str(statement_book))
+        guid = self._reconcile_rent(statement_book)
+        assert guid is not None
+        # Post-reconcile base is 200 (1000 anchor − 800 rent); a
+        # re-transcription of the rent line on a tied base is the
+        # double-entry trap the guard exists for.
+        line = _line("1", date(2026, 7, 1), "-800.00",
+                     raw="ACH RENT JULY",
+                     splits=[{"account": "Expenses:Rent",
+                              "amount": "800.00"}])
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "200.00", "-600.00", [line], dry_run=True,
+        )
+        assert _classes(res)["1"] == "OVERLAP"
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "200.00", "-600.00", [line], dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "landed by a prior statement" in res["warnings"]
+
+    def test_autofill_precedent_must_touch_account(
+        self, statement_book
+    ):
+        """A description-matched precedent paid from a DIFFERENT
+        account must not auto-fill (old code picked an arbitrary
+        leg and could fabricate an inter-bank transfer)."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Visa", date(2026, 7, 31), "0.00", "60.00",
+            [_line("1", date(2026, 7, 20), "60.00",
+                   description="Whole Foods")],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "doesn't touch this statement account" in \
+            res["warnings"]
+
+    def test_overlap_claim_wrong_amount_rejects(
+        self, statement_book
+    ):
+        """Claim exactness has no reconciled-split exemption: a
+        wrong-GUID paste naming a reconciled split of a different
+        amount diagnoses at the row (old code silently no-op'd)."""
+        gc = GnuCashBook(str(statement_book))
+        guid = self._reconcile_rent(statement_book)
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "200.00", "150.00",
+            [_line("1", date(2026, 7, 2), "-50.00",
+                   raw="SOMETHING ELSE", match=guid)],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "wrong split" in res["warnings"]
+
+    def test_sub_quantum_amount_rejects(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="finer precision"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "1000.00", "1000.004",
+                [_line("1", date(2026, 7, 3), "0.004", raw="X")],
+            )
+
+    def test_empty_lines_reject(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="no lines"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "1000.00", "1000.00", [],
+            )
+
+    def test_rehearsal_surfaces_autofill_failure(
+        self, statement_book
+    ):
+        """A splitless line commit would reject (no precedent) must
+        warn in the dry run — the old predictor noted it but a row
+        with empty description AND raw said nothing at all."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "990.00",
+            [_line("1", date(2026, 7, 3), "-10.00",
+                   description="Utterly Unprecedented")],
+            dry_run=True,
+        )
+        assert "no matching transaction to auto-fill" in \
+            res["warnings"]
+        assert "warning(s) outstanding" in res["tie"]
+
+    def test_dry_run_detects_double_claim(self, statement_book):
+        gc = GnuCashBook(str(statement_book))
+        rent_guid = _cands(_dry(gc))["1"][0]["split_guid"]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "-600.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT", match=rent_guid),
+             _line("2", date(2026, 7, 1), "-800.00",
+                   raw="ACH RENT AGAIN", match=rent_guid)],
+            dry_run=True,
+        )
+        assert "already claimed by another row" in res["warnings"]
+
+    def test_exact_match_note_flags_commit_refusal(
+        self, statement_book
+    ):
+        """A MATCH line with an exact unreconciled twin says in its
+        note what commit will do with a bare create."""
+        gc = GnuCashBook(str(statement_book))
+        res = _dry(gc)
+        notes = {
+            f[0]: f[3] for f in
+            (ln.split("\t") for ln in res["lines"].splitlines()[1:])
+        }
+        assert "exact twin" in notes["1"]
+
+
 # ── Sign transform (credit card) ───────────────────────────────────
 
 

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -356,10 +356,23 @@ class TestStatementDryRun:
         # Line 1 carries raw only and has no auto-fill precedent,
         # so its proposal side is unknown — split_match blank.
         assert cand["split_match"] == ""
-        # Line 3 auto-fills, so its comparison is complete — and
-        # Decimal-normalized: "5.50" vs "5.5" is the SAME leg.
+        # Line 3 has an exact twin, so the guard short-circuits
+        # prep (mirroring commit) and its proposal side is unknown.
         cand3 = _cands(_dry(gc))["3"][0]
-        assert cand3["split_match"] == "exact"
+        assert cand3["split_match"] == ""
+        # A strong-but-not-exact MATCH does run prep: equal
+        # amounts at 20 days' drift — Decimal-normalized, "800.00"
+        # vs "800" is the SAME leg.
+        res20 = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 21), "-800.00",
+                   description="July Rent",
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert _cands(res20)["1"][0]["split_match"] == "exact"
 
     def test_amount_only_candidate_surfaces(self, statement_book):
         """Ruling 1's rent case: a line 31 days from a same-amount
@@ -511,7 +524,7 @@ class TestStatementCommit:
                    raw="ACH RENT AGAIN", match=rent_guid)],
             dry_run=False,
         )
-        assert "already claimed by another row" in res["results"]
+        assert "already used by another row" in res["results"]
 
     def test_duplicate_guard(self, statement_book):
         """A created line exactly matching an unclaimed unreconciled
@@ -769,7 +782,7 @@ class TestStatementReviewFindings:
         )
         assert "no matching transaction to auto-fill" in \
             res["warnings"]
-        assert "warning(s) outstanding" in res["tie"]
+        assert "would refuse at commit" in res["tie"]
 
     def test_dry_run_detects_double_claim(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -783,20 +796,22 @@ class TestStatementReviewFindings:
                    raw="ACH RENT AGAIN", match=rent_guid)],
             dry_run=True,
         )
-        assert "already claimed by another row" in res["warnings"]
+        assert "already used by another row" in res["warnings"]
 
     def test_exact_match_note_flags_commit_refusal(
         self, statement_book
     ):
-        """A MATCH line with an exact unreconciled twin says in its
-        note what commit will do with a bare create."""
+        """A MATCH line with an exact unreconciled twin carries the
+        guard's coaching VERBATIM in its note — the same text the
+        commit rejection would say (disposition chokepoint)."""
         gc = GnuCashBook(str(statement_book))
         res = _dry(gc)
         notes = {
             f[0]: f[3] for f in
             (ln.split("\t") for ln in res["lines"].splitlines()[1:])
         }
-        assert "exact twin" in notes["1"]
+        assert "claim it with match=" in notes["1"]
+        assert "would refuse at commit" in res["tie"]
 
 
 class TestMaidenVoyageFindings:
@@ -827,6 +842,46 @@ class TestMaidenVoyageFindings:
                 "ref\tdate\tdescription\tamt\tacct\n"
                 "1\t2025-04-01\tDesc\x0bX\t-10\tA\t10\tB"
             )
+
+    def test_remaining_splitlines_exotics_reject(self):
+        """Round two: \\x1c/\\x1d/\\x1e are the other three
+        splitlines boundaries — without them the shatter class was
+        half-fixed and the byte flowed silently into a cell."""
+        for ch, name in (("\x1c", "FILE"), ("\x1d", "GROUP"),
+                         ("\x1e", "RECORD")):
+            with pytest.raises(ValueError, match=f"{name} SEPARATOR"):
+                _parse_statement_tsv(
+                    f"ref\tdate\traw\tamount\n"
+                    f"1\t2026-07-01\tSTAR{ch}BUCKS\t-5.00"
+                )
+
+    def test_exotic_row_number_on_bare_cr_input(self):
+        """Row numbering normalizes \\r first — a classic-Mac file
+        must not blame 'the header' for a data-row artifact."""
+        tsv = ("ref\tdate\traw\tamount\r"
+               "1\t2026-07-01\tOK\t-5.00\r"
+               "2\t2026-07-02\tBAD\u2028X"
+               "\t-5.00")
+        with pytest.raises(ValueError, match="row 2"):
+            _parse_statement_tsv(tsv)
+
+    def test_lazy_amt1_spelling_parses(self):
+        """The docstring's promise, now true: fixed 'amount' AND
+        group 'amt1' both parse — a digit-suffixed token is never
+        swallowed by the fixed section."""
+        rows = _parse_statement_tsv(
+            "ref\tdate\tdesc\tamount\tamt1\tacct1\n"
+            "1\t2026-07-01\tX\t-5.00\t5.00\tExpenses:Groceries"
+        )
+        assert rows[0]["amount"] == "-5.00"
+        assert rows[0]["splits"][0]["account"] == \
+            "Expenses:Groceries"
+
+    def test_fixed_typo_errors_by_name(self):
+        with pytest.raises(
+            ValueError, match="unrecognized column 'descrption'"
+        ):
+            _statement_tsv_layout("ref\tdate\tdescrption\tamount")
 
     def test_real_newlines_still_split(self):
         rows = _parse_statement_tsv(
@@ -1030,6 +1085,346 @@ class TestPlanRoundFindings:
         assert "rejected" in rejected_row
         assert "claim it with match=" in rejected_row
         assert "warnings" not in res
+
+
+class TestDispositionChokepoint:
+    """Locks for the opus adversarial round (round two): the
+    rehearsal runs the SAME disposition procedure commit runs —
+    the scenarios here are the five verified divergences."""
+
+    def _seed(self, statement_book, dt, desc, amt, state=None,
+              memo=""):
+        import piecash as pc
+        b = pc.open_book(str(statement_book), readonly=False,
+                         do_backup=False)
+        checking = [a for a in b.accounts if a.name == "Checking"][0]
+        groceries = [
+            a for a in b.accounts if a.name == "Groceries"
+        ][0]
+        t = pc.Transaction(
+            currency=b.default_currency, description=desc,
+            post_date=dt,
+            splits=[
+                pc.Split(account=checking, value=Decimal(amt),
+                         memo=memo),
+                pc.Split(account=groceries, value=-Decimal(amt)),
+            ],
+        )
+        b.save()
+        guid = None
+        for s in t.splits:
+            if s.account == checking:
+                guid = s.guid
+                if state:
+                    s.reconcile_state = state
+        b.save()
+        b.close()
+        return guid
+
+    def test_reconciled_twin_behind_fuzzy_match_rehearses_refusal(
+        self, statement_book
+    ):
+        """Scenario A: fuzzy unreconciled MATCH + exact RECONCILED
+        twin — the old rehearsal showed a clean tie and commit
+        rejected wholesale. Now the note carries the guard's
+        coaching and the tie counts the refusal."""
+        self._seed(statement_book, date(2026, 7, 11),
+                   "Coffee Shop Downtown", "-4.50")     # fuzzy n
+        self._seed(statement_book, date(2026, 7, 10),
+                   "Starbucks", "-5.00", state="y")     # exact y
+        gc = GnuCashBook(str(statement_book))
+        line = _line("1", date(2026, 7, 10), "-5.00",
+                     description="Coffee Shop",
+                     splits=[{"account": "Expenses:Groceries",
+                              "amount": "5.00"}])
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "995.00", "990.00", [line], dry_run=True,
+        )
+        notes = res["lines"].splitlines()[1].split("\t")[3]
+        assert "landed by a prior statement" in notes
+        assert "would refuse at commit" in res["tie"]
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "995.00", "990.00", [line], dry_run=False,
+        )
+        assert "REJECTED" in commit["summary"]
+        # Same coaching text, both modes — the chokepoint.
+        assert "landed by a prior statement" in commit["results"]
+
+    def test_overlap_class_with_claim_projects_the_claim(
+        self, statement_book
+    ):
+        """Scenario D: an OVERLAP-classified row whose match cell
+        claims a DIFFERENT unreconciled split — projection must
+        contribute the claim's amount, exactly like commit."""
+        self._seed(statement_book, date(2026, 7, 10),
+                   "Gym", "-50.00", state="y")           # exact y
+        z = self._seed(statement_book, date(2026, 7, 22),
+                       "Jim", "-50.00")                  # LOW n
+        gc = GnuCashBook(str(statement_book))
+        line = _line("1", date(2026, 7, 10), "-50.00",
+                     raw="GYM MEMBERSHIP", match=z)
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "900.00", [line], dry_run=True,
+        )
+        assert _classes(res)["1"] == "MATCH"
+        assert "will claim" in res["lines"].splitlines()[1]
+        assert "ties to the statement closing" in res["tie"]
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "900.00", [line], dry_run=False,
+        )
+        assert "1 claimed" in commit["summary"]
+        assert "tied." in commit["tie"]
+
+    def test_forced_dry_run_rehearses_the_forced_commit(
+        self, statement_book
+    ):
+        """Scenario E: under force the guard is off in BOTH modes —
+        a bare line whose exact twin is reconciled projects a
+        create, matching what the forced commit does."""
+        self._seed(statement_book, date(2026, 7, 10),
+                   "Gym", "-50.00", state="y")
+        gc = GnuCashBook(str(statement_book))
+        line = _line("1", date(2026, 7, 10), "-50.00",
+                     description="Gym",
+                     splits=[{"account": "Expenses:Groceries",
+                              "amount": "50.00"}])
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "900.00", [line], dry_run=True, force=True,
+        )
+        assert "ties to the statement closing" in res["tie"]
+        assert "would refuse" not in res["tie"]
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "900.00", [line], dry_run=False, force=True,
+        )
+        assert "1 created" in commit["summary"]
+        assert "LANDED UNDER FORCE" in commit["summary"]
+
+    def test_sibling_claims_exempt_twins_from_guard(
+        self, statement_book
+    ):
+        """Scenario C: three identical charges on the statement,
+        two existing twins both claimed by sibling rows — the
+        third row's create must NOT be guarded (every twin is
+        accounted for; the third is a genuine new charge)."""
+        gc = GnuCashBook(str(statement_book))
+        cands = _cands(_dry(gc))["3"]
+        c1, c2 = (
+            cands[0]["candidate_guid"], cands[1]["candidate_guid"],
+        )
+        lines = [
+            _line("1", date(2026, 7, 10), "-5.50",
+                  raw="BLUE BOTTLE A", match=c1),
+            _line("2", date(2026, 7, 10), "-5.50",
+                  raw="BLUE BOTTLE B", match=c2),
+            _line("3", date(2026, 7, 10), "-5.50",
+                  description="Blue Bottle",
+                  splits=[{"account": "Expenses:Groceries",
+                           "amount": "5.50"}]),
+        ]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "983.50", lines, dry_run=True,
+        )
+        rows = {
+            f[0]: f for f in
+            (ln.split("\t") for ln in res["lines"].splitlines()[1:])
+        }
+        assert "will claim" in rows["1"][3]
+        assert "claim it with match=" not in rows["3"][3]
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "983.50", lines, dry_run=False,
+        )
+        assert "1 created, 2 claimed" in commit["summary"]
+
+    def test_overlap_double_claim_rejects_both_modes(
+        self, statement_book
+    ):
+        """Two rows no-opping ONE reconciled split report two
+        handled lines for one — now an error in both modes."""
+        g = self._seed(statement_book, date(2026, 7, 10),
+                       "Gym", "-50.00", state="y")
+        gc = GnuCashBook(str(statement_book))
+        lines = [
+            _line("1", date(2026, 7, 10), "-50.00",
+                  raw="GYM", match=g),
+            _line("2", date(2026, 7, 10), "-50.00",
+                  raw="GYM AGAIN", match=g),
+        ]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "850.00", lines, dry_run=True,
+        )
+        assert "already used by another row" in res["warnings"]
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "950.00", "850.00", lines, dry_run=False,
+        )
+        assert "REJECTED" in commit["summary"]
+
+    def test_counter_split_may_not_name_statement_account(
+        self, statement_book
+    ):
+        """The tie is an identity over inputs — a counter-split
+        naming the statement account would move the account by
+        more than the printed line while reporting tied."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "900.00",
+            [_line("1", date(2026, 7, 20), "-100.00",
+                   description="Combined",
+                   splits=[
+                       {"account": "Assets:Checking",
+                        "amount": "-50.00"},
+                       {"account": "Expenses:Groceries",
+                        "amount": "150.00"},
+                   ])],
+            dry_run=False,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "must not name the statement account" in \
+            res["results"]
+
+    def test_forced_landing_is_recorded(self, statement_book):
+        """A tie-holding forced commit must not be byte-identical
+        to a clean one — summary and audit both say FORCED."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Visa", date(2026, 7, 31), "0.00", "42.00",
+            [_line("1", date(2026, 7, 20), "42.00",
+                   description="Trader Joes",
+                   splits=[{"account": "Expenses:Groceries",
+                            "amount": "42.00"}])],
+            dry_run=False, force=True,
+        )
+        assert "LANDED UNDER FORCE" in res["summary"]
+        from gnucash_mcp.logging_config import _fmt_statement_enter
+        out = "\n".join(_fmt_statement_enter({
+            "timestamp": "2026-08-24T22:00:00-07:00",
+            "params": {"account": "Visa",
+                       "statement_date": "2026-07-31",
+                       "opening_balance": "0.00",
+                       "closing_balance": "42.00",
+                       "lines": "", "dry_run": False,
+                       "force": True},
+            "after_state": {"summary": res["summary"],
+                            "tie": res["tie"]},
+        }))
+        assert "(FORCED)" in out
+
+
+class TestRoundTwoLockGaps:
+    """The fifth agent's mutation testing found two conventions
+    posing as invariants; these make them invariants."""
+
+    def test_exact_requires_amount_to_the_quantum(
+        self, statement_book
+    ):
+        """A -799.50 line against the -800 rent split is a MATCH
+        candidate (amount within $1) but NOT an exact twin — the
+        guard must not fire and a judged create must land. With
+        ±$1 'exact' fuzz this commit would reject with wrong
+        coaching."""
+        gc = GnuCashBook(str(statement_book))
+        line = _line("1", date(2026, 7, 1), "-799.50",
+                     description="July Rent Adjusted",
+                     splits=[{"account": "Expenses:Rent",
+                              "amount": "799.50"}])
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.50", [line], dry_run=True,
+        )
+        assert _classes(res)["1"] == "MATCH"
+        notes = res["lines"].splitlines()[1].split("\t")[3]
+        assert "claim it with match=" not in notes
+        commit = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.50", [line], dry_run=False,
+        )
+        assert "1 created" in commit["summary"]
+
+    def test_candidate_sort_orders_by_delta_within_tier(
+        self, statement_book
+    ):
+        """§11.13's ordering, locked: same risk tier, nearer
+        amt_delta first."""
+        import piecash as pc
+        b = pc.open_book(str(statement_book), readonly=False,
+                         do_backup=False)
+        checking = [a for a in b.accounts if a.name == "Checking"][0]
+        groceries = [
+            a for a in b.accounts if a.name == "Groceries"
+        ][0]
+        for amt in ("-99.10", "-99.90"):
+            pc.Transaction(
+                currency=b.default_currency, description="Utility",
+                post_date=date(2026, 7, 18),
+                splits=[
+                    pc.Split(account=checking, value=Decimal(amt)),
+                    pc.Split(account=groceries,
+                             value=-Decimal(amt)),
+                ],
+            )
+        b.save()
+        b.close()
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "900.00",
+            [_line("1", date(2026, 7, 18), "-100.00",
+                   raw="UTILITY CO")],
+            dry_run=True, show_all=True,
+        )
+        cands = _cands(res)["1"]
+        deltas = [abs(Decimal(c["amt_delta"])) for c in cands
+                  if c["amt_delta"]]
+        assert deltas == sorted(deltas)
+
+
+class TestOutputEscaping:
+    """The output mirror of the shatter bug: book free text must
+    not splinter response TSVs."""
+
+    def test_multiline_note_stays_one_candidate_row(
+        self, statement_book
+    ):
+        import piecash as pc
+        b = pc.open_book(str(statement_book), readonly=False,
+                         do_backup=False)
+        checking = [a for a in b.accounts if a.name == "Checking"][0]
+        groceries = [
+            a for a in b.accounts if a.name == "Groceries"
+        ][0]
+        pc.Transaction(
+            currency=b.default_currency, description="OFX Import",
+            post_date=date(2026, 7, 18),
+            notes="line1\nline2\tcol2",
+            splits=[
+                pc.Split(account=checking, value=Decimal("-33.00"),
+                         memo="memo\nsecond"),
+                pc.Split(account=groceries, value=Decimal("33.00")),
+            ],
+        )
+        b.save()
+        b.close()
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "967.00",
+            [_line("1", date(2026, 7, 18), "-33.00",
+                   raw="OFX THING")],
+            dry_run=True,
+        )
+        cands = res["candidates"].splitlines()
+        assert len(cands) == 2  # header + ONE row
+        assert "\\n" in res["candidates"]
 
 
 # ── Sign transform (credit card) ───────────────────────────────────

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -739,6 +739,25 @@ class TestStatementAuditFormatter:
         assert len(out) == 2
         assert "(dry run)" in out[0]
 
+    def test_render_through_the_escape_chokepoint(self):
+        """The full production path — _format_audit_entry_text
+        escapes params BEFORE dispatch, and 'lines' must be in
+        _AUDIT_TSV_KEYS or the TSV's tabs get escaped to literal
+        text and every CREATE row renders empty (found by review;
+        the direct-call tests above bypass the chokepoint)."""
+        from gnucash_mcp.logging_config import (
+            _format_audit_entry_text,
+        )
+        entry = self._entry(False)
+        entry["classification"] = "write"
+        entry["operation"] = "enter"
+        entry["entity_type"] = "statement"
+        entry["tool"] = "enter_statement"
+        out = _format_audit_entry_text(entry)
+        assert '"Whole Foods" (2026-07-03, -87.12)' in out
+        assert "memo: (empty) → ACH RENT" in out
+        assert "notes: groceries" in out
+
 
 # ── Tool wrapper ───────────────────────────────────────────────────
 

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -483,7 +483,7 @@ class TestStatementCommit:
             dry_run=False,
         )
         assert "REJECTED" in res["summary"]
-        assert "fix the book entry first" in res["warnings"]
+        assert "fix the book entry first" in res["results"]
 
     def test_match_row_with_splits_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -497,7 +497,7 @@ class TestStatementCommit:
                             "amount": "800.00"}])],
             dry_run=False,
         )
-        assert "cannot also carry counter-splits" in res["warnings"]
+        assert "cannot also carry counter-splits" in res["results"]
 
     def test_double_claim_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -511,7 +511,7 @@ class TestStatementCommit:
                    raw="ACH RENT AGAIN", match=rent_guid)],
             dry_run=False,
         )
-        assert "already claimed by another row" in res["warnings"]
+        assert "already claimed by another row" in res["results"]
 
     def test_duplicate_guard(self, statement_book):
         """A created line exactly matching an unclaimed unreconciled
@@ -526,7 +526,7 @@ class TestStatementCommit:
             dry_run=False,
         )
         assert "REJECTED" in res["summary"]
-        assert "claim it with match=" in res["warnings"]
+        assert "claim it with match=" in res["results"]
 
     def test_tie_failure_refuses_wholesale(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -625,7 +625,7 @@ class TestStatementCommit:
             dry_run=False,
         )
         assert "REJECTED" in res["summary"]
-        assert "supply explicit counter-splits" in res["warnings"]
+        assert "supply explicit counter-splits" in res["results"]
 
 
 class TestStatementReviewFindings:
@@ -699,7 +699,7 @@ class TestStatementReviewFindings:
             "200.00", "-600.00", [line], dry_run=False,
         )
         assert "REJECTED" in res["summary"]
-        assert "landed by a prior statement" in res["warnings"]
+        assert "landed by a prior statement" in res["results"]
 
     def test_autofill_precedent_must_touch_account(
         self, statement_book
@@ -716,7 +716,7 @@ class TestStatementReviewFindings:
         )
         assert "REJECTED" in res["summary"]
         assert "doesn't touch this statement account" in \
-            res["warnings"]
+            res["results"]
 
     def test_overlap_claim_wrong_amount_rejects(
         self, statement_book
@@ -734,7 +734,7 @@ class TestStatementReviewFindings:
             dry_run=False,
         )
         assert "REJECTED" in res["summary"]
-        assert "wrong split" in res["warnings"]
+        assert "wrong split" in res["results"]
 
     def test_sub_quantum_amount_rejects(self, statement_book):
         gc = GnuCashBook(str(statement_book))
@@ -870,6 +870,126 @@ class TestMaidenVoyageFindings:
         assert len(cands) == 1
         assert cands[0]["confidence"] == "LOW"
         assert cands[0]["signals"] == "-A-"
+
+
+class TestPlanRoundFindings:
+    """Locks for the bookkeeper's full test-plan round
+    (2026-08-24 late): T5b, T6, T7, and the LOW-display ruling."""
+
+    def _add_txn(self, statement_book, dt, desc, amt):
+        import piecash as pc
+        b = pc.open_book(str(statement_book), readonly=False,
+                         do_backup=False)
+        checking = [a for a in b.accounts if a.name == "Checking"][0]
+        groceries = [
+            a for a in b.accounts if a.name == "Groceries"
+        ][0]
+        pc.Transaction(
+            currency=b.default_currency, description=desc,
+            post_date=dt,
+            splits=[
+                pc.Split(account=checking, value=Decimal(amt)),
+                pc.Split(account=groceries, value=-Decimal(amt)),
+            ],
+        )
+        b.save()
+        b.close()
+
+    def test_recurring_signature_leans_NEW(self, statement_book):
+        """T6: desc + amount a month away is the recurring-payment
+        signature (the HOA case) — evidence, not a MATCH."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 8, 1), "-800.00",
+                   description="July Rent",
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert _classes(res)["1"] == "NEW"
+        cand = _cands(res)["1"][0]
+        assert cand["signals"] == "DA-"
+        assert cand["date_delta_days"] == "-31"
+
+    def test_short_date_drift_still_matches(self, statement_book):
+        """The other side of T6's line: a few days of clearing
+        drift with desc+amount is still a MATCH — the maiden
+        flight's date-drift claims must keep working."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 6), "-800.00",
+                   description="July Rent")],
+            dry_run=True,
+        )
+        assert _classes(res)["1"] == "MATCH"
+
+    def test_low_suppression_breadcrumb_and_show_all(
+        self, statement_book
+    ):
+        """Ruling: best-evidence-only. A line with a MEDIUM/HIGH
+        candidate suppresses its LOW amount-coincidences, leaving
+        the breadcrumb; show_all lists everything."""
+        self._add_txn(statement_book, date(2026, 7, 20),
+                      "Garden Depot", "-800.00")
+        self._add_txn(statement_book, date(2026, 7, 22),
+                      "Pet Palace", "-800.00")
+        gc = GnuCashBook(str(statement_book))
+        lines = [_line("1", date(2026, 7, 2), "-800.00",
+                       raw="ACH RENT JUL")]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00", lines, dry_run=True,
+        )
+        row = res["lines"].splitlines()[1].split("\t")
+        assert row[2] == "1 (+2 LOW suppressed)"
+        assert len(_cands(res)["1"]) == 1
+        res_all = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00", lines, dry_run=True,
+            show_all=True,
+        )
+        assert len(_cands(res_all)["1"]) == 3
+
+    def test_low_only_line_keeps_its_evidence(self, statement_book):
+        """The rent case is load-bearing: a line whose ONLY
+        evidence is LOW keeps it — suppression needs something
+        better to stand on."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 8, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 8, 1), "-800.00",
+                   raw="ACH RENT AUG",
+                   splits=[{"account": "Expenses:Rent",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert len(_cands(res)["1"]) == 1
+        row = res["lines"].splitlines()[1].split("\t")
+        assert row[2] == "1"
+
+    def test_commit_rejection_coaching_is_inline(
+        self, statement_book
+    ):
+        """T5b: the rejection's next move rides the results note
+        column — the operator is never stranded in a second
+        table."""
+        gc = GnuCashBook(str(statement_book))
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 1), "-800.00",
+                   description="July Rent", raw="ACH RENT")],
+            dry_run=False,
+        )
+        rejected_row = res["results"].splitlines()[1]
+        assert "rejected" in rejected_row
+        assert "claim it with match=" in rejected_row
+        assert "warnings" not in res
 
 
 # ── Sign transform (credit card) ───────────────────────────────────

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -556,10 +556,10 @@ class TestStatementCommit:
                    description="Deposit",
                    splits=[{"account": "Income",
                             "amount": "-100.00"}])],
-            dry_run=False, force=True,
+            dry_run=False, force_base=True,
         )
         assert "DISCREPANCY" in res["tie"]
-        assert "under force" in res["tie"]
+        assert "under force_base" in res["tie"]
 
     def test_atomicity_on_row_error(self, statement_book):
         """One bad row → nothing written, good rows report
@@ -609,7 +609,7 @@ class TestStatementCommit:
             "2907.38", "2107.38",
             [_line("1", date(2026, 7, 1), "-800.00",
                    raw="ACH RENT", match=guid)],
-            dry_run=False, force=True,
+            dry_run=False, force_base=True,
         )
         assert "skipped_duplicate" in res["results"]
         assert "1 skipped" in res["summary"]
@@ -1194,13 +1194,13 @@ class TestDispositionChokepoint:
                               "amount": "50.00"}])
         res = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
-            "950.00", "900.00", [line], dry_run=True, force=True,
+            "950.00", "900.00", [line], dry_run=True, force_duplicates=True,
         )
         assert "ties to the statement closing" in res["tie"]
         assert "would refuse" not in res["tie"]
         commit = gc.enter_statement(
             "Assets:Checking", date(2026, 7, 31),
-            "950.00", "900.00", [line], dry_run=False, force=True,
+            "950.00", "900.00", [line], dry_run=False, force_duplicates=True,
         )
         assert "1 created" in commit["summary"]
         assert "LANDED UNDER FORCE" in commit["summary"]
@@ -1292,6 +1292,52 @@ class TestDispositionChokepoint:
         assert "must not name the statement account" in \
             res["results"]
 
+    def test_force_base_keeps_twin_guard_on(self, statement_book):
+        """THE ruling's point: re-entering a partially-landed
+        statement requires force_base — which must NOT disable the
+        twin guard, the mechanism that detects the already-landed
+        lines. Old single-flag force produced three reconciled
+        charges for two printed lines here."""
+        self._seed(statement_book, date(2026, 7, 10),
+                   "Gym", "-50.00", state="y")
+        gc = GnuCashBook(str(statement_book))
+        # Statement re-prints the landed gym charge plus a new one;
+        # opening (900) deliberately mismatches the base (950).
+        lines = [
+            _line("1", date(2026, 7, 10), "-50.00",
+                  description="Gym",
+                  splits=[{"account": "Expenses:Groceries",
+                           "amount": "50.00"}]),
+            _line("2", date(2026, 7, 12), "-25.00",
+                  description="New Charge",
+                  splits=[{"account": "Expenses:Groceries",
+                           "amount": "25.00"}]),
+        ]
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "900.00", "825.00", lines,
+            dry_run=False, force_base=True,
+        )
+        assert "REJECTED" in res["summary"]
+        assert "landed by a prior statement" in res["results"]
+
+    def test_force_duplicates_keeps_base_gate_on(
+        self, statement_book
+    ):
+        """The inverse independence: force_duplicates does not
+        bypass the opening-balance precondition."""
+        gc = GnuCashBook(str(statement_book))
+        with pytest.raises(ValueError, match="untied base"):
+            gc.enter_statement(
+                "Assets:Checking", date(2026, 7, 31),
+                "900.00", "800.00",
+                [_line("1", date(2026, 7, 20), "-100.00",
+                       description="Thing",
+                       splits=[{"account": "Expenses:Groceries",
+                                "amount": "100.00"}])],
+                dry_run=False, force_duplicates=True,
+            )
+
     def test_forced_landing_is_recorded(self, statement_book):
         """A tie-holding forced commit must not be byte-identical
         to a clean one — summary and audit both say FORCED."""
@@ -1302,9 +1348,9 @@ class TestDispositionChokepoint:
                    description="Trader Joes",
                    splits=[{"account": "Expenses:Groceries",
                             "amount": "42.00"}])],
-            dry_run=False, force=True,
+            dry_run=False, force_duplicates=True,
         )
-        assert "LANDED UNDER FORCE" in res["summary"]
+        assert "LANDED UNDER FORCE (duplicates)" in res["summary"]
         from gnucash_mcp.logging_config import _fmt_statement_enter
         out = "\n".join(_fmt_statement_enter({
             "timestamp": "2026-08-24T22:00:00-07:00",
@@ -1313,11 +1359,11 @@ class TestDispositionChokepoint:
                        "opening_balance": "0.00",
                        "closing_balance": "42.00",
                        "lines": "", "dry_run": False,
-                       "force": True},
+                       "force_duplicates": True},
             "after_state": {"summary": res["summary"],
                             "tie": res["tie"]},
         }))
-        assert "(FORCED)" in out
+        assert "(FORCED: duplicates)" in out
 
 
 class TestRoundTwoLockGaps:

--- a/tests/test_statement_entry.py
+++ b/tests/test_statement_entry.py
@@ -799,6 +799,79 @@ class TestStatementReviewFindings:
         assert "exact twin" in notes["1"]
 
 
+class TestMaidenVoyageFindings:
+    """Locks for the bookkeeper's maiden-flight findings
+    (2026-08-24, Alex demo book, 15-line fabricated statement)."""
+
+    def test_exotic_separator_rejects_by_name(self):
+        """THE open bug: an invisible U+2028 inside a cell made
+        str.splitlines shatter the row — the mid-group error
+        truthfully blamed row 1 while unable to name the invisible
+        byte, and every retyped reduction exorcised it. Four
+        deterministic failures, one night of bisection. Now the
+        artifact is rejected loudly, by name, with a row number."""
+        tsv = (
+            "ref\tdate\traw\tamount\n"
+            "1\t2025-04-01\tRAW\t-10.00\u2028more\t10"
+        )
+        with pytest.raises(ValueError, match="U\\+2028 LINE SEPARATOR"):
+            _parse_statement_tsv(tsv)
+        # The diagnosis names the row, not a downstream symptom.
+        with pytest.raises(ValueError, match="row 1"):
+            _parse_statement_tsv(tsv)
+
+    def test_exotic_separator_rejects_in_batch_too(self):
+        from gnucash_mcp.tools.core import _parse_transactions_tsv
+        with pytest.raises(ValueError, match="U\\+000B VERTICAL TAB"):
+            _parse_transactions_tsv(
+                "ref\tdate\tdescription\tamt\tacct\n"
+                "1\t2025-04-01\tDesc\x0bX\t-10\tA\t10\tB"
+            )
+
+    def test_real_newlines_still_split(self):
+        rows = _parse_statement_tsv(
+            "ref\tdate\traw\tamount\r\n"
+            "1\t2025-04-01\tRAW\t-10.00\r\n"
+            "2\t2025-04-02\tRAW2\t-5.00"
+        )
+        assert [r["ref"] for r in rows] == ["1", "2"]
+
+    def test_claim_row_with_stray_cells_gets_named_error(self):
+        """Finding 1: a claim row carrying anything beyond the
+        fixed columns used to fall into the group chunker and
+        surface as a mid-group miscount. Now it says what it
+        means."""
+        with pytest.raises(
+            ValueError, match="claim row .* takes no split cells"
+        ):
+            _parse_statement_tsv(
+                "ref\tdate\traw\tmatch\tamount\tamt\tacct\n"
+                "1\t2025-04-01\tRAW\tdeadbeef\t-10.00\tstray"
+            )
+
+    def test_low_only_candidates_lean_NEW(self, statement_book):
+        """Finding 2: the invented-ATM case — a line whose only
+        candidates are amount-only LOWs classifies NEW (with the
+        candidates still listed as evidence), not MATCH."""
+        gc = GnuCashBook(str(statement_book))
+        # -800 line 20 days from July Rent: amount signal only
+        # (raw probe matches nothing, date gap > 2).
+        res = gc.enter_statement(
+            "Assets:Checking", date(2026, 7, 31),
+            "1000.00", "200.00",
+            [_line("1", date(2026, 7, 21), "-800.00",
+                   raw="ATM WITHDRAWAL 0042",
+                   splits=[{"account": "Expenses:Groceries",
+                            "amount": "800.00"}])],
+            dry_run=True,
+        )
+        assert _classes(res)["1"] == "NEW"
+        cands = _cands(res)["1"]
+        assert len(cands) == 1
+        assert cands[0]["confidence"] == "LOW"
+        assert cands[0]["signals"] == "-A-"
+
+
 # ── Sign transform (credit card) ───────────────────────────────────
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "gnucash-mcp"
 version = "1.4.2"
 source = { editable = "." }
@@ -467,6 +476,11 @@ dev = [
     { name = "yfinance" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-xdist" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
@@ -479,6 +493,9 @@ requires-dist = [
     { name = "yfinance", marker = "extra == 'dev'", specifier = ">=0.2.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-xdist", specifier = ">=3.8.0" }]
 
 [[package]]
 name = "greenlet"
@@ -1335,6 +1352,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **`enter_statement`**: a complete bank/card statement enters, claims matches, and reconciles in ONE atomic open/save — the four-call statement dance collapses to two calls around the judgment pass (spec: `specs/v1.5/ENTER_STATEMENT_SPEC.md`, rulings 1–9 shipped; ruling 10 deferred per its phasing note).
- Dry-run (default) classifies every line NEW/MATCH/OVERLAP/AMBIGUOUS against the account's own splits and projects the balance tie; every candidate ships as a **self-contained comparison row** (proposed + existing values, deltas, category legs, `split_match`) — the caller never re-reads its own input.
- Commit synthesizes the bank leg (`raw` → memo provenance), validates through the existing chokepoints, claims exact-amount-only with annotation updates, checks the tie **before any mutation**, reconciles every statement-touched split at the statement date, and saves once. Statement-native transcription: amounts/balances exactly as printed; the server applies the sign transform by `GNCAccountType`.
- Guards: statement self-check gate, opening-base precondition, exact-twin duplicate guard (claims-first ordering, inline coaching), invisible-separator rejection by name (the maiden-flight ensemble bug, pinned to a U+2028 shattering `str.splitlines`).
- `create_transactions` inherits the rehearsal surface (ruling 7–9): summary header via the shared clearance-principle renderer, `review_required` status, `max_confidence` column, per-account effects footer, and the shared comparison table.
- Passengers: `_commodity_quantum` hoisted to `_base` (third-caller trigger), audit escape-chokepoint fix for `lines` TSVs, server orientation gains the statement workflow.

## Test plan
- [x] 2,092 tests passing (≈130 new: grammar, gates, classification, commit atomicity, sign transform both directions, audit rendering through the real escape chokepoint, round-trip closure)
- [x] Two adversarial review rounds (3-agent correctness/piecash/spec-conformance + fix verification); every finding fixed with a regression lock
- [x] Live bookkeeper loop closed: maiden flight + full test-plan execution + **signoff (Abe VI, certified for Statement Week)**; carried item and copy quibble fixed and locked same day
- [x] Live-validated on the Alex demo book: two statement months on checking (tied to the penny) and a credit-card statement transcribed statement-native
- [x] CI matrix (3.10/3.13) runs on this PR