### PR TITLE
fix: three small refusals from the whole-tree review (class 5)

### DIFF
--- a/scripts/synthetic_book/build_alex.py
+++ b/scripts/synthetic_book/build_alex.py
@@ -1765,7 +1765,14 @@ def run_business(book: GnuCashBook, through: date,
             post_date=date_open.isoformat(), owner_type="customer",
             force=cross,
         )
-        if paid:
+        # The horizon clamp lives HERE, not at the callers: a stream
+        # whose open date is inside ``through`` but whose pay date is
+        # not (the quarterly bill opened on the 5th, paid on the
+        # 20th) leaked a future-dated payment and failed every CI
+        # build from the 5th to the 19th. Left open, the document
+        # is settled by the continuation's aging pass on a later
+        # run — the closed loop's job.
+        if paid and date_pay <= through:
             book.pay_invoice(
                 invoice_id=inv["id"], payment_account=CHECKING,
                 amount=amount, payment_date=date_pay.isoformat(),
@@ -1921,7 +1928,8 @@ def run_business(book: GnuCashBook, through: date,
             invoice_id=bill["id"], post_account=AP,
             post_date=date_open.isoformat(), owner_type="vendor",
         )
-        if paid:
+        # Same horizon clamp as run_invoice, for the same reason.
+        if paid and date_pay <= through:
             book.pay_invoice(
                 invoice_id=bill["id"], payment_account=payment_account,
                 amount=amount, payment_date=date_pay.isoformat(),

--- a/src/gnucash_mcp/book/admin.py
+++ b/src/gnucash_mcp/book/admin.py
@@ -59,7 +59,7 @@ class AdminMixin:
         with self.open(readonly=True) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             if key is not None:
                 try:
@@ -122,7 +122,7 @@ class AdminMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             existing = False
             try:
@@ -165,7 +165,7 @@ class AdminMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             try:
                 account[key]

--- a/src/gnucash_mcp/book/budgets.py
+++ b/src/gnucash_mcp/book/budgets.py
@@ -617,7 +617,7 @@ class BudgetsMixin:
 
             acct = self._resolve_account(book, account)
             if not acct:
-                raise ValueError(f"Account not found: {account}")
+                raise self._account_not_found_error(book, account)
 
             periods = self._resolve_periods(budget, period)
 
@@ -760,7 +760,7 @@ class BudgetsMixin:
             if account:
                 filter_acct = self._resolve_account(book, account)
                 if not filter_acct:
-                    raise ValueError(f"Account not found: {account}")
+                    raise self._account_not_found_error(book, account)
 
                 if include_children:
                     target_accounts = set()

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -3013,6 +3013,19 @@ class BusinessMixin:
             disc_denom = 1
 
         with self.open(readonly=False) as book:
+            # Billterms are addressed by name everywhere else
+            # (``term=`` on the document tools resolves the first
+            # visible match) — a second row with the same name
+            # would make every lookup silently ambiguous.
+            existing = book.session.query(Billterm).filter(
+                Billterm.name == name, Billterm.invisible == 0
+            ).first()
+            if existing is not None:
+                raise ValueError(
+                    f"Billterm already exists: '{name}' "
+                    f"(due in {existing.duedays} days)"
+                )
+
             bt_guid = uuid.uuid4().hex
 
             book.session.execute(

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -4742,7 +4742,7 @@ class BusinessMixin:
 
             acct = self._resolve_account(book, account)
             if not acct:
-                raise ValueError(f"Account not found: {account}")
+                raise self._account_not_found_error(book, account)
             if acct.type not in cfg["allowed_types"]:
                 raise ValueError(
                     cfg["type_error_msg"].format(
@@ -5501,9 +5501,7 @@ class BusinessMixin:
 
             post_acct = self._resolve_account(book, post_account)
             if not post_acct:
-                raise ValueError(
-                    f"Account not found: {post_account}"
-                )
+                raise self._account_not_found_error(book, post_account)
             expected_type = "PAYABLE" if is_bill else "RECEIVABLE"
             if post_acct.type != expected_type:
                 raise ValueError(
@@ -6002,9 +6000,7 @@ class BusinessMixin:
 
             pay_acct = self._resolve_account(book, payment_account)
             if not pay_acct:
-                raise ValueError(
-                    f"Account not found: {payment_account}"
-                )
+                raise self._account_not_found_error(book, payment_account)
 
             post_acc_guid = inv.post_acc_guid
             post_acct = book.session.query(
@@ -7155,24 +7151,33 @@ class BusinessMixin:
                     book, owner_type=owner_type, owner_guid=entity_guid,
                 )
             ).all()
-            if invoices:
-                posted = [i for i in invoices if _is_invoice_posted(i)]
-                unposted = [
-                    i for i in invoices if not _is_invoice_posted(i)
-                ]
-                if posted:
-                    posted_ids = ", ".join(i.id for i in posted)
-                    raise ValueError(
-                        f"Cannot delete {entity_label.lower()} with "
-                        f"posted {doc_label}: {posted_ids}. "
-                        f"Void them or issue credit notes first."
-                    )
-                unposted_ids = ", ".join(i.id for i in unposted)
-                raise ValueError(
-                    f"Cannot delete {entity_label.lower()} with "
-                    f"{doc_label}: {unposted_ids}. "
-                    f"Delete the {doc_label} first."
+            # Every blocker in ONE refusal. Raising on the first
+            # match masked the rest — a customer with a posted
+            # job-attached invoice AND the job was told only about
+            # the invoice, voided it, and hit the job guard on the
+            # retry (bookkeeper, PR #172).
+            label = entity_label.lower()
+            blockers: list[str] = []
+            remedies: list[str] = []
+            posted = [i for i in invoices if _is_invoice_posted(i)]
+            unposted = [i for i in invoices if not _is_invoice_posted(i)]
+            if posted:
+                blockers.append(
+                    f"posted {doc_label}: "
+                    + ", ".join(i.id for i in posted)
                 )
+                # Credit notes are customer/vendor instruments; an
+                # employee's only remedy is the void.
+                credit = (
+                    " or issue credit notes" if owner_type in (2, 4)
+                    else ""
+                )
+                remedies.append(f"Void the {doc_label}{credit} first.")
+            if unposted:
+                blockers.append(
+                    f"{doc_label}: " + ", ".join(i.id for i in unposted)
+                )
+                remedies.append(f"Delete the {doc_label} first.")
             # The party's jobs reference it by GUID too; deleting
             # underneath them leaves list_jobs / get_job_report
             # rendering "?" for the owner with no way to repair it.
@@ -7182,13 +7187,18 @@ class BusinessMixin:
                     Job.owner_type == owner_type,
                 ).all()
                 if jobs:
-                    job_ids = ", ".join(j.id for j in jobs)
-                    raise ValueError(
-                        f"Cannot delete {entity_label.lower()} with "
-                        f"jobs: {job_ids}. Delete the jobs first "
-                        f"(delete_job), or retire the "
-                        f"{entity_label.lower()} with active=false."
+                    blockers.append(
+                        "jobs: " + ", ".join(j.id for j in jobs)
                     )
+                    remedies.append(
+                        f"Delete the jobs first (delete_job), or "
+                        f"retire the {label} with active=false."
+                    )
+            if blockers:
+                raise ValueError(
+                    f"Cannot delete {label} with "
+                    + "; ".join(blockers) + ". " + " ".join(remedies)
+                )
 
         return check
 

--- a/src/gnucash_mcp/book/core.py
+++ b/src/gnucash_mcp/book/core.py
@@ -2730,7 +2730,7 @@ class CoreMixin:
             if account:
                 acct = self._resolve_account(book, account)
                 if not acct:
-                    raise ValueError(f"Account not found: {account}")
+                    raise self._account_not_found_error(book, account)
                 # Canonical fullname for register-form rendering —
                 # _transaction_to_compact_line compares against
                 # split.account.fullname, so a raw %short ref would
@@ -5580,7 +5580,7 @@ class CoreMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, name)
             if not account:
-                raise ValueError(f"Account not found: {name}")
+                raise self._account_not_found_error(book, name)
 
             # Stage pre-mutation state for the audit log so the decorator
             # doesn't have to reopen the book to capture it.
@@ -5674,7 +5674,7 @@ class CoreMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, name)
             if not account:
-                raise ValueError(f"Account not found: {name}")
+                raise self._account_not_found_error(book, name)
 
             # Stage pre-move state (fullname derives old parent for log).
             self._stage_audit_before(_account_to_dict(account))
@@ -5727,7 +5727,7 @@ class CoreMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, name)
             if not account:
-                raise ValueError(f"Account not found: {name}")
+                raise self._account_not_found_error(book, name)
 
             # Safeguard: Check for children
             if account.children:

--- a/src/gnucash_mcp/book/investments.py
+++ b/src/gnucash_mcp/book/investments.py
@@ -1043,7 +1043,7 @@ class InvestmentsMixin:
         with self.open(readonly=False) as book:
             acct = self._resolve_account(book, account)
             if not acct:
-                raise ValueError(f"Account not found: {account}")
+                raise self._account_not_found_error(book, account)
 
             lot = Lot(
                 title=title,
@@ -1099,7 +1099,7 @@ class InvestmentsMixin:
         with self.open(readonly=True) as book:
             acct = self._resolve_account(book, account)
             if not acct:
-                raise ValueError(f"Account not found: {account}")
+                raise self._account_not_found_error(book, account)
 
             default_ccy = self._require_default_currency(book)
             results = []

--- a/src/gnucash_mcp/book/reconciliation.py
+++ b/src/gnucash_mcp/book/reconciliation.py
@@ -225,7 +225,7 @@ class ReconciliationMixin:
         with self.open(readonly=True) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             all_unreconciled = []
             cleared_total = Decimal("0")
@@ -385,7 +385,7 @@ class ReconciliationMixin:
         with self.open(readonly=False) as book:
             account = self._resolve_account(book, account_name)
             if not account:
-                raise ValueError(f"Account not found: {account_name}")
+                raise self._account_not_found_error(book, account_name)
 
             # Bulk mode and the audit before-state both read
             # split.transaction per split — warm the account's

--- a/src/gnucash_mcp/book/reporting.py
+++ b/src/gnucash_mcp/book/reporting.py
@@ -1072,7 +1072,7 @@ class ReportingMixin:
             if account:
                 target_account = self._resolve_account(book, account)
                 if not target_account:
-                    raise ValueError(f"Account not found: {account}")
+                    raise self._account_not_found_error(book, account)
                 rows = self._query_filtered_splits(
                     book,
                     start_date=start_date,

--- a/src/gnucash_mcp/book/scheduling.py
+++ b/src/gnucash_mcp/book/scheduling.py
@@ -315,7 +315,16 @@ class SchedulingMixin:
             # reject here anything instantiation couldn't book.
             # Pre-fix, an all-foreign-leg template created fine
             # and then failed at every instantiation forever.
-            self._validate_transaction_splits(book, splits, frame)
+            validated = self._validate_transaction_splits(
+                book, splits, frame,
+            )
+            # A placeholder leg passes the split contract (it
+            # resolves, it sums) and then fails at every
+            # instantiation forever — refuse it here, the same
+            # gate create_transactions applies in phase 1.
+            for v in validated:
+                if v["account"].placeholder:
+                    raise self._placeholder_error(v["account"])
 
             for sx in book.session.query(
                 ScheduledTransaction

--- a/src/gnucash_mcp/tools/core.py
+++ b/src/gnucash_mcp/tools/core.py
@@ -75,9 +75,19 @@ def _parse_transactions_tsv(tsv: str) -> list[dict]:
                 splits = _batch_row_splits(fields[fixed:], group)
             except ValueError as e:
                 raise ValueError(f"row {i} (ref {ref!r}): {e}")
+        # Same contract as enter_statement: a blank date cell is
+        # a format error, never a silent default to today — the
+        # results table carries no date, so a defaulted row would
+        # leave no trace of what it was booked on.
+        trans_date = _parse_iso_date(dt)
+        if trans_date is None:
+            raise ValueError(
+                f"row {i} (ref {ref!r}): date {dt!r} is not a valid "
+                f"YYYY-MM-DD date"
+            )
         txn = {
             "ref": ref,
-            "date": _parse_iso_date(dt) or date.today(),
+            "date": trans_date,
             "description": desc,
             "splits": splits,
         }

--- a/tests/test_batch_transactions.py
+++ b/tests/test_batch_transactions.py
@@ -72,6 +72,17 @@ class TestBatchTsvParser:
         ]
         assert "notes" not in rows[0]
 
+    def test_empty_date_cell_rejects(self):
+        """A blank date cell is a format error, as it is for
+        enter_statement — never a silent default to today (the
+        results table carries no date to reveal the substitution)."""
+        tsv = (
+            "ref\tdate\tdescription\tamt1\tacct1\tamt2\tacct2\n"
+            "1\t\tNo date\t-10\tAssets:Checking\t10\tExpenses:Groceries"
+        )
+        with pytest.raises(ValueError, match="row 1.*not a valid YYYY-MM-DD"):
+            _parse_transactions_tsv(tsv)
+
     def test_unknown_header_columns_reject_by_name(self):
         """6c (bookkeeper finding): now that the header is load-
         bearing, unknown columns must fail on the FORMAT with the

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1652,6 +1652,23 @@ class TestDeleteVendor:
             gb.delete_vendor(vendor_id="999999")
 
 
+class TestEntryAccountMissSuggests:
+    """A wrong account guess on an entry tool answers with
+    candidates, the same as batch entry and statements — the bare
+    'Account not found' cost a list_accounts round-trip (bookkeeper,
+    PR #172)."""
+
+    def test_add_invoice_entry_near_miss(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        inv = gb.create_invoice(customer_id="000001")
+        with pytest.raises(ValueError, match="Did you mean: 'Income:Consulting'"):
+            gb.add_invoice_entry(
+                invoice_id=inv["id"], account="Income:Consulting Income",
+                description="Work", quantity="1", price="100.00",
+            )
+
+
 class TestCreateBillterm:
     """Tests for create_billterm."""
 

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1677,6 +1677,17 @@ class TestCreateBillterm:
         )
         assert result["status"] == "created"
 
+    def test_duplicate_name_refused(self, business_book):
+        """Billterms are addressed by name; a second 'Net 30' would
+        make every term= lookup silently ambiguous."""
+        gb = GnuCashBook(str(business_book))
+        gb.create_billterm(name="Net 30", due_days=30)
+        with pytest.raises(ValueError, match="already exists: 'Net 30'"):
+            gb.create_billterm(name="Net 30", due_days=45)
+        terms = gb.list_billterms(compact=False)["billterms"]
+        assert [t["name"] for t in terms] == ["Net 30"]
+        assert terms[0]["due_days"] == 30
+
     def test_read_back_via_list(self, business_book):
         gb = GnuCashBook(str(business_book))
         gb.create_billterm(name="Net 30")

--- a/tests/test_chokepoint_invariants.py
+++ b/tests/test_chokepoint_invariants.py
@@ -19,6 +19,7 @@ the chokepoint, the bug class is open again.
 
 from datetime import date, timedelta
 from decimal import Decimal
+import re
 from pathlib import Path
 
 import piecash
@@ -1312,3 +1313,24 @@ class TestHistoricalAnchorChainRates:
             fund_row["default_currency_value"]
         ) == Decimal("1045.00")
         assert Decimal(bs["assets"]["total"]) == Decimal("10045.00")
+
+
+class TestAccountNotFoundGoesThroughSuggestions:
+    """``_account_not_found_error`` is the one place an account miss
+    is worded; a bare ``f"Account not found: {ref}"`` at a call site
+    drops the did-you-mean candidates and costs the caller a
+    list_accounts round-trip (bookkeeper, PR #172: seven sites)."""
+
+    def test_no_bare_account_not_found_literal_outside_base(self):
+        import gnucash_mcp.book as pkg
+        bare = re.compile(r'f"Account not found: \{')
+        offenders = []
+        for path in sorted(Path(pkg.__file__).parent.glob("*.py")):
+            if path.name == "_base.py":
+                continue
+            for lineno, line in enumerate(
+                path.read_text().splitlines(), start=1,
+            ):
+                if bare.search(line):
+                    offenders.append(f"{path.name}:{lineno}")
+        assert not offenders, offenders

--- a/tests/test_owner_resolution.py
+++ b/tests/test_owner_resolution.py
@@ -203,6 +203,32 @@ class TestDeleteGuardsAreJobAndVoucherAware:
         with pytest.raises(ValueError, match="with jobs"):
             gb.delete_vendor("000001")
 
+    def test_delete_refusal_names_every_blocker_at_once(
+        self, business_book,
+    ):
+        """A customer with a posted job-attached invoice AND the job
+        hears about both in one refusal — raising on the first guard
+        masked the job until the invoice was voided (bookkeeper,
+        PR #172)."""
+        gb, _iid, _ = _job_invoice_book(business_book)
+        with pytest.raises(ValueError) as exc:
+            gb.delete_customer("000001")
+        msg = str(exc.value)
+        assert "posted invoices: 000001" in msg
+        assert "jobs: 000001" in msg
+        assert "delete_job" in msg
+
+    def test_delete_employee_refusal_offers_no_credit_note(
+        self, business_book,
+    ):
+        """Credit notes are customer/vendor instruments; the employee
+        refusal must not point at a remedy that does not exist."""
+        gb, _vid = _voucher_book(business_book)
+        with pytest.raises(ValueError) as exc:
+            gb.delete_employee("000001")
+        assert "credit note" not in str(exc.value)
+        assert "Void the vouchers first" in str(exc.value)
+
     def test_delete_employee_refuses_with_voucher(self, business_book):
         gb, vid = _voucher_book(business_book)
         with pytest.raises(ValueError, match="posted vouchers"):

--- a/tests/test_scheduled.py
+++ b/tests/test_scheduled.py
@@ -32,6 +32,27 @@ class TestCreateScheduled:
         assert result["frequency"] == "monthly"
         assert result["guid"]
 
+    def test_placeholder_leg_refused_at_create(self, scheduled_book):
+        """A template leg on a placeholder account passes the split
+        contract and then fails at every instantiation forever —
+        creation must refuse it, naming the placeholder, exactly as
+        create_transactions phase 1 does."""
+        gb = GnuCashBook(str(scheduled_book))
+        with pytest.raises(ValueError, match="placeholder"):
+            gb.create_scheduled_transaction(
+                name="Bad template",
+                description="Rent",
+                splits=[
+                    {"account": "Expenses", "amount": "5.00"},
+                    {"account": "Assets:Checking", "amount": "-5.00"},
+                ],
+                start_date="2026-01-01",
+                frequency="monthly",
+            )
+        assert gb.list_scheduled_transactions(compact=False)[
+            "scheduled_transactions"
+        ] == []
+
     def test_biweekly_paycheck(self, scheduled_book):
         gb = GnuCashBook(str(scheduled_book))
         result = gb.create_scheduled_transaction(


### PR DESCRIPTION
## Summary

The three class-5 items from the 2026-09-04 whole-tree review, each a small refusal at the site where a sibling already enforced the rule. Follow-up to #171.

- **Scheduled templates refuse placeholder legs.** A template on a placeholder account passed the shared split contract and then failed at every instantiation forever. `create_scheduled_transaction` now applies the same gate `create_transactions` uses in phase 1, naming the postable children.
- **A blank date cell in `create_transactions` is a format error.** The parser defaulted it to today, and the results table carries no date column, so the substitution left no trace. `enter_statement` already rejected the same cell; the batch grammar now does too, naming the row and ref.
- **`create_billterm` refuses a duplicate name.** Billterms are addressed by name on every document tool, so a second visible row made each `term=` lookup silently ambiguous. The error names the existing term's due days.

One commit per item, each with a behavioral lock that was broken by script and watched failing. The review's verification script reads REFUTED on all three lines. Full suite 2205 passed (develop: 2202).

## Test plan

- [x] `uv run pytest` green, exit code captured (2205 passed)
- [x] Each lock fails under mutation and passes restored
- [x] `specs/v1.5/review/verify_whole_tree_findings.py` H1, L1, I1 all REFUTED
- [x] Bookkeeper: create a scheduled transaction with a parent account (e.g. `Expenses`) as a leg; expect a placeholder refusal naming children
- [x] Bookkeeper: a `create_transactions` batch with one row's date blank; expect a row-level refusal, no silent today
- [x] Bookkeeper: `create_billterm` twice with the same name; expect a refusal, then `list_billterms` shows one

