### PR TITLE
feat: one-question install; backup store append-only for the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,17 @@ on GitHub — that number belongs to a registry-side rebuild.)
 **One-click install (#153).**
 
 - The MCPB bundle: download, double-click, and Claude Desktop runs
-  the server — book file picker, persona checkboxes, demo books
-  behind one checkbox. Built and attached by the project's first CI
-  (locked tests on Python 3.10 and 3.13, bundle artifact on every
-  PR); validated end-to-end through a real Desktop install.
+  the server — book file picker, demo books behind one checkbox.
+  Built and attached by the project's first CI (locked tests on
+  Python 3.10 and 3.13, bundle artifact on every PR); validated
+  end-to-end through a real Desktop install.
+- The installer asks ONE module question: "Do you invoice
+  clients?" Budgets, scheduled transactions, and investment
+  tracking proved too common a need to gate behind checkboxes —
+  they're always on now (even a 401(k) wants the portfolio
+  surface). The business suite is the only genuinely optional
+  branch, and the Advanced field remains the full `--modules`
+  escape hatch.
 
 **A surface that tells the truth about itself.**
 
@@ -109,6 +116,12 @@ replacement needs no deprecation grace period. Two moves:
   can never mass-erase by accident) to close the last gap first.
   `create_transactions` and `update_transactions` are canonical
   for one transaction or many.
+- **The backup store is append-only from the model's side**:
+  `list_backups` and `prune_backups` removed (88 → 86). The safety
+  net exists to survive model mistakes; no tool may enumerate or
+  shrink it. Automatic staged retention keeps running internally,
+  `create_backup` stays, and reviewing or deleting backups is the
+  human's filesystem operation.
 
 Validated by a live bookkeeper-style pass on the sample books:
 full invoice, bill (partial pay), credit-note (apply), and

--- a/README.md
+++ b/README.md
@@ -453,9 +453,8 @@ for the rollback procedure.
 > timestamps (filesystem-safe and unambiguous across travel
 > and DST); audit and debug logs use *local-dated* daily
 > files, matching how you'd search for "what happened
-> Tuesday." Near midnight these can differ by a day — the
-> `list_backups` tool always reports both the ISO timestamp
-> and a human age, so prefer it over eyeballing filenames.
+> Tuesday." Near midnight these can differ by a day — keep
+> that in mind when matching a backup to a day's log.
 
 **Reconciled splits are protected.** The server refuses to
 delete or modify reconciled splits without an explicit

--- a/docs/RESTORE_FROM_BACKUP.md
+++ b/docs/RESTORE_FROM_BACKUP.md
@@ -15,10 +15,13 @@ Follow these steps with a text editor or terminal, not via Claude.
 
 You'll need:
 - Your backup file — typically at
-  `{book_path}.mcp/backups/{book}-{timestamp}-{stage}.gnucash`. Use
-  the `list_backups` MCP tool (before anything goes wrong) to see
-  what's available. Once you're in a recovery situation, you can
-  look at that directory directly via Finder / `ls`.
+  `{book_path}.mcp/backups/{book}-{timestamp}-{stage}.gnucash`.
+  Look at that directory directly via Finder / `ls` — filenames
+  carry a UTC timestamp and the retention stage. (There is
+  deliberately no MCP tool that lists or deletes backups: the
+  store is append-only from the model's side, so the safety net
+  can't be enumerated or shrunk by a confused or manipulated
+  session.)
 - Your live book path — typically from the `GNUCASH_BOOK_PATH`
   environment variable in your MCP client config. Example:
   `/Users/stephen/Finances/books.gnucash`.

--- a/manifest.json
+++ b/manifest.json
@@ -35,9 +35,6 @@
         "${user_config.books}"
       ],
       "env": {
-        "GNUCASH_ENABLE_PLANNING": "${user_config.planning}",
-        "GNUCASH_ENABLE_INVESTMENTS": "${user_config.investments}",
-        "GNUCASH_ENABLE_FREELANCER": "${user_config.freelancer}",
         "GNUCASH_ENABLE_BUSINESS": "${user_config.business}",
         "GNUCASH_DEMO_BOOKS": "${user_config.demo_books}",
         "GNUCASH_DEMO_DIR": "${__dirname}/samples",
@@ -54,29 +51,11 @@
       "title": "Your GnuCash book(s)",
       "description": "Pick one or more .gnucash files saved in SQLite format. Pick several to switch between them in-chat. (Books in GnuCash's older XML format need a one-time File > Save As with the sqlite3 format first.)"
     },
-    "planning": {
-      "type": "boolean",
-      "default": true,
-      "title": "Budgets & scheduled transactions",
-      "description": "Set budgets, track pacing, and manage recurring transactions"
-    },
-    "investments": {
-      "type": "boolean",
-      "default": false,
-      "title": "Investment tracking",
-      "description": "Lots, cost basis, capital gains, and price updates"
-    },
-    "freelancer": {
-      "type": "boolean",
-      "default": false,
-      "title": "Client invoicing",
-      "description": "Send invoices to clients and record their payments"
-    },
     "business": {
       "type": "boolean",
       "default": false,
-      "title": "Full business suite",
-      "description": "Everything in Client invoicing, plus vendors, bills, and employee expenses"
+      "title": "Do you invoice clients?",
+      "description": "Adds the business suite: client invoices and payments, plus vendors, bills, and employee expenses. Everything else — budgets, scheduled transactions, and investment tracking — is always included."
     },
     "demo_books": {
       "type": "boolean",

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -184,11 +184,12 @@ TOOL_MODULES: dict[str, list[str]] = {
         "get_audit_log",
     ],
     "backup": [
-        # Manual control surface; the auto-snapshot hook is
-        # always-on regardless.
+        # On-demand snapshot only; the auto-snapshot hook and staged
+        # retention are always-on regardless. The store is APPEND-ONLY
+        # from the model's side by design — no tool lists or deletes
+        # backups (the safety net must survive model mistakes;
+        # list_backups/prune_backups were removed for exactly that).
         "create_backup",
-        "list_backups",
-        "prune_backups",
     ],
     "balance_sheet": [
         # THE canonical report; analytical reports stay in
@@ -1447,11 +1448,17 @@ def _parse_cli_argv(
 # host app. Values map to module/group names in TOOL_MODULES /
 # MODULE_GROUPS ("planning" spans two leaf modules).
 _ENV_MODULE_TOGGLES: dict[str, tuple[str, ...]] = {
-    "GNUCASH_ENABLE_PLANNING": ("budgets", "scheduling"),
-    "GNUCASH_ENABLE_INVESTMENTS": ("investor",),
-    "GNUCASH_ENABLE_FREELANCER": ("freelancer",),
     "GNUCASH_ENABLE_BUSINESS": ("business",),
 }
+
+# The bundle base: what every install gets before the one question.
+# Planning and investments joined it 2026-08-31 (maintainer ruling:
+# too common a need to gate — even a 401(k) wants the portfolio
+# surface, and budgets/scheduling are too small a set to be worth an
+# installer decision). The retired GNUCASH_ENABLE_PLANNING /
+# _INVESTMENTS / _FREELANCER variables are ignored if present — an
+# old install's stored config must not subtract from the new base.
+_ENV_TOGGLE_BASE = ("reporting", "budgets", "scheduling", "investor")
 
 
 def _modules_from_env_toggles() -> str | None:
@@ -1459,17 +1466,18 @@ def _modules_from_env_toggles() -> str | None:
 
     Returns None when no toggle variable is present at all, so CLI
     and GNUCASH_MCP_MODULES users (and the core-only default) are
-    untouched. When any toggle is present, the selection is
-    ``reporting`` plus every enabled toggle's modules — core is
-    force-added downstream by _apply_module_filter, matching the
-    bundle design where core + reporting are always on.
+    untouched. When a toggle is present, the selection is the bundle
+    base (reporting + planning + investor) plus every enabled
+    toggle's modules — core is force-added downstream by
+    _apply_module_filter, matching the bundle design where the base
+    surface is always on and business is the one question.
 
     Raises ValueError on an unparseable value: a typo'd toggle must
     not silently serve the wrong tool surface.
     """
     if not any(v in os.environ for v in _ENV_MODULE_TOGGLES):
         return None
-    selected: list[str] = ["reporting"]
+    selected: list[str] = list(_ENV_TOGGLE_BASE)
     for var, modules in _ENV_MODULE_TOGGLES.items():
         if _parse_env_toggle(var):
             selected.extend(modules)
@@ -1566,12 +1574,13 @@ Environment variables:
                              (switch_book matches by name).
   GNUCASH_MCP_MODULES        Tool modules to load — same values as
                              --modules (e.g. "bookkeeper" or "core,reporting")
-  GNUCASH_ENABLE_PLANNING    Boolean module toggles (true/false) — the
-  GNUCASH_ENABLE_INVESTMENTS interface the MCPB bundle's checkboxes use.
-  GNUCASH_ENABLE_FREELANCER  When any is set, modules = core + reporting
-  GNUCASH_ENABLE_BUSINESS    plus each enabled toggle's modules (planning
-                             = budgets + scheduling; investments =
-                             investor; business supersedes freelancer).
+  GNUCASH_ENABLE_BUSINESS    Boolean (true/false) — the MCPB bundle's one
+                             module question ("Do you invoice clients?").
+                             When set, modules = core + reporting +
+                             budgets + scheduling + investor, plus the
+                             business suite when true. The retired
+                             _PLANNING/_INVESTMENTS/_FREELANCER toggles
+                             are ignored (that surface is now always on).
                              --modules / GNUCASH_MCP_MODULES win when set.
   GNUCASH_MCP_DEBUG=true     Enable debug logging (true/1/yes/on)
   GNUCASH_MCP_NOAUDIT=true   Disable audit logging (true/1/yes/on)

--- a/src/gnucash_mcp/tools/backup.py
+++ b/src/gnucash_mcp/tools/backup.py
@@ -1,18 +1,22 @@
-"""Backup tools: manual snapshot creation, listing, and retention.
+"""Backup tools: on-demand snapshot creation.
 
 Always registered — `_apply_module_filter` forces 'backup' into the
 enabled set the same way it forces 'core'. Automatic backups happen
-regardless (via `@audit_log`'s `_maybe_auto_backup` hook); these
-tools give users the option to snapshot on demand, review what's on
-disk, and prune manually.
+regardless (via `@audit_log`'s `_maybe_auto_backup` hook), with
+staged retention pruning them internally; this tool gives users the
+option to snapshot on demand.
 
-Restore is deliberately NOT a tool — it's a documented filesystem
-procedure performed with the server stopped. See
+The backup store is deliberately APPEND-ONLY from the model's side:
+the safety net exists to survive model mistakes, so no tool may
+enumerate or delete it. Listing and manual pruning are filesystem
+operations the user performs directly (the ``.mcp/backups``
+directory beside the book), and restore is a documented procedure
+performed with the server stopped — see
 ``docs/RESTORE_FROM_BACKUP.md``.
 """
 
 from gnucash_mcp.logging_config import audit_log
-from gnucash_mcp.tools._helpers import _json, _paginate, safe_tool
+from gnucash_mcp.tools._helpers import _json, safe_tool
 
 
 def register(mcp, get_book) -> None:
@@ -23,11 +27,11 @@ def register(mcp, get_book) -> None:
         get_book: Callable returning the shared GnuCashBook instance.
     """
 
-    # Classified as read-w.r.t.-the-book: these tools touch disk but
-    # never mutate the GnuCash file. Read classification also prevents
-    # the backup tools from triggering the auto-backup hook on
-    # themselves (which the process-level flag would short-circuit
-    # anyway, but the cleaner contract is "the book didn't change").
+    # Classified as read-w.r.t.-the-book: this tool touches disk but
+    # never mutates the GnuCash file. Read classification also prevents
+    # it from triggering the auto-backup hook on itself (which the
+    # process-level flag would short-circuit anyway, but the cleaner
+    # contract is "the book didn't change").
     @mcp.tool()
     @safe_tool
     @audit_log(classification="read")
@@ -41,9 +45,10 @@ def register(mcp, get_book) -> None:
         backup and raises.
 
         Manual backups are kept indefinitely — automatic retention
-        (session / weekly / monthly stages) does not touch them. Use
-        ``prune_backups(stage="manual")`` if you want to clean them
-        up explicitly.
+        (session / weekly / monthly stages) does not touch them. To
+        review or remove backups, the user works with the files
+        directly in the backup directory; no tool can list or delete
+        them.
 
         The response includes a ``restore_hint`` describing the
         filesystem command to restore from this backup. Restore is a
@@ -58,78 +63,4 @@ def register(mcp, get_book) -> None:
         """
         book = get_book()
         result = book.create_backup(stage="manual", label=label)
-        return _json(result)
-
-    @mcp.tool()
-    @safe_tool
-    @audit_log(classification="read")
-    def list_backups(limit: int = 50, offset: int = 0) -> str:
-        """List all available backups, newest first.
-
-        Leads with a ``Showing X-Y of Z backups (date range)`` line,
-        then a compact tab-separated table with one row per backup:
-        ``stage``, ``timestamp`` (ISO UTC), ``age``, ``size`` (MB),
-        and ``label`` (if any). Stages are ``session`` / ``weekly`` /
-        ``monthly`` (automatic retention tiers) and ``manual`` (user-
-        invoked, unlimited retention). Page with ``offset``; ``limit=0``
-        returns the count only.
-
-        Args:
-            limit: Page size (default 50, max 250). 0 = count only.
-            offset: 0-indexed first row to return (default 0).
-        """
-        book = get_book()
-        entries = book.list_backups()
-        page, indicator = _paginate(
-            entries, offset=offset, limit=limit,
-            entity_name="backups", date_key=lambda e: e["timestamp"],
-        )
-        if not page:
-            return indicator
-
-        # Indicator + header + rows. TSV is compact and the LLM can
-        # parse it without a schema reminder.
-        lines = [indicator, "stage\ttimestamp\tage\tsize_mb\tlabel"]
-        for e in page:
-            size_mb = f"{e['size_bytes'] / (1024 * 1024):.1f}"
-            label = e.get("label") or ""
-            lines.append(
-                f"{e['stage']}\t{e['timestamp']}\t{e['age']}\t"
-                f"{size_mb}\t{label}"
-            )
-        return "\n".join(lines)
-
-    @mcp.tool()
-    @safe_tool
-    @audit_log(classification="read")
-    def prune_backups(
-        keep_last_n: int,
-        stage: str | None = None,
-        dry_run: bool = True,
-    ) -> str:
-        """Remove older backups, keeping the most recent N per stage.
-
-        Default is ``dry_run=True`` — the response shows what WOULD
-        be deleted without touching disk, so the caller can confirm
-        before committing. Pass ``dry_run=False`` to actually delete.
-
-        When ``stage`` is None (default), only auto-retention stages
-        (session / weekly / monthly) are pruned. Manual backups are
-        never auto-pruned; target them explicitly with
-        ``stage="manual"``.
-
-        Args:
-            keep_last_n: Number of backups to retain per affected
-                stage. Must be >= 0.
-            stage: If set, only prune within this stage. One of
-                ``session``, ``weekly``, ``monthly``, ``manual``.
-            dry_run: When True (default), report only. When False,
-                delete.
-        """
-        book = get_book()
-        result = book.prune_backups(
-            keep_last_n=keep_last_n,
-            stage=stage,
-            dry_run=dry_run,
-        )
         return _json(result)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -84,23 +84,25 @@ class TestToolModulesMapping:
                 seen.add(tool)
 
     def test_core_group_resolves_to_31_tools(self):
-        """The ``core`` group expands to 33 tools across its nine
-        sub-modules (summary 1 + accounts 7 + transactions 12 + slots
-        3 + audit 1 + backup 3 + balance_sheet 1 + diagnostic 1 +
-        reconciliation 4). Reconciliation joined core in v1.3.1
-        per the bookkeeper-driven principle that any configuration
-        which handles money must include reconciliation.
+        """The ``core`` group expands across its nine sub-modules
+        (summary 1 + accounts 7 + transactions 12 + slots 3 + audit 1
+        + backup 1 + balance_sheet 1 + diagnostic 1 + reconciliation
+        4). Reconciliation joined core in v1.3.1 per the bookkeeper-
+        driven principle that any configuration which handles money
+        must include reconciliation; backup shrank to create-only in
+        v1.4.4 (the store is append-only from the model's side).
         """
-        assert len(_core_tool_names()) == 31
+        assert len(_core_tool_names()) == 29
 
     def test_total_tool_count(self):
         """Total tools across all sub-modules should be 111 —
         88 post-module-restructure + 3 voucher tools +
         4 credit-note tools + 5 job CRUD tools +
         1 get_job_report + 5 taxtable CRUD tools added in v1.3 +
-        1 enter_statement added in v1.4.4."""
+        1 enter_statement added in v1.4.4, minus list_backups +
+        prune_backups (removed v1.4.4 — append-only backup store)."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
-        assert total == 88
+        assert total == 86
 
     def test_expected_modules_exist(self):
         """All expected leaf-module names should be present.
@@ -266,7 +268,7 @@ class TestApplyModuleFilter:
     def test_all_keeps_everything(self):
         """--modules=all should keep all 88 tools (the consolidated business surface: 5 parties + 9 documents + 6 reference + 5 jobs + 2 reports, alongside the unchanged modules)."""
         _apply_module_filter("all")
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 86
 
     def test_none_defaults_to_core_only(self):
         """No --modules flag defaults to the ``core`` group, which
@@ -298,12 +300,12 @@ class TestApplyModuleFilter:
         """Specifying every module individually should equal 'all'."""
         all_names = ",".join(TOOL_MODULES.keys())
         _apply_module_filter(all_names)
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 86
 
     def test_all_in_list_keeps_everything(self):
         """'all' mixed with other modules should keep all 111 tools."""
         _apply_module_filter("scheduling,reconciliation,all")
-        assert len(self._tool_names()) == 88
+        assert len(self._tool_names()) == 86
 
     def test_unknown_module_fails_fast(self, capsys):
         """Unknown module names fail-fast at startup with SystemExit.
@@ -1136,17 +1138,17 @@ class TestMultiBook:
         alex, _ = two_books
         srv._book_paths = [alex.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 88
+        assert len(mcp._tool_manager._tools) == 86
 
     def test_tool_count_multi_book(self, two_books):
-        """The lone runtime delta from single-book: switch_book (112).
+        """The lone runtime delta from single-book: switch_book (87).
         Each filter call relies on switch_book being registered at
         import; the production flow filters once at startup."""
         import gnucash_mcp.server as srv
         alex, beast = two_books
         srv._book_paths = [alex.resolve(), beast.resolve()]
         _apply_module_filter("all")
-        assert len(mcp._tool_manager._tools) == 89
+        assert len(mcp._tool_manager._tools) == 87
 
     # ── switch_book matching ───────────────────────────────────────
 
@@ -1771,31 +1773,37 @@ class TestEnvModuleToggles:
         from gnucash_mcp.server import _modules_from_env_toggles
         assert _modules_from_env_toggles() is None
 
-    def test_planning_only(self, monkeypatch):
+    def test_business_false_still_gets_base(self, monkeypatch):
+        """The one-question install: business off still serves the
+        full base — reporting + planning + investor (always-on per
+        the 2026-08-31 ruling; too common a need to gate)."""
         from gnucash_mcp.server import _modules_from_env_toggles
-        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "true")
-        assert _modules_from_env_toggles() == "reporting,budgets,scheduling"
+        monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
+        assert (_modules_from_env_toggles()
+                == "reporting,budgets,scheduling,investor")
 
-    def test_all_false_still_gets_reporting(self, monkeypatch):
-        from gnucash_mcp.server import (
-            _ENV_MODULE_TOGGLES, _modules_from_env_toggles,
-        )
-        for var in _ENV_MODULE_TOGGLES:
-            monkeypatch.setenv(var, "false")
-        assert _modules_from_env_toggles() == "reporting"
-
-    def test_mcpb_style_selection(self, monkeypatch):
+    def test_business_true_adds_the_suite(self, monkeypatch):
         from gnucash_mcp.server import _modules_from_env_toggles
-        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "false")
-        monkeypatch.setenv("GNUCASH_ENABLE_INVESTMENTS", "true")
-        monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "false")
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "true")
-        assert _modules_from_env_toggles() == "reporting,investor,business"
+        assert (_modules_from_env_toggles()
+                == "reporting,budgets,scheduling,investor,business")
+
+    def test_retired_toggles_are_ignored(self, monkeypatch):
+        """An old install's stored config (pre-unification manifest)
+        may still export the retired toggles; they must neither
+        trigger composition alone nor subtract from the base."""
+        from gnucash_mcp.server import _modules_from_env_toggles
+        monkeypatch.setenv("GNUCASH_ENABLE_INVESTMENTS", "false")
+        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "false")
+        assert _modules_from_env_toggles() is None
+        monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
+        assert (_modules_from_env_toggles()
+                == "reporting,budgets,scheduling,investor")
 
     def test_invalid_value_fails_fast(self, monkeypatch):
         from gnucash_mcp.server import _modules_from_env_toggles
-        monkeypatch.setenv("GNUCASH_ENABLE_PLANNING", "ture")
-        with pytest.raises(ValueError, match="GNUCASH_ENABLE_PLANNING"):
+        monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "ture")
+        with pytest.raises(ValueError, match="GNUCASH_ENABLE_BUSINESS"):
             _modules_from_env_toggles()
 
     def test_toggle_targets_exist_in_registry(self):
@@ -1803,9 +1811,10 @@ class TestEnvModuleToggles:
         ``reporting``) must be a real module or group name, so a
         module rename cannot silently strand the bundle's checkboxes
         on an unknown-module startup error."""
-        from gnucash_mcp.server import _ENV_MODULE_TOGGLES
+        from gnucash_mcp.server import _ENV_MODULE_TOGGLES, _ENV_TOGGLE_BASE
         valid = set(TOOL_MODULES) | set(MODULE_GROUPS)
-        assert "reporting" in valid
+        for name in _ENV_TOGGLE_BASE:
+            assert name in valid, name
         for modules in _ENV_MODULE_TOGGLES.values():
             for name in modules:
                 assert name in valid, name

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1144,7 +1144,6 @@ _PAGINATED_TOOLS = [
     ("get_prices", {"commodity": "USD", "namespace": "CURRENCY"}, "prices"),
     ("list_lots", {"account": "Assets:Checking"}, "lots"),
     ("list_budgets", {}, "budgets"),
-    ("list_backups", {}, None),
     ("get_audit_log", {}, None),
     ("get_reconciliation_status", {}, None),
 ]


### PR DESCRIPTION
## Summary
- The installer's four module checkboxes collapse to one: **"Do you invoice clients?"** Budgets, scheduled transactions, and the investor surface are always on (maintainer ruling — too common a need to gate; even a 401(k) wants the portfolio view). Env contract: any `GNUCASH_ENABLE_*` toggle present → base = reporting + planning + investor, business per the single toggle. Retired toggles from an old install's stored config are **ignored, never subtracted** (locked by test).
- `list_backups` and `prune_backups` removed (88 → 86 tools): the backup store exists to survive model mistakes, so no tool may enumerate or delete it — prune was a file-deletion primitive that didn't even audit as a write. Automatic staged retention keeps running internally; `create_backup` stays; review and pruning are the human's filesystem operations, and `docs/RESTORE_FROM_BACKUP.md` now documents the append-only design.
- `--help`, README, CHANGELOG, and the module contract tests updated; counts re-locked at 86 (87 multi-book).

## Test plan
- [x] Full suite green (2,126 passed) including rewritten env-toggle tests and the retired-toggle regression lock
- [x] Manifest validates (`tests/test_manifest.py`)
- [ ] CI green; bundle artifact packs with the one-question manifest
- [ ] Maintainer: real Claude Desktop re-install over an existing config (the silently-breaking class per the MCPB mechanics notes)