### PR TITLE
feat(business): pay_invoice dry-run + review-week riders + v1.4.4 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,108 @@
 # Changelog
 
+## v1.4.4 - The statement is the call
+
+The bulk-operations line closes with its capstone: a complete bank
+statement — opening balance, closing balance, every line between —
+enters, claims its matches, and reconciles in ONE atomic call. And
+because rehearsal proved itself there, it spread: every consequential
+write in the server now rehearses before it books. Distribution grew
+doors to match — a one-click Claude Desktop bundle, built by the
+project's first CI. Much of this release was designed in public: an
+outside model's live critiques, cross-examined by the maintainer,
+became rulings; the rulings became code. (v1.4.3 was never released
+on GitHub — that number belongs to a registry-side rebuild.)
+
+**The headliner: `enter_statement` (#154).**
+
+- A statement is now first-class input, verified for
+  self-consistency before anything else (opening + Σlines must
+  equal closing — completeness becomes a checkable claim).
+- Dry-run is the default and the workflow: every line classified
+  (NEW / MATCH / OVERLAP / AMBIGUOUS) with self-contained
+  comparisons — both sides, deltas, category legs — so the
+  judgment pass gets evidence, not homework. The projected tie is
+  the only verdict the server offers; adjudication stays with the
+  caller (the clearance principle).
+- Commit is one open, one save, or nothing: creates, claims, and
+  reconciliation land together, the closing tie is verified
+  POST-write from the saved splits, and a reconciled-by-statement
+  `y` now means tied-to-evidence. Amounts transcribe
+  statement-native — the server applies the sign convention per
+  account class, eliminating a transcription-error class.
+- Forged in three live probe rounds: signed amounts reach the
+  duplicate scorer (a refund no longer blocks as its payment's
+  "twin"), invisible Unicode separators reject by name, and
+  `force` split into `force_base` / `force_duplicates` so clearing
+  an opening gap can never silently disable duplicate detection.
+
+**Rehearsal everywhere.**
+
+- `pay_invoice` gains `dry_run` — the most consequence-dense write
+  in the server (FX routing, discount windows, lot selection,
+  partial payments) now rehearses fully: proposed splits, projected
+  remaining balance, FX/discount treatment, and any account the
+  real call would auto-create, with zero writes and one shared
+  computation so the rehearsal cannot diverge from the booking.
+- `create_transactions` dry-run inherits the statement surface:
+  summary header with homework framing, `review_required` status
+  (a projected-action label may not masquerade as clearance),
+  self-contained duplicate comparisons with deltas and split-match
+  verdicts, and reconciled candidates showing their state.
+
+**One-click install (#153).**
+
+- The MCPB bundle: download, double-click, and Claude Desktop runs
+  the server — book file picker, persona checkboxes, demo books
+  behind one checkbox. Built and attached by the project's first CI
+  (locked tests on Python 3.10 and 3.13, bundle artifact on every
+  PR); validated end-to-end through a real Desktop install.
+
+**A surface that tells the truth about itself.**
+
+- MCP ToolAnnotations on every tool, derived from the audit-log
+  classification at a single chokepoint — read-only tools say so,
+  destructive tools say so, and a contract test keeps the
+  derivation honest (#150).
+- CLI arguments reject unknown values instead of silently no-oping
+  (`--modules all` now means what it says) (#151).
+- Business-document lifecycle hardening: credit-note identity
+  survives the piecash slot-sweep on transaction delete,
+  owner-mismatch errors name the per-type ID collision instead of
+  contradicting themselves, and voucher posting is reachable
+  (#152).
+- Invoice/bill status vocabulary defined once (open / posted /
+  paid / outstanding) with `get_outstanding_invoices` named the
+  one-call answer to "what is actually unpaid?"
+- `debt_payoff_plan` confesses balance-carrying debts that lack an
+  `apr` slot — the third exclusion class, alongside its stated
+  assumptions (monthly apr/12 compounding, avalanche order,
+  today's balances).
+- Defaults resolve loudly: `create_transaction` echoes the date
+  when it defaulted to today (a UTC-hosted deployment is a day
+  ahead of a Pacific book every evening).
+
+**The un-blooming begins.**
+
+- The tool surface peaked at 111 this release and starts shrinking
+  by design. `create_transaction` and `update_transaction` carry
+  deprecation notices: the batch tools are canonical for one
+  transaction or many, at full capability parity — the updates TSV
+  gained an opt-in `clear` column (explicit per row; a sparse
+  batch still can never mass-erase by accident) to close the last
+  gap first. Removal follows in v1.5.0, which consolidates the
+  business surface from 48 tools to 25 — announced here, specified
+  in `specs/v1.5/BUSINESS_CONSOLIDATION_SPEC.md`, designed by an
+  outside audit and ordered by the maintainer.
+
+**Under the hood.**
+
+- Batch entry runs one signal sweep per batch instead of up to two
+  per row — the flagship workflow's 7-second p95 tail, retired.
+- The test suite (2,100+ tests) runs parallel by default via
+  pytest-xdist: full suite in under 40 seconds.
+- `cryptography` 49 → 50.0.1 (#155).
+
 ## v1.4.2 - One call wide, every surface honest
 
 Every entry in this release traces to a named moment of live

--- a/README.md
+++ b/README.md
@@ -343,6 +343,20 @@ run `uv run gnucash-mcp --help` from the repo for the full menu.
 A non-exhaustive tour. Phrase any of these naturally — the
 assistant translates.
 
+### Entering a whole statement
+
+> "Here's my August checking statement." *(attach the PDF)*
+>
+> Rehearsed 31 lines against your book: 24 new, 6 already
+> entered (claimed), 1 needs a look — here's the comparison.
+> Confirm and I'll land the month: entered, categorized, and
+> reconciled to the closing balance in one step.
+
+One statement, two calls, a tied book. The dry-run classifies
+every line with evidence before anything is written, and the
+commit refuses wholesale rather than land a month that doesn't
+tie.
+
 ### Recording activity
 
 > "I spent \$47.50 at Safeway today on groceries, paid with my
@@ -477,6 +491,37 @@ environment variable instead of `--modules=...` in the JSON
 args.
 
 ---
+
+## What's new in v1.4.4
+
+The statement is the call — the bulk-operations line closes with
+its capstone, and rehearsal spreads to every consequential write:
+
+- **`enter_statement`** — a complete bank statement (opening
+  balance, closing balance, every line) enters, claims its
+  matches against transactions already in the book, and
+  reconciles in ONE atomic call. Dry-run first by default: every
+  line classified with side-by-side evidence, and a projected
+  balance tie that guarantees a rehearsal that ties is a commit
+  that will tie. No half-landed months, ever.
+- **Rehearsal everywhere** — `pay_invoice` gains `dry_run`
+  (proposed splits, FX and discount treatment, projected balance,
+  zero writes), and batch entry's dry-run shows self-contained
+  duplicate comparisons with a `review_required` status that
+  never masquerades as clearance.
+- **One-click install** — the MCPB bundle: download, double-click,
+  and Claude Desktop runs the server. Built by the project's first
+  CI on every PR.
+- **A surface that tells the truth about itself** — MCP
+  ToolAnnotations on every tool (read-only says so, destructive
+  says so), strict CLI arguments, a defined status vocabulary,
+  and a debt plan that names every debt it had to leave out.
+- **The un-blooming begins** — the tool surface peaked at 111 and
+  starts shrinking: the batch tools are now canonical (deprecation
+  notices on the singular create/update), and v1.5 consolidates
+  the business surface from 48 tools to 25.
+
+**Tests:** 2,100+ passing, parallel by default (full suite < 40s).
 
 ## What's new in v1.4.2
 
@@ -660,7 +705,7 @@ Contributor guide and design notes live in
 
 ```bash
 uv sync --extra dev
-uv run pytest                       # 1,954 tests as of v1.4.2
+uv run pytest                       # 2,100+ tests as of v1.4.4, parallel by default
 uv run ruff check src/ tests/
 uv run black --check src/ tests/
 ```

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -41,6 +41,24 @@ from gnucash_mcp._format import (
 debug_logger = logging.getLogger("gnucash_mcp.debug")
 
 
+class _PlannedAccount:
+    """Stand-in for an account a rehearsal WOULD create.
+
+    The FX/discount resolvers auto-create their canonical account on
+    first use; a ``pay_invoice`` dry run must not (no piecash objects
+    during dry_run — the batch precedent). Carries exactly what the
+    rehearsal path reads; ``planned`` lets the response mark it.
+    """
+
+    placeholder = False
+    planned = True
+
+    def __init__(self, fullname: str, commodity, type: str):
+        self.fullname = fullname
+        self.commodity = commodity
+        self.type = type
+
+
 def _safe_invoice_date(inv, attr: str):
     """Read an invoice datetime column defensively.
 
@@ -405,12 +423,20 @@ class BusinessMixin:
             account.guid = uuid.uuid4().hex
         book.root_account[slot_key] = account.guid
 
-    def _get_or_create_fx_account(self, book, fx_account: str | None = None):
+    def _get_or_create_fx_account(
+        self, book, fx_account: str | None = None,
+        dry_run: bool = False,
+    ):
         """Find or lazily create the FX-gain/loss account.
 
         Returns ``(account, notice)``; ``notice`` is ``None`` except
         when the fuzzy match found multiple candidates and fell back
         to the canonical default.
+
+        ``dry_run=True`` resolves without side effects: no account
+        construction (a would-be create returns a
+        ``_PlannedAccount``) and no designation-slot writes (the
+        self-heal happens on the real run instead).
 
         Resolution order:
 
@@ -535,7 +561,7 @@ class BusinessMixin:
             # book's machinery generates is the resolver re-finding
             # its own account — designate it so the next call hits
             # Layer 0 and the healed slot survives renames.
-            if only.name.lower() in own_fx_leaves:
+            if only.name.lower() in own_fx_leaves and not dry_run:
                 self._store_designated_account(
                     book, self._FX_ACCOUNT_SLOT_KEY, only
                 )
@@ -580,9 +606,10 @@ class BusinessMixin:
         ):
             # Lock in the designation so the next call hits Layer 0
             # directly — even on a book that already had this account.
-            self._store_designated_account(
-                book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
-            )
+            if not dry_run:
+                self._store_designated_account(
+                    book, self._FX_ACCOUNT_SLOT_KEY, fx_acct
+                )
             return fx_acct, _ambiguity_notice(fx_acct.fullname)
 
         # Resolve the parent by TYPE, not the English name "Income".
@@ -594,7 +621,8 @@ class BusinessMixin:
         income, parent_notice = self._top_level_account_of_type(
             book, "INCOME"
         )
-        if income is None:
+        income_fullname = income.fullname if income is not None else "Income"
+        if income is None and not dry_run:
             income = piecash.Account(
                 name="Income",
                 type="INCOME",
@@ -618,7 +646,7 @@ class BusinessMixin:
         # identically — a permanently wedged cross-currency pay path.
         existing = next(
             (c for c in income.children if c.name == fx_leaf), None
-        )
+        ) if income is not None else None
         if existing is not None:
             if (
                 existing.type in {"INCOME", "EXPENSE"}
@@ -626,9 +654,10 @@ class BusinessMixin:
                 and not existing.placeholder
                 and existing.guid not in template_guids
             ):
-                self._store_designated_account(
-                    book, self._FX_ACCOUNT_SLOT_KEY, existing
-                )
+                if not dry_run:
+                    self._store_designated_account(
+                        book, self._FX_ACCOUNT_SLOT_KEY, existing
+                    )
                 adopted_notice = _ambiguity_notice(existing.fullname)
                 return existing, (
                     adopted_notice if adopted_notice is not None
@@ -645,6 +674,15 @@ class BusinessMixin:
                 f"{default_currency.mnemonic}). Pass fx_account "
                 f"explicitly to choose a different account."
             )
+
+        # Rehearsal: report the planned account instead of creating.
+        if dry_run:
+            planned = _PlannedAccount(
+                f"{income_fullname}:{fx_leaf}",
+                default_currency, "INCOME",
+            )
+            notice = _ambiguity_notice(planned.fullname)
+            return planned, notice if notice is not None else parent_notice
 
         # Construct — piecash.Account auto-adds to the session via the
         # parent linkage. Don't flush here: the caller is still building
@@ -672,13 +710,16 @@ class BusinessMixin:
     def _get_or_create_discount_account(
         self, book, owner_type_is_bill: bool,
         discount_account: str | None = None,
+        dry_run: bool = False,
     ):
         """Find or lazily create the early-payment-discount account.
 
         Direct parallel to ``_get_or_create_fx_account`` — same
         four-layer resolution (stored designation > explicit > fuzzy
-        match > canonical default with auto-create) and the same
-        ``(account, notice)`` return shape. The Layer-0 slot is
+        match > canonical default with auto-create), the same
+        ``(account, notice)`` return shape, and the same
+        ``dry_run`` contract (no creates, no slot writes; a would-be
+        create returns a ``_PlannedAccount``). The Layer-0 slot is
         per-side, so the sales and purchase designations are
         independent.
 
@@ -785,7 +826,8 @@ class BusinessMixin:
             and disc_acct.type in {"INCOME", "EXPENSE"}
             and not disc_acct.placeholder
         ):
-            self._store_designated_account(book, slot_key, disc_acct)
+            if not dry_run:
+                self._store_designated_account(book, slot_key, disc_acct)
             return disc_acct, _ambiguity_notice(disc_acct.fullname)
 
         # Resolve the parent by TYPE (INCOME/EXPENSE), not the English
@@ -796,7 +838,11 @@ class BusinessMixin:
             book, canonical_type
         )
         default_currency = self._require_default_currency(book)
-        if parent is None:
+        parent_fullname = (
+            parent.fullname if parent is not None
+            else canonical_parent_path
+        )
+        if parent is None and not dry_run:
             parent = piecash.Account(
                 name=canonical_parent_path,
                 type=canonical_type,
@@ -824,14 +870,17 @@ class BusinessMixin:
         # ship.
         existing = next(
             (c for c in parent.children if c.name == leaf_name), None
-        )
+        ) if parent is not None else None
         if existing is not None:
             if (
                 existing.type in {"INCOME", "EXPENSE"}
                 and not existing.placeholder
                 and existing.guid not in template_guids
             ):
-                self._store_designated_account(book, slot_key, existing)
+                if not dry_run:
+                    self._store_designated_account(
+                        book, slot_key, existing
+                    )
                 adopted_notice = _ambiguity_notice(existing.fullname)
                 return existing, (
                     adopted_notice if adopted_notice is not None
@@ -845,6 +894,17 @@ class BusinessMixin:
                 f"INCOME or EXPENSE account. Pass discount_account "
                 f"explicitly to choose a different account."
             )
+        # Rehearsal: report the planned account instead of creating.
+        if dry_run:
+            planned = _PlannedAccount(
+                f"{parent_fullname}:{leaf_name}",
+                default_currency, canonical_type,
+            )
+            notice = _ambiguity_notice(planned.fullname)
+            return planned, (
+                notice if notice is not None else parent_notice
+            )
+
         disc_acct = piecash.Account(
             name=leaf_name,
             type=canonical_type,
@@ -988,8 +1048,14 @@ class BusinessMixin:
         discount_amount: Decimal = Decimal("0"),
         discount_quantity: Decimal | None = None,
         discount_commodity=None,
+        dry_run: bool = False,
     ) -> dict | None:
         """Compute the realized FX gain/loss for a cross-currency payment.
+
+        ``dry_run=True`` computes identically but constructs no Split
+        (``"split"`` is None) and resolves the FX account without
+        side effects; ``"quantity"`` / ``"memo"`` carry what the
+        split would hold, for rehearsal rendering.
 
         When ``pay_invoice`` settles a foreign-currency invoice and
         the rate moved between post-date and pay-date, the amount
@@ -1136,7 +1202,7 @@ class BusinessMixin:
             return None
 
         fx_acct, fx_notice = self._get_or_create_fx_account(
-            book, fx_account=fx_account,
+            book, fx_account=fx_account, dry_run=dry_run,
         )
 
         # Customer (is_bill=False): received more → gain → credit
@@ -1148,21 +1214,27 @@ class BusinessMixin:
             (is_bill and fx_diff_default > 0)
             or (not is_bill and fx_diff_default < 0)
         )
-        split = piecash.Split(
-            account=fx_acct,
-            value=Decimal("0"),
-            quantity=quantity_sign * fx_diff_default,
-            memo=(
-                f"FX {'loss' if is_loss else 'gain'} on invoice "
-                f"{inv.id}: post-rate {rate_at_post:.4f}, pay-rate "
-                f"{exchange_rate}"
-            ),
+        fx_quantity = quantity_sign * fx_diff_default
+        fx_memo = (
+            f"FX {'loss' if is_loss else 'gain'} on invoice "
+            f"{inv.id}: post-rate {rate_at_post:.4f}, pay-rate "
+            f"{exchange_rate}"
         )
+        split = None
+        if not dry_run:
+            split = piecash.Split(
+                account=fx_acct,
+                value=Decimal("0"),
+                quantity=fx_quantity,
+                memo=fx_memo,
+            )
         return {
             "split": split,
             "fx_diff_default": fx_diff_default,
             "fx_acct": fx_acct,
             "fx_notice": fx_notice,
+            "quantity": fx_quantity,
+            "memo": fx_memo,
         }
 
     @staticmethod
@@ -5570,11 +5642,22 @@ class BusinessMixin:
         discount_account: str | None = None,
         force: bool = False,
         memo: str = "",
+        dry_run: bool = False,
     ) -> dict:
         """Record a payment against a posted invoice or bill.
 
         Creates a payment transaction and assigns the A/R or A/P
         split to the invoice's lot. Partial payments are supported.
+
+        ``dry_run=True`` is a full rehearsal: every validation,
+        conversion, discount precondition, and FX computation runs
+        identically (readonly session, nothing persists, no piecash
+        objects constructed), returning the proposed splits,
+        remaining balance after, and any FX/discount treatment. An
+        account the real run would auto-create (FX gain/loss,
+        discounts) is reported under ``would_create_accounts``
+        rather than created. A dry run that succeeds is a payment
+        that will book — same inputs, same code path.
 
         ``memo`` lands on the bank-account split (check number, wire
         reference). The A/R//A/P split keeps its ``action="Payment"``
@@ -5622,7 +5705,7 @@ class BusinessMixin:
             else date.today()
         )
 
-        with self.open(readonly=False) as book:
+        with self.open(readonly=dry_run) as book:
             inv = self._find_invoice(book, invoice_id, owner_type=ot)
             if not inv:
                 raise ValueError(
@@ -5785,9 +5868,12 @@ class BusinessMixin:
             # all invariants and books the discount split, or
             # rejects.
             discount_split: piecash.Split | None = None
+            discount_booked = False
             discount_acct = None
             discount_notice = None
             discount_amount_invoice_ccy = Decimal("0")
+            disc_quantity: Decimal | None = None
+            disc_value_sign = 1
             if apply_discount:
                 if is_credit_note:
                     raise ValueError(
@@ -5890,6 +5976,7 @@ class BusinessMixin:
                         book,
                         owner_type_is_bill=effective_is_bill,
                         discount_account=discount_account,
+                        dry_run=dry_run,
                     )
                 )
                 disc_quantity, _disc_rate = _convert(
@@ -5898,12 +5985,14 @@ class BusinessMixin:
                 # Customer payment: discount is EXPENSE (debit), +value
                 # Vendor bill payment: discount is INCOME (credit), -value
                 disc_value_sign = -1 if effective_is_bill else 1
-                discount_split = piecash.Split(
-                    account=discount_acct,
-                    value=disc_value_sign * expected,
-                    quantity=disc_value_sign * disc_quantity,
-                    memo="Early-payment discount",
-                )
+                discount_booked = True
+                if not dry_run:
+                    discount_split = piecash.Split(
+                        account=discount_acct,
+                        value=disc_value_sign * expected,
+                        quantity=disc_value_sign * disc_quantity,
+                        memo="Early-payment discount",
+                    )
                 discount_amount_invoice_ccy = expected
 
                 # With a discount the A/R side absorbs the FULL
@@ -5943,38 +6032,35 @@ class BusinessMixin:
                         / remaining_before_pay
                     ).quantize(_commodity_quantum(post_acct.commodity))
 
-            if effective_is_bill:
-                # Pay vendor bill (or refund customer credit note):
-                # debit A/P, credit bank.
-                ar_ap_split = piecash.Split(
-                    account=post_acct,
-                    value=full_settle_amount,
-                    quantity=full_settle_post_qty,
-                    memo="",
-                    action="Payment",
-                )
-                bank_split = piecash.Split(
-                    account=pay_acct,
-                    value=-payment_amount,
-                    quantity=-pay_quantity,
-                    memo=memo,
-                )
-            else:
-                # Receive customer payment (or refund-in from a
-                # vendor credit note): credit A/R, debit bank.
-                ar_ap_split = piecash.Split(
-                    account=post_acct,
-                    value=-full_settle_amount,
-                    quantity=-full_settle_post_qty,
-                    memo="",
-                    action="Payment",
-                )
-                bank_split = piecash.Split(
-                    account=pay_acct,
-                    value=payment_amount,
-                    quantity=pay_quantity,
-                    memo=memo,
-                )
+            # Sign-factored split data: a bill payment (or customer
+            # credit-note refund) debits A/P and credits bank; the
+            # customer receipt is the exact mirror. ONE set of
+            # values feeds both the rehearsal's proposed-splits
+            # table and the real Split construction below — the
+            # rehearsal cannot diverge from the booking.
+            sgn = 1 if effective_is_bill else -1
+            proposed: list[dict] = [
+                {
+                    "account": post_acct.fullname,
+                    "value": sgn * full_settle_amount,
+                    "quantity": sgn * full_settle_post_qty,
+                    "memo": "",
+                    "action": "Payment",
+                },
+                {
+                    "account": pay_acct.fullname,
+                    "value": -sgn * payment_amount,
+                    "quantity": -sgn * pay_quantity,
+                    "memo": memo,
+                },
+            ]
+            if discount_booked:
+                proposed.append({
+                    "account": discount_acct.fullname,
+                    "value": disc_value_sign * discount_amount_invoice_ccy,
+                    "quantity": disc_value_sign * disc_quantity,
+                    "memo": "Early-payment discount",
+                })
 
             # Realized FX gain/loss on post→pay rate drift, factored
             # into _compute_fx_gain_loss (the four sign quadrants
@@ -5982,9 +6068,6 @@ class BusinessMixin:
             # transaction currency, non-zero quantity in the FX
             # account's commodity (book default). One account both
             # directions; sign decides gain vs loss.
-            splits = [ar_ap_split, bank_split]
-            if discount_split is not None:
-                splits.append(discount_split)
             fx_result: dict | None = None
             default_currency = self._require_default_currency(book)
             if exchange_rate is not None:
@@ -6004,18 +6087,142 @@ class BusinessMixin:
                     default_currency=default_currency,
                     discount_amount=discount_amount_invoice_ccy,
                     discount_quantity=(
-                        discount_split.quantity * (
-                            -1 if effective_is_bill else 1
-                        )
-                        if discount_split is not None else None
+                        disc_quantity if discount_booked else None
                     ),
                     discount_commodity=(
                         discount_acct.commodity
                         if discount_acct is not None else None
                     ),
+                    dry_run=dry_run,
                 )
                 if fx_result is not None:
-                    splits.append(fx_result["split"])
+                    proposed.append({
+                        "account": fx_result["fx_acct"].fullname,
+                        "value": Decimal("0"),
+                        "quantity": fx_result["quantity"],
+                        "memo": fx_result["memo"],
+                    })
+
+            # Shared result tail — identical blocks on the rehearsal
+            # and the booked response, built from the same locals.
+            def _attach_extras(result: dict) -> None:
+                if exchange_rate is not None:
+                    result["exchange_rate"] = str(exchange_rate)
+                    result["payment_account_amount"] = str(pay_quantity)
+                    result["invoice_currency"] = inv.currency.mnemonic
+                    result["payment_account_currency"] = (
+                        pay_acct.commodity.mnemonic
+                    )
+                    if fx_result is not None:
+                        fx_diff_default = fx_result["fx_diff_default"]
+                        # Label follows effective_is_bill (the
+                        # direction the split was booked with) —
+                        # keyed on is_bill, an FX loss on a customer
+                        # credit-note refund would be labeled "gain".
+                        direction = (
+                            "loss"
+                            if (effective_is_bill and fx_diff_default > 0)
+                            or (
+                                not effective_is_bill
+                                and fx_diff_default < 0
+                            )
+                            else "gain"
+                        )
+                        result["fx_realized"] = {
+                            # In the book default — the FX account's
+                            # commodity.
+                            "amount": str(
+                                abs(fx_diff_default).quantize(
+                                    _commodity_quantum(default_currency)
+                                )
+                            ),
+                            "currency": default_currency.mnemonic,
+                            "direction": direction,
+                            "account": fx_result["fx_acct"].fullname,
+                        }
+                        if fx_result["fx_notice"] is not None:
+                            result["fx_notice"] = fx_result["fx_notice"]
+                if discount_booked:
+                    # ``account`` is the canonical path — the resolver
+                    # may have picked an account the caller didn't pass.
+                    result["discount"] = {
+                        "amount": str(discount_amount_invoice_ccy),
+                        "currency": inv.currency.mnemonic,
+                        "account": discount_acct.fullname,
+                    }
+                    if discount_notice is not None:
+                        result["discount_notice"] = discount_notice
+                # Surface the worst-aged forced FX override (if any).
+                if fx_stale_overrides:
+                    result["fx_stale"] = max(
+                        fx_stale_overrides, key=lambda m: m["age_days"]
+                    )
+
+            doc_type = (
+                "credit_note"
+                if is_credit_note
+                else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                    inv.owner_type, "invoice"
+                )
+            )
+
+            # ── Rehearsal exit: everything above ran; nothing books.
+            # Projected remaining derives from the same directional
+            # balance the overpayment guard used (invoice currency,
+            # positive = still owed).
+            if dry_run:
+                remaining_after = (
+                    remaining_before_pay - full_settle_amount
+                )
+                result = {
+                    "dry_run": True,
+                    "id": inv.id,
+                    "type": doc_type,
+                    "status": "would_pay",
+                    "amount": str(payment_amount),
+                    "remaining_balance_after": str(remaining_after),
+                    "would_close_lot": remaining_after == Decimal(0),
+                    "payment_account": pay_acct.fullname,
+                    "payment_date": str(parsed_date),
+                    "proposed_splits": [
+                        {
+                            k: (str(v) if isinstance(v, Decimal) else v)
+                            for k, v in row.items()
+                        }
+                        for row in proposed
+                    ],
+                }
+                would_create = sorted(
+                    a.fullname
+                    for a in (
+                        discount_acct,
+                        fx_result["fx_acct"] if fx_result else None,
+                    )
+                    if a is not None and getattr(a, "planned", False)
+                )
+                if would_create:
+                    result["would_create_accounts"] = would_create
+                _attach_extras(result)
+                return result
+
+            ar_ap_split = piecash.Split(
+                account=post_acct,
+                value=proposed[0]["value"],
+                quantity=proposed[0]["quantity"],
+                memo="",
+                action="Payment",
+            )
+            bank_split = piecash.Split(
+                account=pay_acct,
+                value=proposed[1]["value"],
+                quantity=proposed[1]["quantity"],
+                memo=memo,
+            )
+            splits = [ar_ap_split, bank_split]
+            if discount_split is not None:
+                splits.append(discount_split)
+            if fx_result is not None:
+                splits.append(fx_result["split"])
 
             txn = piecash.Transaction(
                 currency=inv.currency,
@@ -6047,13 +6254,7 @@ class BusinessMixin:
 
             result = {
                 "id": inv.id,
-                "type": (
-                    "credit_note"
-                    if is_credit_note
-                    else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                        inv.owner_type, "invoice"
-                    )
-                ),
+                "type": doc_type,
                 "status": "paid",
                 "amount_paid": str(payment_amount),
                 "remaining_balance": str(remaining_directional),
@@ -6067,51 +6268,7 @@ class BusinessMixin:
                 "payment_account": pay_acct.fullname,
                 "payment_date": str(parsed_date),
             }
-            if exchange_rate is not None:
-                result["exchange_rate"] = str(exchange_rate)
-                result["payment_account_amount"] = str(pay_quantity)
-                result["invoice_currency"] = inv.currency.mnemonic
-                result["payment_account_currency"] = pay_acct.commodity.mnemonic
-                if fx_result is not None:
-                    fx_diff_default = fx_result["fx_diff_default"]
-                    # Label follows effective_is_bill (the direction
-                    # the split was booked with) — keyed on is_bill,
-                    # an FX loss on a customer credit-note refund
-                    # would be labeled "gain".
-                    direction = (
-                        "loss" if (effective_is_bill and fx_diff_default > 0)
-                        or (not effective_is_bill and fx_diff_default < 0)
-                        else "gain"
-                    )
-                    result["fx_realized"] = {
-                        # In the book default — the FX account's
-                        # commodity.
-                        "amount": str(
-                            abs(fx_diff_default).quantize(
-                                _commodity_quantum(default_currency)
-                            )
-                        ),
-                        "currency": default_currency.mnemonic,
-                        "direction": direction,
-                        "account": fx_result["fx_acct"].fullname,
-                    }
-                    if fx_result["fx_notice"] is not None:
-                        result["fx_notice"] = fx_result["fx_notice"]
-            if discount_split is not None:
-                # ``account`` is the canonical path — the resolver
-                # may have picked an account the caller didn't pass.
-                result["discount"] = {
-                    "amount": str(discount_amount_invoice_ccy),
-                    "currency": inv.currency.mnemonic,
-                    "account": discount_acct.fullname,
-                }
-                if discount_notice is not None:
-                    result["discount_notice"] = discount_notice
-            # Surface the worst-aged forced FX override (if any).
-            if fx_stale_overrides:
-                result["fx_stale"] = max(
-                    fx_stale_overrides, key=lambda m: m["age_days"]
-                )
+            _attach_extras(result)
 
         return result
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -3296,6 +3296,12 @@ class CoreMixin:
         """
         # Dry runs don't need a writable session; all other paths do.
         readonly = dry_run
+        # Defaults resolve loudly, explicit inputs echo nothing: when
+        # the caller omitted the date, the response says which day
+        # "today" resolved to — server, client, and book can sit in
+        # different time zones (a UTC-hosted deployment is a day
+        # ahead of a Pacific book every evening).
+        date_defaulted = trans_date is None
         if trans_date is None:
             trans_date = date.today()
 
@@ -3488,6 +3494,8 @@ class CoreMixin:
                 transaction.guid, (t.guid for t in book.transactions)
             )
             result = {"guid": short_guid, "status": "created"}
+            if date_defaulted:
+                result["date"] = trans_date.isoformat()
             if warnings:
                 result["warnings"] = warnings
             if duplicates:

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1391,6 +1391,11 @@ class ReportingMixin:
             # loan_term_months slot). Omitted from the plan rather than
             # estimated from a guessed term — see the LIABILITY branch.
             unestimable_debts: list[str] = []
+            # Debt-typed accounts CARRYING A BALANCE but lacking a
+            # usable 'apr' slot — the plan can't order or cost them.
+            # Confessed alongside the other two exclusion classes; a
+            # silently partial payoff plan reads as a complete one.
+            no_apr_debts: list[str] = []
             # Counted so the no-debts error distinguishes "no debt
             # accounts at all" from "they exist but lack the apr
             # slot" — the user's next action differs.
@@ -1431,21 +1436,13 @@ class ReportingMixin:
                 # accesses each re-walk the slots collection.
                 slot_by_name = {s.name: s for s in account.slots}
 
-                apr_val = slot_by_name.get("apr")
-                if apr_val is None:
-                    continue
-                try:
-                    apr_str = str(apr_val.value) if hasattr(apr_val, "value") else str(apr_val)
-                    apr = Decimal(apr_str)
-                except InvalidOperation:
-                    continue
-
-                if apr <= 0:
-                    continue
-
-                # Balance in book default, today-capped (a payment
-                # scheduled next week hasn't reduced today's payoff
-                # balance); voided and null-date splits excluded.
+                # Balance FIRST (book default, today-capped — a
+                # payment scheduled next week hasn't reduced today's
+                # payoff balance; voided and null-date splits
+                # excluded), so a missing APR on a balance-carrying
+                # debt is CONFESSED below instead of silently
+                # dropped; zero-balance accounts stay silent either
+                # way — a closed old card is not a gap in the plan.
                 today = date.today()
                 balance = Decimal("0")
                 for split in account.splits:
@@ -1461,6 +1458,18 @@ class ReportingMixin:
 
                 if balance <= 0:
                     continue  # Skip zero or overpaid balances
+
+                apr_val = slot_by_name.get("apr")
+                apr = None
+                if apr_val is not None:
+                    try:
+                        apr_str = str(apr_val.value) if hasattr(apr_val, "value") else str(apr_val)
+                        apr = Decimal(apr_str)
+                    except InvalidOperation:
+                        apr = None
+                if apr is None or apr <= 0:
+                    no_apr_debts.append(account.fullname)
+                    continue
 
                 min_payment = None
 
@@ -1586,6 +1595,18 @@ class ReportingMixin:
                 f"term: {', '.join(sorted(unestimable_debts))}. Set "
                 f"loan_term_months (or minimum_payment) via "
                 f"set_account_slot for payment estimates."
+            )
+
+        # Balance-carrying debts invisible to the plan for lack of an
+        # APR — the third exclusion class, same confession contract.
+        no_apr_warning = None
+        if no_apr_debts:
+            no_apr_warning = (
+                f"{len(no_apr_debts)} balance-carrying debt(s) not in "
+                f"the plan — no 'apr' slot (or APR <= 0): "
+                f"{', '.join(sorted(no_apr_debts))}. Set 'apr' via "
+                f"set_account_slot to include them in the payoff "
+                f"order."
             )
 
         if not debts:
@@ -1714,6 +1735,9 @@ class ReportingMixin:
         if unestimable_warning:
             full["unestimable"] = sorted(unestimable_debts)
             warnings.append(unestimable_warning)
+        if no_apr_warning:
+            full["no_apr"] = sorted(no_apr_debts)
+            warnings.append(no_apr_warning)
         if warnings:
             full["warnings"] = warnings
 
@@ -1737,4 +1761,6 @@ class ReportingMixin:
             compact_out += f"\n⚠ {excluded_warning}"
         if unestimable_warning:
             compact_out += f"\n⚠ {unestimable_warning}"
+        if no_apr_warning:
+            compact_out += f"\n⚠ {no_apr_warning}"
         return compact_out

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1069,6 +1069,16 @@ def register(mcp, get_book) -> None:
         ``offset``; ``limit=0`` returns the count only. Use verbose=true
         for structured JSON with GUIDs, dates, notes, etc.
 
+        Status vocabulary (shared by every invoice/bill tool):
+        **open** = created and editable, not yet booked to A/R//A/P —
+        not payable. **posted** = booked to A/R//A/P with a lot
+        tracking its balance — payable. **paid** = posted with a zero
+        remaining balance (lot closed). **outstanding** = posted with
+        a remaining balance — the unpaid subset; get it directly from
+        ``get_outstanding_invoices`` rather than deriving it here.
+        The ``status`` filter below covers document state
+        (open/posted) only; settlement state lives on the lot.
+
         Args:
             owner_type: Filter by type: "customer" for invoices,
                         "vendor" for bills, or omit for all.
@@ -1110,6 +1120,11 @@ def register(mcp, get_book) -> None:
         vendor bills, employee vouchers, and credit notes (reported
         as type='credit_note'). Returns all entries with quantities,
         prices, and totals.
+
+        Status vocabulary: open = editable, not yet booked; posted =
+        on the books, payable; paid = remaining balance zero. The
+        full definitions live on ``list_invoices``; the unpaid list
+        is ``get_outstanding_invoices``.
 
         Args:
             id: Invoice or bill ID (e.g., "000001"). This is the
@@ -1606,6 +1621,11 @@ def register(mcp, get_book) -> None:
         offset: int = 0,
     ) -> str:
         """Get all posted invoices/bills with outstanding balances.
+
+        This is the authoritative unpaid list: outstanding = posted
+        with a remaining balance > 0. One call answers "what is
+        actually unpaid?" — no need to combine ``list_invoices`` and
+        ``get_invoice`` (full status vocabulary on ``list_invoices``).
 
         Leads with a ``Showing X-Y of Z invoices (date range)`` line,
         then a compact one-line-per-doc format by default with action

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -1217,11 +1217,21 @@ def register(mcp, get_book) -> None:
         discount_account: str | None = None,
         force: bool = False,
         memo: str = "",
+        dry_run: bool = False,
     ) -> str:
         """Record a payment against a posted invoice or bill.
 
         Creates a payment transaction from the specified bank/cash account
         to the invoice's A/R or A/P account. Partial payments are supported.
+
+        ``dry_run=true`` rehearses the payment without booking it:
+        the full validation, conversion, discount, and FX pipeline
+        runs and the response shows the proposed splits, the
+        remaining balance after, whether the invoice would settle in
+        full, and any account the real call would auto-create. Same
+        inputs, same code path — a rehearsal that succeeds is a
+        payment that will book. Recommended before complex payments
+        (cross-currency, discounts, credit-note refunds).
 
         For cross-currency payments where the rate moved between
         post-date and pay-date, a realized FX gain/loss split is
@@ -1277,6 +1287,9 @@ def register(mcp, get_book) -> None:
                 check number or wire reference). ``description``
                 names the whole transaction; ``memo`` annotates the
                 cash movement.
+            dry_run: When True, rehearse without writing — returns
+                the proposed splits and projected outcome instead of
+                booking. Default False.
         """
         owner_type = _gate_owner_type(owner_type)
         book = get_book()
@@ -1292,6 +1305,7 @@ def register(mcp, get_book) -> None:
             discount_account=discount_account,
             force=force,
             memo=memo,
+            dry_run=dry_run,
         )
         return _json(result)
 

--- a/src/gnucash_mcp/tools/reporting.py
+++ b/src/gnucash_mcp/tools/reporting.py
@@ -222,6 +222,17 @@ def register(mcp, get_book) -> None:
         Auto-discovers CREDIT/LIABILITY accounts that have an 'apr' slot set.
         Set APRs via set_account_slot (e.g., set_account_slot("Liabilities:Visa", "apr", "23.49")).
 
+        Assumptions the schedule is computed under: interest
+        compounds monthly at apr/12 on the running balance; one
+        payment per debt per month starting this month; extra budget
+        beyond the minimums goes to the highest-APR debt first
+        (avalanche); balances are as of today in the book default
+        currency; amounts round to 0.01. Debts the plan cannot
+        include are CONFESSED in ⚠ lines, never silently dropped:
+        foreign-currency debts with no FX rate, loans with no
+        minimum_payment/loan_term_months to estimate a payment from,
+        and balance-carrying debts with no 'apr' slot.
+
         Returns a compact text summary by default — kill order with
         balances/APRs/payoff months, YETI line, totals, debt-free date.
         Use verbose=true for the structured dict (per-account

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -13111,3 +13111,33 @@ class TestSplitGraphPreload:
                 f"{len(statements)} SQL statements — the preload's "
                 f"strong reference has been lost"
             )
+
+
+class TestDefaultedDateEcho:
+    """Defaults resolve loudly, explicit inputs echo nothing: a
+    create_transaction that let the date default to today learns
+    which day 'today' resolved to; an explicit date echoes nothing
+    (the caller already has it)."""
+
+    def test_defaulted_date_is_echoed(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Defaulted date",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+                {"account": "Assets:Checking", "amount": "-10.00"},
+            ],
+        )
+        assert result["date"] == date.today().isoformat()
+
+    def test_explicit_date_is_not_echoed(self, test_book: Path):
+        gc_book = GnuCashBook(str(test_book))
+        result = gc_book.create_transaction(
+            description="Explicit date",
+            splits=[
+                {"account": "Expenses:Groceries", "amount": "10.00"},
+                {"account": "Assets:Checking", "amount": "-10.00"},
+            ],
+            trans_date=date(2024, 2, 1),
+        )
+        assert "date" not in result

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -11245,3 +11245,261 @@ class TestCodexCrossModelFindings:
             post_account="Liabilities:Accounts Payable",
         )
         assert result["status"] == "posted"
+
+
+class TestPayInvoiceDryRun:
+    """pay_invoice(dry_run=True) — full rehearsal, zero writes.
+
+    The rehearsal runs the identical validation/conversion/FX
+    pipeline (same code path, sign-factored shared split data), so
+    these tests assert both halves of the contract: the proposal is
+    faithful to what the real call books, and the book is untouched
+    — including the accounts and designation slots the resolvers
+    would otherwise lazily create.
+    """
+
+    def _post_invoice(self, gb, amount="500.00"):
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        return "000001"
+
+    def test_dry_run_proposes_and_writes_nothing(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+            dry_run=True,
+        )
+        assert result["dry_run"] is True
+        assert result["status"] == "would_pay"
+        assert Decimal(result["remaining_balance_after"]) == Decimal("300")
+        assert result["would_close_lot"] is False
+        # Customer receipt: credit A/R, debit bank.
+        by_acct = {
+            s["account"]: s for s in result["proposed_splits"]
+        }
+        assert Decimal(
+            by_acct["Assets:Accounts Receivable"]["value"]
+        ) == Decimal("-200")
+        assert Decimal(
+            by_acct["Assets:Checking"]["value"]
+        ) == Decimal("200")
+        assert by_acct["Assets:Accounts Receivable"]["action"] == "Payment"
+        # Nothing booked: A/R still carries the full invoice.
+        assert gb.get_balance(
+            account_name="Assets:Accounts Receivable"
+        ) == Decimal("500")
+
+    def test_dry_run_full_settlement_would_close_lot(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+            dry_run=True,
+        )
+        assert result["would_close_lot"] is True
+        assert Decimal(result["remaining_balance_after"]) == Decimal("0")
+        # Rehearsal parity: the identical real call then succeeds.
+        real = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+        assert real["status"] == "paid"
+        assert Decimal(real["remaining_balance"]) == Decimal("0")
+
+    def test_dry_run_validation_parity_overpayment(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        with pytest.raises(ValueError, match="exceeds the outstanding"):
+            gb.pay_invoice(
+                invoice_id="000001",
+                payment_account="Assets:Checking",
+                amount="600",
+                dry_run=True,
+            )
+
+    def test_dry_run_vendor_bill_sign_direction(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_bill(vendor_id="000001")
+        gb.add_bill_entry(
+            bill_id="000001",
+            account="Expenses:Office Supplies",
+            description="Paper",
+            quantity="1",
+            price="50.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Liabilities:Accounts Payable",
+            owner_type="vendor",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="50",
+            owner_type="vendor",
+            dry_run=True,
+        )
+        by_acct = {
+            s["account"]: s for s in result["proposed_splits"]
+        }
+        # Bill payment: debit A/P, credit bank.
+        assert Decimal(
+            by_acct["Liabilities:Accounts Payable"]["value"]
+        ) == Decimal("50")
+        assert Decimal(
+            by_acct["Assets:Checking"]["value"]
+        ) == Decimal("-50")
+
+    def test_dry_run_discount_reports_without_creating_account(
+        self, business_book,
+    ):
+        """apply_discount rehearsal: discount block present, proposed
+        discount split present, and the Sales Discounts account the
+        real run would auto-create does NOT appear."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_billterm(
+            name="2/10 Net 30", due_days=30,
+            discount_days=10, discount_percent="2",
+        )
+        today = date.today()
+        gb.create_invoice(
+            customer_id="000001", term="2/10 Net 30",
+            date_opened=today.isoformat(),
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price="1000.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date=today.isoformat(),
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="980.00",
+            apply_discount=True,
+            dry_run=True,
+        )
+        assert result["dry_run"] is True
+        assert result["discount"]["amount"] == "20.00"
+        assert result["would_close_lot"] is True
+        disc_rows = [
+            s for s in result["proposed_splits"]
+            if s["memo"] == "Early-payment discount"
+        ]
+        assert len(disc_rows) == 1
+        assert Decimal(disc_rows[0]["value"]) == Decimal("20.00")
+        # The auto-create was rehearsed, not performed.
+        assert result["would_create_accounts"] == [
+            "Expenses:Sales Discounts"
+        ]
+        accounts = gb.list_accounts()
+        assert "Sales Discounts" not in str(accounts)
+        # A/R untouched.
+        assert gb.get_balance(
+            account_name="Assets:Accounts Receivable"
+        ) == Decimal("1000")
+
+    def test_dry_run_cross_currency_fx_projection(self, business_book):
+        """EUR invoice, USD book, rate drift between post and pay:
+        the rehearsal projects the FX gain split and reports the FX
+        account as would-create — and creates nothing."""
+        import piecash
+
+        gb = GnuCashBook(str(business_book))
+        with gb.open(readonly=False) as book:
+            usd = book.default_currency
+            eur = piecash.factories.create_currency_from_ISO("EUR")
+            book.session.add(eur)
+            book.flush()
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date(2026, 3, 10),
+                value="1.10", source="user:test", type="nav",
+            ))
+            book.session.add(piecash.Price(
+                commodity=eur, currency=usd,
+                date=date(2026, 3, 20),
+                value="1.20", source="user:test", type="nav",
+            ))
+            book.save()
+
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(
+            customer_id="000001", currency="EUR",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Consulting",
+            description="EUR services",
+            quantity="1", price="1000.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-03-10",
+        )
+        result = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="1000.00",
+            payment_date="2026-03-20",
+            dry_run=True,
+        )
+        assert Decimal(result["exchange_rate"]) == Decimal("1.20")
+        # €1000 × (1.20 − 1.10) = $100 realized gain, projected.
+        assert result["fx_realized"]["direction"] == "gain"
+        assert Decimal(result["fx_realized"]["amount"]) == Decimal("100")
+        assert result["would_create_accounts"] == [
+            "Income:Foreign Exchange Gain/Loss"
+        ]
+        fx_rows = [
+            s for s in result["proposed_splits"]
+            if s["account"] == "Income:Foreign Exchange Gain/Loss"
+        ]
+        assert len(fx_rows) == 1
+        assert Decimal(fx_rows[0]["value"]) == Decimal("0")
+        # Nothing created, nothing designated, nothing paid.
+        accounts = gb.list_accounts()
+        assert "Foreign Exchange" not in str(accounts)
+        assert gb.get_balance(
+            account_name="Assets:Accounts Receivable"
+        ) == Decimal("1100")
+        # Rehearsal parity: the identical real call books it all.
+        real = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="1000.00",
+            payment_date="2026-03-20",
+        )
+        assert real["status"] == "paid"
+        assert real["fx_realized"]["account"] == (
+            "Income:Foreign Exchange Gain/Loss"
+        )
+        accounts = gb.list_accounts()
+        assert "Foreign Exchange" in str(accounts)

--- a/tests/test_debt_payoff.py
+++ b/tests/test_debt_payoff.py
@@ -813,3 +813,39 @@ class TestDebtPayoffCompactFormat:
         # per account in the old shape. Should appear at most once now
         # (or zero times — we use "total debt impact" wording instead).
         assert result.count("by the time your debt is paid off") <= 1
+
+
+class TestNoAprConfession:
+    """Balance-carrying debts without an APR are confessed, not
+    silently dropped — the third exclusion class, same contract as
+    the FX-unvalued and unestimable confessions."""
+
+    def test_balance_carrying_debt_without_apr_is_confessed(
+        self, debt_book: Path,
+    ):
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.delete_account_slot("Liabilities:Visa", "apr")
+
+        result = gc_book.debt_payoff_plan(
+            compact=False, monthly_budget="1000",
+        )
+
+        names = [d["account"] for d in result["debts"]]
+        assert "Liabilities:Visa" not in names
+        assert result["no_apr"] == ["Liabilities:Visa"]
+        assert any("'apr'" in w for w in result["warnings"])
+        # The other debts still plan.
+        assert "Liabilities:Mastercard" in names
+
+    def test_compact_output_carries_the_confession(
+        self, debt_book: Path,
+    ):
+        gc_book = GnuCashBook(str(debt_book))
+        gc_book.delete_account_slot("Liabilities:Visa", "apr")
+
+        out = gc_book.debt_payoff_plan(
+            compact=True, monthly_budget="1000",
+        )
+        assert "⚠" in out
+        assert "Liabilities:Visa" in out
+        assert "balance-carrying" in out


### PR DESCRIPTION
## Summary
- `pay_invoice` gains `dry_run` — full rehearsal of the most consequence-dense write (FX, discounts, lots, partials): proposed splits, projected remaining, would-create accounts, zero writes; one shared computation so rehearsal cannot diverge from booking
- `debt_payoff_plan` confesses balance-carrying debts lacking an 'apr' slot (third exclusion class) + stated assumptions in the docstring
- Invoice/bill status vocabulary defined once (open/posted/paid/outstanding); `get_outstanding_invoices` named the one-call unpaid answer
- `create_transaction` echoes its date when defaulted to today (defaults resolve loudly)
- v1.4.4 CHANGELOG entry + README refresh (statement-entry tour example, counts)

All four adopted findings from the outside-model docstring review, 2026-08-26.

## Test plan
- [x] Full suite green
- [x] Live smoke on Alex copy: dry-run parity exact (projection == booked remaining), book untouched after rehearsal, real pay verified
- [x] Cross-currency rehearsal: FX projection + would_create_accounts, nothing created, identical real call books it all