### PR TITLE
chore(docker): the Glama image ships living demo books

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,12 @@
 tests
 specs
 docs
-scripts
+# The build runs the closed-loop updater (same as CI), so the
+# generator package ships in the context; the rest of scripts/
+# stays out.
+scripts/*
+!scripts/synthetic_book
+scripts/synthetic_book/__pycache__
 samples/*.generated.gnucash*
 samples/*.mcp
 samples/scratch.gnucash.mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.13"]
+        python: ["3.10", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - name: Install uv

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,26 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
-# Project source + two sample books: multi-book mode registers the
-# conditional switch_book tool, so the full 111-tool surface is
-# introspectable (Alex: USD freelancer; Lin Wei: CNY multi-currency).
+# Project source + the three sample books: multi-book mode
+# registers the conditional switch_book tool, so the full 86-tool
+# surface is introspectable (Alex: USD freelancer; Lin Wei: CNY
+# multi-currency; Sabine: EUR, German SKR03 chart).
 COPY README.md ./
 COPY src ./src
-COPY samples/alex-chen-morales.gnucash samples/lin-wei.gnucash ./samples/
+COPY samples/alex-chen-morales.gnucash samples/lin-wei.gnucash samples/sabine-brenner.gnucash ./samples/
 RUN uv sync --frozen --no-dev
 
-ENV GNUCASH_BOOK_PATH=/app/samples/alex-chen-morales.gnucash:/app/samples/lin-wei.gnucash
+# Bring the demo books current through the build date, the way CI
+# does for the MCPB bundle: the closed-loop updater extends each
+# frozen book deterministically, priced from the committed offline
+# rates cache — no network, and the prefix-integrity check makes
+# every image build a regression test of the updater itself. The
+# /tmp pre-continue backups are build-layer junk; drop them.
+COPY scripts/synthetic_book ./scripts/synthetic_book
+RUN uv run --no-sync python scripts/synthetic_book/rebuild_all.py --continue-only \
+    && rm -f /tmp/pre-continue-*
+
+ENV GNUCASH_BOOK_PATH=/app/samples/alex-chen-morales.gnucash:/app/samples/lin-wei.gnucash:/app/samples/sabine-brenner.gnucash
 
 # MCP stdio transport: the client (or registry checker) talks
 # JSON-RPC over stdin/stdout.

--- a/scripts/synthetic_book/continue_book.py
+++ b/scripts/synthetic_book/continue_book.py
@@ -171,9 +171,16 @@ def main() -> int:
         # segment ("…/gnucash-mcp/scripts/…") is always followed by
         # "/". The bare-substring pattern matched THIS script's own
         # checkout path on CI runners — the guard vetoed itself.
-        probe = subprocess.run(["pgrep", "-f", "gnucash-mcp( |$)"],
-                               capture_output=True, text=True)
-        if probe.stdout.strip():
+        try:
+            probe = subprocess.run(["pgrep", "-f", "gnucash-mcp( |$)"],
+                                   capture_output=True, text=True)
+        except FileNotFoundError:
+            # No pgrep at all (minimal containers — the Glama image's
+            # bookworm-slim base ships without procps). Can't
+            # determine, so proceed: an environment this bare isn't
+            # running a desktop MCP client either.
+            probe = None
+        if probe is not None and probe.stdout.strip():
             raise SystemExit(
                 "A gnucash-mcp server appears to be running (pids: "
                 f"{' '.join(probe.stdout.split())}). It may be serving "


### PR DESCRIPTION
## Summary
- The image build now runs the closed-loop updater the way CI does for the MCPB bundle: all three personas (Sabine joins Alex and Lin Wei) continue through the build date from the committed rates cache, fully offline.
- The prefix-integrity check runs inside the build, making every image build a regression test of the updater itself.
- `continue_book.py`'s server-running guard learns to proceed when `pgrep` doesn't exist (bookworm-slim ships without procps) — can't-determine is not is-running.
- CI now tests Python 3.14 alongside 3.10 and 3.13 — the interpreter Glama's builder runs the server on is a tested target.
- Launch contract unchanged: same `ENV GNUCASH_BOOK_PATH` + exec-form stdio CMD the currently-published Glama image serves.

## Test plan
- [x] Fresh `--no-cache` build, twice (Docker engine 20.10.22 and 29.7.2, freshly-pulled base): green, updater verified all three books current through 2026-09-03
- [x] Independent probe (raw SQLite inside the container): latest `post_date` 2026-09-03 in all three books
- [x] MCP stdio smoke against the container: initialize, 87 tools, `switch_book` registered (multi-book), `get_book_summary` live dashboard
- [x] HTTP-wrapped LLM test (mcp-proxy `--pass-environment`): book-touching tool calls served correctly over `/mcp`
- [x] Python 3.14 pre-flighted locally: existing lockfile installs clean, full suite green (2,165 passed)
- [ ] CI matrix run on 3.14 on a clean runner — this PR's own checks are the first