### PR TITLE
refactor(modules): one business module, party_type, payment state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Entries are terse by design: what changed, one line each, PR numbers where they 
 ## Unreleased
 
 ### Changed
+- `--modules=bookkeeper` is everything except business: `tax_lots` and `portfolio` join `reporting`, `budgets`, and `scheduling`. The MCPB bundle's always-on base is now defined as this group rather than a parallel list. `investor` remains selectable on its own.
 - `--modules=business` is one module. The `freelancer` / `business_complete` split reduced to a runtime gate on `owner_type` plus one report once the party and document tools went polymorphic; both halves merged into the single `business` leaf and the gate is gone. The retired names are still accepted on `--modules` / `GNUCASH_MCP_MODULES` and resolve to `business`, so existing config files keep starting the server. A stored `GNUCASH_ENABLE_FREELANCER=true` from a pre-#163 bundle install now unlocks the whole business suite.
 
 ## v1.4.4 - The statement is the call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Entries are terse by design: what changed, one line each, PR numbers where they 
 - `get_document` carries `status` (open / posted / paid) and, once posted, `amount_paid` and `amount_due`; a paid document keeps its amounts after leaving the unpaid list. `pay_document` reports the per-call `payment` beside a cumulative `total_paid` (the old `amount_paid` read as the only payment on a second partial). One chokepoint, `_document_settlement`, now feeds both and `get_outstanding_documents`.
 - `apply_credit_note`, `create_job`, and `list_jobs` take `party_type`, the name the other twenty-two business tools use; `owner_type` no longer appears on any tool.
 - The document ID-collision error names `document_type` and `party_type`; it used to coach a parameter no tool exposes.
+- Every amount on `get_document`, `pay_document`, and `get_outstanding_documents` leaves at the commodity's quantum (250.00 beside 200.00, not 250); the pay audit line inherits it.
+- `create_job`, `list_jobs`, and `get_job_report` answer `party_type`, the same name they accept, so the field a client is handed round-trips.
+- Audit CREATE lines for invoices, bills, vouchers, credit notes, and jobs render the counterparty as `Name (id)`; older entries keep the bare id.
+- A credit note at zero balance reports `status: applied` on `get_document`; it settles by application, not cash.
 
 ## v1.4.4 - The statement is the call
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Entries are terse by design: what changed, one line each, PR numbers where they exist. Rationale lives in the PRs, the specs, and the bookkeeper rulings recorded under `specs/`.
 
+## Unreleased
+
+### Changed
+- `--modules=business` is one module. The `freelancer` / `business_complete` split reduced to a runtime gate on `owner_type` plus one report once the party and document tools went polymorphic; both halves merged into the single `business` leaf and the gate is gone. The retired names are still accepted on `--modules` / `GNUCASH_MCP_MODULES` and resolve to `business`, so existing config files keep starting the server. A stored `GNUCASH_ENABLE_FREELANCER=true` from a pre-#163 bundle install now unlocks the whole business suite.
+
 ## v1.4.4 - The statement is the call
 
 A complete bank statement enters, claims its matches, and reconciles in one atomic call; every consequential write now rehearses before it books; a one-click Claude Desktop bundle ships from the project's first CI. (v1.4.3 was never released on GitHub — that number belongs to a registry-side rebuild.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Entries are terse by design: what changed, one line each, PR numbers where they 
 ### Changed
 - `--modules=bookkeeper` is everything except business: `tax_lots` and `portfolio` join `reporting`, `budgets`, and `scheduling`. The MCPB bundle's always-on base is now defined as this group rather than a parallel list. `investor` remains selectable on its own.
 - `--modules=business` is one module. The `freelancer` / `business_complete` split reduced to a runtime gate on `owner_type` plus one report once the party and document tools went polymorphic; both halves merged into the single `business` leaf and the gate is gone. The retired names are still accepted on `--modules` / `GNUCASH_MCP_MODULES` and resolve to `business`, so existing config files keep starting the server. A stored `GNUCASH_ENABLE_FREELANCER=true` from a pre-#163 bundle install now unlocks the whole business suite.
+- `get_document` carries `status` (open / posted / paid) and, once posted, `amount_paid` and `amount_due`; a paid document keeps its amounts after leaving the unpaid list. `pay_document` reports the per-call `payment` beside a cumulative `total_paid` (the old `amount_paid` read as the only payment on a second partial). One chokepoint, `_document_settlement`, now feeds both and `get_outstanding_documents`.
+- `apply_credit_note`, `create_job`, and `list_jobs` take `party_type`, the name the other twenty-two business tools use; `owner_type` no longer appears on any tool.
+- The document ID-collision error names `document_type` and `party_type`; it used to coach a parameter no tool exposes.
 
 ## v1.4.4 - The statement is the call
 

--- a/specs/v1.5/testing/BOOKKEEPER_REPORT_MODULE_MERGE.md
+++ b/specs/v1.5/testing/BOOKKEEPER_REPORT_MODULE_MERGE.md
@@ -1,0 +1,60 @@
+# Bookkeeper loop: refactor/merge-business-modules
+
+Three rounds on Alex (`samples/alex-chen-morales.gnucash`), server
+bounced onto the branch before each. All three closed clean; the
+bookkeeper's final word was "ship it". Probe data was left in the
+sample book and is removed by `git restore` on the sample.
+
+## Round 1: module realignment
+
+- `--modules=bookkeeper`: 60 tools reported (59 plus `switch_book`
+  on a multi-book config). core[9 sub-modules] plus
+  bookkeeper[budgets, portfolio, reporting, scheduling, tax_lots].
+  The 27 business tools absent from the client, not gated.
+- Lot path end to end (create_lot, create_transactions with qty,
+  assign_split_to_lot, calculate_lot_gain, get_lot), the sequence
+  the old gate refused. Clean.
+- `--modules=business`: 57 tools (30 core, 27 business); every
+  bookkeeper tool gone from the client. Vendor bill and employee
+  voucher end to end, partial and final payments, unpost refusal
+  with payments applied. Audit labels correct throughout.
+
+Findings, all fixed on the branch: the ID-collision error coached
+`owner_type`, a parameter no document tool exposes; `get_document`
+carried no payment state; `pay_document`'s `amount_paid` was per
+call, not cumulative. One out-of-scope bug hashbanged:
+`delete_transaction` silently orphans a lot-assigned split.
+
+## Round 2: the fixes
+
+- Payment state on `get_document` for a bill and a voucher: open
+  with no amounts; posted with paid 0 and full due; partial; paid
+  and still legible after leaving the unpaid list; agreement with
+  `get_outstanding_documents` to the character.
+- Audit PAY lines carry `total paid`.
+- Three-way ID collision (invoice, bill, voucher on 000010): error
+  names `document_type` and `party_type`; following it literally
+  resolved without a schema rejection.
+- `create_job` / `list_jobs` / `apply_credit_note` with
+  `party_type`; `owner_type` rejected at the schema.
+
+Findings, all fixed on the branch: amount_due and remaining_balance
+unpadded beside padded paid totals; job responses echoed
+`owner_type`. Rulings taken: CREATE audit lines render the
+counterparty as `Name (id)`; a settled credit note reads `applied`.
+
+## Round 3: the round-two fixes and rulings
+
+- Every settlement amount at two places on pay and get.
+- CREATE BILL, CREATE CREDIT NOTE, CREATE JOB lines render
+  `Name (id)`.
+- Job response carries `party_type` and `owner_name`, no
+  `owner_type`.
+- Credit note applied in full reads `applied`; its target invoice
+  still reads `posted` with the applied amount as `amount_paid`.
+
+Routed around: nothing. Residual, not a blocker: entry rows inside
+`get_document` still render `price: 450 / total: 450` under a
+document total of `450.00`. A unit price may carry more precision
+than the currency quantum, so this needs a small design call
+rather than a blind quantize; deferred.

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1494,8 +1494,11 @@ class BusinessMixin:
             candidates.append(f"{label} (currency={currency})")
         raise ValueError(
             f"Found {len(matches)} documents with ID {invoice_id!r}: "
-            f"{', '.join(candidates)}. Pass owner_type='customer', "
-            f"'vendor', or 'employee' to disambiguate."
+            f"{', '.join(candidates)}. Narrow the lookup with "
+            f"document_type ('invoice', 'bill', or 'voucher') or the "
+            f"party side ('customer', 'vendor', or 'employee' via "
+            f"party_type; owner_type on apply_credit_note and the job "
+            f"tools)."
         )
 
     @staticmethod

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -4259,6 +4259,8 @@ class BusinessMixin:
             return {
                 "id": doc_id,
                 config["owner_id_key"]: owner_id,
+                # The audit CREATE line renders ``Name (id)`` from this.
+                "owner_name": getattr(owner, "name", None),
                 "date_opened": str(open_date.date()),
                 "status": "created",
             }
@@ -5347,7 +5349,13 @@ class BusinessMixin:
                     result["status"] = "posted"
                 else:
                     due = settlement["amount_due"]
-                    result["status"] = "paid" if due <= 0 else "posted"
+                    # A credit note settles by being applied, never
+                    # by cash: "applied" is the truer word for it.
+                    settled = (
+                        "applied" if self._get_is_credit_note(inv)
+                        else "paid"
+                    )
+                    result["status"] = settled if due <= 0 else "posted"
                     result["amount_paid"] = str(settlement["amount_paid"])
                     result["amount_due"] = str(due)
                     if settlement["overpaid"]:
@@ -7487,6 +7495,7 @@ class BusinessMixin:
                 "reference": reference,
                 "active": True,
                 "party_type": owner_type,
+                "owner_name": owner.name,
                 "status": "created",
             }
 

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1611,7 +1611,9 @@ class BusinessMixin:
             "name": job.name,
             "reference": job.reference or "",
             "active": bool(job.active),
-            "owner_type": (
+            # ``party_type``: the tool-surface name (create_job takes
+            # party_type), so the field a client is handed round-trips.
+            "party_type": (
                 "customer" if job.owner_type == 2 else "vendor"
             ),
             "owner_name": owner_name,
@@ -1753,9 +1755,9 @@ class BusinessMixin:
         underlying counterparty via ``_find_invoice_owner_by_guid``.
         """
         if invoice.owner_type == 3 and job is not None:
-            # job['owner_type'] is the string form from the caller.
+            # job['party_type'] is the string form from the caller.
             type_field = (
-                "invoice" if job.get("owner_type") == "customer"
+                "invoice" if job.get("party_type") == "customer"
                 else "bill"
             )
         else:
@@ -2264,11 +2266,17 @@ class BusinessMixin:
         if lot_obj is None:
             return None
         balance = self._calculate_lot_balance(lot_obj)
-        amount_due = -balance if (is_bill ^ is_credit_note) else balance
+        # Every amount leaves here at the lot commodity's quantum, so
+        # paid/due/total read alike (250.00, not 250 beside 200.00)
+        # on every surface and in the audit line that echoes them.
+        quantum = _commodity_quantum(post_acct.commodity)
+        amount_due = (
+            -balance if (is_bill ^ is_credit_note) else balance
+        ).quantize(quantum)
         try:
             grand_total = self._get_invoice_entries_and_total(
                 book, inv,
-            )["grand_total"]
+            )["grand_total"].quantize(quantum)
         except ValueError:
             grand_total = max(amount_due, Decimal("0"))
         # Signed arithmetic keeps amount_paid honest when overpaid:
@@ -6527,7 +6535,7 @@ class BusinessMixin:
             if dry_run:
                 remaining_after = (
                     remaining_before_pay - full_settle_amount
-                )
+                ).quantize(_commodity_quantum(inv.currency))
                 result = {
                     "dry_run": True,
                     "id": inv.id,
@@ -6603,16 +6611,19 @@ class BusinessMixin:
             # abs() a lot balance — if some other path left it
             # negative, a credit must surface as negative rather
             # than masquerade as money owed.
+            quantum = _commodity_quantum(lot_obj.account.commodity)
             remaining_directional = (
                 -remaining if effective_is_bill else remaining
-            )
+            ).quantize(quantum)
             # Cumulative, from the document total: a second partial
             # payment must not read as the only one (the per-call
             # amount is ``payment``).
             try:
-                total_paid = self._get_invoice_entries_and_total(
-                    book, inv,
-                )["grand_total"] - remaining_directional
+                total_paid = (
+                    self._get_invoice_entries_and_total(
+                        book, inv,
+                    )["grand_total"] - remaining_directional
+                ).quantize(quantum)
             except ValueError:
                 total_paid = None
 
@@ -7475,7 +7486,7 @@ class BusinessMixin:
                 "name": name,
                 "reference": reference,
                 "active": True,
-                "owner_type": owner_type,
+                "party_type": owner_type,
                 "status": "created",
             }
 
@@ -8057,7 +8068,7 @@ class BusinessMixin:
             return {
                 "job_id": job.id,
                 "job_name": job.name,
-                "owner_type": owner_type,
+                "party_type": owner_type,
                 "owner_name": owner_name,
                 "linked_invoices_count": len(invoices),
                 "posted_count": posted_count,

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -1495,10 +1495,8 @@ class BusinessMixin:
         raise ValueError(
             f"Found {len(matches)} documents with ID {invoice_id!r}: "
             f"{', '.join(candidates)}. Narrow the lookup with "
-            f"document_type ('invoice', 'bill', or 'voucher') or the "
-            f"party side ('customer', 'vendor', or 'employee' via "
-            f"party_type; owner_type on apply_credit_note and the job "
-            f"tools)."
+            f"document_type ('invoice', 'bill', or 'voucher') or "
+            f"party_type ('customer', 'vendor', or 'employee')."
         )
 
     @staticmethod

--- a/src/gnucash_mcp/book/business.py
+++ b/src/gnucash_mcp/book/business.py
@@ -2225,6 +2225,64 @@ class BusinessMixin:
             posted = posted.date()
         return posted + timedelta(days=30), True
 
+    def _document_settlement(
+        self, book, inv, *, is_bill=None, is_credit_note=None,
+    ) -> dict | None:
+        """Payment state of a POSTED document, read from its A/R or
+        A/P lot. ``None`` when the document is unposted or its lot
+        cannot be found.
+
+        This is the one place paid/due are derived. ``get_invoice``
+        and ``get_outstanding_invoices`` both read from here so the
+        two surfaces agree by construction; ``pay_invoice`` derives
+        ``total_paid`` from the same seam. Callers that already
+        resolved the side may pass ``is_bill`` / ``is_credit_note``
+        to save a Job query.
+
+        Returns a dict of ``post_account``, ``lot``, ``balance``
+        (signed lot balance), ``grand_total``, ``amount_paid``,
+        ``amount_due`` (direction-normalized: positive = still owed,
+        NEGATIVE = overpaid, never abs()'d), and ``overpaid``.
+        """
+        if not _is_invoice_posted(inv):
+            return None
+        if is_credit_note is None:
+            is_credit_note = self._get_is_credit_note(inv)
+        if is_bill is None:
+            is_bill = self._is_bill_side(
+                self._effective_owner_type(book, inv)
+            )
+        post_acct = book.session.query(
+            piecash.Account
+        ).filter_by(guid=inv.post_acc_guid).first()
+        if not post_acct:
+            return None
+        lot_obj = next(
+            (l for l in post_acct.lots if l.guid == inv.post_lot_guid),
+            None,
+        )
+        if lot_obj is None:
+            return None
+        balance = self._calculate_lot_balance(lot_obj)
+        amount_due = -balance if (is_bill ^ is_credit_note) else balance
+        try:
+            grand_total = self._get_invoice_entries_and_total(
+                book, inv,
+            )["grand_total"]
+        except ValueError:
+            grand_total = max(amount_due, Decimal("0"))
+        # Signed arithmetic keeps amount_paid honest when overpaid:
+        # grand 3500, due -1000 -> paid 4500.
+        return {
+            "post_account": post_acct,
+            "lot": lot_obj,
+            "balance": balance,
+            "grand_total": grand_total,
+            "amount_paid": grand_total - amount_due,
+            "amount_due": amount_due,
+            "overpaid": amount_due < 0 and not is_credit_note,
+        }
+
     def _get_invoice_entries_and_total(self, book, inv):
         """Query entries for an invoice/bill and compute totals,
         absorbing per-line tax math (via ``_compute_entry_tax``).
@@ -5269,6 +5327,24 @@ class BusinessMixin:
             )
             result["total"] = str(total)
 
+            # Payment state from the same lot arithmetic the unpaid
+            # list uses, so the two surfaces agree by construction.
+            # open = not yet booked; posted = booked, balance owed;
+            # paid = balance zero (or below: ``overpaid`` flags it).
+            if not _is_invoice_posted(inv):
+                result["status"] = "open"
+            else:
+                settlement = self._document_settlement(book, inv)
+                if settlement is None:
+                    result["status"] = "posted"
+                else:
+                    due = settlement["amount_due"]
+                    result["status"] = "paid" if due <= 0 else "posted"
+                    result["amount_paid"] = str(settlement["amount_paid"])
+                    result["amount_due"] = str(due)
+                    if settlement["overpaid"]:
+                        result["overpaid"] = True
+
             # Forward signal: surface available (or just-expired)
             # early-payment discount so get_invoice is actionable
             # ("save $X by paying before Y") without the caller
@@ -6530,6 +6606,15 @@ class BusinessMixin:
             remaining_directional = (
                 -remaining if effective_is_bill else remaining
             )
+            # Cumulative, from the document total: a second partial
+            # payment must not read as the only one (the per-call
+            # amount is ``payment``).
+            try:
+                total_paid = self._get_invoice_entries_and_total(
+                    book, inv,
+                )["grand_total"] - remaining_directional
+            except ValueError:
+                total_paid = None
 
             result = {
                 "id": inv.id,
@@ -6540,7 +6625,7 @@ class BusinessMixin:
                 "status": (
                     "partial" if remaining_directional > 0 else "paid"
                 ),
-                "amount_paid": str(payment_amount),
+                "payment": str(payment_amount),
                 "remaining_balance": str(remaining_directional),
                 # Transaction GUID emitted as a short prefix —
                 # consumers (e.g. get_transaction lookup) accept
@@ -6552,6 +6637,8 @@ class BusinessMixin:
                 "payment_account": pay_acct.fullname,
                 "payment_date": str(parsed_date),
             }
+            if total_paid is not None:
+                result["total_paid"] = str(total_paid)
             _attach_extras(result)
 
         return result
@@ -7741,44 +7828,20 @@ class BusinessMixin:
                 )
                 is_bill = self._is_bill_side(effective_ot)
 
-                post_acc_guid = inv.post_acc_guid
-                post_acct = book.session.query(
-                    piecash.Account
-                ).filter_by(guid=post_acc_guid).first()
-                if not post_acct:
+                settlement = self._document_settlement(
+                    book, inv, is_bill=is_bill,
+                    is_credit_note=is_credit_note,
+                )
+                # Unposted, lot missing, or settled: not outstanding.
+                if settlement is None or settlement["balance"] == Decimal(0):
                     continue
-
-                lot_obj = None
-                for lot in post_acct.lots:
-                    if lot.guid == inv.post_lot_guid:
-                        lot_obj = lot
-                        break
-                if not lot_obj:
-                    continue
-
-                balance = self._calculate_lot_balance(lot_obj)
-                if balance == Decimal(0):
-                    continue
-
-                # Direction-normalize the signed lot balance to
-                # "amount still owed" (credit notes: credit still
-                # available). NEGATIVE means overpaid — never abs()
-                # it, or an overpaid invoice renders as money owed
-                # and invites double-collection.
-                amount_due = -balance if (is_bill ^ is_credit_note) else balance
-                overpaid = amount_due < 0 and not is_credit_note
-
-                try:
-                    grand_total = self._get_invoice_entries_and_total(
-                        book, inv,
-                    )["grand_total"]
-                except ValueError:
-                    grand_total = max(amount_due, Decimal("0"))
-
-                # Signed arithmetic keeps amount_paid honest in the
-                # overpaid case: grand 3500, due −1000 → paid 4500
-                # (an abs() derivation would show paid 2500).
-                amount_paid = grand_total - amount_due
+                post_acct = settlement["post_account"]
+                lot_obj = settlement["lot"]
+                balance = settlement["balance"]
+                amount_due = settlement["amount_due"]
+                overpaid = settlement["overpaid"]
+                grand_total = settlement["grand_total"]
+                amount_paid = settlement["amount_paid"]
 
                 # Polymorphic owner dispatch — the direct finders
                 # return None on job-attached invoices (owner_guid

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1303,7 +1303,8 @@ def _fmt_job_create(entry: dict) -> list[str]:
     # document tools); owner_type is the book-layer name and what
     # older log entries carry.
     owner_type = (
-        after.get("owner_type")
+        after.get("party_type")
+        or after.get("owner_type")
         or params.get("party_type")
         or params.get("owner_type", "")
     )

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1299,8 +1299,13 @@ def _fmt_job_create(entry: dict) -> list[str]:
     after = entry.get("after_state") or {}
     job_id = after.get("id", "")
     name = after.get("name", params.get("name", ""))
+    # create_job's tool parameter is party_type (unified with the
+    # document tools); owner_type is the book-layer name and what
+    # older log entries carry.
     owner_type = (
-        after.get("owner_type") or params.get("owner_type", "")
+        after.get("owner_type")
+        or params.get("party_type")
+        or params.get("owner_type", "")
     )
     owner_id = params.get("owner_id", "")
     ref = after.get("reference") or params.get("reference", "")

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1287,6 +1287,16 @@ def _fmt_employee_delete(entry: dict) -> list[str]:
     return _fmt_person_delete(entry, "employee", "employee_id")
 
 
+def _party_label(name, party_id) -> str:
+    """``Emerald Analytics (000004)`` when the after-state carries the
+    counterparty's name, bare ``000004`` when it doesn't (entries
+    written before v1.5 have only the id). The audit log is the
+    human-readable surface; an id alone sends the reader to a lookup.
+    """
+    name = (name or "").strip()
+    return f"{name} ({party_id})" if name and party_id else str(party_id)
+
+
 # ── Job formatters ───────────────────────────────────────────
 # Jobs aren't business-persons (no currency/address), so they get
 # their own formatters; the owner surfaces so a reviewer sees the
@@ -1308,11 +1318,11 @@ def _fmt_job_create(entry: dict) -> list[str]:
         or params.get("party_type")
         or params.get("owner_type", "")
     )
-    owner_id = params.get("owner_id", "")
+    owner = _party_label(after.get("owner_name"), params.get("owner_id", ""))
     ref = after.get("reference") or params.get("reference", "")
     lines = [
         f"{time_part}  CREATE JOB  id:{job_id}",
-        f'{_INDENT}name: "{name}"  {owner_type}: {owner_id}',
+        f'{_INDENT}name: "{name}"  {owner_type}: {owner}',
     ]
     if ref:
         lines.append(f"{_INDENT}reference: {ref}")
@@ -1457,7 +1467,8 @@ def _fmt_invoice_create(entry: dict) -> list[str]:
     customer_id = after.get("customer_id", params.get("customer_id", ""))
     return [
         f"{time_part}  CREATE INVOICE  id:{inv_id}",
-        f"{_INDENT}customer: {customer_id}",
+        f"{_INDENT}customer: "
+        f"{_party_label(after.get('owner_name'), customer_id)}",
     ]
 
 
@@ -1762,7 +1773,8 @@ def _fmt_bill_create(entry: dict) -> list[str]:
     vendor_id = after.get("vendor_id", params.get("vendor_id", ""))
     return [
         f"{time_part}  CREATE BILL  id:{bill_id}",
-        f"{_INDENT}vendor: {vendor_id}",
+        f"{_INDENT}vendor: "
+        f"{_party_label(after.get('owner_name'), vendor_id)}",
     ]
 
 
@@ -1816,7 +1828,8 @@ def _fmt_voucher_create(entry: dict) -> list[str]:
     employee_id = after.get("employee_id", params.get("employee_id", ""))
     return [
         f"{time_part}  CREATE VOUCHER  id:{voucher_id}",
-        f"{_INDENT}employee: {employee_id}",
+        f"{_INDENT}employee: "
+        f"{_party_label(after.get('owner_name'), employee_id)}",
     ]
 
 
@@ -1940,7 +1953,10 @@ def _fmt_credit_note_create(entry: dict) -> list[str]:
         or params.get("owner_id", "")
     )
     lines = [f"{time_part}  CREATE CREDIT NOTE  id:{cn_id}"]
-    detail = f"{_INDENT}{owner_type}: {owner_id}"
+    detail = (
+        f"{_INDENT}{owner_type}: "
+        f"{_party_label(after.get('owner_name'), owner_id)}"
+    )
     applies_to = after.get("applies_to")
     if applies_to:
         detail += f"  applies to: {applies_to.get('id', '')}"

--- a/src/gnucash_mcp/logging_config.py
+++ b/src/gnucash_mcp/logging_config.py
@@ -1703,10 +1703,19 @@ def _fmt_invoice_pay(entry: dict) -> list[str]:
 
     lines = [f"{time_part}  PAY INVOICE  id:{params.get('id', '')}"]
     if after:
-        amount = after.get("amount_paid", "")
+        # ``payment`` is the per-call amount (``amount_paid`` in
+        # entries written before v1.5); ``total_paid`` is cumulative.
+        amount = after.get("payment") or after.get("amount_paid", "")
+        total_paid = after.get("total_paid")
         remaining = after.get("remaining_balance", "")
         txn_guid = after.get("transaction_guid") or ""
-        lines.append(f"{_INDENT}paid: {amount}  remaining: {remaining}")
+        if total_paid:
+            lines.append(
+                f"{_INDENT}paid: {amount}  total paid: {total_paid}"
+                f"  remaining: {remaining}"
+            )
+        else:
+            lines.append(f"{_INDENT}paid: {amount}  remaining: {remaining}")
         lines.append(
             f"{_INDENT}from: {params.get('payment_account', '')}  txn:{txn_guid}"
         )

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -98,9 +98,13 @@ MODULE_GROUPS: dict[str, list[str]] = {
         "audit", "backup", "balance_sheet", "diagnostic",
         "reconciliation",
     ],
-    # Personal-finance cluster; members stay separately selectable.
+    # Everything except business: the persona that wants the whole
+    # ledger, reports, planning, and investment surface but never
+    # invoices anyone. Members stay separately selectable, and
+    # ``investor`` remains its own group for the subset.
     "bookkeeper": [
         "reporting", "budgets", "scheduling",
+        "tax_lots", "portfolio",
     ],
     # Both halves of the legacy ``investments`` module — tax-lot
     # accounting is meaningless without prices, but a multi-currency
@@ -1593,13 +1597,14 @@ _RETIRED_ENV_TOGGLES: frozenset[str] = frozenset(
 )
 
 # The bundle base: what every install gets before the one question.
+# It is the ``bookkeeper`` group — everything except business.
 # Planning and investments joined it 2026-08-31 (maintainer ruling:
 # too common a need to gate — even a 401(k) wants the portfolio
 # surface, and budgets/scheduling are too small a set to be worth an
 # installer decision). The retired GNUCASH_ENABLE_PLANNING /
 # _INVESTMENTS variables are ignored if present — their surfaces are
 # in the base, so an old install's stored config cannot subtract.
-_ENV_TOGGLE_BASE = ("reporting", "budgets", "scheduling", "investor")
+_ENV_TOGGLE_BASE = ("bookkeeper",)
 
 
 def _modules_from_env_toggles() -> str | None:
@@ -1608,7 +1613,7 @@ def _modules_from_env_toggles() -> str | None:
     Returns None when no toggle variable is present at all, so CLI
     and GNUCASH_MCP_MODULES users (and the core-only default) are
     untouched. When a toggle is present, the selection is the bundle
-    base (reporting + planning + investor) plus every enabled
+    base (``bookkeeper``: everything but business) plus every enabled
     toggle's modules — core is force-added downstream by
     _apply_module_filter, matching the bundle design where the base
     surface is always on and business is the one question.
@@ -1662,8 +1667,9 @@ Options:
                        underlying modules, business is one module):
                          core         Ledger primitives + reconciliation.
                                       Always on regardless. {core} tools.
-                         bookkeeper   Reporting + budgets + scheduling.
-                                      {bookkeeper} tools.
+                         bookkeeper   Everything except business:
+                                      reporting, budgets, scheduling,
+                                      prices, tax lots. {bookkeeper} tools.
                          investor     tax_lots + portfolio (cost basis
                                       + prices). {investor} tools.
                          business     Customers, vendors, employees;
@@ -1682,7 +1688,7 @@ Options:
                        balance_sheet, diagnostic, reconciliation.
 
                        Bookkeeper members ({n_bookkeeper}): reporting, budgets,
-                       scheduling.
+                       scheduling, tax_lots, portfolio.
 
                        Investor members ({n_investor}): tax_lots, portfolio.
 
@@ -1706,8 +1712,8 @@ Environment variables:
                              --modules (e.g. "bookkeeper" or "core,reporting")
   GNUCASH_ENABLE_BUSINESS    Boolean (true/false) — the MCPB bundle's one
                              module question ("Do you invoice clients?").
-                             When set, modules = core + reporting +
-                             budgets + scheduling + investor, plus the
+                             When set, modules = core + bookkeeper
+                             (everything but business), plus the
                              business suite when true. The retired
                              _PLANNING/_INVESTMENTS toggles are ignored
                              (their surface is now always on); the

--- a/src/gnucash_mcp/server.py
+++ b/src/gnucash_mcp/server.py
@@ -83,9 +83,10 @@ SAFETY: Reconciled splits are protected (use force=true to override). Prefer voi
 
 # ---------------------------------------------------------------------------
 # MODULE_GROUPS — composition aliases expanding to underlying module
-# keys; the role-aligned partition (core / bookkeeper / investor /
-# business). Expansion is single-pass — groups don't reference other
-# groups; add cycle detection if nesting ever lands.
+# keys; the role-aligned partition (core / bookkeeper / investor;
+# ``business`` is a single leaf). Expansion is single-pass — groups
+# don't reference other groups; add cycle detection if nesting ever
+# lands.
 # ---------------------------------------------------------------------------
 MODULE_GROUPS: dict[str, list[str]] = {
     # ``core`` is always-on (force-added in _apply_module_filter).
@@ -107,13 +108,18 @@ MODULE_GROUPS: dict[str, list[str]] = {
     "investor": [
         "tax_lots", "portfolio",
     ],
-    # Small-business persona. The group must stay the SUPERSET of
-    # both halves — loading only the vendor half would give
-    # "small business workflow" users vendor management without the
-    # ability to create or post a customer invoice.
-    "business": [
-        "freelancer", "business_complete",
-    ],
+}
+
+# Retired module names, accepted on --modules / GNUCASH_MCP_MODULES
+# so a config file written for an earlier release keeps starting the
+# server. ``freelancer`` and ``business_complete`` were the two halves
+# of the business surface until the party/document tools went
+# polymorphic; the split then reduced to a runtime gate on
+# ``owner_type`` plus one report, and was merged into the single
+# ``business`` leaf. Both names resolve to the whole business surface.
+MODULE_ALIASES: dict[str, str] = {
+    "freelancer": "business",
+    "business_complete": "business",
 }
 
 
@@ -138,11 +144,7 @@ MODULE_BACKED_BY: dict[str, set[str]] = {
     "diagnostic": set(),
     "portfolio": {"investments"},
     "tax_lots": {"investments"},
-    # freelancer / business_complete are subsets of one underlying
-    # tools/business.py registration. The ``business`` group alias
-    # doesn't appear here — groups resolve via their members.
-    "freelancer": {"business"},
-    "business_complete": {"business"},
+    # ``business`` is 1:1 with tools/business.py (the default).
 }
 
 
@@ -247,16 +249,11 @@ TOOL_MODULES: dict[str, list[str]] = {
         "calculate_lot_gain",
         "close_lot",
     ],
-    # Placement rule for the freelancer/business_complete split:
-    # polymorphic and shared-registry tools (invoice lifecycle,
-    # taxtables, billterms, jobs, credit notes) live in freelancer
-    # because the customer side is the dominant solo-consultant use
-    # case; vendor-side use of the same tools is rejected at runtime
-    # by _gate_owner_type (tools/_helpers.py) when
-    # business_complete isn't loaded. business_complete owns the
-    # vendor/employee ENTITIES and the workflows that don't make
-    # sense without them.
-    "freelancer": [
+    # The whole business surface. Party and document tools are
+    # polymorphic (customer / vendor / employee; invoice / bill /
+    # voucher / credit note), so there is no customer-only half to
+    # carve out — see MODULE_ALIASES for the retired split.
+    "business": [
         "create_party",
         "list_parties",
         "get_party",
@@ -275,7 +272,6 @@ TOOL_MODULES: dict[str, list[str]] = {
         "list_taxtables",
         "update_taxtable",
         "delete_taxtable",
-        # Billterms, jobs, credit notes — placement rule above.
         "create_billterm",
         "list_billterms",
         "create_job",
@@ -284,11 +280,6 @@ TOOL_MODULES: dict[str, list[str]] = {
         "delete_job",
         "get_job_report",
         "apply_credit_note",
-    ],
-    # Vendor + employee surface — see the placement rule above.
-    "business_complete": [
-        # Voucher lifecycle (post/unpost/pay) flows through the
-        # polymorphic invoice tools with owner_type='employee'.
         "vendor_spending_report",
     ],
 }
@@ -404,10 +395,8 @@ def _reset_lazy_load_state() -> None:
 
 
 # Snapshot of which public module names are enabled in the current
-# run. Populated by ``_apply_module_filter``; read by tool wrappers
-# that need to gate behavior on module availability (e.g., the
-# Freelancer-side shared-lifecycle invoice tools reject
-# ``owner_type='vendor'`` when ``business`` isn't loaded).
+# run. Populated by ``_apply_module_filter``; read by anything that
+# needs to gate behavior on module availability.
 _LOADED_MODULES: set[str] = set()
 
 
@@ -455,6 +444,9 @@ def _apply_module_filter(modules_str: str | None) -> list[str]:
         requested = {"core"}
     else:
         requested = {m.strip() for m in modules_str.split(",")}
+    # Retired names map to their successor before validation, so an
+    # old config file neither fails fast nor loads a partial surface.
+    requested = {MODULE_ALIASES.get(m, m) for m in requested}
 
     # Fail fast on unknown names — a stderr warning + partial load
     # is silent in practice (Claude Desktop buries MCP stderr), so
@@ -1581,14 +1573,15 @@ def _parse_cli_argv(
 # Values map to module/group names in TOOL_MODULES / MODULE_GROUPS.
 # GNUCASH_ENABLE_BUSINESS is the only var the CURRENT manifest sets
 # (the one question). GNUCASH_ENABLE_FREELANCER is retired from the
-# manifest but still HONORED: unlike planning/investments, the
-# freelancer surface did NOT join the always-on base, so ignoring a
-# stored freelancer=true would subtract the invoicing tools from an
-# old install (release-review finding 4 — a pre-#163 bundle install
-# that answered freelancer=yes, business=no must keep its surface).
+# manifest but still HONORED: the invoicing surface is not in the
+# always-on base, so ignoring a stored freelancer=true would subtract
+# it from a pre-#163 bundle install that answered freelancer=yes,
+# business=no. Since the freelancer/business_complete merge the
+# toggle unlocks the whole business surface (the customer-only half
+# no longer exists).
 _ENV_MODULE_TOGGLES: dict[str, tuple[str, ...]] = {
     "GNUCASH_ENABLE_BUSINESS": ("business",),
-    "GNUCASH_ENABLE_FREELANCER": ("freelancer",),
+    "GNUCASH_ENABLE_FREELANCER": ("business",),
 }
 
 # Honored when present in the environment, but deliberately absent
@@ -1643,13 +1636,11 @@ def _build_help_text() -> str:
     core = _module_tool_count("core")
     bookkeeper = _module_tool_count("bookkeeper")
     investor = _module_tool_count("investor")
-    freelancer = _module_tool_count("freelancer")
     business = _module_tool_count("business")
     total = _module_tool_count("all")
     n_core = len(MODULE_GROUPS["core"])
     n_bookkeeper = len(MODULE_GROUPS["bookkeeper"])
     n_investor = len(MODULE_GROUPS["investor"])
-    n_business = len(MODULE_GROUPS["business"])
     return f"""GnuCash MCP Server
 
 Usage: gnucash-mcp [OPTIONS]
@@ -1666,25 +1657,22 @@ Options:
                        for every module ({total} tools; configuring
                        multiple books adds switch_book on top).
 
-                       Role-based selections (group aliases that
-                       expand to underlying modules — start here):
+                       Role-based selections (start here; the first
+                       three are group aliases that expand to
+                       underlying modules, business is one module):
                          core         Ledger primitives + reconciliation.
                                       Always on regardless. {core} tools.
                          bookkeeper   Reporting + budgets + scheduling.
                                       {bookkeeper} tools.
                          investor     tax_lots + portfolio (cost basis
                                       + prices). {investor} tools.
-                         freelancer   Customer invoicing + sales tax,
-                                      plus billterms (payment terms),
-                                      jobs (per-project P&L), and
-                                      credit notes (customer refunds).
-                                      The full solo-consultant
-                                      toolkit. {freelancer} tools.
-                         business     Full small-business package:
-                                      freelancer (invoicing) +
-                                      business_complete (vendors,
-                                      employees, bills, vouchers,
-                                      vendor reports). {business} tools.
+                         business     Customers, vendors, employees;
+                                      invoices, bills, vouchers, credit
+                                      notes; sales tax, payment terms,
+                                      jobs, vendor reports.
+                                      {business} tools. (freelancer and
+                                      business_complete are accepted as
+                                      retired names for this module.)
 
                        Leaf modules (pick individually for finer
                        control, or as members of the groups above):
@@ -1698,16 +1686,10 @@ Options:
 
                        Investor members ({n_investor}): tax_lots, portfolio.
 
-                       Business members ({n_business}): freelancer,
-                       business_complete.
-
-                       Example: --modules=freelancer for a solo
-                       invoicer with no vendor activity;
-                       --modules=bookkeeper for personal finance;
-                       --modules=business for a complete small-
-                       business workflow (invoices + vendor + employee
-                       management). ``core`` is always added
-                       regardless.
+                       Example: --modules=bookkeeper for personal
+                       finance; --modules=business for invoicing and
+                       vendor/employee management; --modules=all for
+                       everything. ``core`` is always added regardless.
   --debug              Enable debug logging (MCP protocol traffic, timing)
   --noaudit            Disable audit logging
   -h, --help           Show this help message
@@ -1730,8 +1712,9 @@ Environment variables:
                              _PLANNING/_INVESTMENTS toggles are ignored
                              (their surface is now always on); the
                              retired _FREELANCER toggle is still honored
-                             (its invoicing surface is NOT in the base,
-                             so old freelancer-only installs keep it).
+                             and now unlocks the whole business suite
+                             (its surface is NOT in the base, so old
+                             freelancer-only installs keep invoicing).
                              --modules / GNUCASH_MCP_MODULES win when set.
   GNUCASH_MCP_DEBUG=true     Enable debug logging (true/1/yes/on)
   GNUCASH_MCP_NOAUDIT=true   Disable audit logging (true/1/yes/on)

--- a/src/gnucash_mcp/tools/_helpers.py
+++ b/src/gnucash_mcp/tools/_helpers.py
@@ -276,59 +276,6 @@ def _json(obj) -> str:
     )
 
 
-def _gate_owner_type(owner_type: str | None) -> str | None:
-    """Enforce the Freelancer/Business module split at the
-    ``owner_type`` boundary.
-
-    The shared-lifecycle invoice tools live in Freelancer, but
-    vendor bills and employee vouchers travel through them via
-    owner_type dispatch — and Business owns both vendor and
-    employee management.
-
-    Three cases:
-
-    - Explicit ``'vendor'`` / ``'employee'`` without Business:
-      reject with a clear error.
-    - Omitted or ``'customer'`` without Business: coerce to
-      ``'customer'`` — the tool only sees customer entities.
-    - Business loaded: pass through unchanged.
-
-    Returns the (possibly coerced) owner_type for the book method.
-    Imports server lazily to avoid an import-time cycle.
-    """
-    from gnucash_mcp.server import is_module_enabled
-
-    # Gate on the business_complete LEAF (not the group alias) so an
-    # explicit business_complete-only selection also unlocks.
-    if is_module_enabled("business_complete"):
-        return owner_type  # All three halves available; no gating.
-
-    if owner_type == "vendor":
-        raise ValueError(
-            "owner_type='vendor' requires the business module. "
-            "Restart the server with --modules=business (or add "
-            "business_complete to your current selection) to access "
-            "vendor bills, or omit owner_type to operate on customer "
-            "invoices only."
-        )
-    if owner_type == "employee":
-        raise ValueError(
-            "owner_type='employee' requires the business module. "
-            "Employee expense vouchers live with employee "
-            "management. Restart the server with --modules=business "
-            "(or add business_complete to your current selection) "
-            "or omit owner_type to operate on customer invoices only."
-        )
-    # Only None / 'customer' coerce; anything else (typos, unknown
-    # future types) rejects loudly rather than masquerading as
-    # "searched customer invoices, found nothing".
-    if owner_type is not None and owner_type != "customer":
-        raise ValueError(
-            f"Invalid owner_type {owner_type!r}. Must be 'customer' "
-            f"(or omit). 'vendor' and 'employee' require the "
-            f"Business module."
-        )
-    return "customer"
 
 
 # The consolidated business surface's two type axes. Literal types
@@ -336,57 +283,6 @@ def _gate_owner_type(owner_type: str | None) -> str | None:
 # at decode time and a wrong value never reaches the server.
 PartyType = Literal["customer", "vendor", "employee"]
 DocumentType = Literal["invoice", "bill", "voucher", "credit_note"]
-
-# Which module side each species belongs to. The polymorphic tools
-# live in Freelancer; the vendor/employee species unlock when
-# business_complete is loaded (same split _gate_owner_type enforces
-# for the lifecycle tools).
-_CUSTOMER_SIDE_DOCS = {"invoice"}
-
-
-def _gate_party_type(party_type: str | None) -> str | None:
-    """Enforce the Freelancer/Business split on ``party_type``.
-
-    Freelancer owns the customer side; vendor and employee
-    management requires business_complete. ``None`` (where a tool
-    allows it, e.g. list_parties) coerces to 'customer' without
-    Business and passes through (= all types) with it.
-    """
-    from gnucash_mcp.server import is_module_enabled
-
-    if is_module_enabled("business_complete"):
-        return party_type
-    if party_type in ("vendor", "employee"):
-        raise ValueError(
-            f"party_type={party_type!r} requires the business "
-            f"module. Restart the server with --modules=business "
-            f"(or add business_complete) to manage vendors and "
-            f"employees; Freelancer covers customers."
-        )
-    return "customer"
-
-
-def _gate_document_type(document_type: str | None) -> str | None:
-    """Enforce the Freelancer/Business split on ``document_type``.
-
-    Customer invoices (and credit notes, which carry their own
-    party side) stay Freelancer; vendor bills and employee
-    vouchers require business_complete.
-    """
-    from gnucash_mcp.server import is_module_enabled
-
-    if is_module_enabled("business_complete"):
-        return document_type
-    if document_type in ("bill", "voucher"):
-        raise ValueError(
-            f"document_type={document_type!r} requires the "
-            f"business module. Restart the server with "
-            f"--modules=business (or add business_complete) for "
-            f"vendor bills and employee vouchers; Freelancer "
-            f"covers customer invoices and credit notes."
-        )
-    return document_type if document_type is not None else "invoice"
-
 
 def _resolve_id_alias(
     id: str | None,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -673,7 +673,7 @@ def register(mcp, get_book) -> None:
         applies_to_invoice_id: str,
         amount: str | None = None,
         apply_date: str | None = None,
-        owner_type: str | None = None,
+        party_type: str | None = None,
     ) -> str:
         """Net a posted credit note against a posted invoice or
         bill from the same owner. No cash moves — the credit
@@ -702,7 +702,7 @@ def register(mcp, get_book) -> None:
                 as possible.
             apply_date: ISO date for the netting transaction.
                 Defaults to today.
-            owner_type: Optional 'customer' or 'vendor'
+            party_type: Optional 'customer' or 'vendor'
                 disambiguator for ID collisions.
         """
         book = get_book()
@@ -711,7 +711,7 @@ def register(mcp, get_book) -> None:
             applies_to_invoice_id=applies_to_invoice_id,
             amount=amount,
             apply_date=apply_date,
-            owner_type=owner_type,
+            owner_type=party_type,
         )
         return _json(result)
 
@@ -1033,7 +1033,7 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="write", operation="create", entity_type="job")
     def create_job(
         owner_id: str,
-        owner_type: str,
+        party_type: str,
         name: str,
         reference: str = "",
     ) -> str:
@@ -1047,7 +1047,7 @@ def register(mcp, get_book) -> None:
 
         Args:
             owner_id: Customer or vendor ID (e.g., "000001").
-            owner_type: "customer" or "vendor". Employees are
+            party_type: "customer" or "vendor". Employees are
                 not supported (no GnuCash desktop UI for
                 employee jobs).
             name: Human-readable job name (e.g., "API Rewrite").
@@ -1057,7 +1057,7 @@ def register(mcp, get_book) -> None:
         book = get_book()
         result = book.create_job(
             owner_id=owner_id,
-            owner_type=owner_type,
+            owner_type=party_type,
             name=name,
             reference=reference,
         )
@@ -1068,7 +1068,7 @@ def register(mcp, get_book) -> None:
     @audit_log(classification="read")
     def list_jobs(
         id: str | None = None,
-        owner_type: str | None = None,
+        party_type: str | None = None,
         owner_id: str | None = None,
         active_only: bool = True,
         verbose: bool = False,
@@ -1087,10 +1087,10 @@ def register(mcp, get_book) -> None:
         Args:
             id: Job ID for a single-job detail lookup (e.g.,
                 "000001"). All other filters are ignored.
-            owner_type: Filter by "customer" or "vendor". Omit
+            party_type: Filter by "customer" or "vendor". Omit
                 for all.
             owner_id: Filter by specific customer or vendor ID
-                (requires owner_type).
+                (requires party_type).
             active_only: If True (default), exclude inactive jobs.
             verbose: If false (default), compact text output — optimized
                 for reading and token efficiency. If true, structured
@@ -1103,7 +1103,7 @@ def register(mcp, get_book) -> None:
         if id is not None:
             return _json(book.get_job(job_id=id))
         result = book.list_jobs(
-            owner_type=owner_type,
+            owner_type=party_type,
             owner_id=owner_id,
             active_only=active_only,
             compact=not verbose,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -739,7 +739,9 @@ def register(mcp, get_book) -> None:
         **open** = created and editable, not yet booked to A/R//A/P —
         not payable. **posted** = booked to A/R//A/P with a lot
         tracking its balance — payable. **paid** = posted with a zero
-        remaining balance (lot closed). **outstanding** = posted with
+        remaining balance (lot closed); a credit note at zero balance
+        reads **applied** instead, since it settles by application,
+        not cash. **outstanding** = posted with
         a remaining balance — the unpaid subset; get it directly from
         ``get_outstanding_documents`` rather than deriving it here.
         The ``status`` filter below covers document state
@@ -796,7 +798,8 @@ def register(mcp, get_book) -> None:
 
         The response carries ``status`` (open = editable, not yet
         booked; posted = on the books, balance owed; paid = balance
-        zero) and, once posted, ``amount_paid`` and ``amount_due``
+        zero; applied = a credit note fully consumed against its
+        target) and, once posted, ``amount_paid`` and ``amount_due``
         from the same lot arithmetic ``get_outstanding_documents``
         uses; ``overpaid: true`` marks a negative balance. A paid
         document keeps its amounts here after it leaves the unpaid

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -7,12 +7,9 @@ from gnucash_mcp.logging_config import audit_log
 from gnucash_mcp.tools._helpers import (
     DocumentType,
     PartyType,
-    _gate_document_type,
-    _gate_party_type,
     BusinessAddressInput,
     BusinessNotes,
     BusinessNotesOptional,
-    _gate_owner_type,
     _json,
     _resolve_id_alias,
     safe_tool,
@@ -53,7 +50,6 @@ def register(mcp, get_book) -> None:
                 addr3, addr4, phone, fax, email. Each sub-field
                 capped at 1024 characters.
         """
-        party_type = _gate_party_type(party_type)
         book = get_book()
         addr = address.model_dump() if address else None
         if party_type == "employee":
@@ -106,7 +102,6 @@ def register(mcp, get_book) -> None:
             limit: Page size per type (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
-        party_type = _gate_party_type(party_type)
         book = get_book()
         routes = {
             "customer": book.list_customers,
@@ -148,7 +143,6 @@ def register(mcp, get_book) -> None:
             id: Party ID (e.g., "000001"). This is the human-readable
                 ID shown in GnuCash, not the internal GUID.
         """
-        party_type = _gate_party_type(party_type)
         book = get_book()
         if party_type == "employee":
             result = book.get_employee(employee_id=id)
@@ -188,7 +182,6 @@ def register(mcp, get_book) -> None:
                 default listings but keep their history).
             address: Full replacement address (see create_party).
         """
-        party_type = _gate_party_type(party_type)
         book = get_book()
         addr = address.model_dump() if address else None
         if party_type == "employee":
@@ -234,7 +227,6 @@ def register(mcp, get_book) -> None:
                 counters collide across types — always required).
             id: Party ID (e.g., "000001").
         """
-        party_type = _gate_party_type(party_type)
         book = get_book()
         if party_type == "employee":
             result = book.delete_employee(employee_id=id)
@@ -488,7 +480,6 @@ def register(mcp, get_book) -> None:
                 response notes the divergence when the applied
                 target differs from this link).
         """
-        document_type = _gate_document_type(document_type)
         # Type-scoped parameters refuse loudly when inapplicable.
         # These are DECLARED parameters, so extra="forbid" can't
         # catch them — without this check a supplied value would be
@@ -517,7 +508,6 @@ def register(mcp, get_book) -> None:
                     "party_type='customer' (reduces a receivable) "
                     "or party_type='vendor' (reduces a payable)."
                 )
-            party_type = _gate_party_type(party_type)
             if party_type == "employee":
                 raise ValueError(
                     "party_type='employee' is not valid for credit "
@@ -591,7 +581,6 @@ def register(mcp, get_book) -> None:
             notes: Optional entry notes.
             action: Optional entry action label (e.g., "Hours").
         """
-        document_type = _gate_document_type(document_type)
         book = get_book()
         if document_type == "credit_note":
             result = book.add_credit_note_entry(
@@ -651,7 +640,6 @@ def register(mcp, get_book) -> None:
                 same ID on the other side (ID counters are per
                 type).
         """
-        document_type = _gate_document_type(document_type)
         # The typed species imply their side; only credit notes
         # exist on both sides and can collide. Refuse a meaningless
         # party_type loudly rather than silently ignoring it.
@@ -666,8 +654,7 @@ def register(mcp, get_book) -> None:
         if document_type == "credit_note":
             result = book.delete_credit_note(
                 credit_note_id=id,
-                owner_type=_gate_owner_type(party_type)
-                if party_type else None,
+                owner_type=party_type or None,
             )
         elif document_type == "bill":
             result = book.delete_bill(bill_id=id)
@@ -718,7 +705,6 @@ def register(mcp, get_book) -> None:
             owner_type: Optional 'customer' or 'vendor'
                 disambiguator for ID collisions.
         """
-        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.apply_credit_note(
             credit_note_id=credit_note_id,
@@ -779,8 +765,7 @@ def register(mcp, get_book) -> None:
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",
             "voucher": "employee",
-        }.get(_gate_document_type(document_type) if document_type else None)
-        owner_type = _gate_owner_type(owner_type)
+        }.get(document_type)
         book = get_book()
         result = book.list_invoices(
             doc_type=document_type,
@@ -826,8 +811,7 @@ def register(mcp, get_book) -> None:
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",
             "voucher": "employee",
-        }.get(_gate_document_type(document_type) if document_type else None)
-        owner_type = _gate_owner_type(owner_type)
+        }.get(document_type)
         book = get_book()
         result = book.get_invoice(invoice_id=id, owner_type=owner_type)
         return _json(result)
@@ -876,8 +860,7 @@ def register(mcp, get_book) -> None:
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",
             "voucher": "employee",
-        }.get(_gate_document_type(document_type) if document_type else None)
-        owner_type = _gate_owner_type(owner_type)
+        }.get(document_type)
         book = get_book()
         result = book.post_invoice(
             invoice_id=id,
@@ -917,8 +900,7 @@ def register(mcp, get_book) -> None:
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",
             "voucher": "employee",
-        }.get(_gate_document_type(document_type) if document_type else None)
-        owner_type = _gate_owner_type(owner_type)
+        }.get(document_type)
         book = get_book()
         result = book.unpost_invoice(
             invoice_id=id,
@@ -1028,8 +1010,7 @@ def register(mcp, get_book) -> None:
         owner_type = party_type if party_type else {
             "invoice": "customer", "bill": "vendor",
             "voucher": "employee",
-        }.get(_gate_document_type(document_type) if document_type else None)
-        owner_type = _gate_owner_type(owner_type)
+        }.get(document_type)
         book = get_book()
         result = book.pay_invoice(
             invoice_id=id,
@@ -1073,7 +1054,6 @@ def register(mcp, get_book) -> None:
             reference: Optional reference string (PO number,
                 project code).
         """
-        owner_type = _gate_owner_type(owner_type)
         book = get_book()
         result = book.create_job(
             owner_id=owner_id,
@@ -1122,7 +1102,6 @@ def register(mcp, get_book) -> None:
         book = get_book()
         if id is not None:
             return _json(book.get_job(job_id=id))
-        owner_type = _gate_owner_type(owner_type)
         result = book.list_jobs(
             owner_type=owner_type,
             owner_id=owner_id,
@@ -1257,24 +1236,7 @@ def register(mcp, get_book) -> None:
             limit: Page size (default 50, max 250). 0 = count only.
             offset: 0-indexed first row to return (default 0).
         """
-        owner_type = _gate_owner_type(party_type)
-        # When Business isn't loaded, vendor_id is also a vendor-only
-        # surface — reject it the same way an explicit
-        # owner_type='vendor' is rejected. _gate_owner_type already
-        # handled owner_type; vendor_id needs its own check.
-        if vendor_id is not None:
-            from gnucash_mcp.server import is_module_enabled
-            # Check the leaf (``business_complete``) rather than the
-            # ``business`` group alias, so a user who explicitly
-            # picked the vendor-side carve-out also gets vendor_id
-            # filtering. See _gate_owner_type for the rationale.
-            if not is_module_enabled("business_complete"):
-                raise ValueError(
-                    "vendor_id filtering requires the business module. "
-                    "Restart with --modules=business (or add "
-                    "business_complete to your current selection) to "
-                    "access vendor bills."
-                )
+        owner_type = party_type
         book = get_book()
         result = book.get_outstanding_invoices(
             owner_type=owner_type,

--- a/src/gnucash_mcp/tools/business.py
+++ b/src/gnucash_mcp/tools/business.py
@@ -794,10 +794,13 @@ def register(mcp, get_book) -> None:
         Returns all entries with quantities, prices, and totals;
         the response's ``type`` field names the document kind.
 
-        Status vocabulary: open = editable, not yet booked; posted =
-        on the books, payable; paid = remaining balance zero. The
-        full definitions live on ``list_documents``; the unpaid list
-        is ``get_outstanding_documents``.
+        The response carries ``status`` (open = editable, not yet
+        booked; posted = on the books, balance owed; paid = balance
+        zero) and, once posted, ``amount_paid`` and ``amount_due``
+        from the same lot arithmetic ``get_outstanding_documents``
+        uses; ``overpaid: true`` marks a negative balance. A paid
+        document keeps its amounts here after it leaves the unpaid
+        list.
 
         Args:
             id: Document ID (e.g., "000001"). This is the
@@ -930,7 +933,11 @@ def register(mcp, get_book) -> None:
         vendor bill, employee voucher, or credit note.
 
         Creates a payment transaction from the specified bank/cash account
-        to the document's A/R or A/P account. Partial payments are supported.
+        to the document's A/R or A/P account. Partial payments are supported:
+        the response's ``payment`` is this call's amount, ``total_paid``
+        is cumulative across all payments, and ``remaining_balance`` is
+        what is still owed; ``status`` is ``partial`` until the balance
+        reaches zero, then ``paid``.
 
         ``dry_run=true`` rehearses the payment without booking it:
         the full validation, conversion, discount, and FX pipeline

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -372,7 +372,7 @@ class TestCreateJob:
         )
         assert result["status"] == "created"
         assert result["name"] == "API Rewrite"
-        assert result["owner_type"] == "customer"
+        assert result["party_type"] == "customer"
         assert result["active"] is True
         # counter_job advances independently from invoice/bill
         assert result["id"] == "000001"
@@ -384,7 +384,7 @@ class TestCreateJob:
             owner_id="000001", owner_type="vendor",
             name="Q3 supply contract",
         )
-        assert result["owner_type"] == "vendor"
+        assert result["party_type"] == "vendor"
         assert result["name"] == "Q3 supply contract"
 
     def test_create_job_with_reference(self, business_book):
@@ -472,7 +472,7 @@ class TestListJobs:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["name"] == "X"
-        assert result[0]["owner_type"] == "customer"
+        assert result[0]["party_type"] == "customer"
         assert result[0]["owner_name"] == "Acme Co"
 
     def test_filter_by_owner_type(self, business_book):
@@ -537,7 +537,7 @@ class TestGetJob:
         result = gb.get_job(job_id=job["id"])
         assert result["name"] == "API Rewrite"
         assert result["reference"] == "PO-001"
-        assert result["owner_type"] == "customer"
+        assert result["party_type"] == "customer"
         assert result["owner_name"] == "Acme Co"
         # No linked invoices yet
         assert result["linked_invoices"]["count"] == 0
@@ -867,7 +867,7 @@ class TestGetJobReport:
             owner_type="vendor",
         )
         result = gb.get_job_report(job_id=job["id"])
-        assert result["owner_type"] == "vendor"
+        assert result["party_type"] == "vendor"
         assert result["owner_name"] == "Office Depot"
         usd = result["totals_by_currency"]["USD"]
         assert Decimal(usd["billed"]) == Decimal("150")
@@ -12115,6 +12115,11 @@ class TestDocumentPaymentState:
         # Agreement lock: one chokepoint, two surfaces, same strings.
         assert row["amount_paid"] == doc["amount_paid"]
         assert row["amount_due"] == doc["amount_due"]
+        # Precision lock: every amount at the commodity quantum, so
+        # 250.00 sits beside 200.00 (round-two finding: due/remaining
+        # were unpadded next to padded paid totals).
+        assert doc["amount_due"] == "300.00"
+        assert doc["amount_paid"] == "200.00"
 
     def test_paid_document_keeps_amounts_after_leaving_unpaid_list(
         self, business_book,
@@ -12145,6 +12150,8 @@ class TestDocumentPaymentState:
         assert Decimal(first["payment"]) == Decimal("200")
         assert Decimal(first["total_paid"]) == Decimal("200")
         assert Decimal(first["remaining_balance"]) == Decimal("250")
+        assert first["remaining_balance"] == "250.00"
+        assert first["total_paid"] == "200.00"
         assert first["status"] == "partial"
         second = gb.pay_invoice(
             invoice_id="000001",
@@ -12154,5 +12161,6 @@ class TestDocumentPaymentState:
         assert Decimal(second["payment"]) == Decimal("250")
         assert Decimal(second["total_paid"]) == Decimal("450")
         assert Decimal(second["remaining_balance"]) == Decimal("0")
+        assert second["remaining_balance"] == "0.00"
         assert second["status"] == "paid"
         assert "amount_paid" not in second

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -12044,3 +12044,115 @@ class TestCreditNoteUnpostKeepsAppliesTo:
         after = gb.get_invoice(cn["id"], owner_type="customer")
         assert after["is_credit_note"] is True
         assert "applies_to" not in after
+
+
+# ============== Document payment state ==============
+
+
+class TestDocumentPaymentState:
+    """``get_invoice`` carries ``status`` / ``amount_paid`` /
+    ``amount_due`` and ``pay_invoice`` reports the per-call
+    ``payment`` beside a cumulative ``total_paid``. Both read the
+    ``_document_settlement`` chokepoint that ``get_outstanding_invoices``
+    uses, so the surfaces agree by construction. (Bookkeeper
+    findings on the business-module probe: a paid bill and a
+    half-paid voucher both read as a bare total, and the second
+    payment's ``amount_paid`` reported 250 with 450 paid.)
+    """
+
+    def _post_invoice(self, gb, amount="500.00"):
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        gb.add_invoice_entry(
+            invoice_id="000001",
+            account="Income:Sales",
+            description="Consulting",
+            quantity="1",
+            price=amount,
+        )
+        gb.post_invoice(
+            invoice_id="000001",
+            post_account="Assets:Accounts Receivable",
+        )
+        return "000001"
+
+    def test_open_document_reports_open_without_amounts(self, business_book):
+        gb = GnuCashBook(str(business_book))
+        gb.create_customer(name="Acme Corp")
+        gb.create_invoice(customer_id="000001")
+        doc = gb.get_invoice("000001")
+        assert doc["status"] == "open"
+        # Nothing is owed until posting books it.
+        assert "amount_paid" not in doc
+        assert "amount_due" not in doc
+
+    def test_posted_unpaid_reports_posted_with_full_balance_due(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        doc = gb.get_invoice("000001")
+        assert doc["status"] == "posted"
+        assert Decimal(doc["amount_paid"]) == Decimal("0")
+        assert Decimal(doc["amount_due"]) == Decimal("500")
+        assert "overpaid" not in doc
+
+    def test_partial_payment_amounts_agree_with_unpaid_list(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        doc = gb.get_invoice("000001")
+        assert doc["status"] == "posted"
+        assert Decimal(doc["amount_paid"]) == Decimal("200")
+        assert Decimal(doc["amount_due"]) == Decimal("300")
+        row = gb.get_outstanding_invoices(compact=False)["invoices"][0]
+        # Agreement lock: one chokepoint, two surfaces, same strings.
+        assert row["amount_paid"] == doc["amount_paid"]
+        assert row["amount_due"] == doc["amount_due"]
+
+    def test_paid_document_keeps_amounts_after_leaving_unpaid_list(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "500.00")
+        gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="500",
+        )
+        assert gb.get_outstanding_invoices(compact=False)["invoices"] == []
+        doc = gb.get_invoice("000001")
+        assert doc["status"] == "paid"
+        assert Decimal(doc["amount_paid"]) == Decimal("500")
+        assert Decimal(doc["amount_due"]) == Decimal("0")
+
+    def test_pay_invoice_reports_payment_and_cumulative_total(
+        self, business_book,
+    ):
+        gb = GnuCashBook(str(business_book))
+        self._post_invoice(gb, "450.00")
+        first = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="200",
+        )
+        assert Decimal(first["payment"]) == Decimal("200")
+        assert Decimal(first["total_paid"]) == Decimal("200")
+        assert Decimal(first["remaining_balance"]) == Decimal("250")
+        assert first["status"] == "partial"
+        second = gb.pay_invoice(
+            invoice_id="000001",
+            payment_account="Assets:Checking",
+            amount="250",
+        )
+        assert Decimal(second["payment"]) == Decimal("250")
+        assert Decimal(second["total_paid"]) == Decimal("450")
+        assert Decimal(second["remaining_balance"]) == Decimal("0")
+        assert second["status"] == "paid"
+        assert "amount_paid" not in second

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -5403,6 +5403,24 @@ class TestApplyCreditNote:
         ar_after = gb.get_balance("Assets:Accounts Receivable")
         assert ar_after == ar_before
 
+    def test_fully_applied_credit_note_reads_applied(self, business_book):
+        """A credit note settles by being applied, never by cash;
+        get_invoice says ``applied`` at zero balance where an invoice
+        would say ``paid`` (round-two bookkeeper ruling). Until then
+        it is ``posted`` like any other booked document."""
+        gb = GnuCashBook(str(business_book))
+        src_id, cn_id = self._setup_pair(gb)
+        assert gb.get_invoice(cn_id)["status"] == "posted"
+        gb.apply_credit_note(
+            credit_note_id=cn_id,
+            applies_to_invoice_id=src_id,
+        )
+        cn = gb.get_invoice(cn_id)
+        assert cn["status"] == "applied"
+        assert Decimal(cn["amount_due"]) == Decimal("0")
+        # The target is an invoice: cash vocabulary stays.
+        assert gb.get_invoice(src_id)["status"] == "posted"
+
     def test_apply_partial_amount(self, business_book):
         """Explicit amount, smaller than credit_note_remaining,
         partially applies and leaves both lots open."""

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -6582,7 +6582,12 @@ class TestInvoiceBillIdCollision:
         assert "'000001'" in msg
         assert "customer invoice" in msg
         assert "vendor bill" in msg
-        assert "owner_type" in msg
+        # The coaching must name parameters the document tools
+        # actually expose. The bookkeeper followed an earlier
+        # version that said "pass owner_type" into a schema
+        # rejection: those tools take party_type / document_type.
+        assert "document_type" in msg
+        assert "party_type" in msg
 
     def test_get_invoice_with_owner_type_filter(self, business_book):
         """get_invoice with owner_type disambiguates colliding IDs."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2522,3 +2522,27 @@ class TestAuditInjectionEscaping:
         blob = out["params"]["updates"]
         assert "\t" in blob and "\n" in blob
         assert "\\u202e" in blob and "‮" not in blob
+
+
+class TestPayRenderingCumulativeTotal:
+    """A ``pay`` entry written with the v1.5 keys renders the
+    per-call payment AND the cumulative total; entries written with
+    the older ``amount_paid`` key still render (fallback)."""
+
+    def test_new_keys_render_total_paid(self):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        entry = {
+            "classification": "write",
+            "entity_type": "voucher",
+            "operation": "pay",
+            "timestamp": "2026-09-07T10:00:00",
+            "params": {"id": "000001", "payment_account": "Assets:Checking"},
+            "after_state": {
+                "type": "voucher", "payment": "250.00",
+                "total_paid": "450.00", "remaining_balance": "0.00",
+                "transaction_guid": "abc12345",
+            },
+        }
+        rendered = _format_audit_entry_text(entry)
+        assert "PAY VOUCHER" in rendered
+        assert "paid: 250.00  total paid: 450.00  remaining: 0.00" in rendered

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2546,3 +2546,46 @@ class TestPayRenderingCumulativeTotal:
         rendered = _format_audit_entry_text(entry)
         assert "PAY VOUCHER" in rendered
         assert "paid: 250.00  total paid: 450.00  remaining: 0.00" in rendered
+
+
+class TestCreateLinesCarryCounterpartyName:
+    """CREATE lines for jobs and documents render the counterparty as
+    ``Name (id)`` when the after-state carries ``owner_name``; entries
+    without it (written before v1.5) fall back to the bare id."""
+
+    def _render(self, entity_type, after, params):
+        from gnucash_mcp.logging_config import _format_audit_entry_text
+        return _format_audit_entry_text({
+            "classification": "write",
+            "entity_type": entity_type,
+            "operation": "create",
+            "timestamp": "2026-09-07T10:00:00",
+            "params": params,
+            "after_state": after,
+        })
+
+    def test_job_create_names_the_customer(self):
+        rendered = self._render(
+            "job",
+            {"id": "000004", "name": "Probe job", "party_type": "customer",
+             "owner_name": "Emerald Analytics"},
+            {"owner_id": "000001", "name": "Probe job"},
+        )
+        assert 'customer: Emerald Analytics (000001)' in rendered
+
+    def test_bill_create_names_the_vendor(self):
+        rendered = self._render(
+            "bill",
+            {"id": "000010", "vendor_id": "000003",
+             "owner_name": "Cascade Cloud Services"},
+            {"document_type": "bill", "owner_id": "000003"},
+        )
+        assert "vendor: Cascade Cloud Services (000003)" in rendered
+
+    def test_missing_name_falls_back_to_bare_id(self):
+        rendered = self._render(
+            "voucher", {"id": "000010", "employee_id": "000001"},
+            {"document_type": "voucher", "owner_id": "000001"},
+        )
+        assert "employee: 000001" in rendered
+        assert "(" not in rendered.split("employee:")[1].split("\n")[0]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -45,7 +45,7 @@ class TestManifestContract:
         env = manifest["server"]["mcp_config"]["env"]
         # Retired toggles are honored from stored configs but are
         # deliberately absent from the installer UI (finding 4:
-        # freelancer's surface never joined the always-on base).
+        # the business surface is not in the always-on base).
         expected = (
             set(_ENV_MODULE_TOGGLES) - _RETIRED_ENV_TOGGLES
         ) | {

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -136,7 +136,13 @@ class TestToolModulesMapping:
         }
         assert set(MODULE_GROUPS["bookkeeper"]) == {
             "reporting", "budgets", "scheduling",
+            "tax_lots", "portfolio",
         }
+        # bookkeeper is everything but business: every leaf outside
+        # core and business is a member.
+        assert set(MODULE_GROUPS["bookkeeper"]) == (
+            set(TOOL_MODULES) - set(MODULE_GROUPS["core"]) - {"business"}
+        )
         assert set(MODULE_GROUPS["investor"]) == {
             "tax_lots", "portfolio",
         }
@@ -465,23 +471,25 @@ class TestApplyModuleFilter:
         assert "list_commodities" in remaining
         assert "create_price" in remaining
 
-    def test_bookkeeper_group_bundles_three_modules(self):
-        """``--modules=bookkeeper`` loads reporting + budgets +
-        scheduling — the personal-finance management cluster.
-        Reconciliation moved to core in v1.3.1 and is now
-        always-on regardless of group selection."""
+    def test_bookkeeper_group_is_everything_but_business(self):
+        """``--modules=bookkeeper`` loads every module except
+        business: the persona that wants the whole ledger, reports,
+        planning, and investment surface but never invoices anyone.
+        Reconciliation is always-on via core regardless."""
         _apply_module_filter("bookkeeper")
         remaining = self._tool_names()
         # One probe per bookkeeper member module.
         assert "spending_by_category" in remaining    # reporting
         assert "create_budget" in remaining           # budgets
         assert "create_scheduled_transaction" in remaining
+        assert "create_lot" in remaining              # tax_lots
+        assert "create_price" in remaining            # portfolio
         # reconciliation is now always-on via core.
         assert "reconcile_account" in remaining
-        # Core always loaded; non-bookkeeper modules absent.
         assert "list_accounts" in remaining
+        # The one thing bookkeeper excludes.
         assert "create_document" not in remaining     # business
-        assert "create_lot" not in remaining          # tax_lots
+        assert "vendor_spending_report" not in remaining
 
     def test_reconciliation_loads_with_core_by_default(self):
         """v1.3.1 invariant: any configuration loads reconciliation.
@@ -1896,13 +1904,13 @@ class TestEnvModuleToggles:
         from gnucash_mcp.server import _modules_from_env_toggles
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor")
+                == "bookkeeper")
 
     def test_business_true_adds_the_suite(self, monkeypatch):
         from gnucash_mcp.server import _modules_from_env_toggles
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "true")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor,business")
+                == "bookkeeper,business")
 
     def test_retired_toggles_are_ignored(self, monkeypatch):
         """An old install's stored config (pre-unification manifest)
@@ -1915,7 +1923,7 @@ class TestEnvModuleToggles:
         assert _modules_from_env_toggles() is None
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor")
+                == "bookkeeper")
 
     def test_retired_freelancer_toggle_still_honored(self, monkeypatch):
         """Release-review finding 4: the invoicing surface is not
@@ -1927,11 +1935,11 @@ class TestEnvModuleToggles:
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
         monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "true")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor,business")
+                == "bookkeeper,business")
         # freelancer=false stays base-only (no accidental additions).
         monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "false")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor")
+                == "bookkeeper")
 
     def test_invalid_value_fails_fast(self, monkeypatch):
         from gnucash_mcp.server import _modules_from_env_toggles

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -374,6 +374,24 @@ class TestApplyModuleFilter:
             assert set(self._tool_names()) == full, retired
             assert is_module_enabled("business")
 
+    def test_no_business_tool_exposes_owner_type(self):
+        """Every business tool names the party side ``party_type``.
+        ``owner_type`` is the book-layer (piecash) name; three tools
+        leaked it to the MCP surface and, with unknown kwargs
+        rejected at the schema, a model that learned party_type from
+        the other twenty-two got a schema error on create_job. Lock:
+        the name never reaches a tool signature again.
+        """
+        import inspect
+        _apply_module_filter("business")
+        leaks = {
+            name for name in TOOL_MODULES["business"]
+            if "owner_type" in inspect.signature(
+                mcp._tool_manager._tools[name].fn
+            ).parameters
+        }
+        assert not leaks, sorted(leaks)
+
     def test_unknown_module_alongside_all_still_fails(self, capsys):
         """``all`` is a loading instruction, not a validation bypass.
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -96,12 +96,11 @@ class TestToolModulesMapping:
         assert len(_core_tool_names()) == 29
 
     def test_total_tool_count(self):
-        """Total tools across all sub-modules should be 111 —
-        88 post-module-restructure + 3 voucher tools +
-        4 credit-note tools + 5 job CRUD tools +
-        1 get_job_report + 5 taxtable CRUD tools added in v1.3 +
-        1 enter_statement added in v1.4.4, minus list_backups +
-        prune_backups (removed v1.4.4 — append-only backup store)."""
+        """Total tools across all sub-modules: 86 as of v1.4.4
+        (111 tools consolidated to 88, minus list_backups +
+        prune_backups). Merging freelancer + business_complete
+        into one ``business`` leaf moved tools between keys
+        without adding or removing any."""
         total = sum(len(tools) for tools in TOOL_MODULES.values())
         assert total == 86
 
@@ -118,15 +117,15 @@ class TestToolModulesMapping:
             "reporting", "budgets", "scheduling",
             # Investor-cluster leaves
             "portfolio", "tax_lots",
-            # Business-cluster leaves (``business`` is now a group
-            # alias expanding to these two; the standalone of the
-            # same name was the pre-v1.3 design, retired because it
-            # left small-business users without invoice tools).
-            "freelancer", "business_complete",
+            # The whole business surface, one leaf. The
+            # freelancer / business_complete halves merged once the
+            # party/document tools went polymorphic; the retired
+            # names survive as MODULE_ALIASES.
+            "business",
         }
         assert set(TOOL_MODULES.keys()) == expected
-        # Group aliases — ``core`` always-on plus the three role
-        # groups (bookkeeper, investor, business) landing in v1.3.
+        # Group aliases — ``core`` always-on plus the two role
+        # groups (bookkeeper, investor); ``business`` is a leaf.
         # core grew to 9 in v1.3.1 — reconciliation moved here
         # from bookkeeper so it loads in every configuration that
         # handles money (which is all of them).
@@ -141,9 +140,7 @@ class TestToolModulesMapping:
         assert set(MODULE_GROUPS["investor"]) == {
             "tax_lots", "portfolio",
         }
-        assert set(MODULE_GROUPS["business"]) == {
-            "freelancer", "business_complete",
-        }
+        assert "business" not in MODULE_GROUPS
 
     def test_validate_tool_modules_passes(self):
         """Validation should pass with the current mapping."""
@@ -352,38 +349,24 @@ class TestApplyModuleFilter:
             _apply_module_filter("bookeeper,investor")
         assert exc_info.value.code == 2
 
-    def test_freelancer_carries_jobs_credit_notes_billterms(self):
-        """v1.3.1 redistribution: billterms, jobs, and credit notes
-        moved from business_complete to freelancer.
-
-        Principle: polymorphic-on-owner_type tools + shared
-        infrastructure live in freelancer; vendor-specific surface
-        stays in business_complete. A solo freelancer setting
-        payment terms on customer invoices, running per-project
-        P&L, or issuing customer refunds needs these without
-        pulling in vendor management. The polymorphic gate in
-        _gate_owner_type still restricts vendor-side use of the
-        polymorphic tools (jobs / credit notes) to business mode.
+    def test_retired_business_names_alias_to_business(self):
+        """``freelancer`` and ``business_complete`` were the two
+        halves of the business surface until the party/document
+        tools went polymorphic. Both names still resolve, to the
+        whole ``business`` module, so a config file written for an
+        earlier release neither fails fast nor loads a partial
+        surface.
         """
-        _apply_module_filter("freelancer")
-        remaining = self._tool_names()
-        # Billterms (shared infrastructure).
-        assert "create_billterm" in remaining
-        assert "list_billterms" in remaining
-        # Jobs (polymorphic; customer-side usable in freelancer).
-        assert "create_job" in remaining
-        assert "list_jobs" in remaining
-        assert "get_job_report" in remaining
-        # Credit notes ride the consolidated document tools
-        # (document_type="credit_note"); apply stays standalone.
-        assert "create_document" in remaining
-        assert "apply_credit_note" in remaining
-        # Vendor-specific surface must remain absent.
-        assert "create_vendor" not in remaining
-        assert "create_bill" not in remaining
-        assert "create_employee" not in remaining
-        assert "create_voucher" not in remaining
-        assert "vendor_spending_report" not in remaining
+        from gnucash_mcp.server import MODULE_ALIASES, is_module_enabled
+        _apply_module_filter("business")
+        full = set(self._tool_names())
+        assert "create_document" in full
+        assert "vendor_spending_report" in full
+        for retired in ("freelancer", "business_complete"):
+            assert MODULE_ALIASES[retired] == "business"
+            _apply_module_filter(retired)
+            assert set(self._tool_names()) == full, retired
+            assert is_module_enabled("business")
 
     def test_unknown_module_alongside_all_still_fails(self, capsys):
         """``all`` is a loading instruction, not a validation bypass.
@@ -497,7 +480,7 @@ class TestApplyModuleFilter:
         assert "reconcile_account" in remaining
         # Core always loaded; non-bookkeeper modules absent.
         assert "list_accounts" in remaining
-        assert "create_invoice" not in remaining      # freelancer
+        assert "create_document" not in remaining     # business
         assert "create_lot" not in remaining          # tax_lots
 
     def test_reconciliation_loads_with_core_by_default(self):
@@ -720,97 +703,6 @@ class TestGetServerConfig:
         assert "get_server_config" in TOOL_MODULES["diagnostic"]
         assert "get_server_config" in mcp._tool_manager._tools
 
-
-class TestOwnerTypeGating:
-    """The Freelancer module hosts the shared-lifecycle invoice
-    tools (post/unpost/pay_invoice, list/get_invoice,
-    get_outstanding_invoices). Those tools dispatch on owner_type to
-    handle both customer invoices AND vendor bills — but the Business
-    module owns vendor management. Runtime gating in
-    ``_gate_owner_type`` enforces the split: a Freelancer-only user
-    can't reach vendor bills through the shared tools.
-    """
-
-    @pytest.fixture(autouse=True)
-    def save_and_restore_modules(self):
-        from gnucash_mcp.server import _LOADED_MODULES
-        original = set(_LOADED_MODULES)
-        yield
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update(original)
-
-    def test_business_loaded_passes_through(self):
-        """With business_complete enabled (whether explicitly or via
-        the ``business`` group alias), _gate_owner_type returns its
-        input unchanged — both halves of the polymorphic dispatch work.
-        """
-        from gnucash_mcp.server import _LOADED_MODULES
-        from gnucash_mcp.tools._helpers import _gate_owner_type
-
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({
-            "core", "freelancer", "business_complete", "business",
-        })
-        assert _gate_owner_type("customer") == "customer"
-        assert _gate_owner_type("vendor") == "vendor"
-        assert _gate_owner_type(None) is None
-
-    def test_business_absent_coerces_to_customer(self):
-        """Without business, omitted or 'customer' owner_type is
-        coerced to 'customer' explicitly so the book-layer lookup
-        filters out vendor bills."""
-        from gnucash_mcp.server import _LOADED_MODULES
-        from gnucash_mcp.tools._helpers import _gate_owner_type
-
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({"core", "freelancer"})
-        assert _gate_owner_type(None) == "customer"
-        assert _gate_owner_type("customer") == "customer"
-
-    def test_business_absent_rejects_explicit_vendor(self):
-        """Without business, an explicit owner_type='vendor' raises
-        a clear error rather than silently coercing or returning
-        not-found from the book layer."""
-        import pytest
-        from gnucash_mcp.server import _LOADED_MODULES
-        from gnucash_mcp.tools._helpers import _gate_owner_type
-
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({"core", "freelancer"})
-        with pytest.raises(ValueError, match="requires the business module"):
-            _gate_owner_type("vendor")
-
-    def test_business_absent_rejects_explicit_employee(self):
-        """Symmetric with the vendor rejection — employee gating
-        was added with vouchers (v1.3) and needs the same
-        guardrail. Without business, owner_type='employee' raises
-        with the Business-module-required message. (Copilot PR
-        #86 review found this coverage gap.)"""
-        import pytest
-        from gnucash_mcp.server import _LOADED_MODULES
-        from gnucash_mcp.tools._helpers import _gate_owner_type
-
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({"core", "freelancer"})
-        with pytest.raises(ValueError, match="requires the business module"):
-            _gate_owner_type("employee")
-
-    def test_business_absent_rejects_typo(self):
-        """Without business, a typo like 'venddor' must fail fast
-        — pre-fix the gate silently coerced unknown strings to
-        'customer', masking the typo behind a confusing "invoice
-        not found" downstream error. The gate now rejects anything
-        outside {None, 'customer'} (or the two business-gated
-        names which raise their own messages). (Copilot PR #86
-        review.)"""
-        import pytest
-        from gnucash_mcp.server import _LOADED_MODULES
-        from gnucash_mcp.tools._helpers import _gate_owner_type
-
-        _LOADED_MODULES.clear()
-        _LOADED_MODULES.update({"core", "freelancer"})
-        with pytest.raises(ValueError, match="Invalid owner_type"):
-            _gate_owner_type("venddor")
 
 
 class TestJsonDumpsForbiddenInTools:
@@ -2026,15 +1918,16 @@ class TestEnvModuleToggles:
                 == "reporting,budgets,scheduling,investor")
 
     def test_retired_freelancer_toggle_still_honored(self, monkeypatch):
-        """Release-review finding 4: freelancer's surface did NOT
-        join the base, so an old install that answered
-        freelancer=yes, business=no must keep its invoicing tools —
-        ignoring the stored toggle would silently subtract them."""
+        """Release-review finding 4: the invoicing surface is not
+        in the base, so an old install that answered freelancer=yes,
+        business=no must keep it — ignoring the stored toggle would
+        silently subtract it. Since the freelancer/business_complete
+        merge the toggle unlocks the whole business module."""
         from gnucash_mcp.server import _modules_from_env_toggles
         monkeypatch.setenv("GNUCASH_ENABLE_BUSINESS", "false")
         monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "true")
         assert (_modules_from_env_toggles()
-                == "reporting,budgets,scheduling,investor,freelancer")
+                == "reporting,budgets,scheduling,investor,business")
         # freelancer=false stays base-only (no accidental additions).
         monkeypatch.setenv("GNUCASH_ENABLE_FREELANCER", "false")
         assert (_modules_from_env_toggles()
@@ -2387,7 +2280,7 @@ class TestHelpTextCounts:
         text = _build_help_text()
         assert f"core ({_module_tool_count('core')} tools" in text
         assert f"({_module_tool_count('all')} tools" in text
-        for group in ("bookkeeper", "investor", "freelancer", "business"):
+        for group in ("bookkeeper", "investor", "business"):
             assert f"{_module_tool_count(group)} tools." in text
 
     def test_help_text_mentions_conditional_switch_book(self):


### PR DESCRIPTION
## Summary
- `freelancer` and `business_complete` merge into one `business` leaf. The split had reduced to a runtime gate on `owner_type` plus one report once the party/document tools went polymorphic; three gate helpers and 23 call sites are gone. The retired names still resolve on `--modules` / `GNUCASH_MCP_MODULES`, so existing configs keep starting; a stored `GNUCASH_ENABLE_FREELANCER=true` unlocks the whole suite.
- `bookkeeper` is everything except business (`tax_lots` and `portfolio` join). The bundle's always-on base now derives from the group instead of a parallel list.
- `party_type` everywhere: `apply_credit_note`, `create_job`, and `list_jobs` accept it and job responses answer it; no business tool exposes `owner_type` (contract-locked). The ID-collision error names `document_type` / `party_type`.
- Document payment state: `get_document` carries `status` (open / posted / paid / applied) and, once posted, `amount_paid` / `amount_due`; `pay_document` reports the per-call `payment` beside a cumulative `total_paid`. One new chokepoint, `_document_settlement`, feeds these and `get_outstanding_documents` (agreement-locked), and every amount leaves it at the commodity's quantum.
- Audit CREATE lines for invoices, bills, vouchers, credit notes, and jobs render the counterparty as `Name (id)`; older entries keep the bare id.

Tool count unchanged at 86. Known residual, deferred: entry rows inside `get_document` are still unpadded (a unit price may carry more precision than the currency quantum). Report: `specs/v1.5/testing/BOOKKEEPER_REPORT_MODULE_MERGE.md`.

## Test plan
- [x] Suite green: 2,215 passed, parallel
- [x] Every new lock watched failing under mutation (alias map, owner_type surface, settlement sign, quantum, name label)
- [x] Real-server smoke: `freelancer`, `business_complete`, `business` each serve 56 tools; `bookkeeper` 59; `core` 29
- [x] Bookkeeper loop, three rounds on Alex, closed "ship it"
- [ ] README module table (in the maintainer's working tree) lands with the README refresh