### PR TITLE
fix(business): Sabine battery — six bugs, message sweep, four rulings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,39 @@ tie check is the fleet itself.
   bundle ships demo books current as of the day it was built, and
   every build regression-tests the updater.
 
+**The Sabine battery (#165).** A full business-module test battery
+run against the German sample book closed out the release — six
+bugs fixed, and four design rulings shipped:
+
+- A credit note now nets against a job-grouped invoice from the
+  same customer (the owner check compared a Job's GUID against a
+  Customer's and refused, while naming the same owner on both
+  sides of the error).
+- Payment dry runs render as `PAY INVOICE (dry run)` in the audit
+  log instead of masquerading as booked payments with blank
+  fields; partial payments report `partial`, not `paid`.
+- Invoice line items carry the document's own date — entries no
+  longer date themselves tomorrow (or yesterday) depending on the
+  operator's timezone.
+- Credit notes are `type: "credit_note"` on every surface, with no
+  due date — credit available isn't money owed by a date.
+- Posting a document into an A/R or A/P account of a different
+  commodity warns loudly, naming the valuation freeze and the
+  per-currency-subledger fix.
+- Price sources rank in three tiers (manual quote > other user
+  sources > feeds), and recording a price that loses its date's
+  tie now says so instead of silently not being the rate.
+- Business transactions speak desktop's language — `Invoice`,
+  `Credit Note`, `Payment` on every leg — instead of picking up
+  brokerage `Buy`/`Sell` stamps on cross-currency postings
+  (forward-only; existing transactions are untouched).
+- Applying a credit note to a different document than the one it
+  references is allowed and now says so: "applied to 000014
+  (credit note references 000013)" — in the response and in the
+  permanent record.
+- Every error message and docstring that still named a
+  pre-consolidation tool now names the consolidated surface.
+
 **Under the hood.**
 
 - Batch entry runs one signal sweep per batch instead of up to two

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -130,22 +130,40 @@ def _to_date(dt: date | datetime) -> date:
     return dt
 
 
+# The two sources a deliberate manual quote arrives under:
+# ``user:price`` from create_price, ``user:price-editor`` from
+# GnuCash's editor. An EXPLICIT allowlist — ``user:market-data`` is
+# deliberately feed-ranked despite the prefix.
+_MANUAL_PRICE_SOURCES = frozenset({"user:price", "user:price-editor"})
+
+
+def _price_source_rank(source: str | None) -> int:
+    """Three-tier source rank for same-date ties: 2 = known manual
+    quote, 1 = other ``user:*`` (an explicit operator act, but one
+    that shouldn't silently override a deliberate manual edit),
+    0 = feeds and everything else."""
+    source = source or ""
+    if source in _MANUAL_PRICE_SOURCES:
+        return 2
+    if source.startswith("user:"):
+        return 1
+    return 0
+
+
 def _price_tie_rank(price) -> tuple:
     """Deterministic tie-break key for prices sharing a date
     (bookkeeper finding F3 — the winner used to be an accident of
     query/iteration order, so posting math and month-close valuation
     could flip between runs on books carrying same-date duplicates).
 
-    Higher tuple wins. Rule: a deliberate manual quote
-    (``user:price`` from create_price, ``user:price-editor`` from
-    GnuCash's editor) outranks feed/import sources
-    (``user:market-data``, ``Finance::Quote``, anything else); the
-    guid breaks residual ties — arbitrary but STABLE, which is the
-    property that matters.
+    Higher tuple wins. Rank via ``_price_source_rank`` (manual
+    quote > other user:* > feed); the guid breaks residual ties —
+    arbitrary but STABLE, which is the property that matters.
+    ``create_price``/``create_prices`` report when a written row
+    loses this tie, so any rank order stays visible to the operator.
     """
     source = getattr(price, "source", None) or ""
-    manual = 1 if source in ("user:price", "user:price-editor") else 0
-    return (manual, price.guid or "")
+    return (_price_source_rank(source), price.guid or "")
 
 
 def _is_market_price(price) -> bool:

--- a/src/gnucash_mcp/book/_currency.py
+++ b/src/gnucash_mcp/book/_currency.py
@@ -133,18 +133,23 @@ def _to_date(dt: date | datetime) -> date:
 # The two sources a deliberate manual quote arrives under:
 # ``user:price`` from create_price, ``user:price-editor`` from
 # GnuCash's editor. An EXPLICIT allowlist — ``user:market-data`` is
-# deliberately feed-ranked despite the prefix.
+# deliberately feed-ranked despite the prefix, so it needs its own
+# explicit demotion below the generic ``user:*`` tier.
 _MANUAL_PRICE_SOURCES = frozenset({"user:price", "user:price-editor"})
+_FEED_PRICE_SOURCES = frozenset({"user:market-data"})
 
 
 def _price_source_rank(source: str | None) -> int:
     """Three-tier source rank for same-date ties: 2 = known manual
     quote, 1 = other ``user:*`` (an explicit operator act, but one
     that shouldn't silently override a deliberate manual edit),
-    0 = feeds and everything else."""
+    0 = feeds and everything else — including ``user:market-data``,
+    which is feed-ranked by name despite the prefix."""
     source = source or ""
     if source in _MANUAL_PRICE_SOURCES:
         return 2
+    if source in _FEED_PRICE_SOURCES:
+        return 0
     if source.startswith("user:"):
         return 1
     return 0

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -15,7 +15,7 @@ in the ORM). All raw inserts are paired with `_verify_write` /
 """
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 
 import piecash
@@ -912,7 +912,7 @@ class BusinessMixin:
             commodity=default_currency,
             description=(
                 f"Early-payment discounts {'taken on supplier bills' if owner_type_is_bill else 'given to customers'}, "
-                f"booked when pay_invoice is called with "
+                f"booked when pay_document is called with "
                 f"apply_discount=True and the term + window + amount "
                 f"validation passes. Auto-created on first use."
             ),
@@ -4147,7 +4147,7 @@ class BusinessMixin:
             # surface the same constraint on lookup.
             raise ValueError(
                 "Credit notes are not supported for employees. "
-                "Use unpost_invoice + edit on the original voucher "
+                "Use unpost_document + edit on the original voucher "
                 "to amend an employee reimbursement."
             )
         inv = self._find_invoice(
@@ -4161,26 +4161,15 @@ class BusinessMixin:
             # Regular invoice/bill/voucher with this ID: name the
             # right tool so the LLM course-corrects in one hop.
             # Three-way — a binary branch would misname voucher tools.
-            _ENTRY_TOOLS = {
-                2: "add_invoice_entry",
-                4: "add_bill_entry",
-                5: "add_voucher_entry",
+            _DOC_TYPES = {
+                2: "invoice", 4: "bill", 5: "voucher",
             }
-            _DELETE_TOOLS = {
-                2: "delete_invoice",
-                4: "delete_bill",
-                5: "delete_voucher",
-            }
-            entry_tool = _ENTRY_TOOLS.get(
-                inv.owner_type, "add_invoice_entry",
-            )
-            delete_tool = _DELETE_TOOLS.get(
-                inv.owner_type, "delete_invoice",
-            )
+            doc_type = _DOC_TYPES.get(inv.owner_type, "invoice")
             raise ValueError(
                 f"{self._doc_label_for(inv.owner_type)} "
                 f"{credit_note_id} is not a credit note. Use "
-                f"{entry_tool} / {delete_tool} for the regular "
+                f"add_document_entry / delete_document with "
+                f"document_type='{doc_type}' for the regular "
                 f"document, or check the ID."
             )
         return inv
@@ -4216,7 +4205,7 @@ class BusinessMixin:
 
         **Employees excluded**: GnuCash desktop has no UI for
         employee credit notes; creating them here would produce
-        documents the desktop can't view. Use ``unpost_invoice`` +
+        documents the desktop can't view. Use ``unpost_document`` +
         edit instead.
 
         Args:
@@ -4241,7 +4230,7 @@ class BusinessMixin:
                 "GnuCash desktop has no UI for employee credit "
                 "notes; supporting them at the MCP layer would "
                 "create documents desktop users can't view or "
-                "edit. Use unpost_invoice + edit on the original "
+                "edit. Use unpost_document + edit on the original "
                 "voucher to amend an employee reimbursement."
             )
         if int_owner_type not in (2, 4):
@@ -4411,7 +4400,7 @@ class BusinessMixin:
 
         Validates the target IS a credit note, then delegates to
         ``_delete_invoice_or_bill``. Posted credit notes must be
-        unposted first via ``unpost_invoice``.
+        unposted first via ``unpost_document``.
 
         Raises:
             ValueError: not found, not a credit note, or posted.
@@ -4436,7 +4425,7 @@ class BusinessMixin:
         2: {  # customer invoice
             "label": "Invoice",
             "id_param": "invoice_id",
-            "twin_method": "add_bill_entry",
+            "twin_method": "add_document_entry with document_type='bill'",
             "twin_label": "vendor bill",
             "allowed_types": frozenset({"INCOME"}),
             "type_error_msg": (
@@ -4449,7 +4438,7 @@ class BusinessMixin:
         4: {  # vendor bill
             "label": "Bill",
             "id_param": "bill_id",
-            "twin_method": "add_invoice_entry",
+            "twin_method": "add_document_entry with document_type='invoice'",
             "twin_label": "customer invoice",
             "allowed_types": frozenset({"EXPENSE", "ASSET"}),
             "type_error_msg": (
@@ -4467,7 +4456,7 @@ class BusinessMixin:
             # row distinguishes them.
             "label": "Voucher",
             "id_param": "voucher_id",
-            "twin_method": "add_invoice_entry",
+            "twin_method": "add_document_entry with document_type='invoice'",
             "twin_label": "customer invoice",
             "allowed_types": frozenset({"EXPENSE", "ASSET"}),
             "type_error_msg": (
@@ -4616,10 +4605,26 @@ class BusinessMixin:
                     b_taxable=0, b_taxincluded=0, b_taxtable=None,
                 )
 
+            # Entry date follows the DOCUMENT's opened date, not the
+            # wall clock — GnuCash desktop's default, and what a
+            # backdated invoice's lines should carry. Anchored at
+            # GnuCash's neutral time (10:59) as an explicit-UTC
+            # datetime so piecash's _DateTime local→UTC conversion
+            # is a no-op: a naive local timestamp here stored as
+            # next-day UTC for evening-western users (battery bug 4
+            # — every entry dated tomorrow) and prior-day for
+            # eastern ones. date_entered stays a true "when was
+            # this typed" timestamp.
+            opened_dt = _safe_invoice_date(inv, "date_opened")
+            entry_date = datetime.combine(
+                opened_dt.date() if opened_dt else date.today(),
+                time(10, 59),
+                tzinfo=timezone.utc,
+            )
             book.session.execute(
                 Entry.__table__.insert().values(
                     guid=entry_guid,
-                    date=datetime.now(),
+                    date=entry_date,
                     date_entered=datetime.now(),
                     description=description,
                     action=action,
@@ -5704,8 +5709,10 @@ class BusinessMixin:
         (resolution mirrors ``fx_account``).
 
         Returns:
-            Payment details and remaining balance; plus
-            ``exchange_rate`` / ``payment_account_amount`` /
+            Payment details and remaining balance. ``status`` is
+            ``"paid"`` when the lot settles to zero, ``"partial"``
+            when a balance remains (``"would_pay"`` on dry runs).
+            Plus ``exchange_rate`` / ``payment_account_amount`` /
             ``fx_realized`` on cross-currency, and a ``discount``
             block when a discount was booked.
 
@@ -5879,7 +5886,8 @@ class BusinessMixin:
                     f"{invoice_id}. Pay at most the outstanding "
                     f"balance. To record a genuine overpayment, pay "
                     f"the outstanding balance and book the excess as "
-                    f"a credit note (create_credit_note) so it shows "
+                    f"a credit note (create_document with "
+                    f"document_type='credit_note') so it shows "
                     f"as credit owed to the counterparty rather than "
                     f"a phantom receivable."
                 )
@@ -5915,8 +5923,8 @@ class BusinessMixin:
                             f"apply_discount=True on invoice "
                             f"{invoice_id} which has no billterm "
                             f"linked. Set terms at invoice creation "
-                            f"(via create_invoice or create_bill's "
-                            f"``term`` parameter), repost, then retry."
+                            f"(via create_document's ``term`` "
+                            f"parameter), repost, then retry."
                         )
                     raise ValueError(
                         f"apply_discount=True on invoice "
@@ -6277,7 +6285,12 @@ class BusinessMixin:
             result = {
                 "id": inv.id,
                 "type": doc_type,
-                "status": "paid",
+                # "paid" only when the lot is settled — a partial
+                # payment reporting "paid" invites the caller to
+                # stop collecting with a balance still open.
+                "status": (
+                    "partial" if remaining_directional > 0 else "paid"
+                ),
                 "amount_paid": str(payment_amount),
                 "remaining_balance": str(remaining_directional),
                 # Transaction GUID emitted as a short prefix —
@@ -6376,13 +6389,26 @@ class BusinessMixin:
                     f"posted — post it before applying credits."
                 )
 
-            # Same owner check.
-            if cn.owner_guid != target.owner_guid:
+            # Same owner check — on the EFFECTIVE counterparty, not
+            # the raw owner row. A job-attached invoice's owner_guid
+            # points at the Job, so a raw comparison refuses a
+            # legitimate netting while the error text (built from
+            # the job-chasing helper) names the same customer on
+            # both sides.
+            cn_eff_ot, cn_job = self._resolve_owner_type_and_job(
+                book, cn,
+            )
+            cn_eff_guid = cn_job.owner_guid if cn_job else cn.owner_guid
+            t_eff_ot, t_job = self._resolve_owner_type_and_job(
+                book, target,
+            )
+            t_eff_guid = t_job.owner_guid if t_job else target.owner_guid
+            if (cn_eff_ot, cn_eff_guid) != (t_eff_ot, t_eff_guid):
                 cn_owner = self._find_invoice_owner_by_guid(
-                    book, cn.owner_type, cn.owner_guid,
+                    book, cn_eff_ot, cn_eff_guid,
                 )
                 target_owner = self._find_invoice_owner_by_guid(
-                    book, target.owner_type, target.owner_guid,
+                    book, t_eff_ot, t_eff_guid,
                 )
                 # Owner IDs are per-type sequences: customer 000005
                 # and vendor 000005 are different entities with the
@@ -6392,11 +6418,11 @@ class BusinessMixin:
                 _kind = {2: "customer", 4: "vendor", 5: "employee"}
                 raise ValueError(
                     f"Credit note belongs to "
-                    f"{_kind.get(cn.owner_type, 'owner')} "
+                    f"{_kind.get(cn_eff_ot, 'owner')} "
                     f"{(cn_owner.id if cn_owner else '?')!r}"
                     f"{f' ({cn_owner.name})' if cn_owner else ''} "
                     f"but target belongs to "
-                    f"{_kind.get(target.owner_type, 'owner')} "
+                    f"{_kind.get(t_eff_ot, 'owner')} "
                     f"{(target_owner.id if target_owner else '?')!r}"
                     f"{f' ({target_owner.name})' if target_owner else ''}. "
                     f"Credit notes can only net against documents "
@@ -6513,7 +6539,7 @@ class BusinessMixin:
 
             # Customer side: +apply on the CN lot (settles toward
             # zero), −apply on the target lot. Vendor side symmetric.
-            is_bill_side = self._is_bill_side(cn.owner_type)
+            is_bill_side = self._is_bill_side(cn_eff_ot)
             if is_bill_side:
                 cn_split_value = -apply_amount
                 target_split_value = apply_amount
@@ -6638,7 +6664,7 @@ class BusinessMixin:
         """Delete an unposted employee expense voucher.
 
         Automatically removes associated entries. Posted vouchers
-        cannot be deleted — unpost first via ``unpost_invoice``,
+        cannot be deleted — unpost first via ``unpost_document``,
         then delete.
 
         Args:
@@ -6681,7 +6707,9 @@ class BusinessMixin:
             if _is_invoice_posted(inv):
                 raise ValueError(
                     f"Cannot delete posted {type_label.lower()} '{doc_id}'. "
-                    f"Void it or issue a credit note instead."
+                    f"Unpost it first (unpost_document), or issue a "
+                    f"credit note (create_document with "
+                    f"document_type='credit_note') to reverse it."
                 )
 
             inv_guid = inv.guid
@@ -7465,12 +7493,20 @@ class BusinessMixin:
                 currency = (
                     inv.currency.mnemonic if inv.currency else None
                 )
-                # type stays the owner-type tag; is_credit_note lets
-                # the formatter distinguish.
+                # type agrees with get_document / delete / unpost:
+                # credit notes are their own type everywhere
+                # (battery bug 6 — verbose mode here was the one
+                # surface still tagging them by owner type). The
+                # redundant is_credit_note key stays for callers
+                # already keyed on it. No due_date either — credit
+                # is available, not owed by a date.
                 row = {
                     "id": inv.id,
-                    "type": self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
-                        effective_ot, "invoice"
+                    "type": (
+                        "credit_note" if is_credit_note
+                        else self._OWNER_TYPE_TO_RESPONSE_TYPE.get(
+                            effective_ot, "invoice"
+                        )
                     ),
                     "is_credit_note": is_credit_note,
                     "owner_name": owner_name,
@@ -7479,10 +7515,12 @@ class BusinessMixin:
                         str(posted_dt.date()) if posted_dt else None
                     ),
                     "due_date": (
-                        str(due_date) if due_date is not None else None
+                        str(due_date)
+                        if due_date is not None and not is_credit_note
+                        else None
                     ),
                     "days_past_due": days_past_due,
-                    "no_terms": no_terms,
+                    "no_terms": False if is_credit_note else no_terms,
                     "original_amount": str(grand_total),
                     "amount_paid": str(amount_paid),
                     "amount_due": str(amount_due),

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1227,6 +1227,7 @@ class BusinessMixin:
                 value=Decimal("0"),
                 quantity=fx_quantity,
                 memo=fx_memo,
+                action="Payment",
             )
         return {
             "split": split,
@@ -5387,12 +5388,21 @@ class BusinessMixin:
                 ar_ap_value = -grand_total
             else:
                 ar_ap_value = grand_total
+            # Desktop vocabulary on EVERY leg ("Invoice" / "Credit
+            # Note"), not just A/R: a leg left with action="" gets
+            # auto-stamped "Buy"/"Sell" by piecash when its account
+            # commodity differs from the transaction currency —
+            # brokerage vocabulary on a client bill. Forward-only:
+            # existing transactions are never rewritten to conform.
+            doc_action = (
+                "Credit Note" if is_credit_note else "Invoice"
+            )
             ar_ap_split = piecash.Split(
                 account=post_acct,
                 value=ar_ap_value,
                 quantity=_qty_for_split(post_acct, ar_ap_value),
                 memo="",
-                action="Invoice",
+                action=doc_action,
                 reconcile_date=datetime(1970, 1, 1),
             )
             piecash_splits.append(ar_ap_split)
@@ -5417,6 +5427,7 @@ class BusinessMixin:
                         value=split_value,
                         quantity=_qty_for_split(entry_acct, split_value),
                         memo="",
+                        action=doc_action,
                     )
                 )
 
@@ -5492,6 +5503,26 @@ class BusinessMixin:
             if fx_stale_overrides:
                 result["fx_stale"] = max(
                     fx_stale_overrides, key=lambda m: m["age_days"]
+                )
+            # A receivable held in a different commodity than its
+            # document freezes the A/R balance at post-date FX and
+            # drifts from the document's true value every day after
+            # — per-currency A/R//A/P subledgers are correct
+            # practice (desktop refuses this pairing outright).
+            # Allowed for now with a loud warning; ruled to become
+            # a refusal once no sample book depends on it.
+            if inv.currency_guid != post_acct.commodity.guid:
+                result["warning"] = (
+                    f"{inv.currency.mnemonic} document posted to "
+                    f"{post_acct.commodity.mnemonic}-denominated "
+                    f"'{post_acct.fullname}'. apply_credit_note "
+                    f"will refuse cross-commodity netting against "
+                    f"this posting; payments still settle via FX. "
+                    f"Correct practice is a per-currency "
+                    f"{'A/P' if effective_is_bill else 'A/R'} "
+                    f"account per document currency "
+                    f"(e.g. one denominated in "
+                    f"{inv.currency.mnemonic})."
                 )
 
         return result
@@ -6022,6 +6053,7 @@ class BusinessMixin:
                         value=disc_value_sign * expected,
                         quantity=disc_value_sign * disc_quantity,
                         memo="Early-payment discount",
+                        action="Payment",
                     )
                 discount_amount_invoice_ccy = expected
 
@@ -6247,6 +6279,7 @@ class BusinessMixin:
                 value=proposed[1]["value"],
                 quantity=proposed[1]["quantity"],
                 memo=memo,
+                action="Payment",
             )
             splits = [ar_ap_split, bank_split]
             if discount_split is not None:
@@ -6605,7 +6638,7 @@ class BusinessMixin:
 
             # Quantize response amounts to the post-account
             # commodity — "$100.00", not "$100".
-            return {
+            result = {
                 "credit_note_id": credit_note_id,
                 "applies_to_invoice_id": applies_to_invoice_id,
                 "amount_applied": str(apply_amount.quantize(quantum)),
@@ -6623,6 +6656,18 @@ class BusinessMixin:
                 "apply_date": str(parsed_date),
                 "status": "applied",
             }
+            # The stored applies-to link is provenance, not a
+            # constraint — netting against whatever's open next is
+            # the normal flow. When the applied target diverges
+            # from the link, say so in the moment (and in the
+            # audit log) rather than leaving it discoverable later.
+            linked = self._resolve_applies_to(book, cn)
+            if linked and linked["id"] != target.id:
+                result["note"] = (
+                    f"applied to {target.id} (credit note "
+                    f"references {linked['id']})"
+                )
+            return result
 
     # ── Delete paths ──────────────────────────────────────────────
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -5727,7 +5727,7 @@ class CoreMixin:
           orphans the invoice's posted-state metadata, after which
           the invoice refuses both delete ("posted") and re-post
           ("already posted") — SQL surgery is the only escape.
-          unpost_invoice clears the metadata properly.
+          unpost_document clears the metadata properly.
         - Refuses reconciled splits unless ``force``.
         """
         from sqlalchemy import text
@@ -5738,7 +5738,7 @@ class CoreMixin:
         if posting_for:
             raise ValueError(
                 f"Transaction is the posting record for invoice "
-                f"{posting_for[0]}. Use unpost_invoice first."
+                f"{posting_for[0]}. Use unpost_document first."
             )
 
         reconciled = [

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -311,6 +311,40 @@ class InvestmentsMixin:
         )
         return "created"
 
+    @staticmethod
+    def _same_date_outranker(
+        book, comm, resolved_currency, price_date, source,
+    ) -> str | None:
+        """Source of a same-date row that beats ``source`` in the
+        tie-break (``_price_source_rank`` — Abe's ruling: manual
+        quote > other user:* > feed), or None when the written row
+        is the effective rate for its date.
+
+        An operator who just wrote a price and can't see it winning
+        has been misled by silence — both ``create_price`` and
+        ``create_prices`` surface this so single and batch entry
+        can't diverge on it. Only a strictly higher rank reports;
+        an equal-rank guid tie is arbitrary-but-stable and naming a
+        "winner" there would imply an ordering that isn't semantic.
+        """
+        from gnucash_mcp.book._currency import _price_source_rank
+        own_rank = _price_source_rank(source)
+        best = None
+        for p in book.session.query(Price).filter_by(
+            commodity_guid=comm.guid,
+            currency_guid=resolved_currency.guid,
+        ).all():
+            if _to_date(p.date) != price_date or p.source == source:
+                continue
+            if not _is_market_price(p):
+                continue
+            rank = _price_source_rank(p.source)
+            if rank > own_rank and (
+                best is None or rank > _price_source_rank(best)
+            ):
+                best = p.source
+        return best
+
     def _resolve_price_commodity(self, book, mnemonic: str,
                                  namespace: str | None):
         """Resolve a batch price row's commodity.
@@ -366,6 +400,9 @@ class InvestmentsMixin:
 
         Returns ``{"results": TSV}`` — columns
         ``ref, status, commodity, date, value, currency, reason``.
+        ``reason`` also notes when a same-date row from a
+        higher-ranked source outranks the written row as the
+        effective rate.
         """
         if on_error not in ("abort", "skip"):
             raise ValueError("on_error must be 'abort' or 'skip'")
@@ -488,6 +525,18 @@ class InvestmentsMixin:
                     "value": row["value"],
                     "currency": row["currency"].mnemonic,
                 }
+                # Same-date tie loss surfaces in the reason column
+                # — dry run projects it identically (the outranker
+                # ignores the not-yet-written row either way).
+                outranked_by = self._same_date_outranker(
+                    book, row["comm"], row["currency"],
+                    row["date"], row["source"],
+                )
+                if outranked_by:
+                    by_ref[row["ref"]]["reason"] = (
+                        f"outranked by {outranked_by!r} for this "
+                        f"date (manual sources win same-date ties)"
+                    )
 
             if wrote:
                 book.save()
@@ -536,7 +585,9 @@ class InvestmentsMixin:
         Returns:
             Dict echoing the RESOLVED currency mnemonic, plus
             status "updated" (same commodity/currency/date/source
-            existed) or "created".
+            existed) or "created". A ``note`` key appears when a
+            same-date row from a higher-ranked source outranks the
+            written row as the effective rate.
 
         Raises:
             ValueError: If commodity not found or invalid currency.
@@ -581,6 +632,15 @@ class InvestmentsMixin:
                 "type": price_type,
                 "status": "updated" if existing else "created",
             }
+            outranked_by = self._same_date_outranker(
+                book, comm, resolved_currency, price_date, source,
+            )
+            if outranked_by:
+                result["note"] = (
+                    f"recorded, but a {outranked_by!r} price for "
+                    f"this date outranks it as the effective rate "
+                    f"(manual sources win same-date ties)"
+                )
 
             return result
 

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1639,6 +1639,31 @@ def _fmt_invoice_pay(entry: dict) -> list[str]:
     params = entry.get("params") or {}
     after = entry.get("after_state")
 
+    # A rehearsal must not read as a booked payment (battery bug 2:
+    # dry runs rendered as PAY INVOICE with blank paid/remaining —
+    # phantom payments to an auditor). Tagged rather than omitted,
+    # matching ENTER STATEMENT (dry run): the record of what was
+    # rehearsed is itself audit-relevant.
+    dry = bool(params.get("dry_run")) or bool(
+        (after or {}).get("dry_run")
+    )
+    if dry:
+        lines = [
+            f"{time_part}  PAY INVOICE (dry run)  "
+            f"id:{params.get('id', '')}"
+        ]
+        if after:
+            lines.append(
+                f"{_INDENT}would pay: {after.get('amount', '')}  "
+                f"remaining after: "
+                f"{after.get('remaining_balance_after', '')}"
+            )
+            lines.append(
+                f"{_INDENT}from: {params.get('payment_account', '')}"
+                f"  nothing booked"
+            )
+        return lines
+
     lines = [f"{time_part}  PAY INVOICE  id:{params.get('id', '')}"]
     if after:
         amount = after.get("amount_paid", "")
@@ -1846,7 +1871,16 @@ def _fmt_credit_note_create(entry: dict) -> list[str]:
     params = entry.get("params") or {}
     after = entry.get("after_state") or {}
     cn_id = after.get("id", "")
-    owner_type = params.get("owner_type", "")
+    # Owner-type label: the consolidated create_document sends
+    # party_type (often omitted — inherited from applies_to), so
+    # derive from which side-dependent id key the response carries.
+    # The retired create_credit_note tool sent owner_type; kept as
+    # a last fallback for replaying old entries.
+    owner_type = params.get("party_type") or (
+        "customer" if after.get("customer_id")
+        else "vendor" if after.get("vendor_id")
+        else params.get("owner_type", "owner")
+    )
     # The owner_id key is side-dependent (customer_id / vendor_id).
     owner_id = (
         after.get("customer_id")
@@ -1886,17 +1920,23 @@ def _fmt_entry_create(entry: dict) -> list[str]:
     after = entry.get("after_state") or {}
     desc = after.get("description", params.get("description", ""))
     total = after.get("total", "")
-    # Whichever doc-ID key the tool wrapper used (mutually
-    # exclusive in practice).
+    # The consolidated add_document_entry sends ``id``; the retired
+    # per-type tools sent invoice_id/bill_id/voucher_id/
+    # credit_note_id (kept as fallbacks for replaying old entries).
     inv_id = (
-        params.get("invoice_id", "")
+        params.get("id", "")
+        or params.get("invoice_id", "")
         or params.get("bill_id", "")
         or params.get("voucher_id", "")
         or params.get("credit_note_id", "")
     )
+    # Prefix the document type when the caller named one — a bare
+    # "on: 000014" doesn't say which per-type ID sequence it's from.
+    doc_type = params.get("document_type", "")
+    on_ref = f"{doc_type} {inv_id}".strip()
     lines = [
         f"{time_part}  CREATE ENTRY",
-        f'{_INDENT}"{desc}"  total: {total}  on: {inv_id}',
+        f'{_INDENT}"{desc}"  total: {total}  on: {on_ref}',
     ]
     action = after.get("action", params.get("action", ""))
     notes = after.get("notes", params.get("notes", ""))

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1845,6 +1845,11 @@ def _fmt_credit_note_apply(entry: dict) -> list[str]:
             f"against: {target_id}"
         ),
     ]
+    # Divergence from the stored applies-to link — provenance the
+    # permanent record must carry, not just the live response.
+    note = after.get("note", "")
+    if note:
+        lines.append(f"{_INDENT}{note}")
     # Decimal comparison, not string equality — the response holds
     # quantized strings ("0.00") that "== '0'" would mishandle.
     from decimal import Decimal as _D, InvalidOperation as _IO

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -393,14 +393,16 @@ def _resolve_id_alias(
     legacy: str | None,
     legacy_name: str,
 ) -> str:
-    """Resolve the ``id`` / ``<entity>_id`` parameter pair on
-    delete_invoice / delete_bill / delete_voucher / delete_credit_note.
+    """Resolve the ``id`` / ``<entity>_id`` parameter pair on the
+    document delete path (now ``delete_document``; before the
+    business consolidation, delete_invoice / delete_bill /
+    delete_voucher / delete_credit_note).
 
-    The standard parameter across the invoice tool surface
-    (get_invoice, post_invoice, unpost_invoice, pay_invoice) is
-    ``id``. The delete tools historically used ``<entity>_id``.
-    To converge without breaking older callers, both names are
-    accepted on the delete tools — but exactly one must be set.
+    The standard parameter across the document tool surface
+    (get_document, post_document, unpost_document, pay_document)
+    is ``id``. The retired delete tools used ``<entity>_id``. To
+    converge without breaking older callers, both names are
+    accepted on the delete path — but exactly one must be set.
 
     - Both omitted → ``ValueError`` (caller forgot the ID)
     - Both provided → ``ValueError`` (ambiguous; pick one)

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -654,7 +654,7 @@ def register(mcp, get_book) -> None:
         bookkeeper issues a credit note against an overcharge,
         then nets it against the next invoice from that customer
         (or applies it to an outstanding bill on the vendor side).
-        Use ``pay_invoice`` instead when the credit note will be
+        Use ``pay_document`` instead when the credit note will be
         settled by sending or receiving cash.
 
         Args:
@@ -972,6 +972,12 @@ def register(mcp, get_book) -> None:
             dry_run: When True, rehearse without writing — returns
                 the proposed splits and projected outcome instead of
                 booking. Default False.
+
+        Returns:
+            ``status`` is ``"paid"`` when the document settles to
+            zero, ``"partial"`` when a balance remains, and
+            ``"would_pay"`` on dry runs — plus the amount paid,
+            remaining balance, and transaction reference.
         """
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -482,7 +482,11 @@ def register(mcp, get_book) -> None:
             job_id: Optional Job to group under (invoices and bills;
                 must belong to the same owner).
             applies_to_id: Credit notes only — the invoice/bill this
-                credit note reverses (linked for apply_credit_note).
+                credit note reverses. The link is PROVENANCE, not a
+                constraint: apply_credit_note can net the credit
+                against any open document from the same owner (its
+                response notes the divergence when the applied
+                target differs from this link).
         """
         document_type = _gate_document_type(document_type)
         book = get_book()
@@ -662,7 +666,10 @@ def register(mcp, get_book) -> None:
                 posted).
             applies_to_invoice_id: The target invoice/bill (must
                 be posted, same owner, same currency, same A/R
-                or A/P post account).
+                or A/P post account). Need not be the document
+                the credit note was created against — that link
+                is provenance, and the response notes the
+                divergence when this target differs from it.
             amount: Decimal-string amount to apply, in the
                 document currency. Defaults to ``min(credit_note_
                 remaining, target_remaining)`` — apply as much

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -789,7 +789,7 @@ def register(mcp, get_book) -> None:
 
         Safeguards prevent deletion if a transaction has reconciled
         splits (force=true overrides) or is an invoice's posting
-        record (unpost_invoice first).
+        record (unpost_document first).
 
         Pass a LIST of GUIDs to delete several in one book open /
         one save. The batch is all-or-nothing: every guid is

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -5047,7 +5047,7 @@ class TestAddCreditNoteEntry:
         gb.create_customer(name="Acme Co")
         gb.create_invoice(customer_id="000001")  # regular invoice
         with pytest.raises(
-            ValueError, match="not a credit note.*add_invoice_entry",
+            ValueError, match="not a credit note.*document_type='invoice'",
         ):
             gb.add_credit_note_entry(
                 credit_note_id="000001",
@@ -5123,7 +5123,7 @@ class TestDeleteCreditNote:
         gb.create_customer(name="Acme Co")
         gb.create_invoice(customer_id="000001")
         with pytest.raises(
-            ValueError, match="not a credit note.*delete_invoice",
+            ValueError, match="not a credit note.*document_type='invoice'",
         ):
             gb.delete_credit_note(credit_note_id="000001")
 
@@ -5528,6 +5528,94 @@ class TestApplyCreditNote:
                 applies_to_invoice_id=beta_inv["id"],
             )
 
+    def test_apply_against_job_attached_invoice(self, business_book):
+        """A job-attached invoice nets against a direct credit note
+        from the same customer (battery bug 1: the raw owner_guid
+        comparison saw Job GUID vs Customer GUID and refused, with
+        an error naming the same customer on both sides)."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        job = gb.create_job(
+            owner_id="000001", owner_type="customer",
+            name="Relaunch Website",
+        )
+        inv = gb.create_invoice(
+            customer_id="000001", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=inv["id"], account="Income:Sales",
+            description="Milestone 1", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="Goodwill credit", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        result = gb.apply_credit_note(
+            credit_note_id=cn["id"],
+            applies_to_invoice_id=inv["id"],
+        )
+        assert result["status"] == "applied"
+        assert result["amount_applied"] == "100.00"
+        assert Decimal(result["target_remaining"]) == Decimal("400")
+
+    def test_apply_job_invoice_cross_owner_still_rejected(
+        self, business_book,
+    ):
+        """The job chase must not weaken the cross-owner guard: a
+        job-attached invoice from customer B still refuses customer
+        A's credit note."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        gb.create_customer(name="Beta Inc")
+        job = gb.create_job(
+            owner_id="000002", owner_type="customer",
+            name="Beta Project",
+        )
+        beta_inv = gb.create_invoice(
+            customer_id="000002", job_id=job["id"],
+        )
+        gb.add_invoice_entry(
+            invoice_id=beta_inv["id"], account="Income:Sales",
+            description="x", quantity="1", price="500",
+        )
+        gb.post_invoice(
+            invoice_id=beta_inv["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="50",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        with pytest.raises(
+            ValueError, match="same customer/vendor",
+        ):
+            gb.apply_credit_note(
+                credit_note_id=cn["id"],
+                applies_to_invoice_id=beta_inv["id"],
+            )
+
 
 class TestCreditNotePr87ReviewFollowups:
     """Tests for the five Copilot PR #87 review findings.
@@ -5555,7 +5643,8 @@ class TestCreditNotePr87ReviewFollowups:
         # ID. _resolve_credit_note finds it, sees it's NOT a
         # credit note, and emits the suggestion message.
         with pytest.raises(
-            ValueError, match="add_voucher_entry / delete_voucher",
+            ValueError, match="add_document_entry / delete_document with "
+            "document_type='voucher'",
         ):
             gb.add_credit_note_entry(
                 credit_note_id="000001",
@@ -5810,6 +5899,14 @@ class TestCreditNoteDisplayPolish:
         rows = gb.get_outstanding_invoices(compact=False)["invoices"]
         cn_row = next(r for r in rows if r["id"] == cn["id"])
         assert cn_row["is_credit_note"] is True
+        # Battery bug 6: verbose mode was the one surface still
+        # reporting credit notes as type "invoice" (compact and
+        # get_document both say "credit_note") — and it assigned a
+        # due_date to money nobody owes by a date.
+        assert cn_row["type"] == "credit_note"
+        assert cn_row["due_date"] is None
+        assert cn_row["days_past_due"] is None
+        assert cn_row["no_terms"] is False
 
     def test_dashboard_ar_nets_credit_notes_against_invoices(
         self, business_book,
@@ -6001,6 +6098,53 @@ class TestAddInvoiceEntry:
         # id-key name) — that's the dedup contract.
         assert set(inv_result.keys()) - {"invoice_id"} == \
             set(bill_result.keys()) - {"bill_id"}
+
+    def test_entry_date_follows_document_date_opened(
+        self, business_book,
+    ):
+        """Entry dates carry the DOCUMENT's opened date, not the
+        wall clock (battery bug 4: ``datetime.now()`` stored via
+        piecash's local→UTC conversion dated every evening-Pacific
+        entry tomorrow). Backdate the invoice; the entry must match
+        it regardless of when or where the test runs."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(
+            customer_id="000001", date_opened="2026-08-15",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Backdated line",
+            quantity="1", price="100.00",
+        )
+        fetched = gb.get_invoice("000001")
+        assert fetched["entries"][0]["date"] == "2026-08-15"
+
+    def test_entry_date_stored_at_neutral_time(self, business_book):
+        """The raw stored value sits at GnuCash's neutral 10:59 —
+        timezone-proof for the raw-SQL display path (which
+        truncates the stored string) in every real-world zone."""
+        import sqlite3
+
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(
+            customer_id="000001", date_opened="2026-08-15",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="x", quantity="1", price="1.00",
+        )
+        conn = sqlite3.connect(str(business_book))
+        try:
+            raw = conn.execute(
+                "SELECT date FROM entries"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert raw == "2026-08-15 10:59:00"
 
     def test_rejects_non_income_account(self, business_book):
         """Invoice entries must post to INCOME accounts. Pre-fix any
@@ -7242,7 +7386,7 @@ class TestUnpostInvoice:
         msg = str(exc_info.value)
         assert "posting record" in msg
         assert posted["id"] in msg
-        assert "unpost_invoice" in msg
+        assert "unpost_document" in msg
 
     def test_delete_transaction_works_for_non_posting_records(
         self, business_book,
@@ -7324,6 +7468,28 @@ class TestPayInvoice:
             amount="200",
         )
         assert Decimal(result["remaining_balance"]) == Decimal("300")
+        # Battery bug 3: a partial payment must not report "paid" —
+        # 300 is still owed.
+        assert result["status"] == "partial"
+
+    def test_full_payment_status_paid(self, business_book):
+        """The settling payment — partial first, then the rest —
+        reports "paid" only on the call that zeroes the lot."""
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        first = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        assert first["status"] == "partial"
+        second = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="300",
+        )
+        assert second["status"] == "paid"
+        assert Decimal(second["remaining_balance"]) == Decimal("0")
 
     def test_memo_lands_on_bank_split_only(self, business_book):
         """User memo annotates the cash movement; the A/R//A/P split

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -5528,6 +5528,57 @@ class TestApplyCreditNote:
                 applies_to_invoice_id=beta_inv["id"],
             )
 
+    def test_apply_divergence_from_link_is_echoed(
+        self, business_book,
+    ):
+        """Battery design ruling 5: applies_to is provenance, not a
+        constraint — but applying to a DIFFERENT document than the
+        one the credit note was created against must say so in the
+        response. Applying to the linked document stays note-free."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        for _ in range(2):
+            inv = gb.create_invoice(customer_id="000001")
+            gb.add_invoice_entry(
+                invoice_id=inv["id"], account="Income:Sales",
+                description="x", quantity="1", price="500",
+            )
+            gb.post_invoice(
+                invoice_id=inv["id"],
+                post_account="Assets:Accounts Receivable",
+                owner_type="customer",
+            )
+        # Credit note linked to 000001, applied against 000002.
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id="000001",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="x", quantity="1", price="100",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        diverged = gb.apply_credit_note(
+            credit_note_id=cn["id"],
+            applies_to_invoice_id="000002",
+            amount="60",
+        )
+        assert diverged["status"] == "applied"
+        assert diverged["note"] == (
+            "applied to 000002 (credit note references 000001)"
+        )
+        # Applying the remainder to the LINKED document: no note.
+        aligned = gb.apply_credit_note(
+            credit_note_id=cn["id"],
+            applies_to_invoice_id="000001",
+        )
+        assert aligned["status"] == "applied"
+        assert "note" not in aligned
+
     def test_apply_against_job_attached_invoice(self, business_book):
         """A job-attached invoice nets against a direct credit note
         from the same customer (battery bug 1: the raw owner_guid
@@ -8858,6 +8909,104 @@ class TestPayInvoice:
                 payment_date="2026-03-20",
                 fx_account="Income:Typo Account That Does Not Exist",
             )
+
+    def test_no_brokerage_vocabulary_on_cross_currency_legs(
+        self, business_book,
+    ):
+        """Battery design ruling 3: piecash auto-stamps
+        action="Buy"/"Sell" on any cross-commodity split left with
+        an empty action — brokerage vocabulary on a client bill.
+        Every leg of a posting carries "Invoice" and every leg of a
+        payment (bank, FX gain) carries "Payment", desktop's own
+        words."""
+        gb = GnuCashBook(str(business_book))
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        self._add_eur_ar_and_price(gb, "2026-03-20", "1.12")
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="EUR services", quantity="1",
+            price="4500.00",
+        )
+        posted = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable EUR",
+            post_date="2026-03-10",
+        )
+        paid = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="4500.00",
+            payment_date="2026-03-20",
+        )
+        post_txn = gb.get_transaction(posted["transaction_guid"])
+        assert {s["action"] for s in post_txn["splits"]} == \
+            {"Invoice"}
+        pay_txn = gb.get_transaction(paid["transaction_guid"])
+        # A/R + bank + realized-FX legs — all "Payment".
+        assert len(pay_txn["splits"]) == 3
+        assert {s["action"] for s in pay_txn["splits"]} == \
+            {"Payment"}
+
+    def test_cross_commodity_post_warns(self, business_book):
+        """Battery design ruling 1: posting a EUR document into the
+        USD A/R is allowed (Sabine's book has only one A/R) but
+        must warn loudly — the balance freezes at post-date FX, and
+        apply_credit_note will refuse netting against it. Matched
+        commodities post silently."""
+        gb = GnuCashBook(str(business_book))
+        self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
+        gb.create_customer(name="Berlin Digital", currency="EUR")
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(
+            invoice_id="000001", account="Income:Consulting",
+            description="x", quantity="1", price="1000.00",
+        )
+        mismatched = gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",  # USD
+            post_date="2026-03-10",
+        )
+        assert "warning" in mismatched
+        assert "apply_credit_note" in mismatched["warning"]
+        assert "per-currency" in mismatched["warning"]
+        # Matched pairing stays silent.
+        gb.create_invoice(customer_id="000001", currency="EUR",
+                          date_opened="2026-03-10")
+        gb.add_invoice_entry(
+            invoice_id="000002", account="Income:Consulting",
+            description="x", quantity="1", price="1000.00",
+        )
+        matched = gb.post_invoice(
+            invoice_id="000002",
+            post_account="Assets:Accounts Receivable EUR",
+            post_date="2026-03-10",
+        )
+        assert "warning" not in matched
+
+    def test_credit_note_posting_stamps_credit_note_action(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Co")
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="Kulanz", quantity="1", price="100.00",
+        )
+        posted = gb.post_invoice(
+            invoice_id=cn["id"],
+            post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        txn = gb.get_transaction(posted["transaction_guid"])
+        assert {s["action"] for s in txn["splits"]} == \
+            {"Credit Note"}
 
 
 # ============== Overpayment guard + direction (C2/A4) ==============

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1066,6 +1066,146 @@ class TestAuditEntityTypeBillSwap:
         assert "PAY INVOICE" not in rendered
 
 
+class TestPayDryRunAuditRendering:
+    """``pay_document(dry_run=true)`` must not read as a booked
+    payment (battery bug 2: dry runs rendered as ``PAY INVOICE``
+    with blank paid/remaining/txn fields — phantom payments to an
+    auditor). Tagged ``(dry run)``, matching the ENTER STATEMENT
+    precedent."""
+
+    _DRY_ENTRY = {
+        "classification": "write",
+        "entity_type": "invoice",
+        "operation": "pay",
+        "timestamp": "2026-08-31T18:00:00",
+        "params": {
+            "id": "000013",
+            "payment_account": "Assets:Checking",
+            "dry_run": True,
+        },
+        "after_state": {
+            "dry_run": True,
+            "type": "invoice",
+            "status": "would_pay",
+            "amount": "200.00",
+            "remaining_balance_after": "300.00",
+            "would_close_lot": False,
+            "payment_account": "Assets:Checking",
+            "payment_date": "2026-08-31",
+        },
+    }
+
+    def test_dry_run_tagged_and_no_phantom_fields(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        rendered = _format_audit_entry_text(self._DRY_ENTRY)
+        assert "PAY INVOICE (dry run)" in rendered
+        assert "would pay: 200.00" in rendered
+        assert "remaining after: 300.00" in rendered
+        assert "nothing booked" in rendered
+        # The booked-payment shape must not appear.
+        assert "paid: " not in rendered
+        assert "txn:" not in rendered
+
+    def test_dry_run_bill_keeps_tag_through_label_swap(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            **self._DRY_ENTRY,
+            "entity_type": "bill",
+            "after_state": {
+                **self._DRY_ENTRY["after_state"], "type": "bill",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "PAY BILL (dry run)" in rendered
+
+    def test_real_payment_rendering_unchanged(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "invoice",
+            "operation": "pay",
+            "timestamp": "2026-08-31T18:00:00",
+            "params": {
+                "id": "000013",
+                "payment_account": "Assets:Checking",
+            },
+            "after_state": {
+                "type": "invoice", "amount_paid": "500.00",
+                "remaining_balance": "0.00",
+                "transaction_guid": "abc12345",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "PAY INVOICE  id:000013" in rendered
+        assert "(dry run)" not in rendered
+        assert "paid: 500.00" in rendered
+
+
+class TestConsolidatedParamNamesInFormatters:
+    """The business consolidation renamed tool params (``id``,
+    ``party_type``, ``document_type``); the entry/credit-note CREATE
+    formatters still hunted the retired names and rendered blanks
+    (battery bug 5: ``on:`` with no document ID, ``: 000004`` with
+    no owner-type label)."""
+
+    def test_entry_create_reads_consolidated_id(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "entry",
+            "operation": "create",
+            "timestamp": "2026-08-31T18:00:00",
+            "params": {
+                "document_type": "invoice",
+                "id": "000014",
+                "description": "Beratung August",
+            },
+            "after_state": {
+                "description": "Beratung August",
+                "total": "800.00",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "on: invoice 000014" in rendered
+
+    def test_entry_create_still_reads_retired_keys(self):
+        """Old per-type keys keep rendering — replayed history must
+        not go blank."""
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "entry",
+            "operation": "create",
+            "timestamp": "2026-08-31T18:00:00",
+            "params": {"bill_id": "000002", "description": "Paper"},
+            "after_state": {"description": "Paper", "total": "50.00"},
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "on: 000002" in rendered
+
+    def test_credit_note_create_derives_owner_label(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "credit_note",
+            "operation": "create",
+            "timestamp": "2026-08-31T18:00:00",
+            # party_type omitted — inherited from applies_to, the
+            # common consolidated-call shape.
+            "params": {
+                "document_type": "credit_note",
+                "owner_id": "000004",
+            },
+            "after_state": {
+                "id": "000015",
+                "customer_id": "000004",
+                "is_credit_note": True,
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "customer: 000004" in rendered
+
+
 class TestAuditBeforeStateLeak:
     """Defense-in-depth: a previous call's staged before-state must
     never leak into the next call's audit entry, regardless of how

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -417,6 +417,72 @@ class TestSameDatePriceTieBreak:
             rates = gc._rates_as_of(book, d)
             assert rates[eur.guid] == Decimal("1.10")
 
+    def test_unknown_user_source_ranks_between_manual_and_feed(
+        self, multi_currency_book,
+    ):
+        """Abe's three-tier ruling: an unrecognized ``user:*``
+        source (an explicit operator act) outranks feeds but does
+        NOT silently override a deliberate manual quote."""
+        from datetime import date
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 3, 31)
+        gc.create_price("EUR", "CURRENCY", "1.30", price_date=d,
+                        source="user:market-data")
+        gc.create_price("EUR", "CURRENCY", "1.20", price_date=d,
+                        source="user:test-fx")
+        with gc.open(readonly=True) as book:
+            eur = book.commodities(mnemonic="EUR")
+            usd = book.default_currency
+            assert gc._find_exchange_rate(book, eur, usd, d) == \
+                Decimal("1.20")
+        # A known-manual quote still beats the custom user source.
+        gc.create_price("EUR", "CURRENCY", "1.10", price_date=d,
+                        source="user:price")
+        with gc.open(readonly=True) as book:
+            eur = book.commodities(mnemonic="EUR")
+            usd = book.default_currency
+            assert gc._find_exchange_rate(book, eur, usd, d) == \
+                Decimal("1.10")
+
+    def test_create_price_notes_when_outranked(
+        self, multi_currency_book,
+    ):
+        """An operator who just wrote a price and can't see it
+        winning has been misled by silence — the losing write says
+        so; the winning write carries no note."""
+        from datetime import date
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 3, 31)
+        winner = gc.create_price(
+            "EUR", "CURRENCY", "1.10", price_date=d,
+            source="user:price",
+        )
+        assert "note" not in winner
+        loser = gc.create_price(
+            "EUR", "CURRENCY", "1.30", price_date=d,
+            source="user:market-data",
+        )
+        assert "outranks it as the effective rate" in loser["note"]
+        assert "user:price" in loser["note"]
+
+    def test_create_prices_batch_notes_outranked_in_reason(
+        self, multi_currency_book,
+    ):
+        """Batch entry reports the same tie loss in the reason
+        column — single and batch can't diverge (chokepoint)."""
+        from datetime import date
+        gc = GnuCashBook(str(multi_currency_book))
+        d = date(2026, 3, 31)
+        gc.create_price("EUR", "CURRENCY", "1.10", price_date=d,
+                        source="user:price")
+        out = gc.create_prices([{
+            "ref": "1", "commodity": "EUR", "date": d,
+            "value": "1.30", "source": "user:market-data",
+        }])["results"]
+        row = out.splitlines()[1]
+        assert "created" in row
+        assert "outranked by 'user:price'" in row
+
 
 class TestPriceLookupMemo:
     """_find_prices memoizes each (commodity_guid, currency_guid)


### PR DESCRIPTION
## Summary
- **apply_credit_note vs jobs** (High): the same-owner check compared raw owner GUIDs, so a job-attached invoice (owner_guid = Job) refused netting against its own customer's credit note while the error named the same owner on both sides. Now resolves effective owners through `_resolve_owner_type_and_job`.
- **Dry-run payments in the audit log** (High): `pay_document(dry_run=true)` rendered as a booked `PAY INVOICE` with blank fields. Now tagged `(dry run)` with "would pay / nothing booked", matching the `ENTER STATEMENT` precedent; bill/voucher/refund labels inherit the tag.
- **Partial payment status**: `pay_document` returns `"partial"` when a balance remains, `"paid"` only when the lot settles; vocabulary documented.
- **Entry dates**: line items now carry the document's `date_opened` at GnuCash's neutral 10:59 (UTC-anchored) instead of `datetime.now()`, which piecash's local→UTC conversion dated tomorrow for evening-Pacific entries (and yesterday for eastern-hemisphere mornings).
- **Audit formatter param drift**: the entry/credit-note CREATE formatters read the consolidated param names (`id`, `party_type`, `document_type`); retired keys kept as fallbacks.
- **Credit-note type agreement**: `get_outstanding_documents` verbose reports credit notes as `type: "credit_note"` with no `due_date`, agreeing with `get_document`, compact mode, and delete/unpost.
- **Message sweep**: every caller-facing string naming a retired pre-consolidation tool now names the consolidated surface (`unpost_document`, `create_document(document_type='credit_note')`, `add_document_entry`/`delete_document`, real remedies instead of a nonexistent void tool) — including the persisted description on the auto-created discount account.
- **Ruling 1(b)**: cross-commodity posting warns loudly (valuation freeze, the `apply_credit_note` dead-end, per-currency subledger hint); matched postings stay silent. Warn→refuse sunset recorded in specs/v1.5 (precondition met).
- **Ruling 2**: three-tier price source rank (manual allowlist > other `user:*` > feeds); `create_price`/`create_prices` report when the written row loses its date's tie, via one shared outranker so single and batch can't diverge.
- **Ruling 3**: every leg of new posting/payment transactions carries desktop vocabulary (`Invoice`/`Credit Note`/`Payment`) so piecash's Buy/Sell auto-stamp on cross-commodity legs never fires. Forward-only.
- **Ruling 5**: `apply_credit_note` responses and audit entries note when the applied target diverges from the stored `applies_to` link; docstrings describe the link as provenance, not a constraint.

## Test plan
- [x] Full suite green: 2,144 passed, 1 skipped (exit code verified directly)
- [x] New regression locks for every bug and ruling (job-attached netting both directions, dry-run audit rendering, partial/paid status, entry-date byte-exact neutral-time storage, consolidated formatter params, credit-note type/due_date, action vocabulary incl. credit notes, cross-commodity warning, tie-loss notes single+batch, divergence echo)
- [x] Live smoke against a scratchpad copy of Sabine (EUR/SKR03): all six bug scenarios + all four rulings reproduced fixed
- [x] Bookkeeper loop on Sabine, 2026-08-31: **VERIFIED 4/4, no findings, loop closed** — including forward-only proof (Oct-2025 payment retains piecash's `Buy` stamp untouched beside new `Payment` legs) and the accounting tie (12.00 EUR realized gain = 1200×(0.87−0.86) routed to Sabine's own Realisierter Gewinn/Verlust)