### PR TITLE
fix(tests): reset write-rate-limiter cache after TestWriteRateLimiter

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1941,6 +1941,23 @@ class TestWriteRateLimiter:
     Token bucket; disabled by default; opt-in via
     GNUCASH_WRITE_RATE_LIMIT env var."""
 
+    @pytest.fixture(autouse=True)
+    def _fresh_limiter_state(self):
+        """Reset the limiter cache around every test in this class.
+
+        The limiter is cached process-globally behind an
+        initialized flag, so monkeypatch's env teardown alone
+        leaves a drained bucket live — and any write-classified
+        tool that runs later in the same process gets rate-limited
+        into an error envelope instead of executing. Under xdist
+        that poisons whichever tests land after this class on the
+        same worker.
+        """
+        from gnucash_mcp.logging_config import reset_write_rate_limiter
+        reset_write_rate_limiter()
+        yield
+        reset_write_rate_limiter()
+
     def _setup_decorated_tool(self):
         """Build a minimal write-classified tool decorated by
         audit_log. Returns the wrapped function."""


### PR DESCRIPTION
## Summary
- `tests/test_logging.py::TestTransactionNotesAuditRendering` was flaky under pytest-xdist: `TestWriteRateLimiter` tests reset the limiter cache on entry but never on exit, leaving a drained token bucket cached process-globally (`_write_limiter_initialized=True` survives monkeypatch's env teardown).
- Any write-classified `@audit_log` tool running later in the same worker got a `rate_limited` error envelope before executing — no audit entry written, so the notes-rendering assertions found only the day banner.
- Serial runs passed by accident: the class's own later tests re-cache a `None` limiter. xdist's load distribution breaks that ordering.
- Fix: an autouse fixture on `TestWriteRateLimiter` resets the limiter cache before and after every test in the class, protecting any test that shares a worker.

## Test plan
- [x] Deterministic repro pre-fix: `test_rate_limit_kicks_in` followed by the two notes tests in one process fails with the exact reported signature (audit file = banner only)
- [x] Same sequence passes post-fix
- [x] `tests/test_logging.py` under xdist (`-n auto`, 8 workers): 5 consecutive clean runs, 104 passed each
- [x] Full suite: 2126 passed, 1 skipped