### PR TITLE
fix(business): listing indicator noun follows the document filter

### DIFF
--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -4865,11 +4865,19 @@ class BusinessMixin:
                 invoices = [i for i in invoices if not _is_invoice_posted(i)]
 
             total = len(invoices)
+            # The indicator noun follows the doc_type filter — a
+            # voucher listing saying "0 of 0 invoices" reads as the
+            # wrong tool answering (bookkeeper-pass finding,
+            # 2026-08-30). Unfiltered listings span all four kinds,
+            # so the generic noun is the honest one there.
+            entity_noun = (
+                f"{doc_type}s" if doc_type is not None else "documents"
+            )
             page, indicator = _paginate(
                 invoices,
                 offset=offset,
                 limit=limit,
-                entity_name="invoices",
+                entity_name=entity_noun,
                 date_key=lambda i: i.date_opened,
             )
             invoices = page
@@ -7493,7 +7501,7 @@ class BusinessMixin:
                 results,
                 offset=offset,
                 limit=limit,
-                entity_name="invoices",
+                entity_name="documents",
                 date_key=lambda r: r["date_posted"],
             )
             if compact:

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -6143,7 +6143,7 @@ class TestListInvoices:
     def test_empty_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         result = gb.list_invoices()
-        assert result == "Showing 0 of 0 invoices"
+        assert result == "Showing 0 of 0 documents"
 
     def test_compact_format(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -6170,7 +6170,7 @@ class TestListInvoices:
         assert len(invoices) == 1
         assert invoices[0]["type"] == "invoice"
         assert result["total"] == 1
-        assert result["showing"].startswith("Showing 1-1 of 1 invoices")
+        assert result["showing"].startswith("Showing 1-1 of 1 documents")
 
     def test_filter_by_customer_type(self, business_book):
         gb = GnuCashBook(str(business_book))
@@ -9875,7 +9875,7 @@ class TestPhase3CommsContracts:
         assert result["count"] == 3
         assert result["total"] == 5
         assert result["offset"] == 0
-        assert "Showing 1-3 of 5 invoices" in result["showing"]
+        assert "Showing 1-3 of 5 documents" in result["showing"]
 
 
 # ============== Vendor Spending Report Tests ==============


### PR DESCRIPTION
## Summary
- `list_documents(document_type="voucher")` said "Showing 0 of 0 invoices"; the indicator noun now follows the filter, and unfiltered/outstanding listings say "documents"

## Test plan
- [x] Full suite green (2,129)