### PR TITLE
feat(core): clear column on update batch; deprecate update_transaction

### DIFF
--- a/src/gnucash_mcp/_format.py
+++ b/src/gnucash_mcp/_format.py
@@ -1000,12 +1000,23 @@ def _parse_update_tsv(tsv: str) -> list[dict]:
     """``update_transactions`` TSV → row dicts.
 
     Header: ``guid`` then any of ``description``, ``notes``,
-    ``date`` (at least one, any order, no repeats); unknown tokens
-    reject by name. An EMPTY cell leaves that field unchanged — the
-    key is simply absent from the row dict. ``date`` stays an ISO
-    string here (the tool layer parses; the audit display reuses
-    this parser and wants text). Shared with the audit formatter so
-    the display parse can't drift from the tool parse.
+    ``date`` (at least one, any order, no repeats), plus an
+    optional ``clear`` column; unknown tokens reject by name. An
+    EMPTY cell leaves that field unchanged — the key is simply
+    absent from the row dict.
+
+    ``clear`` is the explicit opt-in that empty-cell-means-
+    unchanged deliberately forecloses: its cell holds
+    comma-separated field names (``description`` and/or ``notes``)
+    to blank on that row, emitted as ``""`` values (the book layer
+    already treats empty as clear). ``date`` is not clearable —
+    transactions must have one. A row that both sets and clears
+    the same field is contradictory and rejects.
+
+    ``date`` stays an ISO string here (the tool layer parses; the
+    audit display reuses this parser and wants text). Shared with
+    the audit formatter so the display parse can't drift from the
+    tool parse.
     """
     lines = _tsv_lines(tsv, "the updates TSV")
     if len(lines) < 2:
@@ -1021,14 +1032,15 @@ def _parse_update_tsv(tsv: str) -> list[dict]:
     if not fields:
         raise ValueError(
             "updates header needs at least one field column "
-            "(description, notes, date)"
+            "(description, notes, date) or a clear column"
         )
     seen: set = set()
     for tok in fields:
-        if tok not in _UPDATE_TSV_FIELDS:
+        if tok != "clear" and tok not in _UPDATE_TSV_FIELDS:
             raise ValueError(
                 f"unrecognized column {tok!r} in updates header — "
-                f"columns are guid, then description, notes, date"
+                f"columns are guid, then description, notes, date, "
+                f"and optionally clear"
             )
         if tok in seen:
             raise ValueError(f"duplicate {tok!r} column in updates header")
@@ -1041,8 +1053,31 @@ def _parse_update_tsv(tsv: str) -> list[dict]:
         if not guid:
             raise ValueError(f"row {i}: empty guid")
         row: dict = {"guid": guid}
+        clear_spec = ""
         for j, tok in enumerate(fields, start=1):
-            if j < len(cells) and cells[j].strip():
-                row[tok] = cells[j].strip()
+            cell = cells[j].strip() if j < len(cells) else ""
+            if tok == "clear":
+                clear_spec = cell
+            elif cell:
+                row[tok] = cell
+        for name in (
+            n.strip().lower()
+            for n in clear_spec.split(",") if n.strip()
+        ):
+            if name == "date":
+                raise ValueError(
+                    f"row {i}: 'date' is not clearable — every "
+                    f"transaction needs a posting date"
+                )
+            if name not in ("description", "notes"):
+                raise ValueError(
+                    f"row {i}: unknown field {name!r} in clear cell "
+                    f"— clearable fields are description, notes"
+                )
+            if name in row:
+                raise ValueError(
+                    f"row {i}: sets AND clears {name!r} — pick one"
+                )
+            row[name] = ""
         out.append(row)
     return out

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -5888,10 +5888,10 @@ class CoreMixin:
 
         Each entry: ``{guid, description (optional), notes
         (optional), date (optional, datetime.date)}`` — absent keys
-        leave the field unchanged (the TSV's empty cells). Clearing
-        a field is deliberately single-tool territory
-        (``update_transaction`` with ``notes=""``) so a sparse batch
-        can never mass-erase.
+        leave the field unchanged (the TSV's empty cells), while an
+        explicit ``""`` clears (produced only by the TSV ``clear``
+        column — an opt-in per-row declaration, so a sparse batch
+        still can never mass-erase by accident).
 
         ``on_error="abort"`` (default) sinks the batch on any bad
         row; ``"skip"`` keeps the good rows. ``force`` allows date

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -897,7 +897,23 @@ def register(mcp, get_book) -> None:
         notes: str | None = None,
         force: bool = False,
     ) -> str:
-        """Update an existing transaction — or broadcast to several.
+        """DEPRECATED — use ``update_transactions``. Scheduled for
+        removal in a future release; it still works as documented
+        below through the deprecation window.
+
+        Full parity lives in the batch tool and one specialist:
+        per-row values are TSV rows; clearing a field is the
+        ``clear`` column; same-values-across-N is N repeated rows;
+        split edits are ``replace_splits`` (which preserves
+        unchanged legs' memos and reconcile states)::
+
+            guid<TAB>notes<TAB>clear
+            56926ac2<TAB>Card payment, resolved<TAB>
+            7f0fc117<TAB><TAB>notes
+
+        ---
+
+        Update an existing transaction — or broadcast to several.
 
         Pass a LIST of GUIDs to apply the SAME supplied values to
         every listed transaction in one book open / one save
@@ -954,19 +970,28 @@ def register(mcp, get_book) -> None:
             56926ac2<TAB>PayPal Credit Payment<TAB>Resolved — card payment
             7f0fc117<TAB><TAB>Netflix subscription, $22.10/mo
 
-        An EMPTY cell leaves that field UNCHANGED — this batch can
-        annotate but never clear (clearing is ``update_transaction``
-        with ``notes=""``, deliberately single-transaction). Splits
-        and memos are not updatable here (``replace_splits``).
+        An EMPTY cell leaves that field UNCHANGED. To blank a field,
+        opt in with a ``clear`` column: its cell names the fields to
+        clear on that row (``notes`` or ``description,notes``) —
+        explicit per row, so a sparse batch can never mass-erase by
+        accident. ``date`` is not clearable; a row that sets and
+        clears the same field rejects. Splits and memos are not
+        updatable here (``replace_splits``)::
+
+            guid<TAB>notes<TAB>clear
+            56926ac2<TAB>Verified subscription<TAB>
+            7f0fc117<TAB><TAB>notes
 
         One book open, one save; ``on_error="abort"`` (default)
         sinks the batch on any bad row, ``"skip"`` keeps good rows.
         Date moves on transactions with reconciled splits are
         rejected per row unless ``force=true`` (they shift the
         transaction out of its reconciled statement period).
-        Returns a results TSV keyed by your input guids. For the
-        SAME value across many transactions, ``update_transaction``
-        with a guid list is cheaper than repeating rows.
+        Returns a results TSV keyed by your input guids. This is
+        the canonical update tool for one transaction or many; the
+        deprecated ``update_transaction`` redirects here (same
+        value across many transactions = the same cells repeated
+        per row).
         """
         book = get_book()
         rows = _parse_update_tsv(updates)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -13111,3 +13111,70 @@ class TestSplitGraphPreload:
                 f"{len(statements)} SQL statements — the preload's "
                 f"strong reference has been lost"
             )
+
+
+class TestUpdateClearColumn:
+    """The TSV ``clear`` column — the explicit opt-in that
+    empty-cell-means-unchanged deliberately forecloses. Parser
+    produces ``""`` values; the book layer already treats empty as
+    clear (notes → None, verified by _verify_transaction_state's
+    None↔"" normalization)."""
+
+    def _one(self, gc):
+        return gc.create_transaction(
+            description="Netflix via PayPal",
+            notes="investigate this",
+            splits=[
+                {"account": "Assets:Checking", "amount": "-22.10"},
+                {"account": "Expenses:Groceries", "amount": "22.10"},
+            ],
+        )["guid"]
+
+    def test_parser_clear_emits_empty_values(self):
+        from gnucash_mcp._format import _parse_update_tsv
+        rows = _parse_update_tsv(
+            "guid\tnotes\tclear\n"
+            "aaaa1111\tkeep me\t\n"
+            "bbbb2222\t\tnotes\n"
+            "cccc3333\t\tdescription, notes\n"
+        )
+        assert "notes" not in rows[0] or rows[0]["notes"] == "keep me"
+        assert rows[1]["notes"] == ""
+        assert rows[2]["description"] == ""
+        assert rows[2]["notes"] == ""
+
+    def test_parser_clear_only_header_is_valid(self):
+        from gnucash_mcp._format import _parse_update_tsv
+        rows = _parse_update_tsv(
+            "guid\tclear\naaaa1111\tnotes\n"
+        )
+        assert rows[0]["notes"] == ""
+
+    def test_parser_set_and_clear_conflict_rejects(self):
+        from gnucash_mcp._format import _parse_update_tsv
+        with pytest.raises(ValueError, match="sets AND clears"):
+            _parse_update_tsv(
+                "guid\tnotes\tclear\naaaa1111\tnew note\tnotes\n"
+            )
+
+    def test_parser_date_not_clearable(self):
+        from gnucash_mcp._format import _parse_update_tsv
+        with pytest.raises(ValueError, match="not clearable"):
+            _parse_update_tsv(
+                "guid\tclear\naaaa1111\tdate\n"
+            )
+
+    def test_parser_unknown_clear_field_rejects_by_name(self):
+        from gnucash_mcp._format import _parse_update_tsv
+        with pytest.raises(ValueError, match="'memo'"):
+            _parse_update_tsv(
+                "guid\tclear\naaaa1111\tmemo\n"
+            )
+
+    def test_clear_flows_through_to_the_book(self, test_book: Path):
+        gc = GnuCashBook(str(test_book))
+        guid = self._one(gc)
+        env = gc.update_transactions([{"guid": guid, "notes": ""}])
+        rows = _parse_results_tsv(env["results"])
+        assert rows[0]["status"] == "updated"
+        assert not gc.get_transaction(guid).get("notes")


### PR DESCRIPTION
## Summary
- The updates TSV gains an opt-in `clear` column (comma-separated field names per row) — the one capability the batch lacked; empty-cell-means-unchanged stays sacred, 'date' is not clearable, set-and-clear conflicts reject, clear-only batches valid
- With parity closed, `update_transaction` carries the same deprecation banner as its create sibling: per-row values are rows, broadcast is repeated rows, split edits are `replace_splits`; `update_transactions` is canonical
- Book layer needed nothing — it already treated "" as clear; only the parser gated it (the verifier's None↔"" normalization confirms end-to-end)

## Test plan
- [x] Parser suite: clear emits empty values, clear-only headers valid, conflicts and 'date'/unknown fields reject by name
- [x] End-to-end: clear flows through book.update_transactions and verifies
- [x] Live smoke on Alex copy: set-then-clear through the real TSV parser
- [x] Full suite green