### PR TITLE
fix: owner resolution, _to_decimal, credit-note link, query budgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,11 @@ Established chokepoints and the rule each one owns:
 - `_upsert_price` — single/batch price writes can't diverge.
 - `_classify_reconciliation` — dashboard aggregates and the
   drill-down table bucket rows identically.
+- `_find_invoice_owner_by_guid` / `_document_owner_clause` — who a
+  document belongs to, by name and by SQL filter. `owner_guid` is
+  polymorphic (a Job on job-attached documents, an Employee on
+  vouchers); a hand-rolled `owner_type == 4` or `owner_guid ==
+  guid` silently drops both. Locked by `test_owner_resolution.py`.
 - `_parse_owner_type`, `_commodity_quantum`, `_is_market_price`,
   `_effective_owner_type` — same story, smaller surface.
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1875,6 +1875,33 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         book._gnucash_mcp_split_graph = (accounts, transactions)
 
     @staticmethod
+    def _preload_account_transactions(book, account) -> list:
+        """Warm ONE account's transaction rows in a single indexed
+        query, so a later walk over ``account.splits`` that touches
+        ``split.transaction`` resolves in memory instead of one
+        SELECT per split. The account-scoped sibling of
+        ``_preload_split_graph`` (which loads the whole book and is
+        wrong for a single-account tool).
+
+        Returns the loaded rows; THE CALLER MUST HOLD THE RETURNED
+        LIST for as long as the walk runs — the identity map holds
+        rows only weakly, and without a strong reference they are
+        collected immediately and every access queries again. First
+        built inline for enter_statement (release-review finding 8);
+        hoisted when the whole-tree review found the reconciliation
+        tools paying the same per-split SELECT.
+        """
+        from piecash.core.transaction import Split, Transaction
+
+        return (
+            book.session.query(Transaction)
+            .join(Split, Split.transaction_guid == Transaction.guid)
+            .filter(Split.account_guid == account.guid)
+            .distinct()
+            .all()
+        )
+
+    @staticmethod
     def _is_template_transaction(txn, template_guids: set) -> bool:
         """True iff ``txn`` is a scheduled-transaction template recipe.
 

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -1876,10 +1876,11 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
 
     @staticmethod
     def _preload_account_transactions(book, account) -> list:
-        """Warm ONE account's transaction rows in a single indexed
-        query, so a later walk over ``account.splits`` that touches
-        ``split.transaction`` resolves in memory instead of one
-        SELECT per split. The account-scoped sibling of
+        """Warm ONE account's transaction rows (with their split
+        and slot collections) in three indexed queries, so a later walk over
+        ``account.splits`` that touches ``split.transaction`` or
+        ``txn.splits`` resolves in memory instead of one SELECT per
+        row. The account-scoped sibling of
         ``_preload_split_graph`` (which loads the whole book and is
         wrong for a single-account tool).
 
@@ -1892,11 +1893,20 @@ class BaseGnuCashBook(CurrencyMixin, QueryMixin):
         tools paying the same per-split SELECT.
         """
         from piecash.core.transaction import Split, Transaction
+        from sqlalchemy.orm import selectinload
 
+        # selectinload: the register renderer and the statement
+        # candidate scan read txn.splits per transaction, and
+        # ``txn.notes`` is slot-backed (one slots SELECT per row) —
+        # two IN-queries here instead of two SELECTs per row there.
         return (
             book.session.query(Transaction)
             .join(Split, Split.transaction_guid == Transaction.guid)
             .filter(Split.account_guid == account.guid)
+            .options(
+                selectinload(Transaction.splits),
+                selectinload(Transaction.slots),
+            )
             .distinct()
             .all()
         )

--- a/src/gnucash_mcp/book/_base.py
+++ b/src/gnucash_mcp/book/_base.py
@@ -18,7 +18,7 @@ import threading
 import time
 from contextlib import contextmanager
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Generator, Iterable
 
@@ -143,10 +143,30 @@ def _to_decimal(value) -> Decimal:
 
     Use everywhere user-supplied money hits ``Decimal(...)`` —
     direct callers (tests, scripts) bypass the pydantic coercion.
+
+    Raises ``ValueError`` — never ``decimal.InvalidOperation`` — on
+    text that isn't a number, and on NaN / infinity. InvalidOperation
+    is an ``ArithmeticError``, so it slipped past every ``except
+    ValueError`` on the write paths: one ``$10`` cell sank a whole
+    ``create_transactions`` batch as ``unexpected_error`` (and
+    ``on_error="skip"`` could not rescue it) while ``create_prices``
+    happened to catch ``ArithmeticError`` and rejected the same cell
+    per row (whole-tree review, 2026-09-04, class 2). Converting here
+    retires the class at every caller and lets ``safe_tool`` report
+    it as the ``validation_error`` it is.
     """
     if isinstance(value, Decimal):
-        return value
-    return Decimal(str(value))
+        d = value
+    else:
+        try:
+            d = Decimal(str(value))
+        except InvalidOperation:
+            raise ValueError(
+                f"not a valid decimal amount: {value!r}"
+            ) from None
+    if not d.is_finite():
+        raise ValueError(f"amount must be a finite number, got {value!r}")
+    return d
 
 
 def _verify_write(session, table, guid: str, label: str) -> None:

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -26,6 +26,7 @@ from gnucash_mcp.book._base import (
     _to_decimal,
     _unique_prefix,
     _verify_composite_write,
+    _verify_delete,
     _verify_write,
 )
 from gnucash_mcp._format import (
@@ -1986,6 +1987,84 @@ class BusinessMixin:
             book.session, Slot.__table__,
             {"obj_guid": frame_guid, "name": "invoice"},
             f"gncInvoice ref slot for frame {frame_guid[:8]}",
+        )
+
+    @staticmethod
+    def _write_applies_to_slot(book, invoice_guid: str, source_guid: str):
+        """Write the ``gnc-mcp/applies-to-invoice`` link via Core.
+
+        piecash stores a path-style key as two rows: a FRAME slot on
+        the invoice named ``gnc-mcp`` (``guid_val`` = a fresh frame
+        guid) and the string value on the frame's guid under the full
+        path name. This is the raw-SQL twin of the ORM write in
+        ``_set_applies_to_invoice_guid``, for the one caller
+        (``unpost_invoice``) that must write after the posting-
+        transaction delete has swept the invoice's own slots — the
+        ORM accessors are unreliable in that state. Any leftover
+        ``gnc-mcp`` frame on the invoice is removed first so the key
+        never doubles.
+        """
+        import uuid
+        from piecash.kvp import KVP_Type, Slot
+
+        stale = book.session.execute(
+            Slot.__table__.select().where(
+                (Slot.__table__.c.obj_guid == invoice_guid)
+                & (Slot.__table__.c.name == "gnc-mcp")
+            )
+        ).fetchall()
+        for row in stale:
+            if row.guid_val:
+                book.session.execute(
+                    Slot.__table__.delete().where(
+                        Slot.__table__.c.obj_guid == row.guid_val
+                    )
+                )
+                _verify_delete(
+                    book.session, Slot.__table__,
+                    {"obj_guid": row.guid_val},
+                    f"stale gnc-mcp frame children for {invoice_guid[:8]}",
+                )
+        if stale:
+            book.session.execute(
+                Slot.__table__.delete().where(
+                    (Slot.__table__.c.obj_guid == invoice_guid)
+                    & (Slot.__table__.c.name == "gnc-mcp")
+                )
+            )
+            _verify_delete(
+                book.session, Slot.__table__,
+                {"obj_guid": invoice_guid, "name": "gnc-mcp"},
+                f"stale gnc-mcp frame for {invoice_guid[:8]}",
+            )
+
+        frame_guid = uuid.uuid4().hex
+        book.session.execute(
+            Slot.__table__.insert().values(
+                obj_guid=invoice_guid,
+                name="gnc-mcp",
+                slot_type=KVP_Type.KVP_TYPE_FRAME,
+                guid_val=frame_guid,
+            )
+        )
+        _verify_composite_write(
+            book.session, Slot.__table__,
+            {"obj_guid": invoice_guid, "name": "gnc-mcp"},
+            f"gnc-mcp frame slot for {invoice_guid[:8]}",
+        )
+        book.session.execute(
+            Slot.__table__.insert().values(
+                obj_guid=frame_guid,
+                name=BusinessMixin._APPLIES_TO_SLOT_KEY,
+                slot_type=KVP_Type.KVP_TYPE_STRING,
+                string_val=source_guid,
+            )
+        )
+        _verify_composite_write(
+            book.session, Slot.__table__,
+            {"obj_guid": frame_guid,
+             "name": BusinessMixin._APPLIES_TO_SLOT_KEY},
+            f"applies-to slot for frame {frame_guid[:8]}",
         )
 
     @staticmethod
@@ -5737,11 +5816,16 @@ class BusinessMixin:
             inv.post_account = None
             book.flush()
 
-            # Read the credit-note flag BEFORE deleting: slot reads
-            # can flake ("Multiple rows returned with uselist=False")
-            # while lots/transactions are being deleted in the same
-            # session.
+            # Read the credit-note flag AND the applies-to link
+            # BEFORE deleting: slot reads can flake ("Multiple rows
+            # returned with uselist=False") while lots/transactions
+            # are being deleted in the same session, and the delete
+            # sweeps both slots (see below).
             is_credit_note = self._get_is_credit_note(inv)
+            applies_to_guid = (
+                self._get_applies_to_invoice_guid(inv)
+                if is_credit_note else None
+            )
             inv_id_snapshot = inv.id
             owner_type_snapshot = inv.owner_type
             inv_guid_snapshot = inv.guid
@@ -5784,6 +5868,16 @@ class BusinessMixin:
                      "name": "credit-note"},
                     "credit-note flag restore",
                 )
+                # The applies-to link rides the same sweep. It is
+                # stored as a FRAME row on the invoice (``gnc-mcp``)
+                # with the value hung off the frame's guid, so the
+                # restore rebuilds both rows — the identity flag alone
+                # came back and the link silently vanished on every
+                # unpost (whole-tree review, 2026-09-04, class 3).
+                if applies_to_guid:
+                    self._write_applies_to_slot(
+                        book, inv_guid_snapshot, applies_to_guid,
+                    )
 
             book.save()
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -301,6 +301,53 @@ class BusinessMixin:
             )
         return None
 
+    @staticmethod
+    def _document_owner_clause(
+        book, owner_type: int | None = None, owner_guid: str | None = None,
+    ):
+        """SQL filter matching every document owned by the given
+        side and/or party — DIRECTLY (``owner_type`` 2/4/5 on the
+        invoice row) or THROUGH A JOB (``owner_type=3`` whose Job
+        carries the requested side / party).
+
+        THE owner-filter chokepoint. ``invoices.owner_guid`` is a
+        polymorphic pointer: on a job-attached document it names the
+        Job, not the customer or vendor, so any site that filters on
+        ``Invoice.owner_type == N`` or ``Invoice.owner_guid == guid``
+        by hand silently drops every job-attached document — the
+        whole-tree review (2026-09-04) found six such sites, from the
+        collections list to the customer-delete guard. Every owner
+        filter routes here so the job indirection is handled once.
+
+        Employees (5) have no jobs, so their clause stays direct.
+        Both arguments ``None`` matches everything.
+        """
+        from sqlalchemy import and_, or_, true
+        from piecash.business.invoice import Invoice, Job
+
+        direct = []
+        via_job = []
+        if owner_type is not None:
+            direct.append(Invoice.owner_type == owner_type)
+            via_job.append(Job.owner_type == owner_type)
+        if owner_guid is not None:
+            direct.append(Invoice.owner_guid == owner_guid)
+            via_job.append(Job.owner_guid == owner_guid)
+        if not direct:
+            return true()
+        if owner_type == 5:
+            return and_(*direct)
+        job_guid_sq = book.session.query(Job.guid).filter(
+            *via_job
+        ).subquery()
+        return or_(
+            and_(*direct),
+            and_(
+                Invoice.owner_type == 3,
+                Invoice.owner_guid.in_(job_guid_sq),
+            ),
+        )
+
     # Path for the auto-created realized-FX-gain/loss income account.
     # Single credit-natural account: positive balance = net gain, negative
     # = net loss across the period. Named to match GAAP convention
@@ -1419,20 +1466,11 @@ class BusinessMixin:
             # fails "not found" on job-attached invoices. Employee
             # (owner_type=5) is exempt: piecash jobs are
             # customer/vendor only.
-            from sqlalchemy import and_, or_
-            from piecash.business.invoice import Job
-            if owner_type in (2, 4):
-                job_guid_sq = book.session.query(Job.guid).filter(
-                    Job.owner_type == owner_type
-                ).subquery()
-                return query.filter(or_(
-                    Invoice.owner_type == owner_type,
-                    and_(
-                        Invoice.owner_type == 3,
-                        Invoice.owner_guid.in_(job_guid_sq),
-                    ),
-                )).first()
-            return query.filter(Invoice.owner_type == owner_type).first()
+            return query.filter(
+                BusinessMixin._document_owner_clause(
+                    book, owner_type=owner_type,
+                )
+            ).first()
 
         # owner_type=None: pull all matches and fail loud on
         # collision rather than returning a row-order-dependent pick.
@@ -4907,7 +4945,11 @@ class BusinessMixin:
                     Invoice.owner_guid == job.guid,
                 )
             elif ot is not None:
-                query = query.filter(Invoice.owner_type == ot)
+                # Job-aware: a customer listing must include the
+                # customer's job-attached invoices (owner_type=3).
+                query = query.filter(
+                    self._document_owner_clause(book, owner_type=ot)
+                )
 
             invoices = query.order_by(Invoice.date_opened.desc()).all()
 
@@ -5413,13 +5455,15 @@ class BusinessMixin:
             # an explicit session.add would be redundant (see
             # the matching note in investments.py).
 
-            # GnuCash UI uses the customer/vendor name, not "Invoice NNNNNN"
-            if is_bill:
-                owner = self._find_vendor_by_guid(book, inv.owner_guid)
-            else:
-                owner = self._find_customer_by_guid(
-                    book, inv.owner_guid
-                )
+            # GnuCash UI uses the counterparty's name, not "Invoice
+            # NNNNNN". Resolved through the polymorphic finder: a
+            # side-keyed customer/vendor lookup returns None for
+            # vouchers (employee owner) and job-attached documents
+            # (owner_guid names the Job), which posted every such
+            # document as "Invoice NNN" (whole-tree review, 1a).
+            owner = self._find_invoice_owner_by_guid(
+                book, inv.owner_type, inv.owner_guid,
+            )
             owner_name = owner.name if owner else f"Invoice {inv.id}"
             # description=None falls back to the owner name (GnuCash
             # UI convention); an explicit "" deliberately blanks the
@@ -5894,15 +5938,15 @@ class BusinessMixin:
                         f"then retry payment."
                     )
 
-            if is_bill:
-                owner = self._find_vendor_by_guid(
-                    book, inv.owner_guid
-                )
-            else:
-                owner = self._find_customer_by_guid(
-                    book, inv.owner_guid
-                )
-            owner_name = owner.name if owner else ""
+            # Polymorphic owner lookup — the side-keyed finder
+            # returned None for vouchers and job-attached documents,
+            # and every such payment landed with an EMPTY description
+            # (whole-tree review, 1b). Same fallback as post_invoice
+            # so a dangling owner still yields a readable line.
+            owner = self._find_invoice_owner_by_guid(
+                book, inv.owner_type, inv.owner_guid,
+            )
+            owner_name = owner.name if owner else f"Invoice {inv.id}"
             # description: None → owner name; explicit "" blanks the
             # field deliberately. Same pattern as post_invoice.
             txn_desc = description if description is not None else owner_name
@@ -6991,30 +7035,53 @@ class BusinessMixin:
         delete: raises ValueError (posted/unposted-specific wording)
         if any Invoice rows match the owner_type.
         """
-        from piecash.business.invoice import Invoice
+        from piecash.business.invoice import Invoice, Job
 
         def check(book, entity_guid):
+            # Job-aware: a job-attached document's owner_guid names
+            # the Job, so a direct owner_guid match missed it and
+            # delete_customer succeeded with POSTED invoices on the
+            # books — leaving an owner that resolved to nothing
+            # forever (whole-tree review, 1g).
             invoices = book.session.query(Invoice).filter(
-                Invoice.owner_guid == entity_guid,
-                Invoice.owner_type == owner_type,
-            ).all()
-            if not invoices:
-                return
-            posted = [i for i in invoices if _is_invoice_posted(i)]
-            unposted = [i for i in invoices if not _is_invoice_posted(i)]
-            if posted:
-                posted_ids = ", ".join(i.id for i in posted)
-                raise ValueError(
-                    f"Cannot delete {entity_label.lower()} with posted "
-                    f"{doc_label}: {posted_ids}. "
-                    f"Void them or issue credit notes first."
+                BusinessMixin._document_owner_clause(
+                    book, owner_type=owner_type, owner_guid=entity_guid,
                 )
-            unposted_ids = ", ".join(i.id for i in unposted)
-            raise ValueError(
-                f"Cannot delete {entity_label.lower()} with "
-                f"{doc_label}: {unposted_ids}. "
-                f"Delete the {doc_label} first."
-            )
+            ).all()
+            if invoices:
+                posted = [i for i in invoices if _is_invoice_posted(i)]
+                unposted = [
+                    i for i in invoices if not _is_invoice_posted(i)
+                ]
+                if posted:
+                    posted_ids = ", ".join(i.id for i in posted)
+                    raise ValueError(
+                        f"Cannot delete {entity_label.lower()} with "
+                        f"posted {doc_label}: {posted_ids}. "
+                        f"Void them or issue credit notes first."
+                    )
+                unposted_ids = ", ".join(i.id for i in unposted)
+                raise ValueError(
+                    f"Cannot delete {entity_label.lower()} with "
+                    f"{doc_label}: {unposted_ids}. "
+                    f"Delete the {doc_label} first."
+                )
+            # The party's jobs reference it by GUID too; deleting
+            # underneath them leaves list_jobs / get_job_report
+            # rendering "?" for the owner with no way to repair it.
+            if owner_type in (2, 4):
+                jobs = book.session.query(Job).filter(
+                    Job.owner_guid == entity_guid,
+                    Job.owner_type == owner_type,
+                ).all()
+                if jobs:
+                    job_ids = ", ".join(j.id for j in jobs)
+                    raise ValueError(
+                        f"Cannot delete {entity_label.lower()} with "
+                        f"jobs: {job_ids}. Delete the jobs first "
+                        f"(delete_job), or retire the "
+                        f"{entity_label.lower()} with active=false."
+                    )
 
         return check
 
@@ -7071,12 +7138,13 @@ class BusinessMixin:
         )
 
     def delete_employee(self, employee_id: str) -> dict:
-        """Delete an employee.
+        """Delete an employee with no expense vouchers.
 
-        Employees in the 1.3.0 release have no associated documents —
-        expense vouchers (``counter_exp_voucher`` / ``owner_type=5``)
-        are out of scope. The delete proceeds unconditionally after
-        slot cleanup.
+        Employees with any vouchers (posted or unposted) cannot be
+        deleted — the same guard customers and vendors have had since
+        their documents existed. Vouchers arrived in v1.3 and the
+        guard did not follow until the whole-tree review (2026-09-04):
+        an employee could be deleted from under a posted voucher.
 
         Args:
             employee_id: Employee ID (e.g., '000001').
@@ -7085,13 +7153,17 @@ class BusinessMixin:
             Dict with id, name, type, status.
 
         Raises:
-            ValueError: If employee not found.
+            ValueError: If employee not found or has vouchers.
         """
         return self._delete_business_person(
             entity_id=employee_id,
             entity_label="Employee",
             find_entity_method="_find_employee",
-            # Employees own nothing in 1.3.0 — no dependency check.
+            dependency_check=self._invoice_dependency_check(
+                entity_label="Employee",
+                owner_type=5,
+                doc_label="vouchers",
+            ),
         )
 
     # ── Job CRUD ─────────────────────────────────────────────────
@@ -7500,8 +7572,14 @@ class BusinessMixin:
                 Invoice.date_posted.isnot(None)
             )
 
+            # Every owner filter is job-aware via the chokepoint —
+            # a plain owner_type / owner_guid match dropped every
+            # job-attached document from the collections list
+            # (whole-tree review, 1e).
             if ot is not None:
-                query = query.filter(Invoice.owner_type == ot)
+                query = query.filter(
+                    self._document_owner_clause(book, owner_type=ot)
+                )
 
             if customer_id:
                 customer = self._find_customer(book, customer_id)
@@ -7510,7 +7588,9 @@ class BusinessMixin:
                         f"Customer not found: {customer_id}"
                     )
                 query = query.filter(
-                    Invoice.owner_guid == customer.guid
+                    self._document_owner_clause(
+                        book, owner_type=2, owner_guid=customer.guid,
+                    )
                 )
 
             if vendor_id:
@@ -7520,7 +7600,9 @@ class BusinessMixin:
                         f"Vendor not found: {vendor_id}"
                     )
                 query = query.filter(
-                    Invoice.owner_guid == vendor.guid
+                    self._document_owner_clause(
+                        book, owner_type=4, owner_guid=vendor.guid,
+                    )
                 )
 
             invoices = query.order_by(
@@ -7962,7 +8044,9 @@ class BusinessMixin:
                 u["bill_count"] += 1
                 continue
 
-            v = self._find_vendor_by_guid(book, bill.owner_guid)
+            v = self._find_invoice_owner_by_guid(
+                book, bill.owner_type, bill.owner_guid,
+            )
             v_name = v.name if v else "Unknown"
             bucket = totals.setdefault(v_name, {})
             bucket[plabel] = bucket.get(plabel, Decimal(0)) + total
@@ -8048,20 +8132,23 @@ class BusinessMixin:
             default_currency = self._require_default_currency(book)
             default_currency_mnemonic = default_currency.mnemonic
 
-            query = book.session.query(Invoice).filter(
-                Invoice.owner_type == 4,
-                Invoice.date_posted.isnot(None),
-            )
-
+            # Job-aware (chokepoint): a vendor bill grouped under a
+            # job is owner_type=3 and was excluded from spend totals
+            # by the direct owner_type match (whole-tree review, 1f).
+            vendor_guid = None
             if vendor_id:
                 vendor = self._find_vendor(book, vendor_id)
                 if not vendor:
                     raise ValueError(
                         f"Vendor not found: {vendor_id}"
                     )
-                query = query.filter(
-                    Invoice.owner_guid == vendor.guid
-                )
+                vendor_guid = vendor.guid
+            query = book.session.query(Invoice).filter(
+                self._document_owner_clause(
+                    book, owner_type=4, owner_guid=vendor_guid,
+                ),
+                Invoice.date_posted.isnot(None),
+            )
 
             bills = query.all()
 
@@ -8094,8 +8181,8 @@ class BusinessMixin:
             # as a warning.
             unconverted: dict[str, dict] = {}
             for bill in bills:
-                v = self._find_vendor_by_guid(
-                    book, bill.owner_guid
+                v = self._find_invoice_owner_by_guid(
+                    book, bill.owner_type, bill.owner_guid,
                 )
                 v_name = v.name if v else "Unknown"
                 v_id = v.id if v else ""

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2870,7 +2870,7 @@ class CoreMixin:
             if acct.type not in self._FUNDING_ACCOUNT_TYPES:
                 try:
                     legs.append(_to_decimal(sp["amount"]))
-                except (InvalidOperation, ValueError):
+                except ValueError:
                     return None
         if not legs:
             return None
@@ -4272,7 +4272,7 @@ class CoreMixin:
             for ln in lines:
                 try:
                     amt = _to_decimal(ln["amount"])
-                except (InvalidOperation, ValueError):
+                except ValueError:
                     raise ValueError(
                         f"line {ln['ref']}: amount "
                         f"{ln['amount']!r} is not a decimal"

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2736,6 +2736,15 @@ class CoreMixin:
                 # split.account.fullname, so a raw %short ref would
                 # silently fall through to the multi-split form.
                 focus_fullname = acct.fullname
+                # One indexed query for the account's transactions —
+                # the set comprehension below reads split.transaction
+                # per split, one lazy SELECT each (1,351 statements
+                # per register page on the Alex sample; whole-tree
+                # review, class 4). Strong reference held for the
+                # call; see the helper.
+                _txn_keepalive = (  # noqa: F841 — keepalive
+                    self._preload_account_transactions(book, acct)
+                )
                 transactions = {split.transaction for split in acct.splits}
             else:
                 # Hide scheduled-transaction template recipes — real

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -4351,25 +4351,11 @@ class CoreMixin:
 
             # Warm this account's transaction rows in ONE indexed
             # query before the universe filter touches
-            # s.transaction.post_date per split — the lazy
-            # many-to-one was a SELECT per transaction, making the
-            # headline workflow O(account history) in round-trips on
-            # large books, paid by dry-run and commit alike
-            # (release-review finding 8). Account-scoped on purpose:
-            # _preload_split_graph loads the whole book, which a
-            # single-statement entry never needs. The strong
-            # reference is load-bearing — the identity map holds
-            # rows only weakly (same trap the preload documents).
-            from piecash.core.transaction import (
-                Split as _Split,
-                Transaction as _Txn,
-            )
-            _txn_keepalive = (  # noqa: F841 — keepalive, see above
-                book.session.query(_Txn)
-                .join(_Split, _Split.transaction_guid == _Txn.guid)
-                .filter(_Split.account_guid == account.guid)
-                .distinct()
-                .all()
+            # s.transaction.post_date per split (release-review
+            # finding 8). The strong reference is load-bearing —
+            # see the helper.
+            _txn_keepalive = (  # noqa: F841 — keepalive, see helper
+                self._preload_account_transactions(book, account)
             )
 
             # Candidate universe: this account's splits within the

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -883,11 +883,20 @@ class CoreMixin:
             try:
                 from piecash.business.invoice import Invoice
                 from sqlalchemy import text
-                find_customer_by_guid = getattr(
-                    self, "_find_customer_by_guid", None,
+                # Polymorphic owner + effective side (BusinessMixin
+                # chokepoints). The side-keyed finders rendered every
+                # overdue voucher and job-attached bill as "Past due
+                # invoice: #NNN" — wrong type, no name — while
+                # get_outstanding_documents named it correctly
+                # (whole-tree review, 1c).
+                find_owner = getattr(
+                    self, "_find_invoice_owner_by_guid", None,
                 )
-                find_vendor_by_guid = getattr(
-                    self, "_find_vendor_by_guid", None,
+                effective_owner_type = getattr(
+                    self, "_effective_owner_type", None,
+                )
+                type_labels = getattr(
+                    self, "_OWNER_TYPE_TO_RESPONSE_TYPE", {},
                 )
                 overdue_inv_entries: list[tuple[int, str]] = []
                 get_is_cn = getattr(
@@ -924,22 +933,19 @@ class CoreMixin:
                             continue
 
                         days_overdue = (today - due_date).days
-                        is_bill = (inv.owner_type == 4)
-                        doc_type = "bill" if is_bill else "invoice"
+                        eff_ot = (
+                            effective_owner_type(book, inv)
+                            if effective_owner_type is not None
+                            else inv.owner_type
+                        )
+                        doc_type = type_labels.get(eff_ot, "invoice")
 
-                        if is_bill and find_vendor_by_guid is not None:
-                            owner = find_vendor_by_guid(
-                                book, inv.owner_guid,
+                        owner = (
+                            find_owner(
+                                book, inv.owner_type, inv.owner_guid,
                             )
-                        elif (
-                            not is_bill
-                            and find_customer_by_guid is not None
-                        ):
-                            owner = find_customer_by_guid(
-                                book, inv.owner_guid,
-                            )
-                        else:
-                            owner = None
+                            if find_owner is not None else None
+                        )
                         owner_name = (
                             owner.name if owner
                             else f"#{inv.id}"

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -1166,11 +1166,9 @@ class InvestmentsMixin:
                 raise ValueError(f"Lot not found: {guid}")
 
             # Split prefixes span the whole book — they feed back
-            # into table-wide _resolve_guid lookups.
-            all_split_guids = (
-                s.guid for txn in book.transactions for s in txn.splits
-            )
-            prefixes = _guid_prefix_map(all_split_guids)
+            # into table-wide _resolve_guid lookups. Cached, one
+            # indexed query (whole-tree review, class 4).
+            prefixes = self._split_prefix_map(book)
 
             splits = []
             for split in lot.splits:

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -452,7 +452,7 @@ class InvestmentsMixin:
                         "type": p.get("price_type") or "nav",
                         "source": p.get("source") or "user:price",
                     })
-                except (ValueError, KeyError, ArithmeticError) as e:
+                except (ValueError, KeyError) as e:
                     by_ref[ref] = {
                         "ref": ref, "status": "rejected",
                         "reason": str(e),

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -15,7 +15,6 @@ from decimal import Decimal
 
 from gnucash_mcp.book._base import (
     _commodity_quantum,
-    _guid_prefix_map,
     _is_unreconciled,
     _is_voided,
     _split_to_compact_dict,
@@ -116,10 +115,10 @@ class ReconciliationMixin:
             # Short split prefix + context the LLM only had a GUID
             # for. The requested state is an echo — dropped;
             # reconcile_date stays (computed when not provided).
-            all_split_guids = (
-                s.guid for txn in book.transactions for s in txn.splits
-            )
-            short_guid = _unique_prefix(split.guid, all_split_guids)
+            # The cached table-wide map is one indexed query; the
+            # relationship walk it replaces lazy-loaded one splits
+            # collection per transaction (whole-tree review, class 4).
+            short_guid = self._split_prefix_map(book)[split.guid]
             return {
                 "split_guid": short_guid,
                 "account": split.account.fullname,
@@ -232,6 +231,14 @@ class ReconciliationMixin:
             cleared_total = Decimal("0")
             uncleared_total = Decimal("0")
 
+            # One indexed query for this account's transactions —
+            # the sort key below reads split.transaction per split,
+            # which lazy-loaded one SELECT each (whole-tree review,
+            # class 4's second head). Strong reference held for the
+            # walk; see the helper.
+            _txn_keepalive = (  # noqa: F841 — keepalive
+                self._preload_account_transactions(book, account)
+            )
             splits = sorted(
                 account.splits,
                 key=lambda s: (s.transaction.post_date, s.transaction.enter_date)
@@ -286,11 +293,9 @@ class ReconciliationMixin:
 
             if compact:
                 # Prefixes span every split in the book — the
-                # consuming tools resolve GUIDs table-wide.
-                all_split_guids = (
-                    s.guid for txn in book.transactions for s in txn.splits
-                )
-                prefixes = _guid_prefix_map(all_split_guids)
+                # consuming tools resolve GUIDs table-wide. Cached,
+                # one indexed query (whole-tree review, class 4).
+                prefixes = self._split_prefix_map(book)
                 lines = [indicator]
                 lines += [
                     _unreconciled_split_to_compact_line(s, prefixes=prefixes)
@@ -381,6 +386,13 @@ class ReconciliationMixin:
             account = self._resolve_account(book, account_name)
             if not account:
                 raise ValueError(f"Account not found: {account_name}")
+
+            # Bulk mode and the audit before-state both read
+            # split.transaction per split — warm the account's
+            # transactions once (strong reference held for the call).
+            _txn_keepalive = (  # noqa: F841 — keepalive
+                self._preload_account_transactions(book, account)
+            )
 
             reconciled_balance = Decimal("0")
             for split in account.splits:

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -327,9 +327,8 @@ class TestGetEmployee:
 class TestDeleteEmployee:
     """Tests for delete_employee.
 
-    Employees in the 1.3.0 release have no associated documents —
-    expense vouchers are out of scope. delete_employee proceeds
-    unconditionally after slot cleanup.
+    Voucher-bearing employees are guarded the same way customers and
+    vendors are — see tests/test_owner_resolution.py for those cases.
     """
 
     def test_delete_employee(self, business_book):

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -11911,3 +11911,103 @@ class TestPayInvoiceDryRun:
         )
         accounts = gb.list_accounts()
         assert "Foreign Exchange" in str(accounts)
+
+
+class TestCreditNoteUnpostKeepsAppliesTo:
+    """Whole-tree review (2026-09-04), class 3: deleting the posting
+    transaction sweeps the credit note's own slots. ``unpost_invoice``
+    restored the ``credit-note`` identity flag but not the
+    ``gnc-mcp/applies-to-invoice`` link, so every post/unpost
+    round-trip silently dropped the provenance the note was created
+    with. The link is a FRAME row plus a child row, so the restore
+    rebuilds both.
+    """
+
+    @staticmethod
+    def _linked_credit_note(business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        inv = gb.create_invoice(customer_id="000001", date_opened="2026-06-01")
+        gb.add_invoice_entry(
+            invoice_id=inv["id"], account="Income:Sales",
+            description="Work", quantity="1", price="500.00",
+        )
+        gb.post_invoice(
+            invoice_id=inv["id"], post_account="Assets:Accounts Receivable",
+            post_date="2026-06-01", owner_type="customer",
+        )
+        cn = gb.create_credit_note(
+            owner_id="000001", owner_type="customer",
+            applies_to_invoice_id=inv["id"], date_opened="2026-06-10",
+        )
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="Refund", quantity="1", price="100.00",
+            owner_type="customer",
+        )
+        return gb, inv["id"], cn["id"]
+
+    def test_post_unpost_round_trip_keeps_the_link(self, business_book):
+        gb, inv_id, cn_id = self._linked_credit_note(business_book)
+        expected = {"id": inv_id, "type": "invoice"}
+        assert gb.get_invoice(cn_id, owner_type="customer")["applies_to"] \
+            == expected
+        gb.post_invoice(
+            invoice_id=cn_id, post_account="Assets:Accounts Receivable",
+            post_date="2026-06-10", owner_type="customer",
+        )
+        gb.unpost_invoice(invoice_id=cn_id, owner_type="customer")
+        after = gb.get_invoice(cn_id, owner_type="customer")
+        assert after["is_credit_note"] is True
+        assert after["applies_to"] == expected
+
+    def test_link_survives_repost_and_apply(self, business_book):
+        """The restored rows are real slots: a second post/unpost keeps
+        the link (no doubled frame), and apply_credit_note still
+        reads it for its provenance note."""
+        gb, inv_id, cn_id = self._linked_credit_note(business_book)
+        for _ in range(2):
+            gb.post_invoice(
+                invoice_id=cn_id, post_account="Assets:Accounts Receivable",
+                post_date="2026-06-10", owner_type="customer",
+            )
+            gb.unpost_invoice(invoice_id=cn_id, owner_type="customer")
+        gb.post_invoice(
+            invoice_id=cn_id, post_account="Assets:Accounts Receivable",
+            post_date="2026-06-10", owner_type="customer",
+        )
+        # Exactly one gnc-mcp frame on the credit note.
+        from sqlalchemy import text
+        from piecash.business.invoice import Invoice
+        with gb.open() as b:
+            guid = b.session.query(Invoice).filter_by(id=cn_id).first().guid
+            n = b.session.execute(
+                text("SELECT COUNT(*) FROM slots WHERE obj_guid=:g "
+                     "AND name='gnc-mcp'"), {"g": guid},
+            ).scalar()
+        assert n == 1
+        # Applying to the linked target produces no divergence note.
+        result = gb.apply_credit_note(
+            credit_note_id=cn_id, applies_to_invoice_id=inv_id,
+            owner_type="customer",
+        )
+        assert result["status"] == "applied"
+        assert "note" not in result
+
+    def test_unlinked_credit_note_unpost_unchanged(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        cn = gb.create_credit_note(owner_id="000001", owner_type="customer")
+        gb.add_credit_note_entry(
+            credit_note_id=cn["id"], account="Income:Sales",
+            description="Refund", quantity="1", price="100.00",
+            owner_type="customer",
+        )
+        gb.post_invoice(
+            invoice_id=cn["id"], post_account="Assets:Accounts Receivable",
+            owner_type="customer",
+        )
+        gb.unpost_invoice(invoice_id=cn["id"], owner_type="customer")
+        after = gb.get_invoice(cn["id"], owner_type="customer")
+        assert after["is_credit_note"] is True
+        assert "applies_to" not in after

--- a/tests/test_float_precision.py
+++ b/tests/test_float_precision.py
@@ -526,3 +526,110 @@ class TestIsMarketPriceHelper:
         class _Price:
             pass
         assert _is_market_price(_Price()) is True
+
+
+# ── Non-numeric input raises ValueError, never InvalidOperation ──────
+#
+# Whole-tree review (2026-09-04), class 2: ``decimal.InvalidOperation``
+# is an ArithmeticError, so it escaped every ``except ValueError`` on
+# the write paths. One ``$10`` cell sank a whole batch as
+# ``unexpected_error`` while ``create_prices`` happened to catch it
+# per row. ``_to_decimal`` now converts, so every caller and
+# ``safe_tool``'s ``validation_error`` mapping see one exception type.
+
+
+class TestToDecimalRejectsNonNumeric:
+
+    @pytest.mark.parametrize("bad", ["$10", "10x", "", "abc", "1,000"])
+    def test_text_raises_value_error_naming_the_input(self, bad):
+        with pytest.raises(ValueError, match="not a valid decimal") as exc:
+            _to_decimal(bad)
+        assert repr(bad) in str(exc.value)
+
+    @pytest.mark.parametrize("bad", ["NaN", "Infinity", "-inf", float("nan")])
+    def test_non_finite_raises_value_error(self, bad):
+        with pytest.raises(ValueError, match="finite"):
+            _to_decimal(bad)
+
+    def test_never_leaks_invalid_operation(self):
+        from decimal import InvalidOperation
+        try:
+            _to_decimal("$10")
+        except InvalidOperation:  # pragma: no cover — the bug shape
+            pytest.fail("InvalidOperation escaped _to_decimal")
+        except ValueError:
+            pass
+
+
+class TestBadAmountCellRejectsPerRow:
+    """The batch surfaces: a typo'd amount is a ROW rejection with a
+    readable reason, and ``on_error="skip"`` keeps the good rows."""
+
+    _TSV = (
+        "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\n"
+        "1\t2024-02-01\tGood row\t-10\tAssets:Checking\t10\tExpenses:Groceries\n"
+        "2\t2024-02-02\tBad row\t-$10\tAssets:Checking\t10\tExpenses:Groceries\n"
+    )
+
+    def _rows(self, results_tsv: str) -> dict:
+        lines = results_tsv.splitlines()
+        header = lines[0].split("\t")
+        return {r.split("\t")[0]: dict(zip(header, r.split("\t")))
+                for r in lines[1:]}
+
+    def test_create_transactions_skip_keeps_the_good_row(self, test_book):
+        from gnucash_mcp.tools.core import _parse_transactions_tsv
+        gb = GnuCashBook(str(test_book))
+        out = gb.create_transactions(
+            _parse_transactions_tsv(self._TSV), on_error="skip",
+        )
+        rows = self._rows(out["results"])
+        assert rows["1"]["status"] == "created"
+        assert rows["2"]["status"] == "rejected"
+        assert "not a valid decimal" in rows["2"]["reason"]
+        assert "$10" in rows["2"]["reason"]
+
+    def test_create_transactions_abort_names_the_bad_row(self, test_book):
+        from gnucash_mcp.tools.core import _parse_transactions_tsv
+        gb = GnuCashBook(str(test_book))
+        out = gb.create_transactions(_parse_transactions_tsv(self._TSV))
+        rows = self._rows(out["results"])
+        assert rows["1"]["reason"] == "batch_aborted"
+        assert "not a valid decimal" in rows["2"]["reason"]
+
+    def test_enter_statement_counter_split_typo_is_a_row_error(
+        self, test_book,
+    ):
+        """Counter-split cells flow through the shared validator; the
+        dispositions pass must catch them as row errors, not crash."""
+        from datetime import date
+        gb = GnuCashBook(str(test_book))
+        lines = [{
+            "ref": "1", "date": date(2024, 2, 1), "amount": "-10",
+            "description": "Bad counter",
+            "splits": [{"account": "Expenses:Groceries", "amount": "1O"}],
+        }]
+        out = gb.enter_statement(
+            "Assets:Checking", date(2024, 2, 28),
+            opening_balance="2850", closing_balance="2840",
+            lines=lines, dry_run=True,
+        )
+        assert "not a valid decimal" in out["warnings"]
+        assert "1 row(s) this payload would refuse" in out["tie"]
+
+    def test_tool_layer_reports_validation_error(self, test_book, monkeypatch):
+        """End to end through safe_tool: the error_type is
+        validation_error, not unexpected_error."""
+        import json
+        from gnucash_mcp.tools._helpers import safe_tool
+        gb = GnuCashBook(str(test_book))
+
+        @safe_tool
+        def replace():
+            return gb.replace_splits("deadbeef", [
+                {"account": "Assets:Checking", "amount": "ten"},
+                {"account": "Expenses:Groceries", "amount": "-10"},
+            ])
+        out = json.loads(replace())
+        assert out["error_type"] == "validation_error"
+        assert "ten" in out["error"]

--- a/tests/test_owner_resolution.py
+++ b/tests/test_owner_resolution.py
@@ -1,0 +1,259 @@
+"""Regression locks for the document-owner-resolution family.
+
+Whole-tree review, 2026-09-04, class 1: ``invoices.owner_guid`` is a
+polymorphic pointer — on a job-attached document it names the Job,
+on a voucher the Employee. Seven sites keyed on the owner side by
+hand (``owner_type == 4``, ``_find_vendor_by_guid(book, inv.owner_guid)``)
+and each silently mishandled vouchers and job-attached documents:
+
+- post/pay descriptions defaulted to ``Invoice NNN`` or the EMPTY
+  string (1a, 1b);
+- the dashboard's overdue warning mislabeled the document type and
+  dropped the counterparty name (1c);
+- ``list_invoices`` / ``get_outstanding_invoices`` /
+  ``vendor_spending_report`` owner filters dropped the documents
+  outright (1d, 1e, 1f);
+- ``delete_customer`` succeeded with a job and a POSTED job-attached
+  invoice on the books, and ``delete_employee`` never checked
+  vouchers at all (1g).
+
+Every site now routes through ``_find_invoice_owner_by_guid`` (name)
+or ``_document_owner_clause`` (SQL filter). The structural test at
+the bottom keeps them there.
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gnucash_mcp.book import GnuCashBook
+
+
+def _voucher_book(business_book: Path, post_date: str = "2026-08-01"):
+    """Employee + posted voucher; returns (gb, voucher_id)."""
+    gb = GnuCashBook(str(business_book))
+    gb.create_employee(name="Maria Garcia")
+    v = gb.create_voucher(employee_id="000001", date_opened=post_date)
+    gb.add_voucher_entry(
+        voucher_id=v["id"], account="Expenses:Office Supplies",
+        description="Pens", quantity="1", price="50.00",
+    )
+    gb.post_invoice(
+        invoice_id=v["id"], post_account="Liabilities:Accounts Payable",
+        post_date=post_date, owner_type="employee",
+    )
+    return gb, v["id"]
+
+
+def _job_invoice_book(business_book: Path):
+    """Customer + job + posted job-attached invoice; returns
+    (gb, invoice_id, job_id)."""
+    gb = GnuCashBook(str(business_book))
+    gb.create_customer(name="Acme Corp")
+    job = gb.create_job(
+        owner_id="000001", owner_type="customer", name="API Rewrite",
+    )
+    inv = gb.create_invoice(
+        customer_id="000001", job_id=job["id"], date_opened="2026-07-01",
+    )
+    gb.add_invoice_entry(
+        invoice_id=inv["id"], account="Income:Sales",
+        description="Work", quantity="1", price="500.00",
+    )
+    gb.post_invoice(
+        invoice_id=inv["id"], post_account="Assets:Accounts Receivable",
+        post_date="2026-07-01", owner_type="customer",
+    )
+    return gb, inv["id"], job["id"]
+
+
+class TestPostAndPayDescriptions:
+    """1a / 1b — the counterparty name reaches the ledger."""
+
+    def test_voucher_post_and_pay_name_the_employee(self, business_book):
+        gb, vid = _voucher_book(business_book)
+        with gb.open(readonly=True) as b:
+            post_desc = {t.description for t in b.transactions
+                         if t.num == vid}
+        assert post_desc == {"Maria Garcia"}
+        paid = gb.pay_invoice(
+            invoice_id=vid, payment_account="Assets:Checking",
+            amount="50.00", payment_date="2026-08-05",
+            owner_type="employee",
+        )
+        pay_txn = gb.get_transaction(paid["transaction_guid"])
+        # Pre-fix: "" — the vendor finder was handed an employee guid.
+        assert pay_txn["description"] == "Maria Garcia"
+
+    def test_job_attached_post_and_pay_name_the_customer(
+        self, business_book,
+    ):
+        gb, iid, _job = _job_invoice_book(business_book)
+        with gb.open(readonly=True) as b:
+            post_desc = {t.description for t in b.transactions
+                         if t.num == iid}
+        assert post_desc == {"Acme Corp"}
+        paid = gb.pay_invoice(
+            invoice_id=iid, payment_account="Assets:Checking",
+            amount="200.00", payment_date="2026-07-15",
+            owner_type="customer",
+        )
+        assert gb.get_transaction(paid["transaction_guid"])["description"] \
+            == "Acme Corp"
+
+    def test_explicit_empty_description_still_blanks(self, business_book):
+        """The ``description=""`` deliberate-blank contract survives."""
+        gb, vid = _voucher_book(business_book)
+        paid = gb.pay_invoice(
+            invoice_id=vid, payment_account="Assets:Checking",
+            amount="50.00", description="", owner_type="employee",
+        )
+        assert gb.get_transaction(paid["transaction_guid"])["description"] \
+            == ""
+
+
+class TestOwnerFiltersAreJobAware:
+    """1d / 1e / 1f — job-attached documents survive owner filters."""
+
+    def test_list_invoices_owner_type_includes_job_attached(
+        self, business_book,
+    ):
+        gb, iid, _ = _job_invoice_book(business_book)
+        ids = [i["id"] for i in
+               gb.list_invoices(owner_type="customer", compact=False)["invoices"]]
+        assert iid in ids
+        vendor_ids = [i["id"] for i in
+                      gb.list_invoices(owner_type="vendor", compact=False)["invoices"]]
+        assert iid not in vendor_ids
+
+    def test_outstanding_owner_type_and_customer_id_include_job_attached(
+        self, business_book,
+    ):
+        gb, iid, _ = _job_invoice_book(business_book)
+        by_type = gb.get_outstanding_invoices(owner_type="customer", compact=False)
+        assert [r["id"] for r in by_type["invoices"]] == [iid]
+        by_id = gb.get_outstanding_invoices(customer_id="000001", compact=False)
+        assert [r["id"] for r in by_id["invoices"]] == [iid]
+        assert by_id["invoices"][0]["owner_name"] == "Acme Corp"
+        # A different customer's filter must not pick it up.
+        gb.create_customer(name="Other Co")
+        assert gb.get_outstanding_invoices(
+            customer_id="000002", compact=False,
+        )["invoices"] == []
+
+    def test_vendor_spending_report_includes_job_attached_bill(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        job = gb.create_job(
+            owner_id="000001", owner_type="vendor", name="Fit-out",
+        )
+        bill = gb.create_bill(
+            vendor_id="000001", job_id=job["id"], date_opened="2026-06-01",
+        )
+        gb.add_bill_entry(
+            bill_id=bill["id"], account="Expenses:Office Supplies",
+            description="Desks", quantity="2", price="150.00",
+        )
+        gb.post_invoice(
+            invoice_id=bill["id"], post_account="Liabilities:Accounts Payable",
+            post_date="2026-06-01", owner_type="vendor",
+        )
+        for kwargs in ({}, {"vendor_id": "000001"}):
+            rep = gb.vendor_spending_report(
+                "2026-06-01", "2026-06-30", compact=False, **kwargs,
+            )
+            assert rep["totals"]["bill_count"] == 1, kwargs
+            assert rep["vendors"][0]["vendor_name"] == "Office Depot"
+            assert Decimal(rep["vendors"][0]["total_billed"]) == Decimal("300")
+        grouped = gb.vendor_spending_report(
+            "2026-06-01", "2026-06-30", group_by="month",
+        )
+        assert "Office Depot" in grouped and "300.00" in grouped
+
+
+class TestDeleteGuardsAreJobAndVoucherAware:
+    """1g — no party can be deleted from under its documents or jobs."""
+
+    def test_delete_customer_refuses_with_posted_job_attached_invoice(
+        self, business_book,
+    ):
+        gb, _iid, _ = _job_invoice_book(business_book)
+        with pytest.raises(ValueError, match="posted invoices"):
+            gb.delete_customer("000001")
+
+    def test_delete_customer_refuses_with_bare_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_job(owner_id="000001", owner_type="customer", name="J")
+        with pytest.raises(ValueError, match="with jobs: 000001"):
+            gb.delete_customer("000001")
+        gb.delete_job("000001")
+        assert gb.delete_customer("000001")["status"] == "deleted"
+
+    def test_delete_vendor_refuses_with_bare_job(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_vendor(name="Office Depot")
+        gb.create_job(owner_id="000001", owner_type="vendor", name="J")
+        with pytest.raises(ValueError, match="with jobs"):
+            gb.delete_vendor("000001")
+
+    def test_delete_employee_refuses_with_voucher(self, business_book):
+        gb, vid = _voucher_book(business_book)
+        with pytest.raises(ValueError, match="posted vouchers"):
+            gb.delete_employee("000001")
+        gb.create_employee(name="Temp")
+        gb.create_voucher(employee_id="000002")
+        with pytest.raises(ValueError, match="Delete the vouchers first"):
+            gb.delete_employee("000002")
+
+
+class TestDashboardOverdueWarning:
+    """1c — the Warnings section agrees with get_outstanding_documents."""
+
+    def test_overdue_voucher_labeled_and_named(self, business_book):
+        gb, _vid = _voucher_book(business_book, post_date="2026-01-01")
+        warnings = [
+            ln for ln in gb.get_book_summary().splitlines()
+            if "Past due" in ln
+        ]
+        assert len(warnings) == 1
+        assert "Past due voucher: Maria Garcia" in warnings[0]
+        assert "#000001" not in warnings[0]
+
+
+class TestOwnerResolutionChokepoints:
+    """Structural lock: the seven sites stay on the chokepoints."""
+
+    def test_no_side_keyed_owner_finders_at_the_fixed_sites(self):
+        from gnucash_mcp.book import business, core
+
+        for method in (
+            business.BusinessMixin.post_invoice,
+            business.BusinessMixin.pay_invoice,
+            business.BusinessMixin.vendor_spending_report,
+            business.BusinessMixin._grouped_vendor_spending,
+            core.CoreMixin._collect_warnings,
+        ):
+            src = inspect.getsource(method)
+            assert "_find_vendor_by_guid" not in src, method.__name__
+            assert "_find_customer_by_guid" not in src, method.__name__
+            assert "_find_invoice_owner_by_guid" in src, method.__name__
+
+    def test_owner_filters_route_through_the_clause(self):
+        from gnucash_mcp.book import business
+
+        for method in (
+            business.BusinessMixin._find_invoice,
+            business.BusinessMixin.list_invoices,
+            business.BusinessMixin.get_outstanding_invoices,
+            business.BusinessMixin.vendor_spending_report,
+            business.BusinessMixin._invoice_dependency_check,
+        ):
+            assert "_document_owner_clause" in inspect.getsource(method), \
+                method.__name__

--- a/tests/test_query_budgets.py
+++ b/tests/test_query_budgets.py
@@ -12,7 +12,7 @@ Each test seeds an account with N transactions and asserts the call
 stays well under N statements; the pre-fix shape scales with N, the
 fixed shape does not. Thresholds were calibrated by MEASURING the
 fixed and mutated counts with N=80 — get_unreconciled_splits 7 vs
-172 statements, set_reconcile_state 14 vs 96, get_lot 12 vs 92, and
+172 statements, list_transactions(account) 15 vs 179, set_reconcile_state 14 vs 96, get_lot 12 vs 92, and
 bulk reconcile_account 1 vs 82 SELECTs on the transactions table
 (its total is dominated by legitimate per-row writes and piecash's
 flush validation) — and sit between them. The structural test keeps the sites on the helpers.
@@ -124,6 +124,18 @@ class TestPerAccountQueryBudgets:
             f"are back (prefix walk or split.transaction sort key)"
         )
 
+    def test_list_transactions_register(self, test_book):
+        """The account-filtered register view."""
+        _seed(test_book, "Assets:Checking", "Expenses:Groceries")
+        gb = GnuCashBook(str(test_book))
+        with _Counter(gb) as c:
+            out = gb.list_transactions(account="Assets:Checking", limit=250)
+        assert out.count("\n") >= N
+        assert len(c) < N, (
+            f"{len(c)} statements for list_transactions(account) on a "
+            f"{N}-transaction account — split.transaction is lazy again"
+        )
+
     def test_set_reconcile_state(self, test_book):
         _seed(test_book, "Assets:Checking", "Expenses:Groceries")
         gb = GnuCashBook(str(test_book))
@@ -192,6 +204,7 @@ class TestPrefixAndPreloadChokepoints:
             reconciliation.ReconciliationMixin.get_unreconciled_splits,
             reconciliation.ReconciliationMixin.reconcile_account,
             core.CoreMixin.enter_statement,
+            core.CoreMixin.list_transactions,
         ):
             assert "_preload_account_transactions" in inspect.getsource(
                 method

--- a/tests/test_query_budgets.py
+++ b/tests/test_query_budgets.py
@@ -1,0 +1,198 @@
+"""SQL-statement budgets for the per-account tools.
+
+Whole-tree review (2026-09-04), class 4: release-review finding 8
+made ``_split_prefix_map`` one indexed, mtime-cached query, but three
+callers kept building the map by walking ``book.transactions →
+t.splits`` — one lazy SELECT per transaction — and
+``get_unreconciled_splits`` paid a second head on its sort key
+(``split.transaction`` per split). Measured on the Alex sample
+(1,940 transactions): ~1,940 extra statements per call at each site.
+
+Each test seeds an account with N transactions and asserts the call
+stays well under N statements; the pre-fix shape scales with N, the
+fixed shape does not. Thresholds were calibrated by MEASURING the
+fixed and mutated counts with N=80 — get_unreconciled_splits 7 vs
+172 statements, set_reconcile_state 14 vs 96, get_lot 12 vs 92, and
+bulk reconcile_account 1 vs 82 SELECTs on the transactions table
+(its total is dominated by legitimate per-row writes and piecash's
+flush validation) — and sit between them. The structural test keeps the sites on the helpers.
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import piecash
+import pytest
+from sqlalchemy import event
+
+from gnucash_mcp.book import GnuCashBook
+
+N = 80
+
+
+def _seed(book_path: Path, account_name: str, other_name: str) -> None:
+    """Append N transactions between two accounts."""
+    with piecash.open_book(
+        str(book_path), readonly=False, do_backup=False,
+    ) as b:
+        usd = b.default_currency
+        acct = next(a for a in b.accounts if a.fullname == account_name)
+        other = next(a for a in b.accounts if a.fullname == other_name)
+        for i in range(N):
+            b.session.add(piecash.Transaction(
+                currency=usd, description=f"Seed {i}",
+                post_date=date(2024, 3, 1) + timedelta(days=i),
+                splits=[
+                    piecash.Split(account=acct, value=Decimal("-5")),
+                    piecash.Split(account=other, value=Decimal("5")),
+                ],
+            ))
+        b.save()
+
+
+class _Counter:
+    """Count SQL statements across every session a call opens."""
+
+    def __init__(self, gb: GnuCashBook):
+        self.gb = gb
+        self.statements: list[str] = []
+
+    def __enter__(self):
+        real_open = self.gb.open
+        counter = self
+
+        class _Ctx:
+            def __init__(self, ctx):
+                self._ctx = ctx
+
+            def __enter__(self):
+                book = self._ctx.__enter__()
+                self._engine = book.session.get_bind()
+
+                def _record(conn, cursor, statement, parameters,
+                            context, executemany):
+                    counter.statements.append(statement)
+
+                self._record = _record
+                event.listen(self._engine, "before_cursor_execute", _record)
+                return book
+
+            def __exit__(self, *exc):
+                event.remove(
+                    self._engine, "before_cursor_execute", self._record,
+                )
+                return self._ctx.__exit__(*exc)
+
+        self._real_open = real_open
+        self.gb.open = lambda **kw: _Ctx(real_open(**kw))
+        return self
+
+    def __exit__(self, *exc):
+        self.gb.open = self._real_open
+        return False
+
+    def __len__(self):
+        return len(self.statements)
+
+    def selects_from(self, table: str) -> int:
+        """SELECTs whose first column is on ``table`` — the shape a
+        lazy many-to-one load has. A bulk write legitimately issues
+        one UPDATE per row and piecash's flush validation one splits
+        SELECT per touched transaction, so the write budgets are on
+        the lazy loads alone."""
+        return sum(
+            1 for st in self.statements
+            if st.lstrip().upper().startswith(f"SELECT {table.upper()}.")
+        )
+
+
+class TestPerAccountQueryBudgets:
+
+    def test_get_unreconciled_splits_compact(self, test_book):
+        _seed(test_book, "Assets:Checking", "Expenses:Groceries")
+        gb = GnuCashBook(str(test_book))
+        with _Counter(gb) as c:
+            out = gb.get_unreconciled_splits("Assets:Checking", limit=250)
+        assert out.count("\n") >= N
+        assert len(c) < N, (
+            f"{len(c)} statements for get_unreconciled_splits on a "
+            f"{N}-transaction account — per-transaction lazy loads "
+            f"are back (prefix walk or split.transaction sort key)"
+        )
+
+    def test_set_reconcile_state(self, test_book):
+        _seed(test_book, "Assets:Checking", "Expenses:Groceries")
+        gb = GnuCashBook(str(test_book))
+        with gb.open() as b:
+            guid = next(
+                s.guid for a in b.accounts if a.fullname == "Assets:Checking"
+                for s in a.splits if s.reconcile_state != "y"
+            )
+        with _Counter(gb) as c:
+            gb.set_reconcile_state(guid, "c")
+        assert len(c) < N, (
+            f"{len(c)} statements for set_reconcile_state on a "
+            f"{N}-transaction book — the split prefix is walking "
+            f"book.transactions again"
+        )
+
+    def test_reconcile_account_bulk(self, test_book):
+        _seed(test_book, "Assets:Checking", "Expenses:Groceries")
+        gb = GnuCashBook(str(test_book))
+        # opening 1000 + salary 2000 − groceries 150 − N × 5
+        expected = Decimal("2850") - Decimal(5) * N
+        with _Counter(gb) as c:
+            gb.reconcile_account(
+                "Assets:Checking", date(2024, 12, 31), str(expected),
+                reconcile_all=True,
+            )
+        n_txn = c.selects_from("transactions")
+        assert n_txn < N // 4, (
+            f"{n_txn} transactions SELECTs for bulk reconcile_account "
+            f"on a {N}-transaction account — split.transaction is "
+            f"lazy again (expected ~1: the account preload)"
+        )
+
+    def test_get_lot(self, investment_book):
+        _seed(investment_book, "Assets:Checking", "Income:Capital Gains")
+        gb = GnuCashBook(str(investment_book))
+        lot = gb.create_lot("Assets:Investments:VTSAX", title="L")
+        with _Counter(gb) as c:
+            gb.get_lot(lot["guid"])
+        assert len(c) < N, (
+            f"{len(c)} statements for get_lot on a {N}-transaction "
+            f"book — the split prefix is walking book.transactions again"
+        )
+
+
+class TestPrefixAndPreloadChokepoints:
+    """Structural lock: the sites stay on the shared helpers."""
+
+    def test_no_split_walks_at_the_fixed_sites(self):
+        from gnucash_mcp.book import investments, reconciliation
+
+        walk = "for txn in book.transactions for s in txn.splits"
+        for method in (
+            reconciliation.ReconciliationMixin.set_reconcile_state,
+            reconciliation.ReconciliationMixin.get_unreconciled_splits,
+            investments.InvestmentsMixin.get_lot,
+        ):
+            src = inspect.getsource(method)
+            assert walk not in src, method.__name__
+            assert "_split_prefix_map" in src, method.__name__
+
+    def test_account_walks_preload_transactions(self):
+        from gnucash_mcp.book import core, reconciliation
+
+        for method in (
+            reconciliation.ReconciliationMixin.get_unreconciled_splits,
+            reconciliation.ReconciliationMixin.reconcile_account,
+            core.CoreMixin.enter_statement,
+        ):
+            assert "_preload_account_transactions" in inspect.getsource(
+                method
+            ), method.__name__


### PR DESCRIPTION
## Summary

Four bug classes from the whole-tree review (`specs/v1.5/review/CODE_REVIEW_WHOLE_TREE_2026-09-04.md`, spec commit pending). Every finding was reproduced by script before it was fixed, and every lock was watched failing under mutation.

- **Owner resolution is job- and voucher-aware at seven sites.** `invoices.owner_guid` names a Job on job-attached documents and an Employee on vouchers; hand-rolled `owner_type == 4` / `owner_guid == guid` dropped both. Post and pay descriptions were `Invoice NNN` or the **empty string**; the dashboard overdue warning mislabeled the type and lost the name; `list_documents`, `get_outstanding_documents`, and `vendor_spending_report` filters dropped job-attached documents; `delete_customer` succeeded with a job and a **posted** job-attached invoice on the books. New `_document_owner_clause` is the single SQL filter (`_find_invoice` routes through it too); the name lookups use `_find_invoice_owner_by_guid`. `delete_employee` gains the voucher guard it never had.
- **`_to_decimal` raises `ValueError`, never `InvalidOperation`.** One `$10` cell sank a whole `create_transactions` batch as `unexpected_error` and `on_error="skip"` could not rescue it; now a per-row rejection naming the cell. NaN and infinity reject too.
- **A credit note keeps its `applies_to` link across unpost.** The posting-transaction delete swept it; only the identity flag was being restored. The link is a FRAME row plus a child, both rebuilt via Core with paired `_verify_*`.
- **Query budgets.** Three callers never migrated to the cached `_split_prefix_map`; the register view lazy-loaded three things per row. Alex sample, statements per call: `get_unreconciled_splits` 3,140 → 33, `set_reconcile_state` 1,964 → 24, `get_lot` 1,955 → 14, `list_transactions(account=…)` 1,351 → 84.

Behavior changes to note: `delete_customer` / `delete_vendor` now refuse when the party has a bare job (the message points at `delete_job`); `delete_employee` refuses with vouchers.

## Test plan

- [x] Full suite green before each commit (2,202 at HEAD), exit code read from a file
- [x] New locks: `tests/test_owner_resolution.py`, `tests/test_query_budgets.py`, new classes in `test_float_precision.py` and `test_business.py`; each verified by mutation
- [x] Review verification script: all class 1–4 verdicts flip from CONFIRMED to REFUTED on this branch
- [ ] Bookkeeper loop on a business persona: post + pay a voucher and a job-attached invoice with default descriptions; `get_outstanding_documents(customer_id=…)` on a job customer; attempt `delete_party` on a customer with a job
- [ ] Bookkeeper loop: a batch with one typo'd amount cell under `on_error="skip"`
