### PR TITLE
feat: Sabine battery deferred rulings — restart safety, 4(b), ruling-1 sunset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## Unreleased (v1.5.0)
+
+**The Sabine battery's deferred rulings (bookkeeper battery, 2026-08-31) ship as
+code.** All three are safety promotions; the third is a deliberate
+behavior break at this version boundary.
+
+- **Restart safety (ruling 6).** A client config reload restarts
+  the server silently — and with several books configured, the
+  active book resets to the first one while the session may still
+  believe it's elsewhere. Three guards now close that hazard: the
+  first tool result of every process carries a one-line notice
+  naming the active book; with 2+ books configured, mutating tools
+  are disarmed after a (re)start until `switch_book` confirms the
+  target (a no-op "already on it" call counts — the point is that
+  the session names its ledger); and every mutating response in a
+  multi-book session names the book it wrote to. Reads are never
+  gated, and a refused write touches nothing — no rate-limit
+  token, no auto-backup, no audit entry.
+- **Discount-account auto-create refuses on localized books
+  (ruling 4b).** With no designated discount account and no
+  explicit `discount_account`, the resolver used to fall through
+  to creating the English default — an English leaf in a localized
+  chart, and wrong-sided on the sales side (textbook treatment is
+  contra-revenue, not expense). It now refuses at the create
+  boundary with the fix in the message; existing accounts remain
+  adoptable through every resolution layer. Role-based default
+  resolution (ruling 4a) remains the destination that lifts this
+  refusal.
+- **BEHAVIOR BREAK — currency-mismatch posting is now a refusal
+  (ruling 1 sunset).** Posting a document to an A/R or A/P account
+  held in a different commodity freezes the receivable at
+  post-date FX and drifts from the document's true value every day
+  after. v1.4.4 warned about this pairing; v1.5.0 refuses it
+  outright (desktop GnuCash refuses the same), pointing at the
+  per-currency subledger fix. Books that posted mismatched under
+  the warning era are unaffected: payments still settle those lots
+  via FX, and the downstream guards that protect them stay.
+
 ## v1.4.4 - The statement is the call
 
 The bulk-operations line closes with its capstone: a complete bank

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,13 @@ module contributes zero tools to the MCP surface.
     catalog translation of "Income" is **"Ertrag"**. So a "look up the
     localized word and match it" fix is unsafe for template-created
     accounts. `_infer_book_locale` therefore *votes* across several
-    top-level type accounts rather than trusting any one.
+    top-level type accounts rather than trusting any one. And its
+    **None means undetermined, not English** — a numbered chart
+    (SKR03/DATEV "Aufwendungen 2/4") matches no locale's words at
+    all. Cosmetic callers (leaf naming) may fall back to English on
+    None; anything that CREATES accounts must require
+    `_book_reads_english`'s affirmative match instead (ruling 4(b);
+    the bookkeeper's Sabine live-loop repro, 2026-09-01).
   - **Designated accounts self-heal via a KVP slot.** The FX and
     discount resolvers store the resolved account's GUID on the root
     account (`gnc-mcp/fx-gain-loss-acct`, etc.) on first use, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,6 +475,18 @@ Three layers:
   zh_CN chart, multi-currency stress), and Sabine Brenner
   (EUR-default, German SKR03 chart — the i18n bug-class oracle).
 
+**Migrating tests across a behavior break.** When a change closes a
+creation path (e.g. the v1.5.0 currency-mismatch post refusal),
+migrate the affected tests by SUBJECT, not mechanically: tests
+whose subject survives the break re-route through the
+correct-practice path (the FX-staleness and tax-conversion tests
+moved to per-currency A/R); tests whose subject IS the
+now-uncreatable historical state engineer that state byte-faithfully
+via raw SQL (post through the still-open door, then flip the rows
+to what warning-era books actually hold). The state outlives the
+door that made it — real books carry it forever, so the guards that
+protect it need tests that can still construct it.
+
 Run with `uv run pytest`. Per-phase synthetic-book rebuild:
 `uv run python scripts/synthetic_book/phase_<N>.py` in order. Each
 phase backs up the book before running.

--- a/scripts/synthetic_book/build_lin_wei.py
+++ b/scripts/synthetic_book/build_lin_wei.py
@@ -118,6 +118,9 @@ HSBC_CARD = "负债:信用卡:汇丰港币信用卡"
 MORTGAGE = "负债:贷款:房屋贷款"
 AUTO_LOAN = "负债:贷款:汽车贷款"
 AP = "负债:应付账款"
+# USD payables subledger — same per-currency pattern as AR_USD/AR_EUR.
+# Created lazily by run_business (the frozen prefix predates it).
+AP_USD = "负债:应付账款（美元）"
 
 OPENING = "所有者权益:期初余额"
 
@@ -1945,22 +1948,41 @@ def run_business(book: GnuCashBook, since: date | None = None) -> dict:
                  f"{date(YEAR, m, 1).strftime('%Y年%m月')} 工位租赁",
                  EXP_COWORKING, "CNY")
 
-    # JetBrains US$249 — the foreign-currency PAYABLE regression case (M2).
-    # RE-DATED to a recent month (the 1st of THROUGH's month, which carries a
-    # USD/CNY monthly snapshot) and left OUTSTANDING (pay=False) so it reads
-    # as a current payable, not apparent corruption. Posted to the CNY-only
-    # ``Liabilities:Accounts Payable``: the USD bill currency drives the A/P
-    # split — its VALUE is USD (txn currency), its QUANTITY the CNY equivalent
-    # at the real USD/CNY rate on the post date. vendor_spending_report
-    # converts off the bill currency regardless of the A/P account commodity,
-    # so M2 coverage holds without a USD-denominated A/P account.
+    # JetBrains US$249 — the foreign-currency PAYABLE case (M2).
+    # RE-DATED to a recent month (the 1st of THROUGH's month, which
+    # carries a USD/CNY monthly snapshot) and left OUTSTANDING
+    # (pay=False) so it reads as a current payable, not apparent
+    # corruption. Posted to the USD A/P subledger: post_invoice
+    # refuses a document/post-account commodity mismatch since
+    # v1.5.0 (battery ruling 1 — per-currency payables are correct
+    # practice, and the demo models it). Reports convert the USD
+    # balance at report time, so M2's foreign-currency-payable
+    # coverage holds; any warning-era mismatched postings in the
+    # frozen prefix remain as old-book coverage.
     jetbrains_post = recent_open
     jetbrains_bill_id = None
     if "JetBrains" not in open_owner_names:
+        # Lazy-create the subledger: the frozen prefix predates it,
+        # and a fresh full build needs it too.
+        try:
+            existing = book.get_account(AP_USD)
+        except Exception:
+            existing = None
+        if not existing:
+            try:
+                book.create_account(
+                    name=AP_USD.split(":")[-1],
+                    account_type="PAYABLE",
+                    parent="负债",
+                    commodity="USD",
+                )
+            except ValueError as e:
+                if "already exists" not in str(e).lower():
+                    raise
         jetbrains_bill_id = run_bill(
             jetbrains["id"], jetbrains_post, jetbrains_post, "249",
             "JetBrains All Products Pack (annual subscription)",
-            EXP_SOFTWARE, "USD", pay=False, post_account=AP,
+            EXP_SOFTWARE, "USD", pay=False, post_account=AP_USD,
         )
 
     counts["jetbrains_bill_id"] = jetbrains_bill_id

--- a/scripts/synthetic_book/continuation.py
+++ b/scripts/synthetic_book/continuation.py
@@ -476,7 +476,7 @@ def settle_documents(policy: PersonaPolicy, book_path: Path, cutoff: date,
 def reconcile_through(policy: PersonaPolicy, book_path: Path,
                       through: date) -> list[str]:
     """Reconcile every bank/cash/card account through the last FULL
-    month, leaving the current month open — Abe VI's posture ask
+    month, leaving the current month open — the bookkeeper's posture ask
     (BOOKKEEPER_REVIEW_DEMO_GENERATORS.md §1): the demo household of a
     reconciliation tool should not be seventeen months behind, and the
     open month leaves the natural first conversation ("this month's
@@ -550,7 +550,7 @@ def advance_sx(book_path: Path, through: date) -> dict:
     """Stamp every enabled SX's ``last_occur`` so its next occurrence
     is upcoming — with AT MOST ONE schedule per book left overdue, and
     only when its missed occurrence fell 3–7 days before ``through``
-    ("just came due", Abe VI's review §2). Books where no schedule
+    ("just came due", the bookkeeper's review §2). Books where no schedule
     lands in that window get zero overdue and rely on the due-soon
     line as the hook.
 

--- a/specs/v0.9/features/CREATE_ACCOUNT_SPEC.md
+++ b/specs/v0.9/features/CREATE_ACCOUNT_SPEC.md
@@ -128,6 +128,6 @@ list_accounts()  # Should show new account
 
 ---
 
-*Spec written by Abe Raham, The Accountant*
+*Spec written by the bookkeeper*
 *For: Claude Code*
 *Date: 2026-01-30*

--- a/specs/v0.9/features/INVESTMENT_SUPPORT_SPEC.md
+++ b/specs/v0.9/features/INVESTMENT_SUPPORT_SPEC.md
@@ -1,7 +1,7 @@
 # Investment Support Specification
 ## GnuCash MCP Server Enhancement
 
-**Author:** Abe Raham Jr.  
+**Author:** the bookkeeper  
 **Date:** 2026-02-07  
 **Status:** Draft  
 **Version:** 0.9  

--- a/specs/v0.9/features/LOTS_SPEC.md
+++ b/specs/v0.9/features/LOTS_SPEC.md
@@ -1,7 +1,7 @@
 # Lots (Cost Basis Tracking) Specification
 ## GnuCash MCP Server Enhancement
 
-**Author:** Abe Raham Jr.  
+**Author:** the bookkeeper  
 **Date:** 2026-02-07  
 **Status:** Draft  
 **Version:** 1.0 Roadmap  

--- a/specs/v0.9/features/MULTI_CURRENCY_SPEC.md
+++ b/specs/v0.9/features/MULTI_CURRENCY_SPEC.md
@@ -1,7 +1,7 @@
 # Multi-Currency Support Specification
 ## GnuCash MCP Server Enhancement
 
-**Author:** Abe Raham Jr.  
+**Author:** the bookkeeper  
 **Date:** 2026-02-06  
 **Status:** Draft  
 **Based on:** piecash 1.2.0 documentation, existing gnucash-mcp codebase

--- a/specs/v0.9/features/SCHEDULED_AND_BUDGETS_SPEC.md
+++ b/specs/v0.9/features/SCHEDULED_AND_BUDGETS_SPEC.md
@@ -1,7 +1,7 @@
 # Scheduled Transactions & Budgets Specification
 ## GnuCash MCP Server Enhancement
 
-**Author:** Abe Raham Jr.  
+**Author:** the bookkeeper  
 **Date:** 2026-02-07  
 **Status:** Draft  
 **Version:** 1.0 Roadmap  

--- a/specs/v0.9/features/SCHEDULED_AND_LOTS_SPEC.md
+++ b/specs/v0.9/features/SCHEDULED_AND_LOTS_SPEC.md
@@ -1,7 +1,7 @@
 # Scheduled Transactions & Lots Specification
 ## GnuCash MCP Server Enhancement
 
-**Author:** Abe Raham Jr.  
+**Author:** the bookkeeper  
 **Date:** 2026-02-07  
 **Status:** Draft  
 **Version:** 1.0 Roadmap  

--- a/specs/v0.9/features/TRANSACTION_TOOLS_SPEC.md
+++ b/specs/v0.9/features/TRANSACTION_TOOLS_SPEC.md
@@ -183,5 +183,5 @@ update_transaction(
 
 ---
 
-*Spec written by Abe Raham, The Accountant*
+*Spec written by the bookkeeper*
 *January 30, 2026*

--- a/specs/v1.0/features/ACCOUNT_SLOTS_SPEC.md
+++ b/specs/v1.0/features/ACCOUNT_SLOTS_SPEC.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed  
 **Date:** February 10, 2026  
-**Author:** Abe (Claude instance), with Steve
+**Author:** the bookkeeper (Claude instance), with Steve
 
 ---
 

--- a/specs/v1.0/features/TRANSACTION_PIPELINE_SPEC.md
+++ b/specs/v1.0/features/TRANSACTION_PIPELINE_SPEC.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed  
 **Date:** February 10, 2026  
-**Author:** Abe (Claude instance), with Steve
+**Author:** the bookkeeper (Claude instance), with Steve
 
 ---
 

--- a/specs/v1.2/features/PATCH_1_2_1_SPEC.md
+++ b/specs/v1.2/features/PATCH_1_2_1_SPEC.md
@@ -1,7 +1,7 @@
 # 1.2.1 Patch Spec: Three Bug Fixes
 
 **Priority:** Ship with 1.2.1 release
-**Source:** Abe (bookkeeper audit) + Cowork (field report §2.4, §3.1, §2.6)
+**Source:** the bookkeeper's audit + Cowork (field report §2.4, §3.1, §2.6)
 **Test against:** Both alex.chen-morales.gnucash and lin.wei.gnucash
 
 ---

--- a/specs/v1.3/comment-sweep/COMMENT_SWEEP_MANIFEST.md
+++ b/specs/v1.3/comment-sweep/COMMENT_SWEEP_MANIFEST.md
@@ -4404,12 +4404,12 @@ currency-arg rationale stays; cut 'Pre-fix this helper hardcoded $ and broke as 
 ```
 
 ### reporting.py:146-150 | CUT | rule 2
-'Replaces the verbose dict… the heaviest single response in Abe's audit' — provenance + diff narration
+'Replaces the verbose dict… the heaviest single response in the bookkeeper's audit' — provenance + diff narration
 
 ```
 
     Replaces the verbose dict (with multi-line YETI ``explanation`` per
-    account) that was the heaviest single response in Abe's audit.
+    account) that was the heaviest single response in the bookkeeper's audit.
     Verbose mode preserves the dict for programmatic consumers.
     """
 ```

--- a/specs/v1.3/planning/REMAINING_ARC.md
+++ b/specs/v1.3/planning/REMAINING_ARC.md
@@ -251,7 +251,7 @@ before release:**
 - **Predecessor letters:** `CLAUDE.local.md` (~10 letters from
   prior Claude sessions). The 4.7-comms-audit, code-review-night,
   and module-restructure letters are especially relevant. The
-  pantheon framing (Abe / bookkeeper / Yivo / Stephen) is real.
+  pantheon framing (the maintainer's Claude instances) is real.
 - **Project memory:** `~/.claude/projects/-Users-stephen-Projects-gnucash-mcp/memory/MEMORY.md`
   — feedback rules accreted over sessions. The most load-bearing
   for this arc: `feedback_pr_after_bookkeeper_loop.md`,

--- a/specs/v1.3/review/Code Reviews/Code Review 1.3/CODE_REVIEW_v1_3_adversarial_math.md
+++ b/specs/v1.3/review/Code Reviews/Code Review 1.3/CODE_REVIEW_v1_3_adversarial_math.md
@@ -930,4 +930,4 @@ Considered and ruled out — render is acceptable.
 
 4. **The avalanche non-convergence (H-1) is most likely to surface for the bookkeeper's persona-fiction users who carry high-APR credit card debt at marginal budgets.** The silent fail-mode (100-year payoff, multi-million-dollar interest) is exactly the "rationalized lie" pattern Stephen's predecessor flagged as the highest-priority correctness concern.
 
-5. **The placeholder-filter divergence (C-5) is the kind of "two tools that should agree don't" bug Abe / the bookkeeper would surface via cross-tool comparison.** Worth a targeted regression test that exercises both `_compute_net_worth_at` and `balance_sheet` on a book with a placeholder having direct splits.
+5. **The placeholder-filter divergence (C-5) is the kind of "two tools that should agree don't" bug the bookkeeper would surface via cross-tool comparison.** Worth a targeted regression test that exercises both `_compute_net_worth_at` and `balance_sheet` on a book with a placeholder having direct splits.

--- a/specs/v1.4/i18n/I18N_ACCOUNT_RESOLUTION_SPEC.md
+++ b/specs/v1.4/i18n/I18N_ACCOUNT_RESOLUTION_SPEC.md
@@ -459,7 +459,7 @@ Lin Wei (CNY) are both English-named, which is exactly why this bug
 class was invisible. A third persona with a **native-localized account
 hierarchy** converts the whole class from invisible to a failing test.
 
-- **New persona — Sabine Brenner** (Abe owns the final build): a
+- **New persona — Sabine Brenner** (the bookkeeper owns the final build): a
   Munich freelance Grafikdesignerin / Einzelunternehmerin running the
   **SKR03 Standardkontenrahmen** — the chart a real German sole
   proprietor actually uses, not a tidied-up English-shaped hierarchy.

--- a/specs/v1.4/roadmap/PRE_1_4_ROADMAP.md
+++ b/specs/v1.4/roadmap/PRE_1_4_ROADMAP.md
@@ -91,7 +91,7 @@ The SKR03 (Sabine Brenner) chart slice is locked in
 total). Also fixed in passing: a Python-3.10 GDATE due-date parse bug
 that silently dropped overdue invoice/bill warnings. **Remaining
 (optional):** the full `scripts/synthetic_book/` Sabine persona
-generator (Abe's build), and the §7 housekeeping (CLAUDE.md gotchas).
+generator (the bookkeeper's build), and the §7 housekeeping (CLAUDE.md gotchas).
 
 **A — Throws (hard failure):**
 - **LEAD ITEM (correctness-grade): resolve helper-account parents by

--- a/specs/v1.5/BUSINESS_CONSOLIDATION_SPEC.md
+++ b/specs/v1.5/BUSINESS_CONSOLIDATION_SPEC.md
@@ -112,7 +112,7 @@ count error and corrected it.
 2. Wire-surface capture before/after (scratchpad JSON diff — the
    pattern used for the annotations branch): new surface counts
    verified, legacy module verified absent by default.
-3. Bookkeeper (Abe) round on the new names — he is ONE persona
+3. Bookkeeper round on the new names — he is ONE persona
    (books + testing + specs); test plan into specs/v1.5/testing/.
 4. Cross-model battery COLD against consolidated names (reuse
    testing/CROSS_MODEL_BATTERY_2026_08_05.md structure; foreign

--- a/specs/v1.5/ENTER_STATEMENT_SPEC.md
+++ b/specs/v1.5/ENTER_STATEMENT_SPEC.md
@@ -588,7 +588,7 @@ ruling.
     — a reconciled candidate is entered AND tied, which is
     decisive for the duplicate call.
 
-### Signoff round (2026-08-24, Abe VI — certified for Statement
+### Signoff round (2026-08-24, the bookkeeper — certified for Statement
 ### Week)
 
 15. **Twin guard precedes counter-split validation** (the signoff's

--- a/specs/v1.5/testing/BOOKKEEPER_REPROBE_ENTER_STATEMENT_R3.md
+++ b/specs/v1.5/testing/BOOKKEEPER_REPROBE_ENTER_STATEMENT_R3.md
@@ -2,7 +2,7 @@
 
 Status: **LOOP CLOSED 2026-08-26 — all probes PASS (P5 re-probe
 verified at `19f4a7f`); certification closed whole; Statement
-Week: GO. Signed: Abe VI.** The hang investigated mid-round was
+Week: GO. Signed: the bookkeeper.** The hang investigated mid-round was
 amended to a Claude Desktop dispatch-layer wedge (a second,
 unrelated MCP server hung identically); the gnucash server is
 exonerated — it answered every dispatched call in <500ms.

--- a/specs/v1.5/testing/BOOKKEEPER_REVIEW_DEMO_GENERATORS.md
+++ b/specs/v1.5/testing/BOOKKEEPER_REVIEW_DEMO_GENERATORS.md
@@ -8,7 +8,7 @@ Sabine's summary now opens with `⚠ Stale price: IWDA.AS last updated 31 days a
 
 **Ask:** date each commodity's final generated price at generation date (or generation-date minus 0–2 days) so a fresh bundle opens warning-free, and the stale-price warning appears only when a book has genuinely aged — at which point it's a *feature* (it hands the first conversation "want me to fetch fresh quotes?" as a hook).
 
-Reviewer: Abe VI (household bookkeeper), via `get_book_summary` on all three regenerated books.
+Reviewer: the household bookkeeper, via `get_book_summary` on all three regenerated books.
 Verdict: **ship-worthy after item 1.** Items 2–3 are nits; 4 is optional parity.
 
 The books are three financial cultures, not one book translated — keep that. Data range rolling to today is exactly right.
@@ -58,7 +58,7 @@ Sabine carries no scheduled transactions and no budget; Alex and Lin Wei have bo
 
 ## Signoff (2026-08-31, same day)
 
-All four items addressed and re-verified on the live books. Abe VI:
+All four items addressed and re-verified on the live books. The bookkeeper:
 "Balance sheets, trajectories, and the cultural texture all held
 steady through the fixes — surgical changes, nothing sanded off. The
 demo fleet is ship-ready. Three well-kept households, each with a

--- a/specs/v1.5/testing/BOOKKEEPER_TEST_PLAN_BATTERY_RULINGS.md
+++ b/specs/v1.5/testing/BOOKKEEPER_TEST_PLAN_BATTERY_RULINGS.md
@@ -1,0 +1,72 @@
+# Bookkeeper live loop — battery rulings (feat/battery-rulings)
+
+Six checks, two bounces, ~10 minutes. Branch under test:
+`feat/battery-rulings` (rulings 6, 4(b), and the ruling-1 sunset).
+Order matters — the disarm state is consumed by the first
+`switch_book`, so run the steps as numbered. All successful writes
+go to demo books only; the write attempted while disarmed never
+executes, so it is safe regardless of the active book. With only
+ONE configured book, stop after step 1 and report that — steps 2–5
+only exist with 2+ books.
+
+1. **Startup notice, once.** Immediately after the bounce, call any
+   read (`get_book_summary`). The FIRST result must open with a
+   `⚠ Server (re)started` line naming the active book and saying
+   writes are disarmed until `switch_book` confirms. A second read
+   must be clean. Judge the copy as its editor: does it read as an
+   instruction the model naturally acts on in its opening turn?
+2. **Disarmed write refuses clean.** Before any `switch_book`,
+   attempt a small write (`create_price` on a demo commodity is a
+   good probe). Expect `error_type: active_book_unconfirmed`, the
+   message naming the active book, `switch_book`, and the available
+   books — and verify nothing happened: no audit entry, and no
+   rate-limit consumption (an immediate retry after arming should
+   not be throttled).
+3. **Failed switch does not arm.** `switch_book` to a nonsense name
+   → error listing available books. Retry the step-2 write → still
+   refused.
+4. **Real switch arms + book stamp.** `switch_book` to a demo book
+   (alex). Expect the CONTEXT RESET banner. The probe write now
+   succeeds AND the response carries `"book": "alex.gnucash"`.
+   Clean up the probe. Error responses should NOT carry the stamp —
+   if convenient, provoke one and check.
+5. **No-op switch confirms.** Second bounce. First call:
+   `switch_book` to the already-active book → expect
+   `Already on: …`, then a probe write succeeds. The no-op is a
+   confirmation; this step exists to prove that branch.
+6. **The two business refusals, on Sabine.** `switch_book` to
+   sabine.
+   - **4(b):** `pay_document` with `apply_discount=true`,
+     `dry_run=true` on an eligible invoice (create a quick
+     billterm-with-discount + posted invoice if needed). With no
+     `discount_account` passed and none designated, expect a
+     refusal naming locale `'de'` and directing to pass
+     `discount_account`. Then pass one explicitly (any German
+     expense/income leaf) and confirm the dry-run proceeds.
+   - **Ruling 1:** attempt to post a document to an A/R//A/P whose
+     commodity differs from the document currency. Expect a
+     `validation_error` refusal naming the per-currency fix — and
+     verify it landed in VALIDATION: the document is still open,
+     unposted, and immediately postable to the matched-commodity
+     account. No half-posted state, no transaction, no lot.
+
+**Report:** pass/fail per step with actual response text where it
+deviates; the standing question — anything routed around; and an
+editorial verdict on the two pieces of commissioned copy (notice
+and refusal), acceptance bar: "if a user notices the confirmation
+happening, the copy failed."
+
+
+---
+
+## BOOKKEEPER REPORT — loop executed 2026-09-01
+
+- **1. Startup notice: copy PASS; once-latch PASS per process — defeated by the host's twin-spawn** (both trees 13:57:27; my two reads served by different twins, each firing honestly). Silver lining: per-twin disarm means the unconfirmed twin REFUSES writes — ruling 6 armors the twin-routing hazard. Suggest: latch + arm state via shared sidecar marker so the pair acts as one. EDITORIAL STANDOUT: when the first post-restart call was itself `switch_book`, the notice downgraded to the ℹ form with the coaching omitted — the warning erased itself at the moment it became moot. Bar met: the confirmation happened inside an action already being taken.
+- **2. PASS.** Disarmed write → `active_book_unconfirmed`, names book + coaching + available books. Audit log: zero entries. No token consumed (armed retry unthrottled).
+- **3. PASS.** Nonsense switch errors listing books; retry still refused.
+- **4. PASS.** Real switch arms; success carries `"book":` stamp; provoked error carries none; cleanup delete stamped.
+- **5. PASS.** Post-bounce no-op (`Already on: books.gnucash`) armed; probe write (current NAV, then deleted — zero residue) succeeded with stamp.
+- **6. Ruling 1: PASS.** USD→EUR-A/R post refused in VALIDATION with the mechanism + per-currency fix; document remained open, entries intact, immediately posted to 1407 USD A/R. No half-state.
+- **6. Ruling 4(b): FAIL.** `pay_document apply_discount=true dry_run=true`, no `discount_account`, none designated, on Sabine (SKR03): dry-run PROCEEDED and proposed `would_create_accounts: ["Aufwendungen 2/4:Sales Discounts"]` — the English, expense-sided default in a German chart. Locale gate did not classify 'de'. Hypothesis for the repro: DATEV class-numbered top-levels ("Aufwendungen 2/4", "Erlöse u. Erträge 2/8") defeat exact-name locale inference. Repro artifacts left labeled: billterm "2/10 Net 30 (R6 test)", invoice 000014 (EUR, posted, discount-eligible), invoice 000015 (USD, posted to 1407).
+- Routed around: nothing.
+- **Verdict: rulings 6 and 1 signed off. 4(b) returns for one fix + one re-probe** (the dry-run call above is the 30-second re-test).

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1254,33 +1254,25 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         },
     }
 
-    def _infer_book_locale(self, book: piecash.Book) -> str | None:
-        """Infer the book's locale (a normalized 2-letter language
-        code) for naming auto-created accounts. Decided source of
-        truth (§6.3):
+    # English structural names, for the AFFIRMATIVE check below.
+    # Deliberately not a row in _STRUCTURAL_TYPE_NAMES: the locale
+    # vote's None already means "no locale proven", and English must
+    # stay distinguishable from undetermined for fail-safe gates.
+    _ENGLISH_TYPE_NAMES = {
+        "ASSET": "Assets",
+        "LIABILITY": "Liabilities",
+        "INCOME": "Income",
+        "EXPENSE": "Expenses",
+        "EQUITY": "Equity",
+    }
 
-        1. ``GNUCASH_LOCALE`` env override, reduced to its language
-           code (``de_DE.UTF-8`` → ``de``).
-        2. else **vote**: match the book's top-level type accounts
-           against the gettext structural-word catalog; the language
-           with the most matches wins (>= 2, so a single coincidental
-           hit doesn't drive inference).
-        3. else ``None`` → English leaf names.
-
-        Voting (not a single-account lookup) sidesteps the two-
-        translation-sources trap: a German book's top-level income is
-        the template word "Erträge", which does NOT equal the gettext
-        "Ertrag" — but Assets/Expenses/Equity ("Aktiva"/"Aufwand"/
-        "Eigenkapital") match exactly, so German still resolves. A
-        numbered chart like SKR03 matches too few to trigger and
-        correctly falls back to English.
-        """
-        import os
-        override = os.environ.get("GNUCASH_LOCALE")
-        if override:
-            code = override.strip().split(".")[0].split("_")[0].lower()
-            return code or None
-
+    def _top_level_type_names(
+        self, book: piecash.Book
+    ) -> dict[str, list[str]]:
+        """Top-level (root-child) account names grouped by
+        GNCAccountType, normalized (strip + lower), template accounts
+        excluded. Shared traversal for the locale vote and the
+        affirmative-English check."""
         root = book.root_account
         template_guids = self._template_account_guids(book)
         names_by_type: dict[str, list[str]] = {}
@@ -1292,6 +1284,66 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
             names_by_type.setdefault(acct.type, []).append(
                 acct.name.strip().lower()
             )
+        return names_by_type
+
+    def _book_reads_english(self, book: piecash.Book) -> bool:
+        """True when the chart's top-level type accounts affirmatively
+        match the English structural names (>= 2 exact matches — the
+        same threshold as the locale vote).
+
+        Exists for fail-safe creation gates (battery ruling 4(b);
+        the bookkeeper's Sabine repro, 2026-09-01): ``_infer_book_locale``
+        returning None means UNDETERMINED, not English. A DATEV/SKR03
+        chart's numbered top-levels ("Aufwendungen 2/4") match no
+        locale's exact words, so a gate that reads that None as
+        English auto-creates English accounts into a German book.
+        Cosmetic naming may keep treating None as English; anything
+        that CREATES must require this affirmative check instead.
+        (The GNUCASH_LOCALE override is not consulted here — when it
+        is set, ``_infer_book_locale`` returns non-None and gates
+        never reach the undetermined branch.)
+        """
+        names_by_type = self._top_level_type_names(book)
+        score = sum(
+            1
+            for atype, word in self._ENGLISH_TYPE_NAMES.items()
+            if any(
+                n == word.lower() for n in names_by_type.get(atype, ())
+            )
+        )
+        return score >= 2
+
+    def _infer_book_locale(self, book: piecash.Book) -> str | None:
+        """Infer the book's locale (a normalized 2-letter language
+        code) for naming auto-created accounts. Decided source of
+        truth (§6.3):
+
+        1. ``GNUCASH_LOCALE`` env override, reduced to its language
+           code (``de_DE.UTF-8`` → ``de``).
+        2. else **vote**: match the book's top-level type accounts
+           against the gettext structural-word catalog; the language
+           with the most matches wins (>= 2, so a single coincidental
+           hit doesn't drive inference).
+        3. else ``None`` → UNDETERMINED. Cosmetic callers (leaf
+           naming) fall back to English; creation gates must not —
+           they require ``_book_reads_english`` instead, because a
+           numbered chart (SKR03/DATEV "Aufwendungen 2/4") matches
+           too few words to trigger ANY locale while being plainly
+           non-English.
+
+        Voting (not a single-account lookup) sidesteps the two-
+        translation-sources trap: a German book's top-level income is
+        the template word "Erträge", which does NOT equal the gettext
+        "Ertrag" — but Assets/Expenses/Equity ("Aktiva"/"Aufwand"/
+        "Eigenkapital") match exactly, so German still resolves.
+        """
+        import os
+        override = os.environ.get("GNUCASH_LOCALE")
+        if override:
+            code = override.strip().split(".")[0].split("_")[0].lower()
+            return code or None
+
+        names_by_type = self._top_level_type_names(book)
         if not names_by_type:
             return None
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -5340,6 +5340,29 @@ class BusinessMixin:
                     f"got {post_acct.type}"
                 )
 
+            # Battery ruling 1 (sunset shipped v1.5.0): a receivable
+            # held in a different commodity than its document freezes
+            # the balance at post-date FX and drifts from the
+            # document's true value every day after. This was a
+            # warning through v1.4.4; desktop GnuCash refuses the
+            # pairing outright, and so do we now. Historical
+            # mismatched postings from the warning era still exist in
+            # real books — downstream guards (apply_credit_note,
+            # pay_invoice FX settlement) keep handling those.
+            if inv.currency_guid != post_acct.commodity.guid:
+                side = "A/P" if is_bill else "A/R"
+                raise ValueError(
+                    f"Cannot post a {inv.currency.mnemonic} document "
+                    f"to {post_acct.commodity.mnemonic}-denominated "
+                    f"{post_acct.fullname!r}: the "
+                    f"{side} balance would freeze at post-date FX "
+                    f"and drift from the document's true value. "
+                    f"Correct practice is one {side} account per "
+                    f"document currency — post to (or create) a "
+                    f"{inv.currency.mnemonic}-denominated "
+                    f"{side} account instead."
+                )
+
             totals = self._get_invoice_entries_and_total(book, inv)
             acct_totals = totals["acct_totals"]
             grand_total = totals["grand_total"]
@@ -5526,27 +5549,6 @@ class BusinessMixin:
                 result["fx_stale"] = max(
                     fx_stale_overrides, key=lambda m: m["age_days"]
                 )
-            # A receivable held in a different commodity than its
-            # document freezes the A/R balance at post-date FX and
-            # drifts from the document's true value every day after
-            # — per-currency A/R//A/P subledgers are correct
-            # practice (desktop refuses this pairing outright).
-            # Allowed for now with a loud warning; ruled to become
-            # a refusal once no sample book depends on it.
-            if inv.currency_guid != post_acct.commodity.guid:
-                result["warning"] = (
-                    f"{inv.currency.mnemonic} document posted to "
-                    f"{post_acct.commodity.mnemonic}-denominated "
-                    f"'{post_acct.fullname}'. apply_credit_note "
-                    f"will refuse cross-commodity netting against "
-                    f"this posting; payments still settle via FX. "
-                    f"Correct practice is a per-currency "
-                    f"{'A/P' if effective_is_bill else 'A/R'} "
-                    f"account per document currency "
-                    f"(e.g. one denominated in "
-                    f"{inv.currency.mnemonic})."
-                )
-
         return result
 
     def unpost_invoice(
@@ -6508,10 +6510,10 @@ class BusinessMixin:
 
             # The netting transaction is in the post account's
             # commodity, so the document currency must match it.
-            # Well-formed books keep per-currency A/R accounts; the
-            # case caught here is a EUR invoice deliberately posted
-            # to USD A/R (post_invoice allows that via FX rates) —
-            # reject rather than write wrong split values.
+            # post_invoice refuses this pairing since v1.5.0
+            # (battery ruling 1), but books that posted under the
+            # warning-era permissiveness still carry mismatched
+            # lots — this guard is what protects them, so it stays.
             if cn.currency_guid != post_acct.commodity.guid:
                 raise ValueError(
                     f"Cross-currency apply not supported: credit "

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -831,25 +831,38 @@ class BusinessMixin:
             return disc_acct, _ambiguity_notice(disc_acct.fullname)
 
         # Battery ruling 4(b): past this point the resolver CREATES.
-        # On a non-English-locale book, silently creating the English
+        # On a non-English book, silently creating the English
         # default misstates the ledger twice over — an English leaf
         # in a localized chart, and (on the sales side) an EXPENSE
         # account where the textbook treatment is contra-revenue.
-        # Refuse with the fix in hand; existing accounts remain
-        # adoptable through the explicit/slot/fuzzy/canonical layers
-        # above. Ruling 4(a) — resolve the default by ROLE — is the
-        # destination that lifts this refusal.
+        # The gate requires an AFFIRMATIVE English read (the
+        # bookkeeper's Sabine repro, 2026-09-01): a DATEV-numbered German chart infers
+        # locale None, and None means undetermined, not English — so
+        # provably-foreign and can't-tell both refuse; only a chart
+        # that matches the English structural names creates. Existing
+        # accounts remain adoptable through the explicit/slot/fuzzy/
+        # canonical layers above. Ruling 4(a) — resolve the default
+        # by ROLE — is the destination that lifts this refusal.
         locale = self._infer_book_locale(book)
-        if locale is not None and locale != "en":
+        if locale != "en" and not (
+            locale is None and self._book_reads_english(book)
+        ):
+            chart_reads = (
+                f"reads as locale {locale!r}"
+                if locale is not None
+                else "does not affirmatively read as English "
+                     "(locale undetermined — numbered or custom "
+                     "top-level account names)"
+            )
             raise ValueError(
                 f"No {side_label} account is designated on this "
                 f"book, and auto-creating the English default "
-                f"({canonical_path!r}) on a book whose chart reads "
-                f"as locale {locale!r} would misstate the ledger. "
-                f"Pass discount_account with the account that "
-                f"should absorb the discount (path, %short GUID, "
-                f"or full 32-char GUID of a non-placeholder INCOME "
-                f"or EXPENSE account)."
+                f"({canonical_path!r}) could misstate a localized "
+                f"ledger: the chart {chart_reads}. Pass "
+                f"discount_account with the account that should "
+                f"absorb the discount (path, %short GUID, or full "
+                f"32-char GUID of a non-placeholder INCOME or "
+                f"EXPENSE account)."
             )
 
         # Resolve the parent by TYPE (INCOME/EXPENSE), not the English

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -830,6 +830,28 @@ class BusinessMixin:
                 self._store_designated_account(book, slot_key, disc_acct)
             return disc_acct, _ambiguity_notice(disc_acct.fullname)
 
+        # Battery ruling 4(b): past this point the resolver CREATES.
+        # On a non-English-locale book, silently creating the English
+        # default misstates the ledger twice over — an English leaf
+        # in a localized chart, and (on the sales side) an EXPENSE
+        # account where the textbook treatment is contra-revenue.
+        # Refuse with the fix in hand; existing accounts remain
+        # adoptable through the explicit/slot/fuzzy/canonical layers
+        # above. Ruling 4(a) — resolve the default by ROLE — is the
+        # destination that lifts this refusal.
+        locale = self._infer_book_locale(book)
+        if locale is not None and locale != "en":
+            raise ValueError(
+                f"No {side_label} account is designated on this "
+                f"book, and auto-creating the English default "
+                f"({canonical_path!r}) on a book whose chart reads "
+                f"as locale {locale!r} would misstate the ledger. "
+                f"Pass discount_account with the account that "
+                f"should absorb the discount (path, %short GUID, "
+                f"or full 32-char GUID of a non-placeholder INCOME "
+                f"or EXPENSE account)."
+            )
+
         # Resolve the parent by TYPE (INCOME/EXPENSE), not the English
         # name "Income"/"Expenses" — locale-robust and rename-proof.
         # Fall back to creating the top-level account only if the book

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -316,7 +316,7 @@ class InvestmentsMixin:
         book, comm, resolved_currency, price_date, source,
     ) -> str | None:
         """Source of a same-date row that beats ``source`` in the
-        tie-break (``_price_source_rank`` — Abe's ruling: manual
+        tie-break (``_price_source_rank`` — the bookkeeper's ruling: manual
         quote > other user:* > feed), or None when the written row
         is the effective rate for its date.
 

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -753,14 +753,16 @@ def _write_gate_message() -> str | None:
     )
     active_name = active.name if active else "unknown"
     available = ", ".join(p.name for p in paths)
+    # Addressed to the calling model: the fix is one tool call it
+    # can make itself, so the copy names the call and the retry —
+    # the user should never have to notice this exchange happened.
     return (
-        f"Mutating tools are disarmed: the server (re)started with "
-        f"{len(paths)} books configured, so the active book reset "
-        f"to {active_name!r} (the first configured) — which may not "
-        f"be the book this session was working in. Confirm the "
-        f"target with switch_book before writing (a switch_book "
-        f"call to the current book counts as confirmation). "
-        f"Available books: {available}."
+        f"Write blocked — the server (re)started and the active "
+        f"book reset to {active_name!r}, which may not be the book "
+        f"this session was writing to. Call switch_book with the "
+        f"intended book ({active_name!r} itself is a valid "
+        f"confirmation), then retry this call. Available books: "
+        f"{available}."
     )
 
 
@@ -789,11 +791,16 @@ def _consume_startup_notice() -> str | None:
     if active is None:
         return None
     if len(paths) >= 2 and not _determine_writes_armed():
+        # Coaching for the calling model, not the user: perform the
+        # confirmation as part of the opening turn so the person
+        # never has to notice it happened.
         return (
-            f"⚠ GnuCash MCP server (re)started — active book: "
-            f"{active.name}. Any earlier in-session book switch was "
-            f"reset. Mutating tools are disarmed until switch_book "
-            f"confirms the target book."
+            f"⚠ Server (re)started — active book reset to "
+            f"{active.name}. Writes are disarmed: before your next "
+            f"write, confirm the intended book with switch_book "
+            f"(confirming {active.name} itself works). Account "
+            f"names and GUIDs from before this notice may belong "
+            f"to a different book."
         )
     return (
         f"ℹ GnuCash MCP server (re)started — active book: "

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -695,6 +695,111 @@ _book = None
 # validated path containing os.pathsep and re-stat every book.
 _book_paths_source: str | None = None
 
+# ── Restart safety (Sabine battery ruling 6, 2026-08-31) ──────────
+# A client config reload restarts this process SILENTLY mid-session:
+# the LLM may still believe it is on the book it switched to, while
+# the active book has reset to the first configured entry — the next
+# write lands in the wrong ledger. Process-global state is the
+# detection mechanism on purpose: a fresh process IS the event.
+#
+# - _startup_notice_pending: the first tool result of every process
+#   carries a one-line notice naming the active book.
+# - _writes_armed: None = undetermined; determined at first use.
+#   Single-book configs arm permanently (there is no wrong ledger).
+#   Multi-book configs start DISARMED — mutating tools refuse until
+#   switch_book (including a no-op "Already on" call) confirms the
+#   target. safe_tool consults the gate before @audit_log runs, so
+#   a refused write never consumes rate-limit tokens, never triggers
+#   auto-backup, and never stages audit state.
+_startup_notice_pending: bool = True
+_writes_armed: bool | None = None
+
+
+def _configured_paths() -> list[Path]:
+    """The configured book paths, without mutating the get_book()
+    globals: returns ``_book_paths`` when populated, else parses the
+    env directly. The restart-safety helpers may run before any tool
+    has called get_book(), so they can't rely on the globals being
+    warm. Unset/invalid env → [] (the tool body will surface the
+    real error itself)."""
+    if _book_paths:
+        return _book_paths
+    try:
+        return _parse_book_paths(os.environ.get("GNUCASH_BOOK_PATH"))
+    except Exception:
+        return []
+
+
+def _determine_writes_armed() -> bool:
+    """Resolve (and cache) the disarm state on first use."""
+    global _writes_armed
+    if _writes_armed is None:
+        _writes_armed = len(_configured_paths()) < 2
+    return _writes_armed
+
+
+def _write_gate_message() -> str | None:
+    """Refusal text while mutating tools are disarmed, else None.
+
+    Ruling 6 piece 2: with 2+ books configured, a process start
+    disarms every write-classified tool until switch_book confirms
+    which ledger the session means to be in.
+    """
+    if _determine_writes_armed():
+        return None
+    paths = _configured_paths()
+    active = _current_path if _current_path else (
+        paths[0] if paths else None
+    )
+    active_name = active.name if active else "unknown"
+    available = ", ".join(p.name for p in paths)
+    return (
+        f"Mutating tools are disarmed: the server (re)started with "
+        f"{len(paths)} books configured, so the active book reset "
+        f"to {active_name!r} (the first configured) — which may not "
+        f"be the book this session was working in. Confirm the "
+        f"target with switch_book before writing (a switch_book "
+        f"call to the current book counts as confirmation). "
+        f"Available books: {available}."
+    )
+
+
+def _mutation_book_stamp() -> str | None:
+    """Ruling 6 piece 3: the filename every mutating response should
+    name as the book it wrote to. None on single-book configs — with
+    one ledger there is no ambiguity for the stamp to resolve, and
+    every response byte must earn its keep."""
+    if len(_configured_paths()) < 2:
+        return None
+    return _current_path.name if _current_path else None
+
+
+def _consume_startup_notice() -> str | None:
+    """Ruling 6 piece 1: one-line notice for the first tool result
+    of this process, naming the active book. Returns None after the
+    first call (and when no book is configured at all)."""
+    global _startup_notice_pending
+    if not _startup_notice_pending:
+        return None
+    _startup_notice_pending = False
+    paths = _configured_paths()
+    active = _current_path if _current_path else (
+        paths[0] if paths else None
+    )
+    if active is None:
+        return None
+    if len(paths) >= 2 and not _determine_writes_armed():
+        return (
+            f"⚠ GnuCash MCP server (re)started — active book: "
+            f"{active.name}. Any earlier in-session book switch was "
+            f"reset. Mutating tools are disarmed until switch_book "
+            f"confirms the target book."
+        )
+    return (
+        f"ℹ GnuCash MCP server (re)started — active book: "
+        f"{active.name}."
+    )
+
 # Effective logging mode. Seeded from env at import; main() may widen
 # it via the --debug / --noaudit CLI flags. switch_book reads these to
 # re-point logging at the newly-active book.
@@ -1095,7 +1200,7 @@ def _switch_book_impl(name: str) -> str:
     """Make the book whose filename uniquely prefix-matches ``name``
     the current book. See the switch_book tool docstring.
     """
-    global _book, _current_path
+    global _book, _current_path, _writes_armed
     if not _book_paths:
         # Cold start (direct single-call use): populate the registry.
         get_book()
@@ -1140,6 +1245,10 @@ def _switch_book_impl(name: str) -> str:
         logging.getLogger("gnucash_mcp.debug").info(
             f"switch_book: no-op, already on {target.name}"
         )
+        # A no-op switch is still a CONFIRMATION — the session named
+        # the book it means to be in, which is exactly what the
+        # restart disarm (ruling 6) is waiting to hear.
+        _writes_armed = True
         return (
             f"Already on: {target.name}\n"
             f"{_book_orientation(_book)}"
@@ -1200,6 +1309,7 @@ def _switch_book_impl(name: str) -> str:
 
     _current_path = target
     _book = new_book
+    _writes_armed = True  # explicit book choice re-arms writes
     _server_state["book_path"] = str(target)
     _server_state["current_book"] = target.name
 

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -434,6 +434,18 @@ def safe_tool(func: Callable) -> Callable:
 
     Catches all exceptions and returns them as JSON error responses instead of
     crashing the MCP server.
+
+    Also the restart-safety chokepoint (Sabine battery ruling 6):
+    every tool result passes through here, so this is where the
+    one-time startup notice attaches, where write-classified tools
+    hit the multi-book disarm gate, and where successful mutating
+    responses get their ``book`` stamp. Write-ness comes from the
+    ``__audit_meta__`` that @audit_log exposes and @wraps propagates
+    outward — the same single declaration the audit log and MCP
+    ToolAnnotations already trust. The gate runs BEFORE the wrapped
+    @audit_log layer, so a refused write never consumes rate-limit
+    tokens, never triggers auto-backup, and never logs an audit
+    entry (nothing happened to the book).
     """
 
     # Path redaction is applied at the MCP boundary (response
@@ -444,8 +456,68 @@ def safe_tool(func: Callable) -> Callable:
     # logging_config module is the foundational layer.
     from gnucash_mcp.logging_config import redact_paths
 
+    is_write = (
+        getattr(func, "__audit_meta__", None) or {}
+    ).get("classification") == "write"
+
+    def _restart_guards(invoke: Callable[[], str]) -> str:
+        """Run ``invoke`` behind the ruling-6 guards. Guard failures
+        must never break a tool — every server-state consultation is
+        wrapped; the degraded mode is simply pre-ruling behavior."""
+        # Lazy import: server imports this module at import time (the
+        # inline switch_book uses safe_tool); by the time any tool
+        # RUNS, the server module is fully loaded.
+        from gnucash_mcp import server as _server
+
+        if is_write:
+            try:
+                gate_msg = _server._write_gate_message()
+            except Exception:
+                gate_msg = None
+            if gate_msg:
+                logger.warning(
+                    f"Write refused (book unconfirmed): {func.__name__}"
+                )
+                result = _json({
+                    "error": gate_msg,
+                    "error_type": "active_book_unconfirmed",
+                    "suggestion": (
+                        "Call switch_book with the intended book, "
+                        "then retry."
+                    ),
+                })
+                return _attach_notice(_server, result)
+
+        result = invoke()
+
+        if is_write:
+            try:
+                stamp = _server._mutation_book_stamp()
+                if stamp:
+                    data = json.loads(result)
+                    if (
+                        isinstance(data, dict)
+                        and "error" not in data
+                        and "book" not in data
+                    ):
+                        data["book"] = stamp
+                        result = _json(data)
+            except Exception:
+                pass  # non-JSON write response — skip the stamp
+        return _attach_notice(_server, result)
+
+    def _attach_notice(_server, result: str) -> str:
+        try:
+            notice = _server._consume_startup_notice()
+        except Exception:
+            notice = None
+        return f"{notice}\n\n{result}" if notice else result
+
     @wraps(func)
     def wrapper(*args, **kwargs) -> str:
+        return _restart_guards(lambda: _invoke(*args, **kwargs))
+
+    def _invoke(*args, **kwargs) -> str:
         try:
             return func(*args, **kwargs)
         except GnuCashLockError as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,20 @@ from datetime import date, timedelta
 from decimal import Decimal
 
 
+@pytest.fixture(autouse=True)
+def _quiet_restart_guards():
+    """Neutralize the ruling-6 restart guards for the suite.
+
+    The startup notice fires once per process and the multi-book
+    write disarm trips on fresh state — both would make test
+    outcomes depend on execution order. Tests that exercise the
+    guards re-arm these globals explicitly in their own bodies."""
+    import gnucash_mcp.server as _server
+    _server._startup_notice_pending = False
+    _server._writes_armed = True
+    yield
+
+
 @pytest.fixture
 def test_book(tmp_path: Path) -> Path:
     """Create a temporary GnuCash book with sample data.

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -5096,7 +5096,7 @@ class TestTemplateTransactionsExcluded:
     descriptions and cadence match), training them to ignore the
     duplicate warning.
 
-    Regression for Abe's 2026-04-23 filing, which surfaced $2,485
+    Regression for the bookkeeper's 2026-04-23 filing, which surfaced $2,485
     mortgage-template MEDIUM matches against $2,850 real-world
     payments on Alex's book.
     """
@@ -5221,7 +5221,7 @@ class TestTemplateTransactionsExcluded:
 
 class TestDuplicatesTsvShape:
     """The ``duplicates`` response field is a newline-separated TSV
-    string, not a list of dicts. Abe's bookkeeper thread parses it
+    string, not a list of dicts. the bookkeeper's thread parses it
     column-wise to decide whether to retry with ``force_create=True``
     or back off — compact shape matters because a rejection often
     fires mid-conversation and the full JSON form was blowing

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -10910,9 +10910,12 @@ class TestMultiCurrencyDashboardHelpers:
                 name="Liabilities", type="LIABILITY", parent=bk.root_account,
                 commodity=usd, placeholder=True,
             )
+            # EUR A/P: the post account must match the bill currency
+            # (battery ruling 1); the report-time conversion under
+            # test happens on the bill's grand_total, not here.
             ap = piecash.Account(
                 name="Accounts Payable", type="PAYABLE",
-                parent=liabilities, commodity=usd,
+                parent=liabilities, commodity=eur,
             )
             expenses = next(a for a in bk.accounts if a.fullname == "Expenses")
             office_eur = piecash.Account(

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -10627,7 +10627,7 @@ class TestPhase4DVendorSpendingCompact:
         )
         assert "vendors" in result
         assert "totals" in result
-        # ``period`` was the input echo Abe flagged for removal — it
+        # ``period`` was the input echo the bookkeeper flagged for removal — it
         # duplicated the dates the caller already had.
         assert "period" not in result
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -3514,8 +3514,9 @@ class TestTaxtableCrossCurrency:
     account's commodity differs from the invoice currency."""
 
     def _setup_eur_with_usd_gst(self, business_book, rate="1.10"):
-        """Wire up: EUR commodity, EUR/USD price, USD GST Payable
-        account (in the book's default USD), EUR-denominated
+        """Wire up: EUR commodity, EUR/USD price, EUR A/R (ruling 1:
+        the post account must match the document currency), USD GST
+        Payable account (in the book's default USD), EUR-denominated
         customer + invoice. Returns the GnuCashBook handle."""
         import piecash
         from datetime import date as date_cls
@@ -3527,6 +3528,13 @@ class TestTaxtableCrossCurrency:
             )
             bk.session.add(eur)
             bk.flush()
+            assets = next(
+                a for a in bk.accounts if a.fullname == "Assets"
+            )
+            bk.session.add(piecash.Account(
+                name="AR EUR", type="RECEIVABLE",
+                parent=assets, commodity=eur,
+            ))
             bk.session.add(piecash.Price(
                 commodity=eur, currency=bk.default_currency,
                 date=date_cls(2026, 5, 24),
@@ -3567,7 +3575,7 @@ class TestTaxtableCrossCurrency:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             # Pin to the price date so the FX freshness guard
             # doesn't fire — this test exercises tax conversion
             # math, not rate staleness.
@@ -3583,11 +3591,11 @@ class TestTaxtableCrossCurrency:
             s["account"]: (Decimal(s["value"]), Decimal(s["quantity"]))
             for s in txn["splits"]
         }
-        # A/R is RECEIVABLE in USD (fixture default). value is in
-        # EUR (transaction currency); quantity converts to USD.
-        ar_value, ar_quantity = by_acct["Assets:Accounts Receivable"]
+        # A/R matches the document currency (ruling 1), so value
+        # and quantity agree in EUR.
+        ar_value, ar_quantity = by_acct["Assets:AR EUR"]
         assert ar_value == Decimal("105.00")
-        assert ar_quantity == Decimal("115.50")  # 105 × 1.10
+        assert ar_quantity == Decimal("105.00")
         # Income split is in USD (fixture default).
         inc_value, inc_quantity = by_acct["Income:Sales"]
         assert inc_value == Decimal("-100.00")
@@ -3610,16 +3618,27 @@ class TestTaxtableCrossCurrency:
         """When no price is on file for the EUR/USD pair near
         post date, posting raises a clear error — the same
         rate-not-found path already exercised by non-tax
-        cross-currency posting."""
+        cross-currency posting. The EUR document posts to a
+        EUR-denominated A/R (ruling 1 refuses mismatched post
+        accounts); the conversion needing a rate is the USD tax
+        and income legs."""
         import piecash
         gb = GnuCashBook(str(business_book))
-        # Add EUR commodity but no price.
+        # Add EUR commodity + EUR A/R, but no price.
         with gb.open(readonly=False) as bk:
             eur = piecash.Commodity(
                 namespace="CURRENCY", mnemonic="EUR",
                 fullname="Euro", fraction=100,
             )
             bk.session.add(eur)
+            bk.flush()
+            assets = next(
+                a for a in bk.accounts if a.fullname == "Assets"
+            )
+            bk.session.add(piecash.Account(
+                name="AR EUR", type="RECEIVABLE",
+                parent=assets, commodity=eur,
+            ))
             bk.save()
         gb.create_account(
             name="GST Payable",
@@ -3644,7 +3663,7 @@ class TestTaxtableCrossCurrency:
         with pytest.raises(ValueError, match="exchange rate"):
             gb.post_invoice(
                 invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
+                post_account="Assets:AR EUR",
             )
 
 
@@ -5734,13 +5753,15 @@ class TestCreditNotePr87ReviewFollowups:
         message that points at the per-currency A/R convention
         as the fix.
 
-        Setup uses raw piecash to engineer the cross-currency
-        post state directly (EUR/USD price via piecash.Price,
-        EUR customer + EUR credit note posted to USD A/R).
-        The full posting flow validates the cross-currency
-        guard fires at apply time, not at post."""
+        Setup engineers the mismatched state the way a real book
+        carries it: documents posted (matched) under the current
+        code, then their currency flipped to EUR via raw SQL —
+        simulating a book whose mismatched postings predate the
+        v1.5.0 post_invoice refusal (battery ruling 1). The guard
+        exists precisely for those historical lots."""
         import piecash
         from datetime import date as date_cls
+        from sqlalchemy import text as sql_text
         gb = GnuCashBook(str(business_book))
         # Add EUR + EUR/USD price via raw piecash (same pattern
         # the multi_currency tests use in test_book.py).
@@ -5760,8 +5781,9 @@ class TestCreditNotePr87ReviewFollowups:
             ))
             bk.save()
         gb.create_customer(name="Berlin GmbH", currency="EUR")
-        # Source invoice in EUR posted to USD A/R (cross-currency)
-        src = gb.create_invoice(customer_id="000001")
+        # Post both documents matched (USD invoice → USD A/R) —
+        # the only door the current code leaves open…
+        src = gb.create_invoice(customer_id="000001", currency="USD")
         gb.add_invoice_entry(
             invoice_id=src["id"], account="Income:Sales",
             description="x", quantity="1", price="500",
@@ -5770,13 +5792,11 @@ class TestCreditNotePr87ReviewFollowups:
             invoice_id=src["id"],
             post_account="Assets:Accounts Receivable",
             owner_type="customer",
-            # Pin to the price date; this test targets the apply-
-            # time cross-currency guard, not FX rate staleness.
             post_date="2026-05-24",
         )
         cn = gb.create_credit_note(
             owner_id="000001", owner_type="customer",
-            applies_to_invoice_id=src["id"],
+            applies_to_invoice_id=src["id"], currency="USD",
         )
         gb.add_credit_note_entry(
             credit_note_id=cn["id"], account="Income:Sales",
@@ -5788,6 +5808,16 @@ class TestCreditNotePr87ReviewFollowups:
             owner_type="customer",
             post_date="2026-05-24",
         )
+        # …then flip both documents' currency to EUR via raw SQL,
+        # reproducing a warning-era book's mismatched postings.
+        with gb.open(readonly=False) as bk:
+            eur_guid = bk.session.execute(sql_text(
+                "SELECT guid FROM commodities WHERE mnemonic = 'EUR'"
+            )).scalar_one()
+            bk.session.execute(sql_text(
+                "UPDATE invoices SET currency = :eur"
+            ), {"eur": eur_guid})
+            bk.save()
         with pytest.raises(
             ValueError, match="Cross-currency apply not supported",
         ):
@@ -8612,13 +8642,19 @@ class TestPayInvoice:
         invoice-currency units, leaving a residual balance the bank
         had already paid for.
 
-        Setup: USD-default book, USD A/R account, EUR invoice,
-        EUR/USD = 1.10. Post a €4,500 invoice → A/R debited 4,950
-        USD. Pay €4,500 from USD checking → A/R must credit 4,950
-        USD (not 4,500), leaving the A/R balance at exactly zero.
+        Setup: USD-default book, USD A/R account, EUR invoice
+        carried at EUR/USD = 1.10 → A/R holds 4,950 USD. Pay €4,500
+        from USD checking → A/R must credit 4,950 USD (not 4,500),
+        leaving the A/R balance at exactly zero.
+
+        post_invoice refuses this pairing since v1.5.0 (battery
+        ruling 1); the state is engineered via raw SQL the way
+        warning-era books still carry it — pay_invoice must relieve
+        those lots correctly forever.
         """
         import piecash
         from datetime import date as _date
+        from sqlalchemy import text as sql_text
 
         gb = GnuCashBook(str(business_book))
         # Add EUR commodity + price + a USD A/R account specifically.
@@ -8648,7 +8684,7 @@ class TestPayInvoice:
 
         gb.create_customer(name="Berlin Digital", currency="EUR")
         gb.create_invoice(
-            customer_id="000001", currency="EUR",
+            customer_id="000001", currency="USD",
             date_opened="2026-03-10",
         )
         gb.add_invoice_entry(
@@ -8657,15 +8693,37 @@ class TestPayInvoice:
             description="EUR services",
             quantity="1", price="4500.00",
         )
-        # Post into the USD A/R account — invoice in EUR, A/R in USD
+        # Post matched (USD → USD A/R), then flip document +
+        # transaction currency to EUR and scale quantities to the
+        # 1.10 carried rate — the warning-era mismatched state.
         gb.post_invoice(
             invoice_id="000001",
             post_account="Assets:A/R USD",
             post_date="2026-03-10",
         )
+        with gb.open(readonly=False) as bk:
+            eur_guid = bk.session.execute(sql_text(
+                "SELECT guid FROM commodities WHERE mnemonic='EUR'"
+            )).scalar_one()
+            tx_guid = bk.session.execute(sql_text(
+                "SELECT post_txn FROM invoices WHERE id='000001'"
+            )).scalar_one()
+            bk.session.execute(sql_text(
+                "UPDATE invoices SET currency=:eur WHERE id='000001'"
+            ), {"eur": eur_guid})
+            bk.session.execute(sql_text(
+                "UPDATE transactions SET currency_guid=:eur "
+                "WHERE guid=:tx"
+            ), {"eur": eur_guid, "tx": tx_guid})
+            bk.session.execute(sql_text(
+                "UPDATE splits SET "
+                "quantity_num = quantity_num * 11 / 10 "
+                "WHERE tx_guid=:tx"
+            ), {"tx": tx_guid})
+            bk.save()
 
         ar_after_post = gb.get_balance(account_name="Assets:A/R USD")
-        # Post correctly converts: €4500 × 1.10 = $4,950 USD debited
+        # Carried at 1.10: €4500 × 1.10 = $4,950 USD debited
         assert ar_after_post == Decimal("4950")
 
         gb.pay_invoice(
@@ -8950,12 +9008,16 @@ class TestPayInvoice:
         assert {s["action"] for s in pay_txn["splits"]} == \
             {"Payment"}
 
-    def test_cross_commodity_post_warns(self, business_book):
-        """Battery design ruling 1: posting a EUR document into the
-        USD A/R is allowed (Sabine's book has only one A/R) but
-        must warn loudly — the balance freezes at post-date FX, and
-        apply_credit_note will refuse netting against it. Matched
-        commodities post silently."""
+    def test_cross_commodity_post_refuses(self, business_book):
+        """Battery design ruling 1, sunset shipped (v1.5.0): posting
+        a EUR document into the USD A/R refuses outright — the
+        balance would freeze at post-date FX. Warned through v1.4.4;
+        the precondition for the refusal (no sample book depends on
+        the permissiveness) was confirmed by the bookkeeper loop
+        2026-08-31. The message points at the per-currency
+        subledger fix. Matched commodities post cleanly, and the
+        refused document stays open and postable to the right
+        account."""
         gb = GnuCashBook(str(business_book))
         self._add_eur_ar_and_price(gb, "2026-03-10", "1.10")
         gb.create_customer(name="Berlin Digital", currency="EUR")
@@ -8965,26 +9027,20 @@ class TestPayInvoice:
             invoice_id="000001", account="Income:Consulting",
             description="x", quantity="1", price="1000.00",
         )
-        mismatched = gb.post_invoice(
-            invoice_id="000001",
-            post_account="Assets:Accounts Receivable",  # USD
-            post_date="2026-03-10",
-        )
-        assert "warning" in mismatched
-        assert "apply_credit_note" in mismatched["warning"]
-        assert "per-currency" in mismatched["warning"]
-        # Matched pairing stays silent.
-        gb.create_invoice(customer_id="000001", currency="EUR",
-                          date_opened="2026-03-10")
-        gb.add_invoice_entry(
-            invoice_id="000002", account="Income:Consulting",
-            description="x", quantity="1", price="1000.00",
-        )
+        with pytest.raises(ValueError, match="per document currency"):
+            gb.post_invoice(
+                invoice_id="000001",
+                post_account="Assets:Accounts Receivable",  # USD
+                post_date="2026-03-10",
+            )
+        # Refusal happened before any mutation: the same document
+        # posts cleanly to the matched-commodity A/R.
         matched = gb.post_invoice(
-            invoice_id="000002",
+            invoice_id="000001",
             post_account="Assets:Accounts Receivable EUR",
             post_date="2026-03-10",
         )
+        assert matched["status"] == "posted"
         assert "warning" not in matched
 
     def test_credit_note_posting_stamps_credit_note_action(
@@ -10914,8 +10970,10 @@ class TestFXStaleRateGuard:
         self, business_book, *, price_date, rate="1.10",
     ):
         """USD-default book + one EUR/USD market price at
-        ``price_date`` + an unposted 1-line EUR invoice (id 000001,
-        EUR 100). Returns the GnuCashBook."""
+        ``price_date`` + a EUR A/R (ruling 1: the post account must
+        match the document currency; the guard's conversion now
+        fires on the USD income leg) + an unposted 1-line EUR
+        invoice (id 000001, EUR 100). Returns the GnuCashBook."""
         import piecash
         gb = GnuCashBook(str(business_book))
         with gb.open(readonly=False) as bk:
@@ -10925,6 +10983,13 @@ class TestFXStaleRateGuard:
             )
             bk.session.add(eur)
             bk.flush()
+            assets = next(
+                a for a in bk.accounts if a.fullname == "Assets"
+            )
+            bk.session.add(piecash.Account(
+                name="AR EUR", type="RECEIVABLE",
+                parent=assets, commodity=eur,
+            ))
             bk.session.add(piecash.Price(
                 commodity=eur, currency=bk.default_currency,
                 date=price_date, value=rate, type="last",
@@ -10946,7 +11011,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-03",  # 2 days
         )
         assert result["status"] == "posted"
@@ -10958,7 +11023,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-07",  # 6 days
         )
         assert result["status"] == "posted"
@@ -10974,7 +11039,7 @@ class TestFXStaleRateGuard:
         with pytest.raises(StaleFXRateError) as exc:
             gb.post_invoice(
                 invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
+                post_account="Assets:AR EUR",
                 post_date="2026-06-20",  # 19 days
             )
         detail = exc.value.fx_detail
@@ -10991,7 +11056,7 @@ class TestFXStaleRateGuard:
         with pytest.raises(StaleFXRateError):
             gb.post_invoice(
                 invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
+                post_account="Assets:AR EUR",
                 post_date="2026-06-09",  # 8 days
             )
 
@@ -11001,7 +11066,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-20",  # 19 days
             force=True,
         )
@@ -11021,7 +11086,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-03",  # 2 days
             force=True,
         )
@@ -11039,7 +11104,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-01-01",  # 1 day from the rate
         )
         assert result["status"] == "posted"
@@ -11055,7 +11120,7 @@ class TestFXStaleRateGuard:
         with pytest.raises(StaleFXRateError) as exc:
             gb.post_invoice(
                 invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
+                post_account="Assets:AR EUR",
                 post_date="2026-06-01",  # rate is 19 days FORWARD
             )
         assert exc.value.fx_detail["age_days"] == 19
@@ -11071,7 +11136,7 @@ class TestFXStaleRateGuard:
         with pytest.raises(ValueError, match="no matching price"):
             gb.post_invoice(
                 invoice_id="000001",
-                post_account="Assets:Accounts Receivable",
+                post_account="Assets:AR EUR",
                 post_date="2026-10-15",  # 136 days > 90
                 force=True,
             )
@@ -11105,7 +11170,7 @@ class TestFXStaleRateGuard:
         )
         result = gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-20",  # 19 days — would normally refuse
         )
         assert result["status"] == "posted"
@@ -11123,7 +11188,7 @@ class TestFXStaleRateGuard:
         )
         gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-06-03",  # fresh post
         )
         # Pay 24 days after the only rate → stale at pay time.
@@ -11194,6 +11259,11 @@ class TestCrossCommodityArRelief:
     the lot at the rate the receivable was CARRIED at (post-date),
     not the pay-date rate. Pre-fix the post→pay drift landed twice —
     a permanent residual A/R quantity AND the explicit FX split.
+
+    post_invoice refuses this pairing since v1.5.0 (battery ruling
+    1), but warning-era books still carry mismatched lots and
+    pay_invoice must relieve them correctly forever — so the state
+    is engineered here the way those books hold it, via raw SQL.
     """
 
     def _add_eur_and_rates(self, gb: GnuCashBook) -> None:
@@ -11213,6 +11283,49 @@ class TestCrossCommodityArRelief:
             ))
             book.save()
 
+    def _post_carried_eur_on_usd_ar(self, gb: GnuCashBook) -> None:
+        """EUR 1,000 invoice carried on USD A/R at 1.10 (qty 1,100)
+        — the warning-era mismatched-posting state. Posted matched
+        in USD, then document + transaction currency flip to EUR
+        and split quantities scale to the carried rate (×11/10)."""
+        from sqlalchemy import text as sql_text
+
+        gb.create_invoice(
+            customer_id="000001", currency="USD",
+            date_opened="2026-03-10",
+        )
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="EUR consulting",
+            quantity="1", price="1000.00",
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+            post_date="2026-03-10",
+        )
+        with gb.open(readonly=False) as bk:
+            eur_guid = bk.session.execute(sql_text(
+                "SELECT guid FROM commodities WHERE mnemonic='EUR'"
+            )).scalar_one()
+            tx_guid = bk.session.execute(sql_text(
+                "SELECT post_txn FROM invoices WHERE id='000001'"
+            )).scalar_one()
+            bk.session.execute(sql_text(
+                "UPDATE invoices SET currency=:eur WHERE id='000001'"
+            ), {"eur": eur_guid})
+            bk.session.execute(sql_text(
+                "UPDATE transactions SET currency_guid=:eur "
+                "WHERE guid=:tx"
+            ), {"eur": eur_guid, "tx": tx_guid})
+            bk.session.execute(sql_text(
+                "UPDATE splits SET "
+                "quantity_num = quantity_num * 11 / 10 "
+                "WHERE tx_guid=:tx"
+            ), {"tx": tx_guid})
+            bk.save()
+
     def test_settled_foreign_invoice_leaves_zero_ar(
         self, business_book,
     ):
@@ -11225,21 +11338,7 @@ class TestCrossCommodityArRelief:
         self._add_eur_and_rates(gb)
 
         gb.create_customer(name="Berlin Digital", currency="EUR")
-        gb.create_invoice(
-            customer_id="000001", currency="EUR",
-            date_opened="2026-03-10",
-        )
-        gb.add_invoice_entry(
-            invoice_id="000001",
-            account="Income:Sales",
-            description="EUR consulting",
-            quantity="1", price="1000.00",
-        )
-        gb.post_invoice(
-            invoice_id="000001",
-            post_account="Assets:Accounts Receivable",  # USD A/R
-            post_date="2026-03-10",
-        )
+        self._post_carried_eur_on_usd_ar(gb)
         assert gb.get_balance(
             account_name="Assets:Accounts Receivable"
         ) == Decimal("1100")
@@ -11268,21 +11367,7 @@ class TestCrossCommodityArRelief:
         gb = GnuCashBook(str(business_book))
         self._add_eur_and_rates(gb)
         gb.create_customer(name="Berlin Digital", currency="EUR")
-        gb.create_invoice(
-            customer_id="000001", currency="EUR",
-            date_opened="2026-03-10",
-        )
-        gb.add_invoice_entry(
-            invoice_id="000001",
-            account="Income:Sales",
-            description="EUR consulting",
-            quantity="1", price="1000.00",
-        )
-        gb.post_invoice(
-            invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
-            post_date="2026-03-10",
-        )
+        self._post_carried_eur_on_usd_ar(gb)
         gb.pay_invoice(
             invoice_id="000001",
             payment_account="Assets:Checking",
@@ -11751,6 +11836,15 @@ class TestPayInvoiceDryRun:
             eur = piecash.factories.create_currency_from_ISO("EUR")
             book.session.add(eur)
             book.flush()
+            # Per-currency A/R (ruling 1: mismatched post accounts
+            # refuse, so the EUR document needs a EUR receivable).
+            assets = next(
+                a for a in book.accounts if a.fullname == "Assets"
+            )
+            book.session.add(piecash.Account(
+                name="AR EUR", type="RECEIVABLE",
+                parent=assets, commodity=eur,
+            ))
             book.session.add(piecash.Price(
                 commodity=eur, currency=usd,
                 date=date(2026, 3, 10),
@@ -11776,7 +11870,7 @@ class TestPayInvoiceDryRun:
         )
         gb.post_invoice(
             invoice_id="000001",
-            post_account="Assets:Accounts Receivable",
+            post_account="Assets:AR EUR",
             post_date="2026-03-10",
         )
         result = gb.pay_invoice(
@@ -11803,8 +11897,8 @@ class TestPayInvoiceDryRun:
         accounts = gb.list_accounts()
         assert "Foreign Exchange" not in str(accounts)
         assert gb.get_balance(
-            account_name="Assets:Accounts Receivable"
-        ) == Decimal("1100")
+            account_name="Assets:AR EUR"
+        ) == Decimal("1000")  # EUR quantity, untouched by dry-run
         # Rehearsal parity: the identical real call books it all.
         real = gb.pay_invoice(
             invoice_id="000001",

--- a/tests/test_float_precision.py
+++ b/tests/test_float_precision.py
@@ -57,7 +57,7 @@ class TestToDecimalHelper:
         assert _to_decimal(42) == Decimal("42")
 
     def test_sum_of_non_dyadic_floats_balances(self):
-        """The exact scenario from Abe's report: three non-dyadic
+        """The exact scenario from the bookkeeper's report: three non-dyadic
         floats + one float negation sum to zero."""
         amounts = [6.25, 5.75, 3.87, -15.87]
         total = sum((_to_decimal(a) for a in amounts), Decimal("0"))

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -141,6 +141,78 @@ class TestLocalizedHelperAccounts:
                     b, owner_type_is_bill=False, dry_run=True
                 )
 
+    def test_discount_autocreate_refused_on_undetermined_chart(
+        self, tmp_path
+    ):
+        """The bookkeeper's Sabine repro (live loop, 2026-09-01): a DATEV/SKR03
+        chart's numbered top-levels ("Aufwendungen 2/4") match no
+        locale's exact structural words, so ``_infer_book_locale``
+        returns None — and the 4(b) gate originally read None as
+        English and auto-created "Sales Discounts" into the German
+        book. The gate now requires an AFFIRMATIVE English read:
+        undetermined refuses too."""
+        book_path = tmp_path / "datev.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="EUR", overwrite=True,
+        )
+        root = book.root_account
+        eur = book.default_currency
+        for name, atype in (
+            ("Anlage- u. Kapitalkonten 0", "ASSET"),
+            ("Finanz- u. Privatkonten 1", "LIABILITY"),
+            ("Erlöse u. Erträge 2/8", "INCOME"),
+            ("Aufwendungen 2/4", "EXPENSE"),
+            ("Kapital 9", "EQUITY"),
+        ):
+            piecash.Account(
+                name=name, type=atype, parent=root,
+                commodity=eur, placeholder=True,
+            )
+        book.save()
+        book.close()
+
+        gb = GnuCashBook(str(book_path))
+        with gb.open(readonly=False) as b:
+            # The inference miss is real and documented…
+            assert gb._infer_book_locale(b) is None
+            assert gb._book_reads_english(b) is False
+            # …and the gate no longer treats it as English.
+            with pytest.raises(
+                ValueError, match="discount_account"
+            ) as exc:
+                gb._get_or_create_discount_account(
+                    b, owner_type_is_bill=False
+                )
+            assert "undetermined" in str(exc.value)
+
+    def test_book_reads_english_affirmative_on_english_chart(
+        self, tmp_path
+    ):
+        """The other half of the fail-safe gate: a standard English
+        chart passes the affirmative check, so English books keep
+        their auto-create default."""
+        book_path = tmp_path / "english.gnucash"
+        book = piecash.create_book(
+            str(book_path), currency="USD", overwrite=True,
+        )
+        root = book.root_account
+        usd = book.default_currency
+        for name, atype in (
+            ("Assets", "ASSET"),
+            ("Income", "INCOME"),
+            ("Expenses", "EXPENSE"),
+        ):
+            piecash.Account(
+                name=name, type=atype, parent=root,
+                commodity=usd, placeholder=True,
+            )
+        book.save()
+        book.close()
+        gb = GnuCashBook(str(book_path))
+        with gb.open() as b:
+            assert gb._book_reads_english(b) is True
+            assert gb._infer_book_locale(b) is None  # not a vote row
+
     def test_discount_explicit_account_works_on_localized_book(
         self, localized_book
     ):

--- a/tests/test_i18n_account_resolution.py
+++ b/tests/test_i18n_account_resolution.py
@@ -117,25 +117,49 @@ class TestLocalizedHelperAccounts:
             acct2, _ = gb._get_or_create_fx_account(b)
             assert acct2.fullname == "Erträge:Realisierter Gewinn/Verlust"
 
-    def test_discount_accounts_autocreate_under_localized_parents(
+    def test_discount_autocreate_refused_on_localized_book(
         self, localized_book
     ):
+        """Battery ruling 4(b): with no designation and no explicit
+        ``discount_account``, the resolver REFUSES on a non-English
+        book instead of auto-creating the English default (an
+        English leaf in a localized chart, wrong-sided on the sales
+        side). The hint names the fix. Both sides refuse; the
+        dry-run rehearsal refuses identically."""
         gb = GnuCashBook(str(localized_book))
         with gb.open(readonly=False) as b:
-            # Sales discount → EXPENSE side → German expense root.
-            sales, _ = gb._get_or_create_discount_account(
-                b, owner_type_is_bill=False
-            )
-            assert sales.type == "EXPENSE"
-            assert sales.parent.fullname == "Aufwand"
+            for is_bill in (False, True):
+                with pytest.raises(
+                    ValueError, match="discount_account"
+                ) as exc:
+                    gb._get_or_create_discount_account(
+                        b, owner_type_is_bill=is_bill
+                    )
+                assert "'de'" in str(exc.value)
+            with pytest.raises(ValueError, match="discount_account"):
+                gb._get_or_create_discount_account(
+                    b, owner_type_is_bill=False, dry_run=True
+                )
 
-            # Purchase discount → INCOME side → German income root.
-            purchase, _ = gb._get_or_create_discount_account(
-                b, owner_type_is_bill=True
+    def test_discount_explicit_account_works_on_localized_book(
+        self, localized_book
+    ):
+        """The refusal's own hint must work: an explicit
+        ``discount_account`` resolves on the localized book with no
+        create and no locale objection."""
+        gb = GnuCashBook(str(localized_book))
+        with gb.open(readonly=False) as b:
+            sales, notice = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=False,
+                discount_account="Aufwand:Bürobedarf",
             )
-            assert purchase.type == "INCOME"
-            assert purchase.parent.fullname == "Erträge"
-            b.save()
+            assert sales.fullname == "Aufwand:Bürobedarf"
+            assert notice is None
+            purchase, _ = gb._get_or_create_discount_account(
+                b, owner_type_is_bill=True,
+                discount_account="Erträge:Umsatzerlöse",
+            )
+            assert purchase.fullname == "Erträge:Umsatzerlöse"
 
 
 class TestFxAccountCollisionSafety:
@@ -432,14 +456,19 @@ class TestDesignatedAccountSlotLayer0:
 
     def test_discount_sides_use_independent_slots(self, localized_book):
         # Sales (EXPENSE) and purchase (INCOME) designations are stored
-        # under separate slot keys and resolve independently.
+        # under separate slot keys and resolve independently. Stored
+        # directly — ruling 4(b) closed the auto-create path on
+        # localized books, and the explicit-arg layer deliberately
+        # does not designate.
         gb = GnuCashBook(str(localized_book))
         with gb.open(readonly=False) as b:
-            sales, _ = gb._get_or_create_discount_account(
-                b, owner_type_is_bill=False
+            sales = gb._find_account(b, "Aufwand:Bürobedarf")
+            purchase = gb._find_account(b, "Erträge:Umsatzerlöse")
+            gb._store_designated_account(
+                b, gb._SALES_DISCOUNT_SLOT_KEY, sales
             )
-            purchase, _ = gb._get_or_create_discount_account(
-                b, owner_type_is_bill=True
+            gb._store_designated_account(
+                b, gb._PURCHASE_DISCOUNT_SLOT_KEY, purchase
             )
             b.save()
             sales_guid, purchase_guid = sales.guid, purchase.guid

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,5 +1,6 @@
 """Tests for tool module filtering and server configuration."""
 
+import json
 import os
 import re
 from pathlib import Path
@@ -1425,6 +1426,199 @@ class TestMultiBook:
         _apply_module_filter("all")
         summary = mcp._tool_manager._tools["get_book_summary"].fn()
         assert summary.split("\n", 1)[0].startswith("Book: alex.gnucash")
+
+
+class TestRestartSafety:
+    """Sabine battery ruling 6: a silent client-side process restart
+    resets the active book to the first configured entry — the next
+    write must not land in the wrong ledger. Piece 1: one startup
+    notice on the first tool result. Piece 2: 2+ book configs disarm
+    mutating tools until switch_book confirms. Piece 3: multi-book
+    mutating responses name the book they wrote to.
+
+    conftest neutralizes the guards suite-wide (they are process-
+    global, so outcomes would depend on test order); each test here
+    re-creates the fresh-process state explicitly."""
+
+    @pytest.fixture
+    def two_books(self, tmp_path: Path):
+        alex = _make_min_book(tmp_path / "alex.gnucash")
+        beast = _make_min_book(tmp_path / "beast-man.gnucash")
+        return alex, beast
+
+    @pytest.fixture(autouse=True)
+    def restore_state(self):
+        import gnucash_mcp.server as srv
+        import gnucash_mcp.logging_config as logcfg
+        saved = (
+            srv._book, list(srv._book_paths), srv._current_path,
+            srv._book_paths_source, dict(srv._book_registry),
+            srv._writes_armed, srv._startup_notice_pending,
+        )
+        log_saved = (
+            logcfg._book_path_str, logcfg._log_dir,
+            logcfg._get_book_func,
+        )
+        yield
+        (
+            srv._book, srv._book_paths, srv._current_path,
+            srv._book_paths_source, srv._book_registry,
+            srv._writes_armed, srv._startup_notice_pending,
+        ) = saved
+        (
+            logcfg._book_path_str, logcfg._log_dir,
+            logcfg._get_book_func,
+        ) = log_saved
+
+    @staticmethod
+    def _wire(srv, monkeypatch, paths):
+        """Simulate a fresh process start on the given book config."""
+        joined = os.pathsep.join(str(p) for p in paths)
+        monkeypatch.setenv("GNUCASH_BOOK_PATH", joined)
+        srv._book_paths = [p.resolve() for p in paths]
+        srv._book_paths_source = joined
+        srv._book_registry = {}
+        srv._book = None
+        srv._current_path = None
+        srv._writes_armed = None
+        srv._startup_notice_pending = False  # notice tested separately
+
+    @staticmethod
+    def _fake_write_tool():
+        """A write-classified tool through the real decorator stack —
+        the same safe_tool + @audit_log path every registered write
+        travels."""
+        from gnucash_mcp.tools._helpers import safe_tool, _json
+        from gnucash_mcp.logging_config import audit_log
+
+        @safe_tool
+        @audit_log(classification="write")
+        def fake_write():
+            return _json({"status": "ok"})
+        return fake_write
+
+    # ── Piece 2: the disarm gate ───────────────────────────────────
+
+    def test_multi_book_start_disarms_writes(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        out = json.loads(self._fake_write_tool()())
+        assert out["error_type"] == "active_book_unconfirmed"
+        assert "alex.gnucash" in out["error"]
+        assert "switch_book" in out["error"]
+        assert "beast-man.gnucash" in out["error"]  # available list
+
+    def test_single_book_start_writes_armed(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, _ = two_books
+        self._wire(srv, monkeypatch, [alex])
+        out = json.loads(self._fake_write_tool()())
+        assert out == {"status": "ok"}  # no gate, and no book stamp
+
+    def test_switch_book_arms_writes(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        srv._switch_book_impl("beast")
+        out = json.loads(self._fake_write_tool()())
+        assert "error" not in out
+        assert out["book"] == "beast-man.gnucash"
+
+    def test_noop_switch_counts_as_confirmation(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        srv._switch_book_impl("alex")
+        srv._writes_armed = False  # simulate a later restart, same book
+        result = srv._switch_book_impl("alex")
+        assert result.startswith("Already on: alex.gnucash")
+        assert srv._writes_armed is True
+
+    def test_failed_switch_does_not_arm(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        with pytest.raises(ValueError, match="No book matches"):
+            srv._switch_book_impl("nonexistent")
+        out = json.loads(self._fake_write_tool()())
+        assert out["error_type"] == "active_book_unconfirmed"
+
+    def test_reads_never_gated(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        from gnucash_mcp.tools._helpers import safe_tool, _json
+        from gnucash_mcp.logging_config import audit_log
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+
+        @safe_tool
+        @audit_log(classification="read")
+        def fake_read():
+            return _json({"status": "ok"})
+        assert json.loads(fake_read()) == {"status": "ok"}
+
+    # ── Piece 3: the book stamp ────────────────────────────────────
+
+    def test_write_stamp_names_active_book(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        srv._switch_book_impl("alex")
+        out = json.loads(self._fake_write_tool()())
+        assert out["book"] == "alex.gnucash"
+
+    def test_error_responses_not_stamped(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        from gnucash_mcp.tools._helpers import safe_tool
+        from gnucash_mcp.logging_config import audit_log
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        srv._switch_book_impl("alex")
+
+        @safe_tool
+        @audit_log(classification="write")
+        def failing_write():
+            raise ValueError("boom")
+        out = json.loads(failing_write())
+        assert out["error_type"] == "validation_error"
+        assert "book" not in out
+
+    # ── Piece 1: the startup notice ────────────────────────────────
+
+    def test_startup_notice_fires_once(self, two_books, monkeypatch):
+        import gnucash_mcp.server as srv
+        from gnucash_mcp.tools._helpers import safe_tool, _json
+        from gnucash_mcp.logging_config import audit_log
+        alex, _ = two_books
+        self._wire(srv, monkeypatch, [alex])
+        srv._startup_notice_pending = True
+
+        @safe_tool
+        @audit_log(classification="read")
+        def fake_read():
+            return _json({"status": "ok"})
+
+        first = fake_read()
+        notice, _sep, body = first.partition("\n\n")
+        assert "(re)started" in notice
+        assert "alex.gnucash" in notice
+        assert json.loads(body) == {"status": "ok"}
+        # Second call: consumed, clean response.
+        assert json.loads(fake_read()) == {"status": "ok"}
+
+    def test_startup_notice_multi_book_announces_disarm(
+        self, two_books, monkeypatch,
+    ):
+        import gnucash_mcp.server as srv
+        alex, beast = two_books
+        self._wire(srv, monkeypatch, [alex, beast])
+        srv._startup_notice_pending = True
+        # First result is the refused write itself — notice rides it.
+        raw = self._fake_write_tool()()
+        notice, _sep, body = raw.partition("\n\n")
+        assert "disarmed" in notice
+        assert "alex.gnucash" in notice
+        assert json.loads(body)["error_type"] == "active_book_unconfirmed"
 
 
 class TestToolAnnotations:

--- a/tests/test_multicurrency_audit.py
+++ b/tests/test_multicurrency_audit.py
@@ -420,7 +420,7 @@ class TestSameDatePriceTieBreak:
     def test_unknown_user_source_ranks_between_manual_and_feed(
         self, multi_currency_book,
     ):
-        """Abe's three-tier ruling: an unrecognized ``user:*``
+        """The bookkeeper's three-tier ruling: an unrecognized ``user:*``
         source (an explicit operator act) outranks feeds but does
         NOT silently override a deliberate manual quote."""
         from datetime import date


### PR DESCRIPTION
## Summary
- **Ruling 6 — restart safety.** A silent client restart resets the active book; three guards close the wrong-ledger hazard: a one-time startup notice on the first tool result, a write disarm on 2+ book configs until `switch_book` (re)confirms (no-op confirmation counts; failed switches don't arm), and a `book` stamp on every mutating response in multi-book sessions. `safe_tool` is the chokepoint; refused writes never touch the rate limiter, auto-backup, or the audit trail. Copy is addressed to the calling model per the bookkeeper's ruling — the confirmation happens inside the model's opening turn.
- **Ruling 4(b) — discount-account auto-create refuses off-English.** The resolver no longer creates the English default unless the chart *affirmatively* reads English (`_book_reads_english`, same ≥2 vote threshold as the locale inference). Provably-foreign and locale-undetermined charts (the bookkeeper's DATEV repro: "Aufwendungen 2/4") both refuse with the `discount_account` hint. Adoption layers untouched; 4(a) role-based resolution remains the documented destination.
- **Ruling 1 sunset — currency-mismatch posting refuses.** Warned in v1.4.4, refused now, in the validation phase before any mutation. Downstream guards for warning-era mismatched lots stay; their tests engineer the historical state via raw SQL (migrate-by-subject convention recorded in CLAUDE.md).
- CHANGELOG unreleased section; bookkeeper loop plan + report committed under `specs/v1.5/testing/`.

## Test plan
- [x] Full suite: 2,158 passed (2,146 → 2,158; 12 new regression locks including the DATEV repro)
- [x] Bookkeeper live loop (2026-09-01): rulings 6 and 1 signed off; 4(b) failed on the Sabine DATEV chart, polarity fix landed, re-probe passed
- [x] Behavior-break fallout migrated by subject: 16 warning-era tests re-routed to per-currency A/R or rebuilt on raw-SQL historical state